### PR TITLE
Pass Ride reference to track paint functions

### DIFF
--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5399,7 +5399,7 @@ bool ride_has_adjacent_station(Ride* ride)
 
 bool ride_has_station_shelter(Ride* ride)
 {
-    auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride->GetStationObject();
     return stationObj != nullptr && (stationObj->Flags & STATION_OBJECT_FLAGS::HAS_SHELTER);
 }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5399,7 +5399,7 @@ bool ride_has_adjacent_station(Ride* ride)
 
 bool ride_has_station_shelter(Ride* ride)
 {
-    const auto stationObj = ride->GetStationObject();
+    const auto* stationObj = ride->GetStationObject();
     return stationObj != nullptr && (stationObj->Flags & STATION_OBJECT_FLAGS::HAS_SHELTER);
 }
 

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -361,7 +361,7 @@ static void track_paint_util_draw_station_impl(
     const TrackElement& trackElement, int32_t fenceOffsetA, int32_t fenceOffsetB)
 {
     CoordsXY position = session->MapPosition;
-    const auto stationObj = ride.GetStationObject();
+    const auto* stationObj = ride.GetStationObject();
     const bool hasGreenLight = trackElement.HasGreenLight();
 
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -568,7 +568,7 @@ void track_paint_util_draw_station_inverted(
     uint8_t stationVariant)
 {
     CoordsXY position = session->MapPosition;
-    const auto stationObj = ride.GetStationObject();
+    const auto* stationObj = ride.GetStationObject();
     const bool hasGreenLight = trackElement.HasGreenLight();
 
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -850,7 +850,7 @@ void track_paint_util_draw_narrow_station_platform(
     const TrackElement& trackElement)
 {
     CoordsXY position = session->MapPosition;
-    const auto stationObj = ride.GetStationObject();
+    const auto* stationObj = ride.GetStationObject();
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
         return;
 

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -333,38 +333,35 @@ bool track_paint_util_should_paint_supports(const CoordsXY& position)
 }
 
 static void track_paint_util_draw_station_impl(
-    paint_session* session, const Ride* ride, Direction direction, uint16_t height, uint16_t coverHeight,
+    paint_session* session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TrackElement& trackElement, int32_t fenceOffsetA, int32_t fenceOffsetB);
 
 void track_paint_util_draw_station(
-    paint_session* session, const Ride* ride, Direction direction, uint16_t height, const TrackElement& trackElement)
+    paint_session* session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement)
 {
     track_paint_util_draw_station_impl(session, ride, direction, height, height, trackElement, 5, 7);
 }
 
 void track_paint_util_draw_station_2(
-    paint_session* session, const Ride* ride, Direction direction, uint16_t height, const TrackElement& trackElement,
+    paint_session* session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement,
     int32_t fenceOffsetA, int32_t fenceOffsetB)
 {
     track_paint_util_draw_station_impl(session, ride, direction, height, height, trackElement, fenceOffsetA, fenceOffsetB);
 }
 
 void track_paint_util_draw_station_3(
-    paint_session* session, const Ride* ride, Direction direction, uint16_t height, uint16_t coverHeight,
+    paint_session* session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TrackElement& trackElement)
 {
     track_paint_util_draw_station_impl(session, ride, direction, height, coverHeight, trackElement, 5, 7);
 }
 
 static void track_paint_util_draw_station_impl(
-    paint_session* session, const Ride* ride, Direction direction, uint16_t height, uint16_t coverHeight,
+    paint_session* session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TrackElement& trackElement, int32_t fenceOffsetA, int32_t fenceOffsetB)
 {
-    if (ride == nullptr)
-        return;
-
     CoordsXY position = session->MapPosition;
-    const auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride.GetStationObject();
     const bool hasGreenLight = trackElement.HasGreenLight();
 
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -376,7 +373,7 @@ static void track_paint_util_draw_station_impl(
     if (direction == 0 || direction == 2)
     {
         // height += 5 (height + 5);
-        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, session->CurrentRotation);
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 0)
         {
@@ -424,7 +421,7 @@ static void track_paint_util_draw_station_impl(
         PaintAddImageAsParent(session, imageId, { 0, 24, height + fenceOffsetA }, { 32, 8, 1 });
         // height += 2 (height + 7)
 
-        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
@@ -471,7 +468,7 @@ static void track_paint_util_draw_station_impl(
     else if (direction == 1 || direction == 3)
     {
         // height += 5 (height + 5);
-        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, session->CurrentRotation);
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 3)
         {
@@ -519,7 +516,7 @@ static void track_paint_util_draw_station_impl(
         PaintAddImageAsParent(session, imageId, { 24, 0, height + fenceOffsetA }, { 8, 32, 1 });
         // height += 2 (height + 7)
 
-        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
@@ -567,14 +564,11 @@ static void track_paint_util_draw_station_impl(
 }
 
 void track_paint_util_draw_station_inverted(
-    paint_session* session, const Ride* ride, Direction direction, int32_t height, const TrackElement& trackElement,
+    paint_session* session, const Ride& ride, Direction direction, int32_t height, const TrackElement& trackElement,
     uint8_t stationVariant)
 {
-    if (ride == nullptr)
-        return;
-
     CoordsXY position = session->MapPosition;
-    const auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride.GetStationObject();
     const bool hasGreenLight = trackElement.HasGreenLight();
 
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -586,7 +580,7 @@ void track_paint_util_draw_station_inverted(
     if (direction == 0 || direction == 2)
     {
         // height += 5 (height + 5);
-        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, session->CurrentRotation);
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 0)
         {
@@ -634,7 +628,7 @@ void track_paint_util_draw_station_inverted(
         PaintAddImageAsParent(session, imageId, { 0, 24, height + 6 }, { 32, 8, 1 });
         // height += 2 (height + 7)
 
-        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
@@ -681,7 +675,7 @@ void track_paint_util_draw_station_inverted(
     else if (direction == 1 || direction == 3)
     {
         // height += 5 (height + 5);
-        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, session->CurrentRotation);
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 3)
         {
@@ -729,7 +723,7 @@ void track_paint_util_draw_station_inverted(
         PaintAddImageAsParent(session, imageId, { 24, 0, height + 6 }, { 8, 32, 1 });
         // height += 2 (height + 7)
 
-        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -231,9 +231,9 @@ enum
 };
 
 bool track_paint_util_has_fence(
-    enum edge_t edge, const CoordsXY& position, const TrackElement& trackElement, const Ride* ride, uint8_t rotation)
+    enum edge_t edge, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride, uint8_t rotation)
 {
-    const auto* stationObject = ride->GetStationObject();
+    const auto* stationObject = ride.GetStationObject();
     if (stationObject != nullptr && stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
         return false;
 
@@ -257,8 +257,8 @@ bool track_paint_util_has_fence(
     auto entranceLoc = TileCoordsXY(position) + offset;
 
     int32_t entranceId = trackElement.GetStationIndex();
-    const TileCoordsXYZD entrance = ride_get_entrance_location(ride, entranceId);
-    const TileCoordsXYZD exit = ride_get_exit_location(ride, entranceId);
+    const TileCoordsXYZD entrance = ride_get_entrance_location(&ride, entranceId);
+    const TileCoordsXYZD exit = ride_get_exit_location(&ride, entranceId);
 
     return (entranceLoc != entrance && entranceLoc != exit);
 }
@@ -298,22 +298,22 @@ void track_paint_util_paint_fences(
 {
     uint32_t imageId;
 
-    if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, rotation))
+    if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, position, trackElement, *ride, rotation))
     {
         imageId = fenceSprites[3] | colourFlags;
         PaintAddImageAsChild(session, imageId, 0, 0, 32, 1, 7, height, 0, 2, height + 2);
     }
-    if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, rotation))
+    if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, position, trackElement, *ride, rotation))
     {
         imageId = fenceSprites[0] | colourFlags;
         PaintAddImageAsChild(session, imageId, 0, 0, 1, 32, 7, height, 2, 0, height + 2);
     }
-    if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, rotation))
+    if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, rotation))
     {
         imageId = fenceSprites[1] | colourFlags;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 7 }, { 0, 30, height + 2 });
     }
-    if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, rotation))
+    if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, rotation))
     {
         imageId = fenceSprites[2] | colourFlags;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 30, 0, height + 2 });
@@ -376,7 +376,7 @@ static void track_paint_util_draw_station_impl(
     if (direction == 0 || direction == 2)
     {
         // height += 5 (height + 5);
-        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, *ride, session->CurrentRotation);
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 0)
         {
@@ -424,7 +424,7 @@ static void track_paint_util_draw_station_impl(
         PaintAddImageAsParent(session, imageId, { 0, 24, height + fenceOffsetA }, { 32, 8, 1 });
         // height += 2 (height + 7)
 
-        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
@@ -471,7 +471,7 @@ static void track_paint_util_draw_station_impl(
     else if (direction == 1 || direction == 3)
     {
         // height += 5 (height + 5);
-        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, *ride, session->CurrentRotation);
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 3)
         {
@@ -519,7 +519,7 @@ static void track_paint_util_draw_station_impl(
         PaintAddImageAsParent(session, imageId, { 24, 0, height + fenceOffsetA }, { 8, 32, 1 });
         // height += 2 (height + 7)
 
-        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
@@ -586,7 +586,7 @@ void track_paint_util_draw_station_inverted(
     if (direction == 0 || direction == 2)
     {
         // height += 5 (height + 5);
-        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, *ride, session->CurrentRotation);
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 0)
         {
@@ -634,7 +634,7 @@ void track_paint_util_draw_station_inverted(
         PaintAddImageAsParent(session, imageId, { 0, 24, height + 6 }, { 32, 8, 1 });
         // height += 2 (height + 7)
 
-        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 0)
@@ -681,7 +681,7 @@ void track_paint_util_draw_station_inverted(
     else if (direction == 1 || direction == 3)
     {
         // height += 5 (height + 5);
-        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, *ride, session->CurrentRotation);
 
         if (trackElement.GetTrackType() == TrackElemType::EndStation && direction == 3)
         {
@@ -729,7 +729,7 @@ void track_paint_util_draw_station_inverted(
         PaintAddImageAsParent(session, imageId, { 24, 0, height + 6 }, { 8, 32, 1 });
         // height += 2 (height + 7)
 
-        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             if (trackElement.GetTrackType() == TrackElemType::BeginStation && direction == 3)
@@ -862,7 +862,7 @@ void track_paint_util_draw_narrow_station_platform(
 
     if (direction & 1)
     {
-        bool hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, session->CurrentRotation);
+        bool hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, *ride, session->CurrentRotation);
         uint32_t imageId = (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NE : SPR_STATION_NARROW_EDGE_NE)
             | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height + zOffset }, { 8, 32, 1 });
@@ -871,7 +871,7 @@ void track_paint_util_draw_narrow_station_platform(
         imageId = SPR_STATION_NARROW_EDGE_SW | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 24, 0, height + zOffset }, { 8, 32, 1 });
 
-        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_STATION_FENCE_NW_SE | session->TrackColours[SCHEME_SUPPORTS];
@@ -881,7 +881,7 @@ void track_paint_util_draw_narrow_station_platform(
     }
     else
     {
-        bool hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, session->CurrentRotation);
+        bool hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, *ride, session->CurrentRotation);
         uint32_t imageId = (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NW : SPR_STATION_NARROW_EDGE_NW)
             | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height + zOffset }, { 32, 8, 1 });
@@ -890,7 +890,7 @@ void track_paint_util_draw_narrow_station_platform(
         imageId = SPR_STATION_NARROW_EDGE_SE | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 24, height + zOffset }, { 32, 8, 1 });
 
-        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_STATION_FENCE_SW_NE | session->TrackColours[SCHEME_SUPPORTS];
@@ -912,7 +912,7 @@ void track_paint_util_draw_pier(
 
     if (direction & 1)
     {
-        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, *ride, session->CurrentRotation);
         imageId = (hasFence ? SPR_STATION_PIER_EDGE_NE_FENCED : SPR_STATION_PIER_EDGE_NE)
             | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 1 }, { 2, 0, height });
@@ -921,7 +921,7 @@ void track_paint_util_draw_pier(
         imageId = SPR_STATION_PIER_EDGE_SW | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 24, 0, height }, { 8, 32, 1 });
 
-        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_STATION_PIER_FENCE_SW | session->TrackColours[SCHEME_SUPPORTS];
@@ -931,7 +931,7 @@ void track_paint_util_draw_pier(
     }
     else
     {
-        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, rotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, *ride, rotation);
         imageId = (hasFence ? SPR_STATION_PIER_EDGE_NW_FENCED : SPR_STATION_PIER_EDGE_NW)
             | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 1 }, { 0, 2, height });
@@ -940,7 +940,7 @@ void track_paint_util_draw_pier(
         imageId = SPR_STATION_PIER_EDGE_SE | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 24, height }, { 32, 8, 1 });
 
-        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, rotation);
+        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, rotation);
         if (hasFence)
         {
             imageId = SPR_STATION_PIER_FENCE_SE | session->TrackColours[SCHEME_SUPPORTS];

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -2270,7 +2270,7 @@ void PaintTrack(paint_session* session, Direction direction, int32_t height, con
             TRACK_PAINT_FUNCTION paintFunction = paintFunctionGetter(trackType);
             if (paintFunction != nullptr)
             {
-                paintFunction(session, ride, trackSequence, direction, height, trackElement);
+                paintFunction(session, *ride, trackSequence, direction, height, trackElement);
             }
         }
     }

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -895,7 +895,7 @@ void track_paint_util_draw_narrow_station_platform(
 }
 
 void track_paint_util_draw_pier(
-    paint_session* session, const Ride* ride, const StationObject* stationObj, const CoordsXY& position, Direction direction,
+    paint_session* session, const Ride& ride, const StationObject* stationObj, const CoordsXY& position, Direction direction,
     int32_t height, const TrackElement& trackElement, uint8_t rotation)
 {
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -906,7 +906,7 @@ void track_paint_util_draw_pier(
 
     if (direction & 1)
     {
-        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, session->CurrentRotation);
         imageId = (hasFence ? SPR_STATION_PIER_EDGE_NE_FENCED : SPR_STATION_PIER_EDGE_NE)
             | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 6, 32, 1 }, { 2, 0, height });
@@ -915,7 +915,7 @@ void track_paint_util_draw_pier(
         imageId = SPR_STATION_PIER_EDGE_SW | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 24, 0, height }, { 8, 32, 1 });
 
-        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_STATION_PIER_FENCE_SW | session->TrackColours[SCHEME_SUPPORTS];
@@ -925,7 +925,7 @@ void track_paint_util_draw_pier(
     }
     else
     {
-        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, *ride, rotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, rotation);
         imageId = (hasFence ? SPR_STATION_PIER_EDGE_NW_FENCED : SPR_STATION_PIER_EDGE_NW)
             | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 6, 1 }, { 0, 2, height });
@@ -934,7 +934,7 @@ void track_paint_util_draw_pier(
         imageId = SPR_STATION_PIER_EDGE_SE | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 24, height }, { 32, 8, 1 });
 
-        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, rotation);
+        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, rotation);
         if (hasFence)
         {
             imageId = SPR_STATION_PIER_FENCE_SE | session->TrackColours[SCHEME_SUPPORTS];

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -293,27 +293,27 @@ void track_paint_util_paint_floor(
 }
 
 void track_paint_util_paint_fences(
-    paint_session* session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride* ride,
+    paint_session* session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
     uint32_t colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation)
 {
     uint32_t imageId;
 
-    if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, position, trackElement, *ride, rotation))
+    if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, rotation))
     {
         imageId = fenceSprites[3] | colourFlags;
         PaintAddImageAsChild(session, imageId, 0, 0, 32, 1, 7, height, 0, 2, height + 2);
     }
-    if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, position, trackElement, *ride, rotation))
+    if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, rotation))
     {
         imageId = fenceSprites[0] | colourFlags;
         PaintAddImageAsChild(session, imageId, 0, 0, 1, 32, 7, height, 2, 0, height + 2);
     }
-    if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, rotation))
+    if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, rotation))
     {
         imageId = fenceSprites[1] | colourFlags;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 1, 7 }, { 0, 30, height + 2 });
     }
-    if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, rotation))
+    if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, rotation))
     {
         imageId = fenceSprites[2] | colourFlags;
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 30, 0, height + 2 });
@@ -852,17 +852,17 @@ bool track_paint_util_draw_station_covers_2(
 }
 
 void track_paint_util_draw_narrow_station_platform(
-    paint_session* session, const Ride* ride, Direction direction, int32_t height, int32_t zOffset,
+    paint_session* session, const Ride& ride, Direction direction, int32_t height, int32_t zOffset,
     const TrackElement& trackElement)
 {
     CoordsXY position = session->MapPosition;
-    const auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride.GetStationObject();
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
         return;
 
     if (direction & 1)
     {
-        bool hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, *ride, session->CurrentRotation);
+        bool hasFence = track_paint_util_has_fence(EDGE_NE, position, trackElement, ride, session->CurrentRotation);
         uint32_t imageId = (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NE : SPR_STATION_NARROW_EDGE_NE)
             | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height + zOffset }, { 8, 32, 1 });
@@ -871,7 +871,7 @@ void track_paint_util_draw_narrow_station_platform(
         imageId = SPR_STATION_NARROW_EDGE_SW | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 24, 0, height + zOffset }, { 8, 32, 1 });
 
-        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_STATION_FENCE_NW_SE | session->TrackColours[SCHEME_SUPPORTS];
@@ -881,7 +881,7 @@ void track_paint_util_draw_narrow_station_platform(
     }
     else
     {
-        bool hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, *ride, session->CurrentRotation);
+        bool hasFence = track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, session->CurrentRotation);
         uint32_t imageId = (hasFence ? SPR_STATION_NARROW_EDGE_FENCED_NW : SPR_STATION_NARROW_EDGE_NW)
             | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height + zOffset }, { 32, 8, 1 });
@@ -890,7 +890,7 @@ void track_paint_util_draw_narrow_station_platform(
         imageId = SPR_STATION_NARROW_EDGE_SE | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 24, height + zOffset }, { 32, 8, 1 });
 
-        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_STATION_FENCE_SW_NE | session->TrackColours[SCHEME_SUPPORTS];

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -364,7 +364,7 @@ static void track_paint_util_draw_station_impl(
         return;
 
     CoordsXY position = session->MapPosition;
-    auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride->GetStationObject();
     const bool hasGreenLight = trackElement.HasGreenLight();
 
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -574,7 +574,7 @@ void track_paint_util_draw_station_inverted(
         return;
 
     CoordsXY position = session->MapPosition;
-    auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride->GetStationObject();
     const bool hasGreenLight = trackElement.HasGreenLight();
 
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -856,7 +856,7 @@ void track_paint_util_draw_narrow_station_platform(
     const TrackElement& trackElement)
 {
     CoordsXY position = session->MapPosition;
-    auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride->GetStationObject();
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
         return;
 

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -397,7 +397,7 @@ void track_paint_util_right_vertical_loop_segments(paint_session* session, Direc
 void track_paint_util_left_corkscrew_up_supports(paint_session* session, Direction direction, uint16_t height);
 
 using TRACK_PAINT_FUNCTION = void (*)(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, Direction direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement);
 using TRACK_PAINT_FUNCTION_GETTER = TRACK_PAINT_FUNCTION (*)(int32_t trackType);
 

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -280,7 +280,7 @@ extern const uint8_t mapLeftEighthTurnToOrthogonal[5];
 extern const size_t mini_golf_peep_animation_lengths[];
 
 bool track_paint_util_has_fence(
-    enum edge_t edge, const CoordsXY& position, const TrackElement& trackElement, const Ride* ride, uint8_t rotation);
+    enum edge_t edge, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride, uint8_t rotation);
 void track_paint_util_paint_floor(
     paint_session* session, uint8_t edges, uint32_t colourFlags, uint16_t height, const uint32_t floorSprites[4],
     const StationObject* stationStyle);

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -296,15 +296,15 @@ void track_paint_util_draw_narrow_station_platform(
     paint_session* session, const Ride& ride, Direction direction, int32_t height, int32_t zOffset,
     const TrackElement& trackElement);
 void track_paint_util_draw_station(
-    paint_session* session, const Ride* ride, Direction direction, uint16_t height, const TrackElement& trackElement);
+    paint_session* session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement);
 void track_paint_util_draw_station_2(
-    paint_session* session, const Ride* ride, Direction direction, uint16_t height, const TrackElement& trackElement,
+    paint_session* session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement,
     int32_t fenceOffsetA, int32_t fenceOffsetB);
 void track_paint_util_draw_station_3(
-    paint_session* session, const Ride* ride, Direction direction, uint16_t height, uint16_t coverHeight,
+    paint_session* session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TrackElement& trackElement);
 void track_paint_util_draw_station_inverted(
-    paint_session* session, const Ride* ride, Direction direction, int32_t height, const TrackElement& trackElement,
+    paint_session* session, const Ride& ride, Direction direction, int32_t height, const TrackElement& trackElement,
     uint8_t stationVariant);
 bool track_paint_util_should_paint_supports(const CoordsXY& position);
 void track_paint_util_draw_pier(

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -308,7 +308,7 @@ void track_paint_util_draw_station_inverted(
     uint8_t stationVariant);
 bool track_paint_util_should_paint_supports(const CoordsXY& position);
 void track_paint_util_draw_pier(
-    paint_session* session, const Ride* ride, const StationObject* stationObject, const CoordsXY& position, Direction direction,
+    paint_session* session, const Ride& ride, const StationObject* stationObject, const CoordsXY& position, Direction direction,
     int32_t height, const TrackElement& trackElement, uint8_t rotation);
 void track_paint_util_draw_station_metal_supports(
     paint_session* session, Direction direction, uint16_t height, uint32_t colour);

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -285,7 +285,7 @@ void track_paint_util_paint_floor(
     paint_session* session, uint8_t edges, uint32_t colourFlags, uint16_t height, const uint32_t floorSprites[4],
     const StationObject* stationStyle);
 void track_paint_util_paint_fences(
-    paint_session* session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride* ride,
+    paint_session* session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
     uint32_t colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation);
 bool track_paint_util_draw_station_covers(
     paint_session* session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height);
@@ -293,7 +293,7 @@ bool track_paint_util_draw_station_covers_2(
     paint_session* session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height,
     uint8_t stationVariant);
 void track_paint_util_draw_narrow_station_platform(
-    paint_session* session, const Ride* ride, Direction direction, int32_t height, int32_t zOffset,
+    paint_session* session, const Ride& ride, Direction direction, int32_t height, int32_t zOffset,
     const TrackElement& trackElement);
 void track_paint_util_draw_station(
     paint_session* session, const Ride* ride, Direction direction, uint16_t height, const TrackElement& trackElement);

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -218,7 +218,6 @@ static void air_powered_vertical_rc_track_station(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-    if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 5, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -218,7 +218,7 @@ static void air_powered_vertical_rc_track_station(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-        track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 5, trackElement);
+    track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 5, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -177,7 +177,7 @@ static uint32_t air_powered_vertical_rc_get_support_colour(paint_session* sessio
 
 /** rct2: 0x008AFAD4 */
 static void air_powered_vertical_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -199,7 +199,7 @@ static void air_powered_vertical_rc_track_flat(
 }
 
 static void air_powered_vertical_rc_track_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -218,7 +218,7 @@ static void air_powered_vertical_rc_track_station(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-    track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 5, trackElement);
+    track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 5, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -227,7 +227,7 @@ static void air_powered_vertical_rc_track_station(
 }
 
 static void air_powered_vertical_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb imageIds[4][5] = {
@@ -310,7 +310,7 @@ static void air_powered_vertical_rc_track_right_quarter_turn_5(
 }
 
 static void air_powered_vertical_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -319,7 +319,7 @@ static void air_powered_vertical_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AFB74 */
 static void air_powered_vertical_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -348,7 +348,7 @@ static void air_powered_vertical_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AFB84 */
 static void air_powered_vertical_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -376,7 +376,7 @@ static void air_powered_vertical_rc_track_flat_to_right_bank(
 }
 
 static void air_powered_vertical_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     air_powered_vertical_rc_track_flat_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -384,14 +384,14 @@ static void air_powered_vertical_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008AFBA4 */
 static void air_powered_vertical_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     air_powered_vertical_rc_track_flat_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void air_powered_vertical_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb imageIds[4][5] = {
@@ -488,7 +488,7 @@ static void air_powered_vertical_rc_track_banked_right_quarter_turn_5(
 }
 
 static void air_powered_vertical_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -498,7 +498,7 @@ static void air_powered_vertical_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008AFBD4 */
 static void air_powered_vertical_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -527,14 +527,14 @@ static void air_powered_vertical_rc_track_left_bank(
 }
 
 static void air_powered_vertical_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     air_powered_vertical_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void air_powered_vertical_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -556,7 +556,7 @@ static void air_powered_vertical_rc_track_brakes(
 }
 
 static void air_powered_vertical_rc_track_vertical_slope_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t trackImageIds[7][4] = {
@@ -761,7 +761,7 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
 }
 
 static void air_powered_vertical_rc_track_vertical_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -798,7 +798,7 @@ static void air_powered_vertical_rc_track_vertical_up(
 }
 
 static void air_powered_vertical_rc_track_vertical_top(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -888,14 +888,14 @@ static void air_powered_vertical_rc_track_vertical_top(
 }
 
 static void air_powered_vertical_rc_track_vertical_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     air_powered_vertical_rc_track_vertical_up(session, ride, trackSequence ^ 1, (direction + 2) & 3, height, trackElement);
 }
 
 static void air_powered_vertical_rc_track_vertical_slope_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     air_powered_vertical_rc_track_vertical_slope_up(
@@ -903,7 +903,7 @@ static void air_powered_vertical_rc_track_vertical_slope_down(
 }
 
 static void air_powered_vertical_rc_track_booster(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     // The booster piece is borrowed from the Reverse Freefall Colour.
@@ -936,7 +936,7 @@ static void air_powered_vertical_rc_track_booster(
 }
 
 static void air_powered_vertical_rc_track_onride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {

--- a/src/openrct2/ride/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/ride/coaster/BobsleighCoaster.cpp
@@ -106,7 +106,7 @@ static void bobsleigh_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/ride/coaster/BobsleighCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _BobsleighBlockBrakeImages[NumOrthogonalDirectio
 
 /** rct2: 0x006FE5B4 */
 static void bobsleigh_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -90,7 +90,7 @@ static void bobsleigh_rc_track_flat(
 }
 
 static void bobsleigh_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -106,7 +106,7 @@ static void bobsleigh_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -114,7 +114,7 @@ static void bobsleigh_rc_track_station(
 
 /** rct2: 0x006FE5C4 */
 static void bobsleigh_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -200,7 +200,7 @@ static void bobsleigh_rc_track_25_deg_up(
 
 /** rct2: 0x006FE5D4 */
 static void bobsleigh_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -286,7 +286,7 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x006FE5E4 */
 static void bobsleigh_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -372,7 +372,7 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x006FE5F4 */
 static void bobsleigh_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -380,7 +380,7 @@ static void bobsleigh_rc_track_25_deg_down(
 
 /** rct2: 0x006FE604 */
 static void bobsleigh_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -388,7 +388,7 @@ static void bobsleigh_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x006FE614 */
 static void bobsleigh_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -396,7 +396,7 @@ static void bobsleigh_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x006FE624 */
 static void bobsleigh_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -620,7 +620,7 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x006FE634 */
 static void bobsleigh_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -629,7 +629,7 @@ static void bobsleigh_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x006FE644 */
 static void bobsleigh_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -671,7 +671,7 @@ static void bobsleigh_rc_track_flat_to_left_bank(
 
 /** rct2: 0x006FE654 */
 static void bobsleigh_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -713,7 +713,7 @@ static void bobsleigh_rc_track_flat_to_right_bank(
 
 /** rct2: 0x006FE664 */
 static void bobsleigh_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -755,7 +755,7 @@ static void bobsleigh_rc_track_left_bank_to_flat(
 
 /** rct2: 0x006FE674 */
 static void bobsleigh_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -797,7 +797,7 @@ static void bobsleigh_rc_track_right_bank_to_flat(
 
 /** rct2: 0x006FE684 */
 static void bobsleigh_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1021,7 +1021,7 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x006FE694 */
 static void bobsleigh_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1030,7 +1030,7 @@ static void bobsleigh_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x006FE6A4 */
 static void bobsleigh_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1079,7 +1079,7 @@ static void bobsleigh_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x006FE6B4 */
 static void bobsleigh_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1128,7 +1128,7 @@ static void bobsleigh_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x006FE6C4 */
 static void bobsleigh_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1177,7 +1177,7 @@ static void bobsleigh_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x006FE6D4 */
 static void bobsleigh_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1226,7 +1226,7 @@ static void bobsleigh_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x006FE6E4 */
 static void bobsleigh_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1234,7 +1234,7 @@ static void bobsleigh_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x006FE6F4 */
 static void bobsleigh_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1242,7 +1242,7 @@ static void bobsleigh_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x006FE704 */
 static void bobsleigh_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1250,7 +1250,7 @@ static void bobsleigh_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x006FE714 */
 static void bobsleigh_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1258,7 +1258,7 @@ static void bobsleigh_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x006FE724 */
 static void bobsleigh_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1300,7 +1300,7 @@ static void bobsleigh_rc_track_left_bank(
 
 /** rct2: 0x006FE734 */
 static void bobsleigh_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1308,7 +1308,7 @@ static void bobsleigh_rc_track_right_bank(
 
 /** rct2: 0x006FE744 */
 static void bobsleigh_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1491,7 +1491,7 @@ static void bobsleigh_rc_track_s_bend_left(
 
 /** rct2: 0x006FE754 */
 static void bobsleigh_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1674,7 +1674,7 @@ static void bobsleigh_rc_track_s_bend_right(
 
 /** rct2: 0x006FE794 */
 static void bobsleigh_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1813,7 +1813,7 @@ static void bobsleigh_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x006FE7A4 */
 static void bobsleigh_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1822,7 +1822,7 @@ static void bobsleigh_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x006FE7B4 */
 static void bobsleigh_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1961,7 +1961,7 @@ static void bobsleigh_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x006FE7C4 */
 static void bobsleigh_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1970,7 +1970,7 @@ static void bobsleigh_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x006FE7D4 */
 static void bobsleigh_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2242,7 +2242,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x006FE7E4 */
 static void bobsleigh_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2514,7 +2514,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x006FE7F4 */
 static void bobsleigh_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -2529,7 +2529,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x006FE804 */
 static void bobsleigh_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -2543,7 +2543,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x006FE814 */
 static void bobsleigh_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2985,7 +2985,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x006FE824 */
 static void bobsleigh_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3427,7 +3427,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x006FE834 */
 static void bobsleigh_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3442,7 +3442,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x006FE844 */
 static void bobsleigh_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3456,7 +3456,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x006FE854 */
 static void bobsleigh_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3488,7 +3488,7 @@ static void bobsleigh_rc_track_brakes(
 
 /** rct2: 0x006FE864 */
 static void bobsleigh_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -3522,7 +3522,7 @@ static void bobsleigh_rc_track_block_brakes(
 }
 
 static void bobsleigh_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
@@ -34,7 +34,7 @@ static constexpr const uint32_t _BolligerMabillardBlockBrakeImages[NumOrthogonal
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -80,7 +80,7 @@ static void bolliger_mabillard_track_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -108,7 +108,7 @@ static void bolliger_mabillard_track_station(
     track_paint_util_draw_station_metal_supports_2(
         session, direction, height, session->TrackColours[SCHEME_SUPPORTS], supportType);
 
-    track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 9, trackElement);
+    track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 9, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -117,7 +117,7 @@ static void bolliger_mabillard_track_station(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -187,7 +187,7 @@ static void bolliger_mabillard_track_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -257,7 +257,7 @@ static void bolliger_mabillard_track_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -327,7 +327,7 @@ static void bolliger_mabillard_track_flat_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -405,7 +405,7 @@ static void bolliger_mabillard_track_25_deg_up_to_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -483,7 +483,7 @@ static void bolliger_mabillard_track_60_deg_up_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -553,7 +553,7 @@ static void bolliger_mabillard_track_25_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up<supportType>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -561,7 +561,7 @@ static void bolliger_mabillard_track_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_60_deg_up<supportType>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -569,7 +569,7 @@ static void bolliger_mabillard_track_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_flat<supportType>(
@@ -578,7 +578,7 @@ static void bolliger_mabillard_track_flat_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_60_deg_up_to_25_deg_up<supportType>(
@@ -587,7 +587,7 @@ static void bolliger_mabillard_track_25_deg_down_to_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_60_deg_up<supportType>(
@@ -596,7 +596,7 @@ static void bolliger_mabillard_track_60_deg_down_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_flat_to_25_deg_up<supportType>(
@@ -605,7 +605,7 @@ static void bolliger_mabillard_track_25_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -769,7 +769,7 @@ static void bolliger_mabillard_track_left_quarter_turn_5(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -779,7 +779,7 @@ static void bolliger_mabillard_track_right_quarter_turn_5(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -817,7 +817,7 @@ static void bolliger_mabillard_track_flat_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -855,7 +855,7 @@ static void bolliger_mabillard_track_flat_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -893,7 +893,7 @@ static void bolliger_mabillard_track_left_bank_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -931,7 +931,7 @@ static void bolliger_mabillard_track_right_bank_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1108,7 +1108,7 @@ static void bolliger_mabillard_track_banked_left_quarter_turn_5(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1118,7 +1118,7 @@ static void bolliger_mabillard_track_banked_right_quarter_turn_5(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1163,7 +1163,7 @@ static void bolliger_mabillard_track_left_bank_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1208,7 +1208,7 @@ static void bolliger_mabillard_track_right_bank_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1253,7 +1253,7 @@ static void bolliger_mabillard_track_25_deg_up_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1298,7 +1298,7 @@ static void bolliger_mabillard_track_25_deg_up_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_right_bank<supportType>(
@@ -1307,7 +1307,7 @@ static void bolliger_mabillard_track_left_bank_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_left_bank<supportType>(
@@ -1316,7 +1316,7 @@ static void bolliger_mabillard_track_right_bank_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_bank_to_25_deg_up<supportType>(
@@ -1325,7 +1325,7 @@ static void bolliger_mabillard_track_25_deg_down_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_bank_to_25_deg_up<supportType>(
@@ -1334,7 +1334,7 @@ static void bolliger_mabillard_track_25_deg_down_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1368,7 +1368,7 @@ static void bolliger_mabillard_track_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_bank<supportType>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1376,7 +1376,7 @@ static void bolliger_mabillard_track_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1540,7 +1540,7 @@ static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1704,7 +1704,7 @@ static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1714,7 +1714,7 @@ static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1724,7 +1724,7 @@ static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1855,7 +1855,7 @@ static void bolliger_mabillard_track_s_bend_left(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1986,7 +1986,7 @@ static void bolliger_mabillard_track_s_bend_right(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2249,7 +2249,7 @@ static void bolliger_mabillard_track_left_vertical_loop(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2474,7 +2474,7 @@ static void bolliger_mabillard_track_right_vertical_loop(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2577,7 +2577,7 @@ static void bolliger_mabillard_track_left_quarter_turn_3(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2587,7 +2587,7 @@ static void bolliger_mabillard_track_right_quarter_turn_3(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2699,7 +2699,7 @@ static void bolliger_mabillard_track_left_quarter_turn_3_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2709,7 +2709,7 @@ static void bolliger_mabillard_track_right_quarter_turn_3_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2788,7 +2788,7 @@ static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2870,7 +2870,7 @@ static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2880,7 +2880,7 @@ static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2890,7 +2890,7 @@ static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3108,7 +3108,7 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_small(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3326,7 +3326,7 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_small(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3341,7 +3341,7 @@ static void bolliger_mabillard_track_left_half_banked_helix_down_small(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3356,7 +3356,7 @@ static void bolliger_mabillard_track_right_half_banked_helix_down_small(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3698,7 +3698,7 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4046,7 +4046,7 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4061,7 +4061,7 @@ static void bolliger_mabillard_track_left_half_banked_helix_down_large(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4076,7 +4076,7 @@ static void bolliger_mabillard_track_right_half_banked_helix_down_large(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4113,7 +4113,7 @@ static void bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4150,7 +4150,7 @@ static void bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_60_deg_up<supportType>(
@@ -4159,7 +4159,7 @@ static void bolliger_mabillard_track_left_quarter_turn_1_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_60_deg_up<supportType>(
@@ -4168,7 +4168,7 @@ static void bolliger_mabillard_track_right_quarter_turn_1_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4196,7 +4196,7 @@ static void bolliger_mabillard_track_brakes(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4237,7 +4237,7 @@ static void bolliger_mabillard_track_25_deg_up_left_banked(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4278,7 +4278,7 @@ static void bolliger_mabillard_track_25_deg_up_right_banked(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4320,7 +4320,7 @@ static void bolliger_mabillard_track_on_ride_photo(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_right_banked<supportType>(
@@ -4329,7 +4329,7 @@ static void bolliger_mabillard_track_25_deg_down_left_banked(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_left_banked<supportType>(
@@ -4338,7 +4338,7 @@ static void bolliger_mabillard_track_25_deg_down_right_banked(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4379,7 +4379,7 @@ static void bolliger_mabillard_track_90_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_90_deg_up<supportType>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4387,7 +4387,7 @@ static void bolliger_mabillard_track_90_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_up_to_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4430,7 +4430,7 @@ static void bolliger_mabillard_track_60_deg_up_to_90_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_90_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_60_deg_up_to_90_deg_up<supportType>(
@@ -4439,7 +4439,7 @@ static void bolliger_mabillard_track_90_deg_down_to_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_90_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4477,7 +4477,7 @@ static void bolliger_mabillard_track_90_deg_up_to_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_down_to_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4521,7 +4521,7 @@ static void bolliger_mabillard_track_60_deg_down_to_90_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4656,7 +4656,7 @@ static void bolliger_mabillard_track_left_eighth_to_diag(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4790,7 +4790,7 @@ static void bolliger_mabillard_track_right_eighth_to_diag(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4800,7 +4800,7 @@ static void bolliger_mabillard_track_left_eighth_to_orthogonal(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4810,7 +4810,7 @@ static void bolliger_mabillard_track_right_eighth_to_orthogonal(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4948,7 +4948,7 @@ static void bolliger_mabillard_track_left_eighth_bank_to_diag(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5086,7 +5086,7 @@ static void bolliger_mabillard_track_right_eighth_bank_to_diag(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5096,7 +5096,7 @@ static void bolliger_mabillard_track_left_eighth_bank_to_orthogonal(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5106,7 +5106,7 @@ static void bolliger_mabillard_track_right_eighth_bank_to_orthogonal(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5252,7 +5252,7 @@ static void bolliger_mabillard_track_diag_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5398,7 +5398,7 @@ static void bolliger_mabillard_track_diag_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5544,7 +5544,7 @@ static void bolliger_mabillard_track_diag_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5690,7 +5690,7 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5836,7 +5836,7 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5982,7 +5982,7 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6128,7 +6128,7 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6274,7 +6274,7 @@ static void bolliger_mabillard_track_diag_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6420,7 +6420,7 @@ static void bolliger_mabillard_track_diag_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6564,7 +6564,7 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6710,7 +6710,7 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6856,7 +6856,7 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7002,7 +7002,7 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7148,7 +7148,7 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7294,7 +7294,7 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7440,7 +7440,7 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7586,7 +7586,7 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7661,7 +7661,7 @@ static void bolliger_mabillard_track_diag_flat_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7736,7 +7736,7 @@ static void bolliger_mabillard_track_diag_flat_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7811,7 +7811,7 @@ static void bolliger_mabillard_track_diag_left_bank_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7886,7 +7886,7 @@ static void bolliger_mabillard_track_diag_right_bank_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7961,7 +7961,7 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8036,7 +8036,7 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8111,7 +8111,7 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8186,7 +8186,7 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8259,7 +8259,7 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8332,7 +8332,7 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8407,7 +8407,7 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8482,7 +8482,7 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8554,7 +8554,7 @@ static void bolliger_mabillard_track_diag_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8626,7 +8626,7 @@ static void bolliger_mabillard_track_diag_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8708,7 +8708,7 @@ static void bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8793,7 +8793,7 @@ static void bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_u
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8878,7 +8878,7 @@ static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_ban
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8960,7 +8960,7 @@ static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_b
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -8993,7 +8993,7 @@ static void bolliger_mabillard_track_block_brakes(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9075,7 +9075,7 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9160,7 +9160,7 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -9170,7 +9170,7 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -9180,7 +9180,7 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9350,7 +9350,7 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9520,7 +9520,7 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -9530,7 +9530,7 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -9540,7 +9540,7 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9583,7 +9583,7 @@ static void bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9626,7 +9626,7 @@ static void bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9669,7 +9669,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9712,7 +9712,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up<supportType>(
@@ -9721,7 +9721,7 @@ static void bolliger_mabillard_track_25_deg_down_to_left_banked_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up<supportType>(
@@ -9730,7 +9730,7 @@ static void bolliger_mabillard_track_25_deg_down_to_right_banked_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up<supportType>(
@@ -9739,7 +9739,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_down_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up<supportType>(
@@ -9748,7 +9748,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_down_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9789,7 +9789,7 @@ static void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9830,7 +9830,7 @@ static void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9871,7 +9871,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9912,7 +9912,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat<supportType>(
@@ -9921,7 +9921,7 @@ static void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_down
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat<supportType>(
@@ -9930,7 +9930,7 @@ static void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_do
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up<supportType>(
@@ -9939,7 +9939,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_down_to_left_banked_flat
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up<supportType>(
@@ -9948,7 +9948,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_down_to_right_banked_fl
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9991,7 +9991,7 @@ static void bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10034,7 +10034,7 @@ static void bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10077,7 +10077,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10120,7 +10120,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_flat<supportType>(
@@ -10129,7 +10129,7 @@ static void bolliger_mabillard_track_flat_to_left_banked_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_flat<supportType>(
@@ -10138,7 +10138,7 @@ static void bolliger_mabillard_track_flat_to_right_banked_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_flat_to_right_banked_25_deg_up<supportType>(
@@ -10147,7 +10147,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_flat_to_left_banked_25_deg_up<supportType>(
@@ -10156,7 +10156,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10203,7 +10203,7 @@ static void bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10250,7 +10250,7 @@ static void bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_1_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_90_deg_up<supportType>(
@@ -10259,7 +10259,7 @@ static void bolliger_mabillard_track_left_quarter_turn_1_90_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_1_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_90_deg_up<supportType>(
@@ -10269,7 +10269,7 @@ static void bolliger_mabillard_track_right_quarter_turn_1_90_deg_down(
 /* The following track elements used to be specific to the Vertical Roller Coaster */
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -10345,7 +10345,7 @@ static void bolliger_mabillard_track_flat_to_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -10421,7 +10421,7 @@ static void bolliger_mabillard_track_60_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_60_deg_up_to_flat<supportType>(
@@ -10430,7 +10430,7 @@ static void bolliger_mabillard_track_flat_to_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_up<supportType>(
@@ -10439,7 +10439,7 @@ static void bolliger_mabillard_track_60_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_brake_for_drop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10482,7 +10482,7 @@ static void bolliger_mabillard_track_brake_for_drop(
 /* The following track elements used to be specific to the Steel Twister */
 template<uint8_t supportType>
 static void bolliger_mabillard_track_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10607,7 +10607,7 @@ static void bolliger_mabillard_track_half_loop_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_half_loop_up<supportType>(session, ride, 3 - trackSequence, direction, height, trackElement);
@@ -10615,7 +10615,7 @@ static void bolliger_mabillard_track_half_loop_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10726,7 +10726,7 @@ static void bolliger_mabillard_track_left_corkscrew_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10838,7 +10838,7 @@ static void bolliger_mabillard_track_right_corkscrew_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_corkscrew_up<supportType>(
@@ -10847,7 +10847,7 @@ static void bolliger_mabillard_track_left_corkscrew_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_corkscrew_up<supportType>(
@@ -10856,7 +10856,7 @@ static void bolliger_mabillard_track_right_corkscrew_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10994,7 +10994,7 @@ static void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
 /** rct2: 0x008AC104 */
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11131,7 +11131,7 @@ static void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_down_to_flat_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_up_long_base<supportType>(
@@ -11140,7 +11140,7 @@ static void bolliger_mabillard_track_60_deg_down_to_flat_long_base(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_60_deg_down_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_60_deg_up_to_flat_long_base<supportType>(
@@ -11149,7 +11149,7 @@ static void bolliger_mabillard_track_flat_to_60_deg_down_long_base(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_barrel_roll_up_to_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11289,7 +11289,7 @@ static void bolliger_mabillard_track_left_barrel_roll_up_to_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_barrel_roll_up_to_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11429,7 +11429,7 @@ static void bolliger_mabillard_track_right_barrel_roll_up_to_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_barrel_roll_down_to_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_barrel_roll_up_to_down<supportType>(
@@ -11438,7 +11438,7 @@ static void bolliger_mabillard_track_left_barrel_roll_down_to_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_barrel_roll_down_to_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_barrel_roll_up_to_down<supportType>(
@@ -11447,7 +11447,7 @@ static void bolliger_mabillard_track_right_barrel_roll_down_to_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_powered_lift(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -11485,7 +11485,7 @@ static void bolliger_mabillard_track_powered_lift(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_large_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11706,7 +11706,7 @@ static void bolliger_mabillard_track_left_large_half_loop_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_large_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11927,7 +11927,7 @@ static void bolliger_mabillard_track_right_large_half_loop_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_large_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_large_half_loop_up<supportType>(
@@ -11936,7 +11936,7 @@ static void bolliger_mabillard_track_right_large_half_loop_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_large_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_large_half_loop_up<supportType>(
@@ -11945,7 +11945,7 @@ static void bolliger_mabillard_track_left_large_half_loop_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12043,7 +12043,7 @@ static void bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up<supportType>(
@@ -12052,7 +12052,7 @@ static void bolliger_mabillard_track_inverted_flat_to_90_deg_quarter_loop_down(
 
 template<uint8_t supportType>
 void bolliger_mabillard_track_booster(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     // These offsets could be moved to the g2.dat file when that supports offsets.

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
@@ -108,7 +108,6 @@ static void bolliger_mabillard_track_station(
     track_paint_util_draw_station_metal_supports_2(
         session, direction, height, session->TrackColours[SCHEME_SUPPORTS], supportType);
 
-    if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 9, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
@@ -108,7 +108,7 @@ static void bolliger_mabillard_track_station(
     track_paint_util_draw_station_metal_supports_2(
         session, direction, height, session->TrackColours[SCHEME_SUPPORTS], supportType);
 
-        track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 9, trackElement);
+    track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 9, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008AE6E0 */
 static void compact_inverted_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -74,7 +74,7 @@ static void compact_inverted_rc_track_flat(
 
 /** rct2: 0x008AE950, 0x008AE960, 0x008AE970 */
 static void compact_inverted_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -93,7 +93,7 @@ static void compact_inverted_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -101,7 +101,7 @@ static void compact_inverted_rc_track_station(
 
 /** rct2: 0x008AE6F0 */
 static void compact_inverted_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -195,7 +195,7 @@ static void compact_inverted_rc_track_25_deg_up(
 
 /** rct2: 0x008AE700 */
 static void compact_inverted_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -265,7 +265,7 @@ static void compact_inverted_rc_track_60_deg_up(
 
 /** rct2: 0x008AE710 */
 static void compact_inverted_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -359,7 +359,7 @@ static void compact_inverted_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AE720 */
 static void compact_inverted_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -441,7 +441,7 @@ static void compact_inverted_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AE730 */
 static void compact_inverted_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -547,7 +547,7 @@ static void compact_inverted_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AE740 */
 static void compact_inverted_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -641,7 +641,7 @@ static void compact_inverted_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AE750 */
 static void compact_inverted_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -649,7 +649,7 @@ static void compact_inverted_rc_track_25_deg_down(
 
 /** rct2: 0x008AE760 */
 static void compact_inverted_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -657,7 +657,7 @@ static void compact_inverted_rc_track_60_deg_down(
 
 /** rct2: 0x008AE770 */
 static void compact_inverted_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -665,7 +665,7 @@ static void compact_inverted_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AE780 */
 static void compact_inverted_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -673,7 +673,7 @@ static void compact_inverted_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AE790 */
 static void compact_inverted_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -681,7 +681,7 @@ static void compact_inverted_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008AE7A0 */
 static void compact_inverted_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -689,7 +689,7 @@ static void compact_inverted_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008AE7B0 */
 static void compact_inverted_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -869,7 +869,7 @@ static void compact_inverted_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AE7C0 */
 static void compact_inverted_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -878,7 +878,7 @@ static void compact_inverted_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008AE7D0 */
 static void compact_inverted_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -921,7 +921,7 @@ static void compact_inverted_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AE7E0 */
 static void compact_inverted_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -964,7 +964,7 @@ static void compact_inverted_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008AE7F0 */
 static void compact_inverted_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1007,7 +1007,7 @@ static void compact_inverted_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008AE800 */
 static void compact_inverted_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1050,7 +1050,7 @@ static void compact_inverted_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008AE810 */
 static void compact_inverted_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1230,7 +1230,7 @@ static void compact_inverted_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008AE820 */
 static void compact_inverted_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1240,7 +1240,7 @@ static void compact_inverted_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008AE830 */
 static void compact_inverted_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1307,7 +1307,7 @@ static void compact_inverted_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AE840 */
 static void compact_inverted_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1374,7 +1374,7 @@ static void compact_inverted_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AE850 */
 static void compact_inverted_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1441,7 +1441,7 @@ static void compact_inverted_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AE860 */
 static void compact_inverted_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1508,7 +1508,7 @@ static void compact_inverted_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AE870 */
 static void compact_inverted_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1516,7 +1516,7 @@ static void compact_inverted_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008AE880 */
 static void compact_inverted_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1524,7 +1524,7 @@ static void compact_inverted_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008AE890 */
 static void compact_inverted_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1532,7 +1532,7 @@ static void compact_inverted_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008AE8A0 */
 static void compact_inverted_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1540,7 +1540,7 @@ static void compact_inverted_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008AE8B0 */
 static void compact_inverted_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1583,7 +1583,7 @@ static void compact_inverted_rc_track_left_bank(
 
 /** rct2: 0x008AE8C0 */
 static void compact_inverted_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1591,7 +1591,7 @@ static void compact_inverted_rc_track_right_bank(
 
 /** rct2: 0x008AE8D0 */
 static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1756,7 +1756,7 @@ static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AE8E0 */
 static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1921,7 +1921,7 @@ static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AE8F0 */
 static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1931,7 +1931,7 @@ static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008AE900 */
 static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1941,7 +1941,7 @@ static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008AE910 */
 static void compact_inverted_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2112,7 +2112,7 @@ static void compact_inverted_rc_track_s_bend_left(
 
 /** rct2: 0x008AE920 */
 static void compact_inverted_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2283,7 +2283,7 @@ static void compact_inverted_rc_track_s_bend_right(
 
 /** rct2: 0x008AE930 */
 static void compact_inverted_rc_track_left_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2590,7 +2590,7 @@ static void compact_inverted_rc_track_left_vertical_loop(
 
 /** rct2: 0x008AE940 */
 static void compact_inverted_rc_track_right_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2897,7 +2897,7 @@ static void compact_inverted_rc_track_right_vertical_loop(
 
 /** rct2: 0x008AE980 */
 static void compact_inverted_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3016,7 +3016,7 @@ static void compact_inverted_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AE990 */
 static void compact_inverted_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3025,7 +3025,7 @@ static void compact_inverted_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008AE9A0 */
 static void compact_inverted_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3145,7 +3145,7 @@ static void compact_inverted_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008AE9B0 */
 static void compact_inverted_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3154,7 +3154,7 @@ static void compact_inverted_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008AE9C0 */
 static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3241,7 +3241,7 @@ static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AE9D0 */
 static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3328,7 +3328,7 @@ static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AE9E0 */
 static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3338,7 +3338,7 @@ static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008AE9F0 */
 static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3348,7 +3348,7 @@ static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008AEA00 */
 static void compact_inverted_rc_track_left_twist_down_to_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3458,7 +3458,7 @@ static void compact_inverted_rc_track_left_twist_down_to_up(
 
 /** rct2: 0x008AEA10 */
 static void compact_inverted_rc_track_right_twist_down_to_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3568,7 +3568,7 @@ static void compact_inverted_rc_track_right_twist_down_to_up(
 
 /** rct2: 0x008AEA20 */
 static void compact_inverted_rc_track_left_twist_up_to_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3678,7 +3678,7 @@ static void compact_inverted_rc_track_left_twist_up_to_down(
 
 /** rct2: 0x008AEA30 */
 static void compact_inverted_rc_track_right_twist_up_to_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3788,7 +3788,7 @@ static void compact_inverted_rc_track_right_twist_up_to_down(
 
 /** rct2: 0x008AEA40 */
 static void compact_inverted_rc_track_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3941,7 +3941,7 @@ static void compact_inverted_rc_track_half_loop_up(
 
 /** rct2: 0x008AEA50 */
 static void compact_inverted_rc_track_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, trackElement);
@@ -3949,7 +3949,7 @@ static void compact_inverted_rc_track_half_loop_down(
 
 /** rct2: 0x008AEA60 */
 static void compact_inverted_rc_track_left_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4067,7 +4067,7 @@ static void compact_inverted_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008AEA70 */
 static void compact_inverted_rc_track_right_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4185,7 +4185,7 @@ static void compact_inverted_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008AEA80 */
 static void compact_inverted_rc_track_left_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4193,7 +4193,7 @@ static void compact_inverted_rc_track_left_corkscrew_down(
 
 /** rct2: 0x008AEA90 */
 static void compact_inverted_rc_track_right_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4201,7 +4201,7 @@ static void compact_inverted_rc_track_right_corkscrew_down(
 
 /** rct2: 0x008AEAD0 */
 static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4242,7 +4242,7 @@ static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008AEAB0 */
 static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4284,7 +4284,7 @@ static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008AEAC0 */
 static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_right_quarter_turn_1_60_deg_up(
@@ -4293,7 +4293,7 @@ static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008AEAE0 */
 static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_left_quarter_turn_1_60_deg_up(
@@ -4302,7 +4302,7 @@ static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008AEAA0 */
 static void compact_inverted_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4335,7 +4335,7 @@ static void compact_inverted_rc_track_brakes(
 
 /** rct2: 0x008AEAF0 */
 static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4520,7 +4520,7 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
 
 /** rct2: 0x008AEB00 */
 static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4705,7 +4705,7 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
 
 /** rct2: 0x008AEB10 */
 static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4890,7 +4890,7 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
 
 /** rct2: 0x008AEB20 */
 static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5075,7 +5075,7 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
 
 /** rct2: 0x008AEB30 */
 static void compact_inverted_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5129,7 +5129,7 @@ static void compact_inverted_rc_track_on_ride_photo(
 
 /** rct2: 0x008AEDB0 */
 static void compact_inverted_rc_track_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5199,7 +5199,7 @@ static void compact_inverted_rc_track_90_deg_up(
 
 /** rct2: 0x008AEDC0 */
 static void compact_inverted_rc_track_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5207,7 +5207,7 @@ static void compact_inverted_rc_track_90_deg_down(
 
 /** rct2: 0x008AED70 */
 static void compact_inverted_rc_track_60_deg_up_to_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5281,7 +5281,7 @@ static void compact_inverted_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x008AED80 */
 static void compact_inverted_rc_track_90_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5289,7 +5289,7 @@ static void compact_inverted_rc_track_90_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AED90 */
 static void compact_inverted_rc_track_90_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -5360,7 +5360,7 @@ static void compact_inverted_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AEDA0 */
 static void compact_inverted_rc_track_60_deg_down_to_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5433,7 +5433,7 @@ static void compact_inverted_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x008AEB40 */
 static void compact_inverted_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5596,7 +5596,7 @@ static void compact_inverted_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008AEB50 */
 static void compact_inverted_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5759,7 +5759,7 @@ static void compact_inverted_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008AEB60 */
 static void compact_inverted_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5768,7 +5768,7 @@ static void compact_inverted_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008AEB70 */
 static void compact_inverted_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5777,7 +5777,7 @@ static void compact_inverted_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008AED30 */
 static void compact_inverted_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5940,7 +5940,7 @@ static void compact_inverted_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008AED40 */
 static void compact_inverted_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6103,7 +6103,7 @@ static void compact_inverted_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008AED50 */
 static void compact_inverted_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6113,7 +6113,7 @@ static void compact_inverted_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008AED60 */
 static void compact_inverted_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6122,7 +6122,7 @@ static void compact_inverted_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008AEB80 */
 static void compact_inverted_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6261,7 +6261,7 @@ static void compact_inverted_rc_track_diag_flat(
 
 /** rct2: 0x008AEBB0 */
 static void compact_inverted_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6400,7 +6400,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008AEC10 */
 static void compact_inverted_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6483,7 +6483,7 @@ static void compact_inverted_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008AEB90 */
 static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6622,7 +6622,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AEBF0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6705,7 +6705,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AEC00 */
 static void compact_inverted_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6788,7 +6788,7 @@ static void compact_inverted_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AEBA0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6927,7 +6927,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AEBE0 */
 static void compact_inverted_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7066,7 +7066,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008AEC40 */
 static void compact_inverted_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7149,7 +7149,7 @@ static void compact_inverted_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008AEBC0 */
 static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7285,7 +7285,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008AEC20 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7368,7 +7368,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AEC30 */
 static void compact_inverted_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7451,7 +7451,7 @@ static void compact_inverted_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008AEBD0 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7590,7 +7590,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008AEC70 */
 static void compact_inverted_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7674,7 +7674,7 @@ static void compact_inverted_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008AEC80 */
 static void compact_inverted_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7758,7 +7758,7 @@ static void compact_inverted_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008AEC90 */
 static void compact_inverted_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7842,7 +7842,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008AECA0 */
 static void compact_inverted_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7926,7 +7926,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008AECD0 */
 static void compact_inverted_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8009,7 +8009,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AECE0 */
 static void compact_inverted_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8092,7 +8092,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AECB0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8175,7 +8175,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AECC0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8258,7 +8258,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AECF0 */
 static void compact_inverted_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8338,7 +8338,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008AED00 */
 static void compact_inverted_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8418,7 +8418,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008AED10 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8501,7 +8501,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008AED20 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8584,7 +8584,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008AEC50 */
 static void compact_inverted_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8668,7 +8668,7 @@ static void compact_inverted_rc_track_diag_left_bank(
 
 /** rct2: 0x008AEC60 */
 static void compact_inverted_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8752,7 +8752,7 @@ static void compact_inverted_rc_track_diag_right_bank(
 
 /** rct2: 0x008AEAA0 */
 static void compact_inverted_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
@@ -93,7 +93,7 @@ static void compact_inverted_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _CorkscrewRCBlockBrakeImages[NumOrthogonalDirect
 
 /** rct2: 0x008A7AF8 */
 static void corkscrew_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -89,7 +89,7 @@ static void corkscrew_rc_track_flat(
 
 /** rct2: 0x008A7D68, 0x008A7D78, 0x008A7D88 */
 static void corkscrew_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -115,7 +115,7 @@ static void corkscrew_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -123,7 +123,7 @@ static void corkscrew_rc_track_station(
 
 /** rct2: 0x008A7B08 */
 static void corkscrew_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -193,7 +193,7 @@ static void corkscrew_rc_track_25_deg_up(
 
 /** rct2: 0x008A7B18 */
 static void corkscrew_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -263,7 +263,7 @@ static void corkscrew_rc_track_60_deg_up(
 
 /** rct2: 0x008A7B28 */
 static void corkscrew_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -333,7 +333,7 @@ static void corkscrew_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A7B38 */
 static void corkscrew_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -411,7 +411,7 @@ static void corkscrew_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A7B48 */
 static void corkscrew_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -489,7 +489,7 @@ static void corkscrew_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7B58 */
 static void corkscrew_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -559,7 +559,7 @@ static void corkscrew_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A7B68 */
 static void corkscrew_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -567,7 +567,7 @@ static void corkscrew_rc_track_25_deg_down(
 
 /** rct2: 0x008A7B78 */
 static void corkscrew_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -575,7 +575,7 @@ static void corkscrew_rc_track_60_deg_down(
 
 /** rct2: 0x008A7B88 */
 static void corkscrew_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -583,7 +583,7 @@ static void corkscrew_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A7B98 */
 static void corkscrew_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -591,7 +591,7 @@ static void corkscrew_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A7BA8 */
 static void corkscrew_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -599,7 +599,7 @@ static void corkscrew_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A7BB8 */
 static void corkscrew_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -607,7 +607,7 @@ static void corkscrew_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A7BC8 */
 static void corkscrew_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -771,7 +771,7 @@ static void corkscrew_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A7BD8 */
 static void corkscrew_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -780,7 +780,7 @@ static void corkscrew_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A7BE8 */
 static void corkscrew_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -818,7 +818,7 @@ static void corkscrew_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A7BF8 */
 static void corkscrew_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -856,7 +856,7 @@ static void corkscrew_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A7C08 */
 static void corkscrew_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -894,7 +894,7 @@ static void corkscrew_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A7C18 */
 static void corkscrew_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -932,7 +932,7 @@ static void corkscrew_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A7C28 */
 static void corkscrew_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1106,7 +1106,7 @@ static void corkscrew_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A7C38 */
 static void corkscrew_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1115,7 +1115,7 @@ static void corkscrew_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008A7C48 */
 static void corkscrew_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1160,7 +1160,7 @@ static void corkscrew_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A7C58 */
 static void corkscrew_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1205,7 +1205,7 @@ static void corkscrew_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A7C68 */
 static void corkscrew_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1250,7 +1250,7 @@ static void corkscrew_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A7C78 */
 static void corkscrew_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1295,7 +1295,7 @@ static void corkscrew_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A7C88 */
 static void corkscrew_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1303,7 +1303,7 @@ static void corkscrew_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A7C98 */
 static void corkscrew_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1311,7 +1311,7 @@ static void corkscrew_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A7CA8 */
 static void corkscrew_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1319,7 +1319,7 @@ static void corkscrew_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A7CB8 */
 static void corkscrew_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1327,7 +1327,7 @@ static void corkscrew_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A7CC8 */
 static void corkscrew_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1361,7 +1361,7 @@ static void corkscrew_rc_track_left_bank(
 
 /** rct2: 0x008A7CD8 */
 static void corkscrew_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1369,7 +1369,7 @@ static void corkscrew_rc_track_right_bank(
 
 /** rct2: 0x008A7CE8 */
 static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1533,7 +1533,7 @@ static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7CF8 */
 static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1697,7 +1697,7 @@ static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7D08 */
 static void corkscrew_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1706,7 +1706,7 @@ static void corkscrew_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A7D18 */
 static void corkscrew_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1715,7 +1715,7 @@ static void corkscrew_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A7D28 */
 static void corkscrew_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1850,7 +1850,7 @@ static void corkscrew_rc_track_s_bend_left(
 
 /** rct2: 0x008A7D38 */
 static void corkscrew_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1985,7 +1985,7 @@ static void corkscrew_rc_track_s_bend_right(
 
 /** rct2: 0x008A7D48 */
 static void corkscrew_rc_track_left_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2264,7 +2264,7 @@ static void corkscrew_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A7D58 */
 static void corkscrew_rc_track_right_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2497,7 +2497,7 @@ static void corkscrew_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A7D98 */
 static void corkscrew_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2600,7 +2600,7 @@ static void corkscrew_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A7DA8 */
 static void corkscrew_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2609,7 +2609,7 @@ static void corkscrew_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A7DB8 */
 static void corkscrew_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2721,7 +2721,7 @@ static void corkscrew_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A7DC8 */
 static void corkscrew_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2730,7 +2730,7 @@ static void corkscrew_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008A7DD8 */
 static void corkscrew_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2809,7 +2809,7 @@ static void corkscrew_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7DE8 */
 static void corkscrew_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2895,7 +2895,7 @@ static void corkscrew_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7DF8 */
 static void corkscrew_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2904,7 +2904,7 @@ static void corkscrew_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A7E08 */
 static void corkscrew_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2913,7 +2913,7 @@ static void corkscrew_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A7E18 */
 static void corkscrew_rc_track_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3042,7 +3042,7 @@ static void corkscrew_rc_track_half_loop_up(
 
 /** rct2: 0x008A7E28 */
 static void corkscrew_rc_track_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, trackElement);
@@ -3050,7 +3050,7 @@ static void corkscrew_rc_track_half_loop_down(
 
 /** rct2: 0x008A7E38 */
 static void corkscrew_rc_track_left_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3162,7 +3162,7 @@ static void corkscrew_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A7E48 */
 static void corkscrew_rc_track_right_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3275,7 +3275,7 @@ static void corkscrew_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A7E58 */
 static void corkscrew_rc_track_left_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
@@ -3283,7 +3283,7 @@ static void corkscrew_rc_track_left_corkscrew_down(
 
 /** rct2: 0x008A7E68 */
 static void corkscrew_rc_track_right_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -3291,7 +3291,7 @@ static void corkscrew_rc_track_right_corkscrew_down(
 
 /** rct2: 0x008A7E78 */
 static void corkscrew_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3509,7 +3509,7 @@ static void corkscrew_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A7E88 */
 static void corkscrew_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3727,7 +3727,7 @@ static void corkscrew_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A7E98 */
 static void corkscrew_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3742,7 +3742,7 @@ static void corkscrew_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008A7EA8 */
 static void corkscrew_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3756,7 +3756,7 @@ static void corkscrew_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008A7EB8 */
 static void corkscrew_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4098,7 +4098,7 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A7EC8 */
 static void corkscrew_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4440,7 +4440,7 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A7ED8 */
 static void corkscrew_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4455,7 +4455,7 @@ static void corkscrew_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008A7EE8 */
 static void corkscrew_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4469,7 +4469,7 @@ static void corkscrew_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008A7F18 */
 static void corkscrew_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4506,7 +4506,7 @@ static void corkscrew_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A7EF8 */
 static void corkscrew_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4543,7 +4543,7 @@ static void corkscrew_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A7F08 */
 static void corkscrew_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4551,7 +4551,7 @@ static void corkscrew_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A7F28 */
 static void corkscrew_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4559,7 +4559,7 @@ static void corkscrew_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A7F38 */
 static void corkscrew_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4587,7 +4587,7 @@ static void corkscrew_rc_track_brakes(
 
 /** rct2: 0x008A7F48 */
 static void corkscrew_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4629,7 +4629,7 @@ static void corkscrew_rc_track_on_ride_photo(
 
 /** rct2: 0x008A8198 */
 static void corkscrew_rc_track_flat_to_60_deg_up_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4770,7 +4770,7 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(
 
 /** rct2: 0x008A81A8 */
 static void corkscrew_rc_track_60_deg_up_to_flat_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4911,7 +4911,7 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(
 
 /** rct2: 0x008A81B8 */
 static void corkscrew_rc_track_60_deg_down_to_flat_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_flat_to_60_deg_up_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4919,7 +4919,7 @@ static void corkscrew_rc_track_60_deg_down_to_flat_long_base(
 
 /** rct2: 0x008A81C8 */
 static void corkscrew_rc_track_flat_to_60_deg_down_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_60_deg_up_to_flat_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4927,7 +4927,7 @@ static void corkscrew_rc_track_flat_to_60_deg_down_long_base(
 
 /** rct2: 0x008A7F68 */
 static void corkscrew_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5066,7 +5066,7 @@ static void corkscrew_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A7F78 */
 static void corkscrew_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5204,7 +5204,7 @@ static void corkscrew_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A7F88 */
 static void corkscrew_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5213,7 +5213,7 @@ static void corkscrew_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A7F98 */
 static void corkscrew_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5222,7 +5222,7 @@ static void corkscrew_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A7FA8 */
 static void corkscrew_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5364,7 +5364,7 @@ static void corkscrew_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A7FB8 */
 static void corkscrew_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5505,7 +5505,7 @@ static void corkscrew_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A7FC8 */
 static void corkscrew_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5514,7 +5514,7 @@ static void corkscrew_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A7FD8 */
 static void corkscrew_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5523,7 +5523,7 @@ static void corkscrew_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A7F58 */
 static void corkscrew_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5669,7 +5669,7 @@ static void corkscrew_rc_track_diag_flat(
 
 /** rct2: 0x008A8008 */
 static void corkscrew_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5815,7 +5815,7 @@ static void corkscrew_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A8068 */
 static void corkscrew_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5961,7 +5961,7 @@ static void corkscrew_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A7FE8 */
 static void corkscrew_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6107,7 +6107,7 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A8048 */
 static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6253,7 +6253,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A8058 */
 static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6399,7 +6399,7 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7FF8 */
 static void corkscrew_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6545,7 +6545,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A8038 */
 static void corkscrew_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6691,7 +6691,7 @@ static void corkscrew_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A8098 */
 static void corkscrew_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6837,7 +6837,7 @@ static void corkscrew_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A8018 */
 static void corkscrew_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6981,7 +6981,7 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A8078 */
 static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7127,7 +7127,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A8088 */
 static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7273,7 +7273,7 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A8028 */
 static void corkscrew_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7419,7 +7419,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A80C8 */
 static void corkscrew_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7498,7 +7498,7 @@ static void corkscrew_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A80D8 */
 static void corkscrew_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7577,7 +7577,7 @@ static void corkscrew_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A80E8 */
 static void corkscrew_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7656,7 +7656,7 @@ static void corkscrew_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A80F8 */
 static void corkscrew_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7735,7 +7735,7 @@ static void corkscrew_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A8128 */
 static void corkscrew_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7814,7 +7814,7 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A8138 */
 static void corkscrew_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7893,7 +7893,7 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A8108 */
 static void corkscrew_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7972,7 +7972,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A8118 */
 static void corkscrew_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8051,7 +8051,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A8148 */
 static void corkscrew_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8128,7 +8128,7 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A8158 */
 static void corkscrew_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8205,7 +8205,7 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A8168 */
 static void corkscrew_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8284,7 +8284,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A8178 */
 static void corkscrew_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8363,7 +8363,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A80A8 */
 static void corkscrew_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8439,7 +8439,7 @@ static void corkscrew_rc_track_diag_left_bank(
 
 /** rct2: 0x008A80B8 */
 static void corkscrew_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8515,7 +8515,7 @@ static void corkscrew_rc_track_diag_right_bank(
 
 /** rct2: 0x008A8188 */
 static void corkscrew_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -8530,7 +8530,7 @@ static void corkscrew_rc_track_block_brakes(
 }
 
 static void corkscrew_rc_track_booster(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!is_csg_loaded())

--- a/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
@@ -115,7 +115,7 @@ static void corkscrew_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -154,7 +154,7 @@ static void flying_rc_track_station(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24,
             0, 6, height + 24);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
+        track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_1);
     }
     else
     {
@@ -180,7 +180,7 @@ static void flying_rc_track_station(
         PaintAddImageAsParentRotated(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
+        track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
     }
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -21,7 +21,7 @@
 
 /** rct2: 0x007C6FF4 */
 static void flying_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -133,7 +133,7 @@ static void flying_rc_track_flat(
 
 /** rct2: 0x007C7244, 0x007C7254, 0x007C7264 */
 static void flying_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -154,7 +154,7 @@ static void flying_rc_track_station(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24,
             0, 6, height + 24);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_1);
+        track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
     }
     else
     {
@@ -180,7 +180,7 @@ static void flying_rc_track_station(
         PaintAddImageAsParentRotated(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
+        track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     }
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -190,7 +190,7 @@ static void flying_rc_track_station(
 
 /** rct2: 0x007C7004 */
 static void flying_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -350,7 +350,7 @@ static void flying_rc_track_25_deg_up(
 
 /** rct2: 0x007C7014 */
 static void flying_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -432,7 +432,7 @@ static void flying_rc_track_60_deg_up(
 
 /** rct2: 0x007C7024 */
 static void flying_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -592,7 +592,7 @@ static void flying_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x007C7034 */
 static void flying_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -684,7 +684,7 @@ static void flying_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x007C7044 */
 static void flying_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -800,7 +800,7 @@ static void flying_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7054 */
 static void flying_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -960,7 +960,7 @@ static void flying_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x007C7064 */
 static void flying_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -968,7 +968,7 @@ static void flying_rc_track_25_deg_down(
 
 /** rct2: 0x007C7074 */
 static void flying_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -976,7 +976,7 @@ static void flying_rc_track_60_deg_down(
 
 /** rct2: 0x007C7084 */
 static void flying_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -984,7 +984,7 @@ static void flying_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x007C7094 */
 static void flying_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -992,7 +992,7 @@ static void flying_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x007C70A4 */
 static void flying_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1000,7 +1000,7 @@ static void flying_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x007C70B4 */
 static void flying_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1008,7 +1008,7 @@ static void flying_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x007C70C4 */
 static void flying_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1377,7 +1377,7 @@ static void flying_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x007C70D4 */
 static void flying_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1386,7 +1386,7 @@ static void flying_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x007C70E4 */
 static void flying_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1467,7 +1467,7 @@ static void flying_rc_track_flat_to_left_bank(
 
 /** rct2: 0x007C70F4 */
 static void flying_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1548,7 +1548,7 @@ static void flying_rc_track_flat_to_right_bank(
 
 /** rct2: 0x007C7104 */
 static void flying_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1629,7 +1629,7 @@ static void flying_rc_track_left_bank_to_flat(
 
 /** rct2: 0x007C7114 */
 static void flying_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1710,7 +1710,7 @@ static void flying_rc_track_right_bank_to_flat(
 
 /** rct2: 0x007C7124 */
 static void flying_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2080,7 +2080,7 @@ static void flying_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x007C7134 */
 static void flying_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2089,7 +2089,7 @@ static void flying_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x007C7144 */
 static void flying_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2201,7 +2201,7 @@ static void flying_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x007C7154 */
 static void flying_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2313,7 +2313,7 @@ static void flying_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x007C7164 */
 static void flying_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2425,7 +2425,7 @@ static void flying_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x007C7174 */
 static void flying_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2537,7 +2537,7 @@ static void flying_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x007C7184 */
 static void flying_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2545,7 +2545,7 @@ static void flying_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x007C7194 */
 static void flying_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2553,7 +2553,7 @@ static void flying_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x007C71A4 */
 static void flying_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2561,7 +2561,7 @@ static void flying_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x007C71B4 */
 static void flying_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2569,7 +2569,7 @@ static void flying_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x007C71C4 */
 static void flying_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2646,7 +2646,7 @@ static void flying_rc_track_left_bank(
 
 /** rct2: 0x007C71D4 */
 static void flying_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2654,7 +2654,7 @@ static void flying_rc_track_right_bank(
 
 /** rct2: 0x007C71E4 */
 static void flying_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2998,7 +2998,7 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C71F4 */
 static void flying_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3342,7 +3342,7 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C7204 */
 static void flying_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -3351,7 +3351,7 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x007C7214 */
 static void flying_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -3360,7 +3360,7 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x007C7224 */
 static void flying_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3687,7 +3687,7 @@ static void flying_rc_track_s_bend_left(
 
 /** rct2: 0x007C7234 */
 static void flying_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4014,7 +4014,7 @@ static void flying_rc_track_s_bend_right(
 
 /** rct2: 0x007C7274 */
 static void flying_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4253,7 +4253,7 @@ static void flying_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x007C7284 */
 static void flying_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4262,7 +4262,7 @@ static void flying_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x007C7294 */
 static void flying_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4507,7 +4507,7 @@ static void flying_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x007C72A4 */
 static void flying_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4516,7 +4516,7 @@ static void flying_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x007C72B4 */
 static void flying_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4687,7 +4687,7 @@ static void flying_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C72C4 */
 static void flying_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4864,7 +4864,7 @@ static void flying_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C72D4 */
 static void flying_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4873,7 +4873,7 @@ static void flying_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x007C72E4 */
 static void flying_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4882,7 +4882,7 @@ static void flying_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x007C7314 */
 static void flying_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5104,7 +5104,7 @@ static void flying_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x007C7324 */
 static void flying_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5326,7 +5326,7 @@ static void flying_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x007C7334 */
 static void flying_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -5340,7 +5340,7 @@ static void flying_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x007C7344 */
 static void flying_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -5354,7 +5354,7 @@ static void flying_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x007C7354 */
 static void flying_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5700,7 +5700,7 @@ static void flying_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x007C7364 */
 static void flying_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6046,7 +6046,7 @@ static void flying_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x007C7374 */
 static void flying_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6060,7 +6060,7 @@ static void flying_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x007C7384 */
 static void flying_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6074,7 +6074,7 @@ static void flying_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x007C73B4 */
 static void flying_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6157,7 +6157,7 @@ static void flying_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x007C7394 */
 static void flying_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6239,7 +6239,7 @@ static void flying_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x007C73A4 */
 static void flying_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -6247,7 +6247,7 @@ static void flying_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x007C73C4 */
 static void flying_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -6255,7 +6255,7 @@ static void flying_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x007C73D4 */
 static void flying_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6315,7 +6315,7 @@ static void flying_rc_track_brakes(
 }
 
 static void flying_rc_track_booster(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6332,7 +6332,7 @@ static void flying_rc_track_booster(
 
 /** rct2: 0x007C7674 */
 static void flying_rc_track_left_quarter_banked_helix_large_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6517,7 +6517,7 @@ static void flying_rc_track_left_quarter_banked_helix_large_up(
 
 /** rct2: 0x007C7684 */
 static void flying_rc_track_right_quarter_banked_helix_large_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6702,7 +6702,7 @@ static void flying_rc_track_right_quarter_banked_helix_large_up(
 
 /** rct2: 0x007C7694 */
 static void flying_rc_track_left_quarter_banked_helix_large_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6887,7 +6887,7 @@ static void flying_rc_track_left_quarter_banked_helix_large_down(
 
 /** rct2: 0x007C76A4 */
 static void flying_rc_track_right_quarter_banked_helix_large_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7072,7 +7072,7 @@ static void flying_rc_track_right_quarter_banked_helix_large_down(
 
 /** rct2: 0x007C78B4 */
 static void flying_rc_track_25_deg_up_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7178,7 +7178,7 @@ static void flying_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x007C78C4 */
 static void flying_rc_track_25_deg_up_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7284,7 +7284,7 @@ static void flying_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x007C73E4 */
 static void flying_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7395,7 +7395,7 @@ static void flying_rc_track_on_ride_photo(
 
 /** rct2: 0x007C78D4 */
 static void flying_rc_track_25_deg_down_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -7403,7 +7403,7 @@ static void flying_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x007C78E4 */
 static void flying_rc_track_25_deg_down_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -7411,7 +7411,7 @@ static void flying_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x007C7404 */
 static void flying_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7725,7 +7725,7 @@ static void flying_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x007C7414 */
 static void flying_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8039,7 +8039,7 @@ static void flying_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x007C7424 */
 static void flying_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8048,7 +8048,7 @@ static void flying_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x007C7434 */
 static void flying_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8057,7 +8057,7 @@ static void flying_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x007C7444 */
 static void flying_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8372,7 +8372,7 @@ static void flying_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x007C7454 */
 static void flying_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8687,7 +8687,7 @@ static void flying_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x007C7464 */
 static void flying_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8696,7 +8696,7 @@ static void flying_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x007C7474 */
 static void flying_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8705,7 +8705,7 @@ static void flying_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x007C73F4 */
 static void flying_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8997,7 +8997,7 @@ static void flying_rc_track_diag_flat(
 
 /** rct2: 0x007C74A4 */
 static void flying_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9289,7 +9289,7 @@ static void flying_rc_track_diag_25_deg_up(
 
 /** rct2: 0x007C7504 */
 static void flying_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9525,7 +9525,7 @@ static void flying_rc_track_diag_60_deg_up(
 
 /** rct2: 0x007C7484 */
 static void flying_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9817,7 +9817,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x007C74E4 */
 static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10053,7 +10053,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x007C74F4 */
 static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10289,7 +10289,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7494 */
 static void flying_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10581,7 +10581,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x007C74D4 */
 static void flying_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10817,7 +10817,7 @@ static void flying_rc_track_diag_25_deg_down(
 
 /** rct2: 0x007C7534 */
 static void flying_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11053,7 +11053,7 @@ static void flying_rc_track_diag_60_deg_down(
 
 /** rct2: 0x007C74B4 */
 static void flying_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11282,7 +11282,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x007C7514 */
 static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11518,7 +11518,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x007C7524 */
 static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11754,7 +11754,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x007C74C4 */
 static void flying_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11990,7 +11990,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x007C7564 */
 static void flying_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12160,7 +12160,7 @@ static void flying_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x007C7574 */
 static void flying_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12330,7 +12330,7 @@ static void flying_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x007C7584 */
 static void flying_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12500,7 +12500,7 @@ static void flying_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x007C7594 */
 static void flying_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12670,7 +12670,7 @@ static void flying_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x007C75C4 */
 static void flying_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12839,7 +12839,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x007C75D4 */
 static void flying_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13008,7 +13008,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x007C75A4 */
 static void flying_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13177,7 +13177,7 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x007C75B4 */
 static void flying_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13346,7 +13346,7 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x007C75E4 */
 static void flying_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13508,7 +13508,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x007C75F4 */
 static void flying_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13670,7 +13670,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x007C7604 */
 static void flying_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13839,7 +13839,7 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x007C7614 */
 static void flying_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -14008,7 +14008,7 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x007C7544 */
 static void flying_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -14175,7 +14175,7 @@ static void flying_rc_track_diag_left_bank(
 
 /** rct2: 0x007C7554 */
 static void flying_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -14342,7 +14342,7 @@ static void flying_rc_track_diag_right_bank(
 
 /** rct2: 0x007C7624 */
 static void flying_rc_track_left_flyer_twist_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14454,7 +14454,7 @@ static void flying_rc_track_left_flyer_twist_up(
 
 /** rct2: 0x007C7634 */
 static void flying_rc_track_right_flyer_twist_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14564,7 +14564,7 @@ static void flying_rc_track_right_flyer_twist_up(
 
 /** rct2: 0x007C7644 */
 static void flying_rc_track_left_flyer_twist_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14676,7 +14676,7 @@ static void flying_rc_track_left_flyer_twist_down(
 
 /** rct2: 0x007C7654 */
 static void flying_rc_track_right_flyer_twist_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14786,7 +14786,7 @@ static void flying_rc_track_right_flyer_twist_down(
 
 /** rct2: 0x007C72F4 */
 static void flying_rc_track_flyer_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14916,7 +14916,7 @@ static void flying_rc_track_flyer_half_loop_up(
 
 /** rct2: 0x007C7304 */
 static void flying_rc_track_flyer_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15046,7 +15046,7 @@ static void flying_rc_track_flyer_half_loop_down(
 
 /** rct2: 0x007C7664 */
 static void flying_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -15104,7 +15104,7 @@ static void flying_rc_track_block_brakes(
 
 /** rct2: 0x007C76B4 */
 static void flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -15278,7 +15278,7 @@ static void flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C76C4 */
 static void flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -15458,7 +15458,7 @@ static void flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C76D4 */
 static void flying_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -15468,7 +15468,7 @@ static void flying_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x007C76E4 */
 static void flying_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -15478,7 +15478,7 @@ static void flying_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x007C76F4 */
 static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -15825,7 +15825,7 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C7704 */
 static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16172,7 +16172,7 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C7714 */
 static void flying_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -16182,7 +16182,7 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x007C7724 */
 static void flying_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -16192,7 +16192,7 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x007C7734 */
 static void flying_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16300,7 +16300,7 @@ static void flying_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x007C7744 */
 static void flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16408,7 +16408,7 @@ static void flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x007C7754 */
 static void flying_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16516,7 +16516,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7764 */
 static void flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16624,7 +16624,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7774 */
 static void flying_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
@@ -16633,7 +16633,7 @@ static void flying_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x007C7784 */
 static void flying_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -16641,7 +16641,7 @@ static void flying_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x007C7794 */
 static void flying_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
@@ -16650,7 +16650,7 @@ static void flying_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x007C77A4 */
 static void flying_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -16658,7 +16658,7 @@ static void flying_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x007C77B4 */
 static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16764,7 +16764,7 @@ static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x007C77C4 */
 static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16870,7 +16870,7 @@ static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x007C77F4 */
 static void flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16976,7 +16976,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x007C7804 */
 static void flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17082,7 +17082,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x007C7814 */
 static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -17091,7 +17091,7 @@ static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x007C7824 */
 static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -17100,7 +17100,7 @@ static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x007C77D4 */
 static void flying_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -17109,7 +17109,7 @@ static void flying_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x007C77E4 */
 static void flying_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -17118,7 +17118,7 @@ static void flying_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x007C7834 */
 static void flying_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17226,7 +17226,7 @@ static void flying_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x007C7844 */
 static void flying_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17334,7 +17334,7 @@ static void flying_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x007C7854 */
 static void flying_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17442,7 +17442,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x007C7864 */
 static void flying_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17550,7 +17550,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x007C7874 */
 static void flying_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -17558,7 +17558,7 @@ static void flying_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x007C7884 */
 static void flying_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -17566,7 +17566,7 @@ static void flying_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x007C7894 */
 static void flying_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -17574,7 +17574,7 @@ static void flying_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x007C78A4 */
 static void flying_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);

--- a/src/openrct2/ride/coaster/GigaCoaster.cpp
+++ b/src/openrct2/ride/coaster/GigaCoaster.cpp
@@ -143,7 +143,7 @@ static void giga_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/GigaCoaster.cpp
+++ b/src/openrct2/ride/coaster/GigaCoaster.cpp
@@ -41,7 +41,7 @@ static constexpr const uint32_t _GigaCoasterBrakeImages[NumOrthogonalDirections]
 
 /** rct2: 0x008AD674 */
 static void giga_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -117,7 +117,7 @@ static void giga_rc_track_flat(
 }
 
 static void giga_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -143,7 +143,7 @@ static void giga_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -151,7 +151,7 @@ static void giga_rc_track_station(
 
 /** rct2: 0x008AD684 */
 static void giga_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -247,7 +247,7 @@ static void giga_rc_track_25_deg_up(
 
 /** rct2: 0x008AD694 */
 static void giga_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -317,7 +317,7 @@ static void giga_rc_track_60_deg_up(
 
 /** rct2: 0x008AD6A4 */
 static void giga_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -413,7 +413,7 @@ static void giga_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AD6B4 */
 static void giga_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -491,7 +491,7 @@ static void giga_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AD6C4 */
 static void giga_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -569,7 +569,7 @@ static void giga_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AD6D4 */
 static void giga_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -665,7 +665,7 @@ static void giga_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AD6E4 */
 static void giga_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -673,7 +673,7 @@ static void giga_rc_track_25_deg_down(
 
 /** rct2: 0x008AD6F4 */
 static void giga_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -681,7 +681,7 @@ static void giga_rc_track_60_deg_down(
 
 /** rct2: 0x008AD704 */
 static void giga_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -689,7 +689,7 @@ static void giga_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AD714 */
 static void giga_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -697,7 +697,7 @@ static void giga_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AD724 */
 static void giga_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -705,7 +705,7 @@ static void giga_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008AD734 */
 static void giga_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -713,7 +713,7 @@ static void giga_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008AD744 */
 static void giga_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -877,7 +877,7 @@ static void giga_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AD754 */
 static void giga_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -886,7 +886,7 @@ static void giga_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008AD764 */
 static void giga_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -924,7 +924,7 @@ static void giga_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AD774 */
 static void giga_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -962,7 +962,7 @@ static void giga_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008AD784 */
 static void giga_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1000,7 +1000,7 @@ static void giga_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008AD794 */
 static void giga_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1038,7 +1038,7 @@ static void giga_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008AD7A4 */
 static void giga_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1212,7 +1212,7 @@ static void giga_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008AD7B4 */
 static void giga_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1221,7 +1221,7 @@ static void giga_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008AD7C4 */
 static void giga_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1266,7 +1266,7 @@ static void giga_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AD7D4 */
 static void giga_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1311,7 +1311,7 @@ static void giga_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AD7E4 */
 static void giga_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1356,7 +1356,7 @@ static void giga_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AD7F4 */
 static void giga_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1401,7 +1401,7 @@ static void giga_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AD804 */
 static void giga_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1409,7 +1409,7 @@ static void giga_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008AD814 */
 static void giga_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1417,7 +1417,7 @@ static void giga_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008AD824 */
 static void giga_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1425,7 +1425,7 @@ static void giga_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008AD834 */
 static void giga_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1433,7 +1433,7 @@ static void giga_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008AD844 */
 static void giga_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1467,7 +1467,7 @@ static void giga_rc_track_left_bank(
 
 /** rct2: 0x008AD854 */
 static void giga_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1475,7 +1475,7 @@ static void giga_rc_track_right_bank(
 
 /** rct2: 0x008AD864 */
 static void giga_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1639,7 +1639,7 @@ static void giga_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AD874 */
 static void giga_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1803,7 +1803,7 @@ static void giga_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AD884 */
 static void giga_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1812,7 +1812,7 @@ static void giga_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008AD894 */
 static void giga_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1821,7 +1821,7 @@ static void giga_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008AD8A4 */
 static void giga_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1956,7 +1956,7 @@ static void giga_rc_track_s_bend_left(
 
 /** rct2: 0x008AD8B4 */
 static void giga_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2091,7 +2091,7 @@ static void giga_rc_track_s_bend_right(
 
 /** rct2: 0x008AD8F4 */
 static void giga_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2194,7 +2194,7 @@ static void giga_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AD904 */
 static void giga_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2203,7 +2203,7 @@ static void giga_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008AD914 */
 static void giga_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2315,7 +2315,7 @@ static void giga_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008AD924 */
 static void giga_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2324,7 +2324,7 @@ static void giga_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008AD934 */
 static void giga_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2403,7 +2403,7 @@ static void giga_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AD944 */
 static void giga_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2489,7 +2489,7 @@ static void giga_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AD954 */
 static void giga_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2498,7 +2498,7 @@ static void giga_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008AD964 */
 static void giga_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2507,7 +2507,7 @@ static void giga_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008AD974 */
 static void giga_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2725,7 +2725,7 @@ static void giga_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008AD984 */
 static void giga_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2943,7 +2943,7 @@ static void giga_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008AD994 */
 static void giga_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -2957,7 +2957,7 @@ static void giga_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008AD9A4 */
 static void giga_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -2971,7 +2971,7 @@ static void giga_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008AD9B4 */
 static void giga_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3313,7 +3313,7 @@ static void giga_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008AD9C4 */
 static void giga_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3669,7 +3669,7 @@ static void giga_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008AD9D4 */
 static void giga_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3683,7 +3683,7 @@ static void giga_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008AD9E4 */
 static void giga_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3697,7 +3697,7 @@ static void giga_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008ADA14 */
 static void giga_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3734,7 +3734,7 @@ static void giga_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008AD9F4 */
 static void giga_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3771,7 +3771,7 @@ static void giga_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008ADA04 */
 static void giga_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -3779,7 +3779,7 @@ static void giga_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008ADA24 */
 static void giga_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -3787,7 +3787,7 @@ static void giga_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008ADA34 */
 static void giga_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3823,7 +3823,7 @@ static void giga_rc_track_brakes(
 
 /** rct2: 0x008ADC84 */
 static void giga_rc_track_25_deg_up_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3864,7 +3864,7 @@ static void giga_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008ADC94 */
 static void giga_rc_track_25_deg_up_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3905,7 +3905,7 @@ static void giga_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008ADA44 */
 static void giga_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3947,7 +3947,7 @@ static void giga_rc_track_on_ride_photo(
 
 /** rct2: 0x008ADCA4 */
 static void giga_rc_track_25_deg_down_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -3955,7 +3955,7 @@ static void giga_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x008ADCB4 */
 static void giga_rc_track_25_deg_down_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -3963,7 +3963,7 @@ static void giga_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x008ADED4 */
 static void giga_rc_track_flat_to_60_deg_up_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4254,7 +4254,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
 
 /** rct2: 0x008ADEE4 */
 static void giga_rc_track_60_deg_up_to_flat_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4395,7 +4395,7 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(
 
 /** rct2: 0x008ADEF4 */
 static void giga_rc_track_60_deg_down_to_flat_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_flat_to_60_deg_up_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4403,7 +4403,7 @@ static void giga_rc_track_60_deg_down_to_flat_long_base(
 
 /** rct2: 0x008ADF04 */
 static void giga_rc_track_flat_to_60_deg_down_long_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_60_deg_up_to_flat_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4411,7 +4411,7 @@ static void giga_rc_track_flat_to_60_deg_down_long_base(
 
 /** rct2: 0x008ADF14 */
 static void giga_rc_track_cable_lift_hill(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4577,7 +4577,7 @@ static void giga_rc_track_cable_lift_hill(
 
 /** rct2: 0x008ADA64 */
 static void giga_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4716,7 +4716,7 @@ static void giga_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008ADA74 */
 static void giga_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4854,7 +4854,7 @@ static void giga_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008ADA84 */
 static void giga_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4863,7 +4863,7 @@ static void giga_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008ADA94 */
 static void giga_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4872,7 +4872,7 @@ static void giga_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008ADAA4 */
 static void giga_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5014,7 +5014,7 @@ static void giga_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008ADAB4 */
 static void giga_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5156,7 +5156,7 @@ static void giga_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008ADAC4 */
 static void giga_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5165,7 +5165,7 @@ static void giga_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008ADAD4 */
 static void giga_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5174,7 +5174,7 @@ static void giga_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008ADA54 */
 static void giga_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5320,7 +5320,7 @@ static void giga_rc_track_diag_flat(
 
 /** rct2: 0x008ADB04 */
 static void giga_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5466,7 +5466,7 @@ static void giga_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008ADB64 */
 static void giga_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5542,7 +5542,7 @@ static void giga_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008ADAE4 */
 static void giga_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5688,7 +5688,7 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008ADB44 */
 static void giga_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5764,7 +5764,7 @@ static void giga_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008ADB54 */
 static void giga_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5840,7 +5840,7 @@ static void giga_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ADAF4 */
 static void giga_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5986,7 +5986,7 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008ADB34 */
 static void giga_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6132,7 +6132,7 @@ static void giga_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008ADB94 */
 static void giga_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6208,7 +6208,7 @@ static void giga_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008ADB14 */
 static void giga_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6352,7 +6352,7 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008ADB74 */
 static void giga_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6428,7 +6428,7 @@ static void giga_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008ADB84 */
 static void giga_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6504,7 +6504,7 @@ static void giga_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008ADB24 */
 static void giga_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6650,7 +6650,7 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008ADBC4 */
 static void giga_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6729,7 +6729,7 @@ static void giga_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008ADBD4 */
 static void giga_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6808,7 +6808,7 @@ static void giga_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008ADBE4 */
 static void giga_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6887,7 +6887,7 @@ static void giga_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008ADBF4 */
 static void giga_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6966,7 +6966,7 @@ static void giga_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008ADC24 */
 static void giga_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7045,7 +7045,7 @@ static void giga_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008ADC34 */
 static void giga_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7124,7 +7124,7 @@ static void giga_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008ADC04 */
 static void giga_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7203,7 +7203,7 @@ static void giga_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008ADC14 */
 static void giga_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7282,7 +7282,7 @@ static void giga_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008ADC44 */
 static void giga_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7359,7 +7359,7 @@ static void giga_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008ADC54 */
 static void giga_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7436,7 +7436,7 @@ static void giga_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008ADC64 */
 static void giga_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7515,7 +7515,7 @@ static void giga_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008ADC74 */
 static void giga_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7594,7 +7594,7 @@ static void giga_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008ADBA4 */
 static void giga_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7670,7 +7670,7 @@ static void giga_rc_track_diag_left_bank(
 
 /** rct2: 0x008ADBB4 */
 static void giga_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7746,7 +7746,7 @@ static void giga_rc_track_diag_right_bank(
 
 /** rct2: 0x008ADEC4 */
 static void giga_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -7769,7 +7769,7 @@ static void giga_rc_track_block_brakes(
 
 /** rct2: 0x008ADCC4 */
 static void giga_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7851,7 +7851,7 @@ static void giga_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ADCD4 */
 static void giga_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7940,7 +7940,7 @@ static void giga_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ADCE4 */
 static void giga_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7950,7 +7950,7 @@ static void giga_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008ADCF4 */
 static void giga_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7959,7 +7959,7 @@ static void giga_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008ADD04 */
 static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8129,7 +8129,7 @@ static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008ADD14 */
 static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8299,7 +8299,7 @@ static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008ADD24 */
 static void giga_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8309,7 +8309,7 @@ static void giga_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008ADD34 */
 static void giga_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8318,7 +8318,7 @@ static void giga_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008ADD44 */
 static void giga_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8361,7 +8361,7 @@ static void giga_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ADD54 */
 static void giga_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8404,7 +8404,7 @@ static void giga_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ADD64 */
 static void giga_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8447,7 +8447,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ADD74 */
 static void giga_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8490,7 +8490,7 @@ static void giga_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ADD84 */
 static void giga_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8498,7 +8498,7 @@ static void giga_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x008ADD94 */
 static void giga_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8506,7 +8506,7 @@ static void giga_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x008ADDA4 */
 static void giga_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8514,7 +8514,7 @@ static void giga_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008ADDB4 */
 static void giga_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8522,7 +8522,7 @@ static void giga_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008ADDC4 */
 static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8563,7 +8563,7 @@ static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ADDD4 */
 static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8604,7 +8604,7 @@ static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ADE04 */
 static void giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8645,7 +8645,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008ADE14 */
 static void giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8686,7 +8686,7 @@ static void giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008ADE24 */
 static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -8695,7 +8695,7 @@ static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008ADE34 */
 static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -8704,7 +8704,7 @@ static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008ADDE4 */
 static void giga_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -8713,7 +8713,7 @@ static void giga_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x008ADDF4 */
 static void giga_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -8722,7 +8722,7 @@ static void giga_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x008ADE44 */
 static void giga_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8765,7 +8765,7 @@ static void giga_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ADE54 */
 static void giga_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8808,7 +8808,7 @@ static void giga_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ADE64 */
 static void giga_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8851,7 +8851,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008ADE74 */
 static void giga_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8894,7 +8894,7 @@ static void giga_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008ADE84 */
 static void giga_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8902,7 +8902,7 @@ static void giga_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008ADE94 */
 static void giga_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8910,7 +8910,7 @@ static void giga_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008ADEA4 */
 static void giga_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8918,14 +8918,14 @@ static void giga_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x008ADEB4 */
 static void giga_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void giga_rc_track_booster(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     // These offsets could be moved to the g2.dat file when that supports offsets.

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -101,7 +101,7 @@ static void heartline_twister_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x0087694C */
 static void heartline_twister_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -85,7 +85,7 @@ static void heartline_twister_rc_track_flat(
 }
 
 static void heartline_twister_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -101,7 +101,7 @@ static void heartline_twister_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -109,7 +109,7 @@ static void heartline_twister_rc_track_station(
 
 /** rct2: 0x0087695C */
 static void heartline_twister_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -194,7 +194,7 @@ static void heartline_twister_rc_track_25_deg_up(
 
 /** rct2: 0x008769FC */
 static void heartline_twister_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -279,7 +279,7 @@ static void heartline_twister_rc_track_60_deg_up(
 
 /** rct2: 0x0087696C */
 static void heartline_twister_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -364,7 +364,7 @@ static void heartline_twister_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008769BC */
 static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -449,7 +449,7 @@ static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008769CC */
 static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -534,7 +534,7 @@ static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0087697C */
 static void heartline_twister_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -619,7 +619,7 @@ static void heartline_twister_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0087698C */
 static void heartline_twister_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -627,7 +627,7 @@ static void heartline_twister_rc_track_25_deg_down(
 
 /** rct2: 0x00876A0C */
 static void heartline_twister_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -635,7 +635,7 @@ static void heartline_twister_rc_track_60_deg_down(
 
 /** rct2: 0x0087699C */
 static void heartline_twister_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -643,7 +643,7 @@ static void heartline_twister_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008769DC */
 static void heartline_twister_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -651,7 +651,7 @@ static void heartline_twister_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008769EC */
 static void heartline_twister_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -659,7 +659,7 @@ static void heartline_twister_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008769AC */
 static void heartline_twister_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -667,7 +667,7 @@ static void heartline_twister_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x00876A6C */
 static void heartline_twister_rc_track_heartline_transfer_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -877,7 +877,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
 
 /** rct2: 0x00876A7C */
 static void heartline_twister_rc_track_heartline_transfer_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1087,7 +1087,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
 
 /** rct2: 0x00876A4C */
 static void heartline_twister_rc_track_left_heartline_roll(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1333,7 +1333,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
 
 /** rct2: 0x00876A5C */
 static void heartline_twister_rc_track_right_heartline_roll(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -83,7 +83,6 @@ namespace HybridRC
 
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-        if (ride != nullptr)
             track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 10, trackElement);
 
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -36,7 +36,7 @@ namespace HybridRC
     }
 
     static void TrackFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -58,7 +58,7 @@ namespace HybridRC
     }
 
     static void TrackStation(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         static constexpr const uint32_t imageIds[4][3] = {
@@ -83,7 +83,7 @@ namespace HybridRC
 
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-        track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 10, trackElement);
+        track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 10, trackElement);
 
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -91,7 +91,7 @@ namespace HybridRC
     }
 
     static void Track25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -120,7 +120,7 @@ namespace HybridRC
     }
 
     static void Track60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -174,7 +174,7 @@ namespace HybridRC
     }
 
     static void TrackFlatTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -203,7 +203,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpTo60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -284,7 +284,7 @@ namespace HybridRC
     }
 
     static void Track60DegUpTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -366,7 +366,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -395,49 +395,49 @@ namespace HybridRC
     }
 
     static void Track25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownTo60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDownTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpTo60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -475,14 +475,14 @@ namespace HybridRC
     }
 
     static void Track90DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegUpTo90DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -526,14 +526,14 @@ namespace HybridRC
     }
 
     static void Track90DegDownTo60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpTo90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegUpTo60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -573,7 +573,7 @@ namespace HybridRC
     }
 
     static void Track60DegDownTo90DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -615,7 +615,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -735,7 +735,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -743,7 +743,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn5(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -943,7 +943,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn5(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -951,7 +951,7 @@ namespace HybridRC
     }
 
     static void TrackLeftEighthToDiag(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1103,7 +1103,7 @@ namespace HybridRC
     }
 
     static void TrackRightEighthToDiag(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1255,7 +1255,7 @@ namespace HybridRC
     }
 
     static void TrackLeftEighthToOrthogonal(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1263,7 +1263,7 @@ namespace HybridRC
     }
 
     static void TrackRightEighthToOrthogonal(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1271,7 +1271,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1417,7 +1417,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1560,7 +1560,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1703,7 +1703,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlatTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1846,7 +1846,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1989,7 +1989,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlatTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2130,7 +2130,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2273,7 +2273,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2416,7 +2416,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpTo60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2559,7 +2559,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegUpTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2702,7 +2702,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2845,7 +2845,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownTo60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2988,7 +2988,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegDownTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3131,7 +3131,7 @@ namespace HybridRC
     }
 
     static void TrackFlatToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3170,7 +3170,7 @@ namespace HybridRC
     }
 
     static void TrackFlatToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3209,21 +3209,21 @@ namespace HybridRC
     }
 
     static void TrackLeftBankToflat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankToflat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3269,7 +3269,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3315,7 +3315,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3361,7 +3361,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3407,35 +3407,35 @@ namespace HybridRC
     }
 
     static void TrackLeftBankTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftbank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3474,14 +3474,14 @@ namespace HybridRC
     }
 
     static void TrackRightbank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftbank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackDiagFlatToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3571,7 +3571,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlatToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3661,7 +3661,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBankToflat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3751,7 +3751,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBankToflat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3841,7 +3841,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBankTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3931,7 +3931,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBankTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4021,7 +4021,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4111,7 +4111,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4201,7 +4201,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBankTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4289,7 +4289,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBankTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4377,7 +4377,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4467,7 +4467,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4557,7 +4557,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4647,7 +4647,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4737,7 +4737,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Bank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4869,7 +4869,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Bank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4877,7 +4877,7 @@ namespace HybridRC
     }
 
     static void TrackBankedLeftQuarterTurn5(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5092,7 +5092,7 @@ namespace HybridRC
     }
 
     static void TrackBankedRightQuarterTurn5(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -5100,7 +5100,7 @@ namespace HybridRC
     }
 
     static void TrackLeftEighthBankToDiag(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5264,7 +5264,7 @@ namespace HybridRC
     }
 
     static void TrackRightEighthBankToDiag(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5429,7 +5429,7 @@ namespace HybridRC
     }
 
     static void TrackLeftEighthBankToOrthogonal(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5437,7 +5437,7 @@ namespace HybridRC
     }
 
     static void TrackRightEighthBankToOrthogonal(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5445,7 +5445,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5553,7 +5553,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5661,7 +5661,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5669,7 +5669,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5677,7 +5677,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn5Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5877,7 +5877,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn5Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6077,7 +6077,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn5Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -6085,7 +6085,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn5Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -6093,7 +6093,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn1Tile60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6141,7 +6141,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn1Tile60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6190,21 +6190,21 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn1Tile60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightQuarterTurn1Tile60DegUp(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightQuarterTurn1Tile60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftQuarterTurn1Tile60DegUp(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
     }
 
     static void TrackLeftQuarterTurn1Tile90DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6249,7 +6249,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn1Tile90DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6294,21 +6294,21 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn1Tile90DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightQuarterTurn1Tile90DegUp(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightQuarterTurn1Tile90DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftQuarterTurn1Tile90DegUp(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
     }
 
     static void Track25DegUpToLeftBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6351,7 +6351,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToRightBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6394,7 +6394,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegUpTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6437,7 +6437,7 @@ namespace HybridRC
     }
 
     static void TrackRightBanked25DegUpTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6480,35 +6480,35 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegDownTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToLeftBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToRightBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6554,7 +6554,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedFlatToRightBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6600,7 +6600,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegUpToLeftBankedFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6646,7 +6646,7 @@ namespace HybridRC
     }
 
     static void TrackRightBanked25DegUpToRightBankedFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6692,35 +6692,35 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpToRightBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankedFlatToRightBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpToLeftBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBanked25DegDownToLeftBankedFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBankedFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownToRightBankedFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBankedFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegUpLeftBanked(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6760,7 +6760,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpRightBanked(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6800,21 +6800,21 @@ namespace HybridRC
     }
 
     static void Track25DegDownLeftBanked(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpRightBanked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownRightBanked(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpLeftBanked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatToLeftBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6857,7 +6857,7 @@ namespace HybridRC
     }
 
     static void TrackFlatToRightBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6900,7 +6900,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegUpToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6943,7 +6943,7 @@ namespace HybridRC
     }
 
     static void TrackRightBanked25DegUpToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6986,35 +6986,35 @@ namespace HybridRC
     }
 
     static void TrackFlatToLeftBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatToRightBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBanked25DegDownToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7131,7 +7131,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7248,7 +7248,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7256,7 +7256,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7264,7 +7264,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedQuarterTurn5Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7482,7 +7482,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedQuarterTurn5Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7700,7 +7700,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedQuarterTurn5Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -7708,7 +7708,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedQuarterTurn5Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -7716,7 +7716,7 @@ namespace HybridRC
     }
 
     static void TrackSBendLeft(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7870,7 +7870,7 @@ namespace HybridRC
     }
 
     static void TrackSBendRight(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8024,7 +8024,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixUpSmall(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8309,7 +8309,7 @@ namespace HybridRC
     }
 
     static void TrackRightHalfBankedHelixUpSmall(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8594,7 +8594,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixDownSmall(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 4)
@@ -8607,7 +8607,7 @@ namespace HybridRC
     }
 
     static void TrackRightHalfBankedHelixDownSmall(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 4)
@@ -8620,7 +8620,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixUpLarge(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9041,7 +9041,7 @@ namespace HybridRC
     }
 
     static void TrackRightHalfBankedHelixUpLarge(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9462,7 +9462,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixDownLarge(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 7)
@@ -9475,7 +9475,7 @@ namespace HybridRC
     }
 
     static void TrackRightHalfBankedHelixDownLarge(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 7)
@@ -9488,7 +9488,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBarrelRollUpToDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9630,7 +9630,7 @@ namespace HybridRC
     }
 
     static void TrackRightBarrelRollUpToDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9772,21 +9772,21 @@ namespace HybridRC
     }
 
     static void TrackLeftBarrelRollDownToUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBarrelRollDownToUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegToInvertedFlatQuarterLoopUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9918,14 +9918,14 @@ namespace HybridRC
     }
 
     static void TrackInvertedFlatTo90DegQuarterLoopDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track90DegToInvertedFlatQuarterLoopUp(session, ride, 2 - trackSequence, direction, height, trackElement);
     }
 
     static void Trackbrakes(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
@@ -9938,7 +9938,7 @@ namespace HybridRC
     }
 
     static void TrackOnRidePhoto(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(session, direction, IMAGE_TYPE_REMAP | SPR_STATION_BASE_D, 0, 0, 32, 32, 1, height);
@@ -9953,7 +9953,7 @@ namespace HybridRC
     }
 
     static void TrackFlatTo60DegUpLongBase(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10091,7 +10091,7 @@ namespace HybridRC
     }
 
     static void Track60DegUpToFlatLongBase(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10229,21 +10229,21 @@ namespace HybridRC
     }
 
     static void TrackFlatTo60DegDownLongBase(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpToFlatLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDownToFlatLongBase(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo60DegUpLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackBlockBrakes(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
@@ -10256,7 +10256,7 @@ namespace HybridRC
     }
 
     static void Trackbooster(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
@@ -10269,7 +10269,7 @@ namespace HybridRC
     }
 
     static void Trackpowered_lift(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
@@ -10289,7 +10289,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBankToLeftQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10400,7 +10400,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankToRightQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10511,7 +10511,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDownToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10622,7 +10622,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDownToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -83,7 +83,7 @@ namespace HybridRC
 
         wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-            track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 10, trackElement);
+        track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 10, trackElement);
 
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x00890CB4 */
 static void inverted_hairpin_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -82,7 +82,7 @@ static void inverted_hairpin_rc_track_flat(
 
 /** rct2: 0x00890D84, 0x00890D94, 0x00890DA4 */
 static void inverted_hairpin_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -101,7 +101,7 @@ static void inverted_hairpin_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24, 0, 6,
         height + 24);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_1);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -109,7 +109,7 @@ static void inverted_hairpin_rc_track_station(
 
 /** rct2: 0x00890CC4 */
 static void inverted_hairpin_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -203,7 +203,7 @@ static void inverted_hairpin_rc_track_25_deg_up(
 
 /** rct2: 0x00890CD4 */
 static void inverted_hairpin_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -273,7 +273,7 @@ static void inverted_hairpin_rc_track_60_deg_up(
 
 /** rct2: 0x00890CE4 */
 static void inverted_hairpin_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -367,7 +367,7 @@ static void inverted_hairpin_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x00890CF4 */
 static void inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -449,7 +449,7 @@ static void inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x00890D04 */
 static void inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -555,7 +555,7 @@ static void inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00890D14 */
 static void inverted_hairpin_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -649,7 +649,7 @@ static void inverted_hairpin_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x00890D24 */
 static void inverted_hairpin_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -657,7 +657,7 @@ static void inverted_hairpin_rc_track_25_deg_down(
 
 /** rct2: 0x00890D34 */
 static void inverted_hairpin_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -665,7 +665,7 @@ static void inverted_hairpin_rc_track_60_deg_down(
 
 /** rct2: 0x00890D44 */
 static void inverted_hairpin_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -673,7 +673,7 @@ static void inverted_hairpin_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x00890D54 */
 static void inverted_hairpin_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -681,7 +681,7 @@ static void inverted_hairpin_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x00890D64 */
 static void inverted_hairpin_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -689,7 +689,7 @@ static void inverted_hairpin_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x00890D74 */
 static void inverted_hairpin_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -697,7 +697,7 @@ static void inverted_hairpin_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x00890DB4 */
 static void inverted_hairpin_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -817,7 +817,7 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x00890DC4 */
 static void inverted_hairpin_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -826,7 +826,7 @@ static void inverted_hairpin_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x00890DD4 */
 static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -913,7 +913,7 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00890DE4 */
 static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1000,7 +1000,7 @@ static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00890DF4 */
 static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1010,7 +1010,7 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x00890E04 */
 static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1020,7 +1020,7 @@ static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x00890E64 */
 static void inverted_hairpin_rc_track_left_quarter_turn_1(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1070,7 +1070,7 @@ static void inverted_hairpin_rc_track_left_quarter_turn_1(
 
 /** rct2: 0x00890E74 */
 static void inverted_hairpin_rc_track_right_quarter_turn_1(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_left_quarter_turn_1(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -1078,7 +1078,7 @@ static void inverted_hairpin_rc_track_right_quarter_turn_1(
 
 /** rct2: 0x00890E24 */
 static void inverted_hairpin_rc_track_flat_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -1160,7 +1160,7 @@ static void inverted_hairpin_rc_track_flat_to_60_deg_up(
 
 /** rct2: 0x00890E34 */
 static void inverted_hairpin_rc_track_60_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -1263,7 +1263,7 @@ static void inverted_hairpin_rc_track_60_deg_up_to_flat(
 
 /** rct2: 0x00890E44 */
 static void inverted_hairpin_rc_track_flat_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_60_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1271,7 +1271,7 @@ static void inverted_hairpin_rc_track_flat_to_60_deg_down(
 
 /** rct2: 0x00890E54 */
 static void inverted_hairpin_rc_track_60_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_flat_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1279,7 +1279,7 @@ static void inverted_hairpin_rc_track_60_deg_down_to_flat(
 
 /** rct2: 0x00890E14 */
 static void inverted_hairpin_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1312,7 +1312,7 @@ static void inverted_hairpin_rc_track_brakes(
 
 /** rct2: 0x00890E84 */
 static void inverted_hairpin_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
@@ -101,7 +101,7 @@ static void inverted_hairpin_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24, 0, 6,
         height + 24);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
+    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_1);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
@@ -72,7 +72,7 @@ static void inverted_impulse_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008B0460 */
 static void inverted_impulse_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -53,7 +53,7 @@ static void inverted_impulse_rc_track_flat(
 
 /** rct2: 0x008B0470, 0x008B0480, 0x008B0490 */
 static void inverted_impulse_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -72,7 +72,7 @@ static void inverted_impulse_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -80,7 +80,7 @@ static void inverted_impulse_rc_track_station(
 
 /** rct2: 0x008B04A0 */
 static void inverted_impulse_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -145,7 +145,7 @@ static void inverted_impulse_rc_track_25_deg_up(
 
 /** rct2: 0x008B04B0 */
 static void inverted_impulse_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -186,7 +186,7 @@ static void inverted_impulse_rc_track_60_deg_up(
 
 /** rct2: 0x008B04C0 */
 static void inverted_impulse_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -248,7 +248,7 @@ static void inverted_impulse_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008B04D0 */
 static void inverted_impulse_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -295,7 +295,7 @@ static void inverted_impulse_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008B04E0 */
 static void inverted_impulse_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -342,7 +342,7 @@ static void inverted_impulse_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008B04F0 */
 static void inverted_impulse_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -404,7 +404,7 @@ static void inverted_impulse_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008B0500 */
 static void inverted_impulse_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -412,7 +412,7 @@ static void inverted_impulse_rc_track_25_deg_down(
 
 /** rct2: 0x008B0510 */
 static void inverted_impulse_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -420,7 +420,7 @@ static void inverted_impulse_rc_track_60_deg_down(
 
 /** rct2: 0x008B0520 */
 static void inverted_impulse_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -428,7 +428,7 @@ static void inverted_impulse_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008B0530 */
 static void inverted_impulse_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -436,7 +436,7 @@ static void inverted_impulse_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008B0540 */
 static void inverted_impulse_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -444,7 +444,7 @@ static void inverted_impulse_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008B0550 */
 static void inverted_impulse_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -452,7 +452,7 @@ static void inverted_impulse_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008B05A0 */
 static void inverted_impulse_rc_track_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -493,7 +493,7 @@ static void inverted_impulse_rc_track_90_deg_up(
 
 /** rct2: 0x008B05B0 */
 static void inverted_impulse_rc_track_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -501,7 +501,7 @@ static void inverted_impulse_rc_track_90_deg_down(
 
 /** rct2: 0x008B0560 */
 static void inverted_impulse_rc_track_60_deg_up_to_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -546,7 +546,7 @@ static void inverted_impulse_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x008B0570 */
 static void inverted_impulse_rc_track_90_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -554,7 +554,7 @@ static void inverted_impulse_rc_track_90_deg_down_to_60_deg_down(
 
 /** rct2: 0x008B0580 */
 static void inverted_impulse_rc_track_90_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -596,7 +596,7 @@ static void inverted_impulse_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x008B0590 */
 static void inverted_impulse_rc_track_60_deg_down_to_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -640,7 +640,7 @@ static void inverted_impulse_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x008B05C0 */
 static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -690,7 +690,7 @@ static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008B05D0 */
 static void inverted_impulse_rc_track_right_quarter_turn_1_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -740,7 +740,7 @@ static void inverted_impulse_rc_track_right_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008B05E0 */
 static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_right_quarter_turn_1_90_deg_up(
@@ -749,7 +749,7 @@ static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_down(
 
 /** rct2: 0x008B05F0 */
 static void inverted_impulse_rc_track_right_quarter_turn_1_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_left_quarter_turn_1_90_deg_up(

--- a/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
@@ -92,7 +92,7 @@ static void inverted_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008A92E8 */
 static void inverted_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -73,7 +73,7 @@ static void inverted_rc_track_flat(
 
 /** rct2: 0x008A9558, 0x008A9568, 0x008A9578 */
 static void inverted_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -92,7 +92,7 @@ static void inverted_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -100,7 +100,7 @@ static void inverted_rc_track_station(
 
 /** rct2: 0x008A92F8 */
 static void inverted_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -194,7 +194,7 @@ static void inverted_rc_track_25_deg_up(
 
 /** rct2: 0x008A9308 */
 static void inverted_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -235,7 +235,7 @@ static void inverted_rc_track_60_deg_up(
 
 /** rct2: 0x008A9318 */
 static void inverted_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -329,7 +329,7 @@ static void inverted_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A9328 */
 static void inverted_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -376,7 +376,7 @@ static void inverted_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A9338 */
 static void inverted_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -447,7 +447,7 @@ static void inverted_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A9348 */
 static void inverted_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -541,7 +541,7 @@ static void inverted_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A9358 */
 static void inverted_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -549,7 +549,7 @@ static void inverted_rc_track_25_deg_down(
 
 /** rct2: 0x008A9368 */
 static void inverted_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -557,7 +557,7 @@ static void inverted_rc_track_60_deg_down(
 
 /** rct2: 0x008A9378 */
 static void inverted_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -565,7 +565,7 @@ static void inverted_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A9388 */
 static void inverted_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -573,7 +573,7 @@ static void inverted_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A9398 */
 static void inverted_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -581,7 +581,7 @@ static void inverted_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A93A8 */
 static void inverted_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -589,7 +589,7 @@ static void inverted_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A93B8 */
 static void inverted_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -769,7 +769,7 @@ static void inverted_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A93C8 */
 static void inverted_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -778,7 +778,7 @@ static void inverted_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A93D8 */
 static void inverted_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -820,7 +820,7 @@ static void inverted_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A93E8 */
 static void inverted_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -862,7 +862,7 @@ static void inverted_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A93F8 */
 static void inverted_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -904,7 +904,7 @@ static void inverted_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A9408 */
 static void inverted_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -946,7 +946,7 @@ static void inverted_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A9418 */
 static void inverted_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1126,7 +1126,7 @@ static void inverted_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A9428 */
 static void inverted_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1135,7 +1135,7 @@ static void inverted_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008A9438 */
 static void inverted_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1202,7 +1202,7 @@ static void inverted_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A9448 */
 static void inverted_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1269,7 +1269,7 @@ static void inverted_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A9458 */
 static void inverted_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1336,7 +1336,7 @@ static void inverted_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A9468 */
 static void inverted_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1403,7 +1403,7 @@ static void inverted_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A9478 */
 static void inverted_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1411,7 +1411,7 @@ static void inverted_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A9488 */
 static void inverted_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1419,7 +1419,7 @@ static void inverted_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A9498 */
 static void inverted_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1427,7 +1427,7 @@ static void inverted_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A94A8 */
 static void inverted_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1435,7 +1435,7 @@ static void inverted_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A94B8 */
 static void inverted_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1477,7 +1477,7 @@ static void inverted_rc_track_left_bank(
 
 /** rct2: 0x008A94C8 */
 static void inverted_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1485,7 +1485,7 @@ static void inverted_rc_track_right_bank(
 
 /** rct2: 0x008A94D8 */
 static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1650,7 +1650,7 @@ static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A94E8 */
 static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1815,7 +1815,7 @@ static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A94F8 */
 static void inverted_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1824,7 +1824,7 @@ static void inverted_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A9508 */
 static void inverted_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1833,7 +1833,7 @@ static void inverted_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A9518 */
 static void inverted_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2004,7 +2004,7 @@ static void inverted_rc_track_s_bend_left(
 
 /** rct2: 0x008A9528 */
 static void inverted_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2175,7 +2175,7 @@ static void inverted_rc_track_s_bend_right(
 
 /** rct2: 0x008A9538 */
 static void inverted_rc_track_left_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2482,7 +2482,7 @@ static void inverted_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A9548 */
 static void inverted_rc_track_right_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2789,7 +2789,7 @@ static void inverted_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A9588 */
 static void inverted_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2908,7 +2908,7 @@ static void inverted_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A9598 */
 static void inverted_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2917,7 +2917,7 @@ static void inverted_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A95A8 */
 static void inverted_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3037,7 +3037,7 @@ static void inverted_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A95B8 */
 static void inverted_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3046,7 +3046,7 @@ static void inverted_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008A95C8 */
 static void inverted_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3133,7 +3133,7 @@ static void inverted_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A95D8 */
 static void inverted_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3220,7 +3220,7 @@ static void inverted_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A95E8 */
 static void inverted_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3229,7 +3229,7 @@ static void inverted_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A95F8 */
 static void inverted_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3238,7 +3238,7 @@ static void inverted_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A9608 */
 static void inverted_rc_track_left_twist_down_to_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3347,7 +3347,7 @@ static void inverted_rc_track_left_twist_down_to_up(
 
 /** rct2: 0x008A9618 */
 static void inverted_rc_track_right_twist_down_to_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3456,7 +3456,7 @@ static void inverted_rc_track_right_twist_down_to_up(
 
 /** rct2: 0x008A9628 */
 static void inverted_rc_track_left_twist_up_to_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3565,7 +3565,7 @@ static void inverted_rc_track_left_twist_up_to_down(
 
 /** rct2: 0x008A9638 */
 static void inverted_rc_track_right_twist_up_to_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3674,7 +3674,7 @@ static void inverted_rc_track_right_twist_up_to_down(
 
 /** rct2: 0x008A9648 */
 static void inverted_rc_track_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3827,7 +3827,7 @@ static void inverted_rc_track_half_loop_up(
 
 /** rct2: 0x008A9658 */
 static void inverted_rc_track_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, trackElement);
@@ -3835,7 +3835,7 @@ static void inverted_rc_track_half_loop_down(
 
 /** rct2: 0x008A9668 */
 static void inverted_rc_track_left_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3953,7 +3953,7 @@ static void inverted_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A9678 */
 static void inverted_rc_track_right_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4071,7 +4071,7 @@ static void inverted_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A9688 */
 static void inverted_rc_track_left_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4079,7 +4079,7 @@ static void inverted_rc_track_left_corkscrew_down(
 
 /** rct2: 0x008A9698 */
 static void inverted_rc_track_right_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4087,7 +4087,7 @@ static void inverted_rc_track_right_corkscrew_down(
 
 /** rct2: 0x008A96D8 */
 static void inverted_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4124,7 +4124,7 @@ static void inverted_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A96B8 */
 static void inverted_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4162,7 +4162,7 @@ static void inverted_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A96C8 */
 static void inverted_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4170,7 +4170,7 @@ static void inverted_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A96E8 */
 static void inverted_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4178,7 +4178,7 @@ static void inverted_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A96A8 */
 static void inverted_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4210,7 +4210,7 @@ static void inverted_rc_track_brakes(
 
 /** rct2: 0x008A96F8 */
 static void inverted_rc_track_left_quarter_banked_helix_large_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4395,7 +4395,7 @@ static void inverted_rc_track_left_quarter_banked_helix_large_up(
 
 /** rct2: 0x008A9708 */
 static void inverted_rc_track_right_quarter_banked_helix_large_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4580,7 +4580,7 @@ static void inverted_rc_track_right_quarter_banked_helix_large_up(
 
 /** rct2: 0x008A9718 */
 static void inverted_rc_track_left_quarter_banked_helix_large_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4765,7 +4765,7 @@ static void inverted_rc_track_left_quarter_banked_helix_large_down(
 
 /** rct2: 0x008A9728 */
 static void inverted_rc_track_right_quarter_banked_helix_large_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4950,7 +4950,7 @@ static void inverted_rc_track_right_quarter_banked_helix_large_down(
 
 /** rct2: 0x008A9A38 */
 static void inverted_rc_track_25_deg_up_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5015,7 +5015,7 @@ static void inverted_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008A9A48 */
 static void inverted_rc_track_25_deg_up_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5080,7 +5080,7 @@ static void inverted_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008A9738 */
 static void inverted_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5126,7 +5126,7 @@ static void inverted_rc_track_on_ride_photo(
 
 /** rct2: 0x008A9A58 */
 static void inverted_rc_track_25_deg_down_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5134,7 +5134,7 @@ static void inverted_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x008A9A68 */
 static void inverted_rc_track_25_deg_down_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5142,7 +5142,7 @@ static void inverted_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x008A9748 */
 static void inverted_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5305,7 +5305,7 @@ static void inverted_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A9758 */
 static void inverted_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5468,7 +5468,7 @@ static void inverted_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A9768 */
 static void inverted_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5477,7 +5477,7 @@ static void inverted_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A9778 */
 static void inverted_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5486,7 +5486,7 @@ static void inverted_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A9938 */
 static void inverted_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5649,7 +5649,7 @@ static void inverted_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A9948 */
 static void inverted_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5812,7 +5812,7 @@ static void inverted_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A9958 */
 static void inverted_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5821,7 +5821,7 @@ static void inverted_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A9968 */
 static void inverted_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5830,7 +5830,7 @@ static void inverted_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A9788 */
 static void inverted_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5969,7 +5969,7 @@ static void inverted_rc_track_diag_flat(
 
 /** rct2: 0x008A97B8 */
 static void inverted_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6108,7 +6108,7 @@ static void inverted_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A9818 */
 static void inverted_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6191,7 +6191,7 @@ static void inverted_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A9798 */
 static void inverted_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6330,7 +6330,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A97F8 */
 static void inverted_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6413,7 +6413,7 @@ static void inverted_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A9808 */
 static void inverted_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6496,7 +6496,7 @@ static void inverted_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A97A8 */
 static void inverted_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6635,7 +6635,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A97E8 */
 static void inverted_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6774,7 +6774,7 @@ static void inverted_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A9848 */
 static void inverted_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6857,7 +6857,7 @@ static void inverted_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A97C8 */
 static void inverted_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6993,7 +6993,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A9828 */
 static void inverted_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7076,7 +7076,7 @@ static void inverted_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A9838 */
 static void inverted_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7159,7 +7159,7 @@ static void inverted_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A97D8 */
 static void inverted_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7298,7 +7298,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A9878 */
 static void inverted_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7382,7 +7382,7 @@ static void inverted_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A9888 */
 static void inverted_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7466,7 +7466,7 @@ static void inverted_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A9898 */
 static void inverted_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7550,7 +7550,7 @@ static void inverted_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A98A8 */
 static void inverted_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7634,7 +7634,7 @@ static void inverted_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A98D8 */
 static void inverted_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7717,7 +7717,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A98E8 */
 static void inverted_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7800,7 +7800,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A98B8 */
 static void inverted_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7883,7 +7883,7 @@ static void inverted_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A98C8 */
 static void inverted_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7966,7 +7966,7 @@ static void inverted_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A98F8 */
 static void inverted_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8046,7 +8046,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A9908 */
 static void inverted_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8126,7 +8126,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A9918 */
 static void inverted_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8209,7 +8209,7 @@ static void inverted_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A9928 */
 static void inverted_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8292,7 +8292,7 @@ static void inverted_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A9858 */
 static void inverted_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8376,7 +8376,7 @@ static void inverted_rc_track_diag_left_bank(
 
 /** rct2: 0x008A9868 */
 static void inverted_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8460,7 +8460,7 @@ static void inverted_rc_track_diag_right_bank(
 
 /** rct2: 0x008A9978 */
 static void inverted_rc_track_left_large_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8689,7 +8689,7 @@ static void inverted_rc_track_left_large_half_loop_up(
 
 /** rct2: 0x008A9988 */
 static void inverted_rc_track_right_large_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8918,7 +8918,7 @@ static void inverted_rc_track_right_large_half_loop_up(
 
 /** rct2: 0x008A9998 */
 static void inverted_rc_track_right_large_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_large_half_loop_up(session, ride, 6 - trackSequence, direction, height, trackElement);
@@ -8926,7 +8926,7 @@ static void inverted_rc_track_right_large_half_loop_down(
 
 /** rct2: 0x008A99A8 */
 static void inverted_rc_track_left_large_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_large_half_loop_up(session, ride, 6 - trackSequence, direction, height, trackElement);
@@ -8934,7 +8934,7 @@ static void inverted_rc_track_left_large_half_loop_down(
 
 /** rct2: 0x008A96A8 */
 static void inverted_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8966,7 +8966,7 @@ static void inverted_rc_track_block_brakes(
 
 /** rct2: 0x008A9A78 */
 static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9053,7 +9053,7 @@ static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A9A88 */
 static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9140,7 +9140,7 @@ static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A9A98 */
 static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -9150,7 +9150,7 @@ static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A9AA8 */
 static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -9160,7 +9160,7 @@ static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A9BB8 */
 static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9325,7 +9325,7 @@ static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A9BC8 */
 static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9490,7 +9490,7 @@ static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A9BD8 */
 static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -9500,7 +9500,7 @@ static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A9BE8 */
 static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -9510,7 +9510,7 @@ static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A9AB8 */
 static void inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9575,7 +9575,7 @@ static void inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A9AC8 */
 static void inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9640,7 +9640,7 @@ static void inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A9AD8 */
 static void inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9705,7 +9705,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A9AE8 */
 static void inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9770,7 +9770,7 @@ static void inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A9AF8 */
 static void inverted_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(
@@ -9779,7 +9779,7 @@ static void inverted_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A9B08 */
 static void inverted_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(
@@ -9788,7 +9788,7 @@ static void inverted_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A9B18 */
 static void inverted_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(
@@ -9797,7 +9797,7 @@ static void inverted_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A9B28 */
 static void inverted_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(
@@ -9806,7 +9806,7 @@ static void inverted_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A9B38 */
 static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9871,7 +9871,7 @@ static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A9B48 */
 static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9936,7 +9936,7 @@ static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A9B58 */
 static void inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10001,7 +10001,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008A9B68 */
 static void inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10066,7 +10066,7 @@ static void inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008A9B78 */
 static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -10075,7 +10075,7 @@ static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A9B88 */
 static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -10084,7 +10084,7 @@ static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A9B98 */
 static void inverted_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -10093,7 +10093,7 @@ static void inverted_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x008A9BA8 */
 static void inverted_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -10102,7 +10102,7 @@ static void inverted_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x008A99B8 */
 static void inverted_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10167,7 +10167,7 @@ static void inverted_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A99C8 */
 static void inverted_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10232,7 +10232,7 @@ static void inverted_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A99D8 */
 static void inverted_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10297,7 +10297,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A99E8 */
 static void inverted_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10362,7 +10362,7 @@ static void inverted_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A99F8 */
 static void inverted_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -10370,7 +10370,7 @@ static void inverted_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A9A08 */
 static void inverted_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -10378,7 +10378,7 @@ static void inverted_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A9A18 */
 static void inverted_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -10386,7 +10386,7 @@ static void inverted_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x008A9A28 */
 static void inverted_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -1915,7 +1915,7 @@ void junior_rc_paint_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -1844,7 +1844,7 @@ static constexpr const uint32_t junior_rc_track_pieces_diag_60_deg_down_to_25_de
 };
 
 void junior_rc_paint_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = junior_rc_track_pieces_flat[EnumValue(chainType)][direction] | session->TrackColours[SCHEME_TRACK];
@@ -1864,7 +1864,7 @@ void junior_rc_paint_track_flat(
 }
 
 void junior_rc_paint_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, uint8_t rideType)
 {
     uint32_t imageId;
@@ -1915,14 +1915,14 @@ void junior_rc_paint_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
 void junior_rc_paint_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = junior_rc_track_pieces_25_deg_up[EnumValue(chainType)][direction] | session->TrackColours[SCHEME_TRACK];
@@ -1944,7 +1944,7 @@ void junior_rc_paint_track_25_deg_up(
 }
 
 void junior_rc_paint_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = junior_rc_track_pieces_flat_to_25_deg_up[EnumValue(chainType)][direction]
@@ -1973,7 +1973,7 @@ void junior_rc_paint_track_flat_to_25_deg_up(
 }
 
 void junior_rc_paint_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = junior_rc_track_pieces_25_deg_up_to_flat[EnumValue(chainType)][direction]
@@ -2021,7 +2021,7 @@ static constexpr const int8_t junior_rc_track_right_quarter_turn_5_tiles_support
 };
 
 static void junior_rc_right_quarter_turn_5_tiles_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -2103,7 +2103,7 @@ static constexpr const uint8_t junior_rc_left_quarter_turn_5_tiles_to_right_turn
 
 /* rct2: 0x0051917A */
 static void junior_rc_left_quarter_turn_5_tiles_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence];
@@ -2114,7 +2114,7 @@ static void junior_rc_left_quarter_turn_5_tiles_paint_setup(
  * rct2: 0x008AAFC0, 0x00521593, 0x005216A1, 0x005217AF, 0x00521884
  */
 static void junior_rc_flat_to_left_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id;
@@ -2162,7 +2162,7 @@ static void junior_rc_flat_to_left_bank_paint_setup(
  * rct2: 0x008AAFD0, 0x00521959, 0x00521A2E, 0x00521B03, 0x00521C11
  */
 static void junior_rc_flat_to_right_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id;
@@ -2207,14 +2207,14 @@ static void junior_rc_flat_to_right_bank_paint_setup(
 }
 
 static void junior_rc_left_bank_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_flat_to_right_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void junior_rc_right_bank_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_flat_to_left_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -2284,7 +2284,7 @@ static constexpr const CoordsXYZ junior_rc_banked_right_quarter_turn_5_tiles_bou
 
 /* rct2: 0x008AB010, 0x0052304C */
 static void junior_rc_banked_right_quarter_turn_5_tiles_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t thickness = 1;
@@ -2378,7 +2378,7 @@ static void junior_rc_banked_right_quarter_turn_5_tiles_paint_setup(
 
 /* rct2: 0x008AB000 */
 static void junior_rc_banked_left_quarter_turn_5_tiles_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence];
@@ -2390,7 +2390,7 @@ static void junior_rc_banked_left_quarter_turn_5_tiles_paint_setup(
  * rct2: 0x008AB020, 0x00522073, 0x00522182, 0x00522291, 0x00522367
  */
 static void junior_rc_left_bank_to_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id;
@@ -2450,7 +2450,7 @@ static void junior_rc_left_bank_to_25_deg_up_paint_setup(
  * rct2: 0x008AB030, 0x0052243D, 0x00522513, 0x005225E9, 0x005226F8
  */
 static void junior_rc_right_bank_to_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id;
@@ -2510,7 +2510,7 @@ static void junior_rc_right_bank_to_25_deg_up_paint_setup(
  * rct2: 0x008AB040, 0x00522807, 0x0052291A, 0x00522A2D, 0x00522B07
  */
 static void junior_rc_25_deg_up_to_left_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id;
@@ -2571,7 +2571,7 @@ static void junior_rc_25_deg_up_to_left_bank_paint_setup(
  * rct2: 0x008AB050, 0x00522BE1, 0x00522CBB, 0x00522D95, 0x00522EA8
  */
 static void junior_rc_25_deg_up_to_right_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id;
@@ -2632,7 +2632,7 @@ static void junior_rc_25_deg_up_to_right_bank_paint_setup(
  * rct2: 0x008AB060
  */
 static void junior_rc_left_bank_to_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_25_deg_up_to_right_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -2642,7 +2642,7 @@ static void junior_rc_left_bank_to_25_deg_down_paint_setup(
  * rct2: 0x008AB070
  */
 static void junior_rc_right_bank_to_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_25_deg_up_to_left_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -2652,7 +2652,7 @@ static void junior_rc_right_bank_to_25_deg_down_paint_setup(
  * rct2: 0x008AB080
  */
 static void junior_rc_25_deg_down_to_left_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_right_bank_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -2662,7 +2662,7 @@ static void junior_rc_25_deg_down_to_left_bank_paint_setup(
  * rct2: 0x008AB090
  */
 static void junior_rc_25_deg_down_to_right_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_left_bank_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -2686,7 +2686,7 @@ static constexpr const CoordsXY junior_rc_left_bank_bound_offsets[4] = {
  * rct2: 0x008AB0A0, 0x00521D1F, 0x00521DF4, 0x00521EC9, 0x00521F9E
  */
 static void junior_rc_left_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id;
@@ -2720,14 +2720,14 @@ static void junior_rc_left_bank_paint_setup(
  * rct2: 0x008AB0B0
  */
 static void junior_rc_right_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_left_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -2807,7 +2807,7 @@ void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
 }
 
 void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -2888,7 +2888,7 @@ void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
 
 /* rct2: 0x008AAE10, 0x00519D88, 0x00519DAC, 0x00519DD0, 0x00519DF4 */
 static void junior_rc_left_quarter_turn_5_tiles_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -2899,7 +2899,7 @@ static void junior_rc_left_quarter_turn_5_tiles_25_deg_up_paint_setup(
 
 /* rct2: 0x008AAE20, 0x00519E18, 0x0051A148, 0x0051A452, 0x0051A738 */
 static void junior_rc_right_quarter_turn_5_tiles_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -2910,7 +2910,7 @@ static void junior_rc_right_quarter_turn_5_tiles_25_deg_up_paint_setup(
 
 /* rct2: 0x008AAE30, 0x0051AA42, 0x0051AA68, 0x0051AA8C, 0x0051AAB0 */
 static void junior_rc_left_quarter_turn_5_tiles_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_right_quarter_turn_5_tiles_25_deg_up_paint_setup(
@@ -2920,7 +2920,7 @@ static void junior_rc_left_quarter_turn_5_tiles_25_deg_down_paint_setup(
 
 /* rct2: 0x008AAE40, 0x0051AAD4, 0x0051AE04, 0x0051B10E, 0x0051B3F4 */
 static void junior_rc_right_quarter_turn_5_tiles_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_left_quarter_turn_5_tiles_25_deg_up_paint_setup(
@@ -2930,7 +2930,7 @@ static void junior_rc_right_quarter_turn_5_tiles_25_deg_down_paint_setup(
 
 /* rct2: 0x008AAE50, 0x0051B6FE, 0x0051B946, 0x0051BB8E, 0x0051BBA8 */
 static void junior_rc_s_bend_left_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -3034,7 +3034,7 @@ static void junior_rc_s_bend_left_paint_setup(
 
 /* rct2: 0x008AAE60, 0x0051BBC0, 0x0051BE06, 0x0051C04E, 0x0051C068 */
 static void junior_rc_s_bend_right_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -3138,7 +3138,7 @@ static void junior_rc_s_bend_right_paint_setup(
 
 /** rct2: 0x008AAEB0, 0x0051C0E0, 0x0051C2C1, 0x0051C47F, 0x0051C61D */
 static void junior_rc_right_quarter_turn_3_tiles_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -3180,7 +3180,7 @@ static void junior_rc_right_quarter_turn_3_tiles_paint_setup(
 
 /** rct2: 0x008AAEA0 */
 static void junior_rc_left_quarter_turn_3_tiles_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3235,7 +3235,7 @@ static constexpr const CoordsXYZ junior_rc_right_quarter_turn_3_tiles_bank_offse
 
 /** rct2: 0x008AA0D0, 0x00523EA0, 0x005240CC, 0x0052430F, 0x00524500*/
 static void junior_rc_right_quarter_turn_3_tiles_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t thickness[4][4] = {
@@ -3294,7 +3294,7 @@ static void junior_rc_right_quarter_turn_3_tiles_bank_paint_setup(
 }
 
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = 0;
@@ -3376,7 +3376,7 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
 }
 
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     uint32_t imageId = 0;
@@ -3460,7 +3460,7 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
 
 /** rct2: 0x008AA0C0 */
 static void junior_rc_left_quarter_turn_3_tiles_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3470,7 +3470,7 @@ static void junior_rc_left_quarter_turn_3_tiles_bank_paint_setup(
 
 /** rct2: 0x008AAED0, 0x0051C83C, 0x0051C9EC, 0x0051CB76, 0x0051CCDC*/
 static void junior_rc_right_quarter_turn_3_tiles_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -3481,7 +3481,7 @@ static void junior_rc_right_quarter_turn_3_tiles_25_deg_up_paint_setup(
 
 /** rct2: 0x008AAEF0, 0x0051CEC8, 0x0051D078, 0x0051D202, 0x0051D368*/
 static void junior_rc_right_quarter_turn_3_tiles_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -3499,7 +3499,7 @@ static constexpr const uint8_t junior_rc_left_quarter_turn_3_tiles_to_right_turn
 
 /** rct2: 0x008AAEC0 */
 static void junior_rc_left_quarter_turn_3_tiles_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = junior_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
@@ -3509,7 +3509,7 @@ static void junior_rc_left_quarter_turn_3_tiles_25_deg_up_paint_setup(
 
 /** rct2: 0x008AAEE0 */
 static void junior_rc_left_quarter_turn_3_tiles_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = junior_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
@@ -3519,7 +3519,7 @@ static void junior_rc_left_quarter_turn_3_tiles_25_deg_down_paint_setup(
 
 /** rct2: 0x008AB0F0, 0x0052B3A4, 0x0052B5F8, 0x0052B863, 0x0052BA78 */
 static void junior_rc_right_half_banked_helix_up_small_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t thickness[2] = { 1, 26 };
@@ -3587,7 +3587,7 @@ static void junior_rc_right_half_banked_helix_up_small_paint_setup(
 
 /** rct2: 0x008AB110, 0x0052BD80, 0x0052BFD4, 0x0052C23B, 0x0052C450 */
 static void junior_rc_right_half_banked_helix_down_small_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t thickness[2] = { 1, 26 };
@@ -3655,7 +3655,7 @@ static void junior_rc_right_half_banked_helix_down_small_paint_setup(
 
 /** rct2: 0x008AB0E0 */
 static void junior_rc_left_half_banked_helix_up_small_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence > 3)
@@ -3671,7 +3671,7 @@ static void junior_rc_left_half_banked_helix_up_small_paint_setup(
 
 /** rct2: 0x008AB100 */
 static void junior_rc_left_half_banked_helix_down_small_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence > 3)
@@ -3687,7 +3687,7 @@ static void junior_rc_left_half_banked_helix_down_small_paint_setup(
 
 /** rct2: 0x008AB130, 0x0052C7BC, 0x0052CB6B, 0x0052CF32, 0x0052D2B3 */
 static void junior_rc_right_half_banked_helix_up_large_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t thickness[2] = { 1, 26 };
@@ -3773,7 +3773,7 @@ static void junior_rc_right_half_banked_helix_up_large_paint_setup(
 
 /** rct2: 0x008AB150, 0x0052D778, 0x0052DB27, 0x0052DEEA, 0x0052E26B */
 static void junior_rc_right_half_banked_helix_down_large_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t thickness[2] = { 1, 26 };
@@ -3859,7 +3859,7 @@ static void junior_rc_right_half_banked_helix_down_large_paint_setup(
 
 /** rct2: 0x008AB120 */
 static void junior_rc_left_half_banked_helix_up_large_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence > 6)
@@ -3875,7 +3875,7 @@ static void junior_rc_left_half_banked_helix_up_large_paint_setup(
 
 /** rct2: 0x008AB140 */
 static void junior_rc_left_half_banked_helix_down_large_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence > 6)
@@ -3893,7 +3893,7 @@ static void junior_rc_left_half_banked_helix_down_large_paint_setup(
  * rct2: 0x008AAF00, 0x0051851C, 0x005185D8
  */
 static void junior_rc_brake_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id;
@@ -3927,7 +3927,7 @@ static void junior_rc_brake_paint_setup(
  * rct2: 0x008AB280, 0x00518694, 0x00518759
  */
 static void junior_rc_block_brake_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id;
@@ -3961,7 +3961,7 @@ static void junior_rc_block_brake_paint_setup(
 
 /** rct2: 0x008AAF80 */
 static void junior_rc_left_eighth_to_diag_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -4027,7 +4027,7 @@ static void junior_rc_left_eighth_to_diag_paint_setup(
 
 /** rct2: 0x008AAF90 */
 static void junior_rc_right_eighth_to_diag_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -4093,7 +4093,7 @@ static void junior_rc_right_eighth_to_diag_paint_setup(
 
 /** rct2: 0x008AAFA0 */
 static void junior_rc_left_eighth_to_orthogonal_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -4103,7 +4103,7 @@ static void junior_rc_left_eighth_to_orthogonal_paint_setup(
 
 /** rct2: 0x008AAFB0 */
 static void junior_rc_right_eighth_to_orthogonal_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -4194,7 +4194,7 @@ static constexpr const int8_t junior_rc_left_eighth_to_diag_bank_thickness[4][4]
 
 /** rct2: 0x008AB160 */
 static void junior_rc_left_eighth_to_diag_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -4341,7 +4341,7 @@ static constexpr const int8_t junior_rc_right_eighth_to_diag_bank_thickness[4][4
 
 /** rct2: 0x008AB170 */
 static void junior_rc_right_eighth_to_diag_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -4407,7 +4407,7 @@ static void junior_rc_right_eighth_to_diag_bank_paint_setup(
 
 /** rct2: 0x008AB180 */
 static void junior_rc_left_eighth_to_orthogonal_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -4417,7 +4417,7 @@ static void junior_rc_left_eighth_to_orthogonal_bank_paint_setup(
 
 /** rct2: 0x008AB190 */
 static void junior_rc_right_eighth_to_orthogonal_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -4440,7 +4440,7 @@ static constexpr const uint8_t junior_rc_diag_support_segment[] = {
 };
 
 void junior_rc_paint_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4460,7 +4460,7 @@ void junior_rc_paint_track_diag_flat(
 }
 
 void junior_rc_paint_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4480,7 +4480,7 @@ void junior_rc_paint_track_diag_25_deg_up(
 }
 
 void junior_rc_paint_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4501,7 +4501,7 @@ void junior_rc_paint_track_diag_flat_to_25_deg_up(
 }
 
 void junior_rc_paint_track_diag_flat_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4525,7 +4525,7 @@ void junior_rc_paint_track_diag_flat_to_60_deg_up(
 }
 
 void junior_rc_paint_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4546,7 +4546,7 @@ void junior_rc_paint_track_diag_25_deg_up_to_flat(
 }
 
 void junior_rc_paint_track_diag_60_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4570,7 +4570,7 @@ void junior_rc_paint_track_diag_60_deg_up_to_flat(
 }
 
 void junior_rc_paint_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4591,7 +4591,7 @@ void junior_rc_paint_track_diag_25_deg_down(
 }
 
 void junior_rc_paint_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4612,7 +4612,7 @@ void junior_rc_paint_track_diag_flat_to_25_deg_down(
 }
 
 void junior_rc_paint_track_diag_flat_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4636,7 +4636,7 @@ void junior_rc_paint_track_diag_flat_to_60_deg_down(
 }
 
 void junior_rc_paint_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4657,7 +4657,7 @@ void junior_rc_paint_track_diag_25_deg_down_to_flat(
 }
 
 void junior_rc_paint_track_diag_60_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4682,7 +4682,7 @@ void junior_rc_paint_track_diag_60_deg_down_to_flat(
 
 /** rct2: 0x008AAF10 */
 static void junior_rc_diag_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4693,7 +4693,7 @@ static void junior_rc_diag_flat_paint_setup(
 
 /** rct2: 0x008AAF40 */
 static void junior_rc_diag_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4704,7 +4704,7 @@ static void junior_rc_diag_25_deg_up_paint_setup(
 
 /** rct2: 0x008AAF20 */
 static void junior_rc_diag_flat_to_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4714,7 +4714,7 @@ static void junior_rc_diag_flat_to_25_deg_up_paint_setup(
 }
 
 static void junior_rc_diag_flat_to_60_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4725,7 +4725,7 @@ static void junior_rc_diag_flat_to_60_deg_up_paint_setup(
 
 /** rct2: 0x008AAF30 */
 static void junior_rc_diag_25_deg_up_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4735,7 +4735,7 @@ static void junior_rc_diag_25_deg_up_to_flat_paint_setup(
 }
 
 static void junior_rc_diag_60_deg_up_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4746,7 +4746,7 @@ static void junior_rc_diag_60_deg_up_to_flat_paint_setup(
 
 /** rct2: 0x008AAF70 */
 static void junior_rc_diag_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4757,7 +4757,7 @@ static void junior_rc_diag_25_deg_down_paint_setup(
 
 /** rct2: 0x008AAF50 */
 static void junior_rc_diag_flat_to_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4767,7 +4767,7 @@ static void junior_rc_diag_flat_to_25_deg_down_paint_setup(
 }
 
 static void junior_rc_diag_flat_to_60_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4778,7 +4778,7 @@ static void junior_rc_diag_flat_to_60_deg_down_paint_setup(
 
 /** rct2: 0x008AAF60 */
 static void junior_rc_diag_25_deg_down_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4788,7 +4788,7 @@ static void junior_rc_diag_25_deg_down_to_flat_paint_setup(
 }
 
 static void junior_rc_diag_60_deg_down_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4799,7 +4799,7 @@ static void junior_rc_diag_60_deg_down_to_flat_paint_setup(
 
 /** rct2: 0x008AB1C0 */
 static void junior_rc_diag_flat_to_left_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4826,7 +4826,7 @@ static void junior_rc_diag_flat_to_left_bank_paint_setup(
 
 /** rct2: 0x008AB1D0 */
 static void junior_rc_diag_flat_to_right_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4853,7 +4853,7 @@ static void junior_rc_diag_flat_to_right_bank_paint_setup(
 
 /** rct2: 0x008AB1E0 */
 static void junior_rc_diag_left_bank_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4880,7 +4880,7 @@ static void junior_rc_diag_left_bank_to_flat_paint_setup(
 
 /** rct2: 0x008AB1F0 */
 static void junior_rc_diag_right_bank_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4907,7 +4907,7 @@ static void junior_rc_diag_right_bank_to_flat_paint_setup(
 
 /** rct2: 0x008AB220 */
 static void junior_rc_diag_left_bank_to_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4934,7 +4934,7 @@ static void junior_rc_diag_left_bank_to_25_deg_up_paint_setup(
 
 /** rct2: 0x008AB230 */
 static void junior_rc_diag_right_bank_to_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4961,7 +4961,7 @@ static void junior_rc_diag_right_bank_to_25_deg_up_paint_setup(
 
 /** rct2: 0x008AB200 */
 static void junior_rc_diag_25_deg_up_to_left_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4988,7 +4988,7 @@ static void junior_rc_diag_25_deg_up_to_left_bank_paint_setup(
 
 /** rct2: 0x008AB210 */
 static void junior_rc_diag_25_deg_up_to_right_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -5015,7 +5015,7 @@ static void junior_rc_diag_25_deg_up_to_right_bank_paint_setup(
 
 /** rct2: 0x008AB200 */
 static void junior_rc_diag_left_bank_to_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -5042,7 +5042,7 @@ static void junior_rc_diag_left_bank_to_25_deg_down_paint_setup(
 
 /** rct2: 0x008AB210 */
 static void junior_rc_diag_right_bank_to_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -5069,7 +5069,7 @@ static void junior_rc_diag_right_bank_to_25_deg_down_paint_setup(
 
 /** rct2: 0x008AB220 */
 static void junior_rc_diag_25_deg_down_to_left_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -5096,7 +5096,7 @@ static void junior_rc_diag_25_deg_down_to_left_bank_paint_setup(
 
 /** rct2: 0x008AB230 */
 static void junior_rc_diag_25_deg_down_to_right_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -5137,7 +5137,7 @@ static constexpr const CoordsXYZ junior_rc_diag_right_bank_bound_offsets[4] = {
 
 /** rct2: 0x008AB1A0 */
 static void junior_rc_diag_left_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t thickness = direction == 0 ? 0 : 1;
@@ -5160,7 +5160,7 @@ static void junior_rc_diag_left_bank_paint_setup(
 
 /** rct2: 0x008AB1B0 */
 static void junior_rc_diag_right_bank_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t thickness = direction == 2 ? 0 : 1;
@@ -5210,7 +5210,7 @@ static constexpr const CoordsXY junior_rc_60_deg_up_bound_lengths[4] = {
 };
 
 void junior_rc_paint_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     uint32_t image_id = session->TrackColours[SCHEME_TRACK];
@@ -5252,7 +5252,7 @@ void junior_rc_paint_track_60_deg_up(
 }
 
 static void junior_rc_60_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5262,7 +5262,7 @@ static void junior_rc_60_deg_up_paint_setup(
 }
 
 static void junior_rc_60_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_60_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -5290,7 +5290,7 @@ static constexpr const CoordsXY junior_rc_25_deg_up_to_60_deg_up_bound_offsets[4
 };
 
 void junior_rc_paint_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     uint32_t image_id = session->TrackColours[SCHEME_TRACK];
@@ -5346,7 +5346,7 @@ void junior_rc_paint_track_25_deg_up_to_60_deg_up(
 }
 
 static void junior_rc_25_deg_up_to_60_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5356,14 +5356,14 @@ static void junior_rc_25_deg_up_to_60_deg_up_paint_setup(
 }
 
 static void junior_rc_60_deg_down_to_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_25_deg_up_to_60_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 void junior_rc_paint_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     uint32_t image_id = session->TrackColours[SCHEME_TRACK];
@@ -5418,7 +5418,7 @@ void junior_rc_paint_track_60_deg_up_to_25_deg_up(
 }
 
 static void junior_rc_60_deg_up_to_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5428,14 +5428,14 @@ static void junior_rc_60_deg_up_to_25_deg_up_paint_setup(
 }
 
 static void junior_rc_25_deg_down_to_60_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_60_deg_up_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 void junior_rc_paint_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5455,7 +5455,7 @@ void junior_rc_paint_track_diag_60_deg_up(
 }
 
 void junior_rc_paint_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5476,7 +5476,7 @@ void junior_rc_paint_track_diag_60_deg_down(
 }
 
 void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5497,7 +5497,7 @@ void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
 }
 
 void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     if (direction == 1 && trackSequence == 3)
@@ -5529,7 +5529,7 @@ void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
 }
 
 void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     if (direction == 3 && trackSequence == 0)
@@ -5561,7 +5561,7 @@ void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
 }
 
 void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5582,7 +5582,7 @@ void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
 }
 
 static void junior_rc_diag_60_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5592,7 +5592,7 @@ static void junior_rc_diag_60_deg_up_paint_setup(
 }
 
 static void junior_rc_diag_60_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5602,7 +5602,7 @@ static void junior_rc_diag_60_deg_down_paint_setup(
 }
 
 static void junior_rc_diag_25_deg_up_to_60_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5612,7 +5612,7 @@ static void junior_rc_diag_25_deg_up_to_60_deg_up_paint_setup(
 }
 
 static void junior_rc_diag_60_deg_up_to_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5622,7 +5622,7 @@ static void junior_rc_diag_60_deg_up_to_25_deg_up_paint_setup(
 }
 
 static void junior_rc_diag_25_deg_down_to_60_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5632,7 +5632,7 @@ static void junior_rc_diag_25_deg_down_to_60_deg_down_paint_setup(
 }
 
 static void junior_rc_diag_60_deg_down_to_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5677,7 +5677,7 @@ static constexpr const CoordsXY junior_rc_60_deg_up_to_flat_tile_offsets[4][2] =
 };
 
 static void junior_rc_flat_to_60_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id = session->TrackColours[SCHEME_TRACK];
@@ -5733,14 +5733,14 @@ static void junior_rc_flat_to_60_deg_up_paint_setup(
 }
 
 static void junior_rc_60_deg_down_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_flat_to_60_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void junior_rc_60_deg_up_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id = session->TrackColours[SCHEME_TRACK];
@@ -5795,7 +5795,7 @@ static void junior_rc_60_deg_up_to_flat_paint_setup(
 }
 
 static void junior_rc_flat_to_60_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_60_deg_up_to_flat_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5803,7 +5803,7 @@ static void junior_rc_flat_to_60_deg_down_paint_setup(
 
 /* rct2: 0x00518394 */
 static void junior_rc_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5814,7 +5814,7 @@ static void junior_rc_flat_paint_setup(
 
 /* rct2: 0x00515629, 0x00514D22, 0x005151B9 */
 static void paint_junior_rc_station_track(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_station(session, ride, trackSequence, direction, height, trackElement, RIDE_TYPE_JUNIOR_ROLLER_COASTER);
@@ -5822,7 +5822,7 @@ static void paint_junior_rc_station_track(
 
 /* rct2: 0x0051881E */
 static void junior_rc_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5833,7 +5833,7 @@ static void junior_rc_25_deg_up_paint_setup(
 
 /* rct2: 0x00518B42 */
 static void junior_rc_flat_to_25_deg_up_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5844,7 +5844,7 @@ static void junior_rc_flat_to_25_deg_up_paint_setup(
 
 /* rct2: 0x00518E56 */
 static void junior_rc_25_deg_up_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5855,7 +5855,7 @@ static void junior_rc_25_deg_up_to_flat_paint_setup(
 
 /* rct2: 0x005189B0 */
 static void junior_rc_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5863,7 +5863,7 @@ static void junior_rc_25_deg_down_paint_setup(
 
 /* rct2: 0x00518FE8 */
 static void junior_rc_flat_to_25_deg_down_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_25_deg_up_to_flat_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5871,14 +5871,14 @@ static void junior_rc_flat_to_25_deg_down_paint_setup(
 
 /* rct2: 0x00518CCC */
 static void junior_rc_25_deg_down_to_flat_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_flat_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void junior_rc_booster_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction & 1)
@@ -5908,7 +5908,7 @@ static void junior_rc_booster_paint_setup(
 }
 
 static void junior_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = junior_rc_track_pieces_flat[0][direction] | session->TrackColours[SCHEME_TRACK];

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.h
@@ -23,93 +23,93 @@ struct paint_session;
 struct TrackElement;
 
 void junior_rc_paint_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, uint8_t rideType);
 
 void junior_rc_paint_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 
 void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 
 void junior_rc_paint_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);

--- a/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
@@ -154,7 +154,7 @@ static void lay_down_rc_track_station(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24,
             0, 6, height + 24);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
+        track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_1);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     }
     else
@@ -181,7 +181,7 @@ static void lay_down_rc_track_station(
         PaintAddImageAsParentRotated(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
+        track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     }
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x0082491C */
 static void lay_down_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -132,7 +132,7 @@ static void lay_down_rc_track_flat(
 
 /** rct2: 0x00824B8C, 0x00824B9C, 0x00824BAC */
 static void lay_down_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -154,7 +154,7 @@ static void lay_down_rc_track_station(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24,
             0, 6, height + 24);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_1);
+        track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     }
     else
@@ -181,7 +181,7 @@ static void lay_down_rc_track_station(
         PaintAddImageAsParentRotated(
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
-        track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
+        track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     }
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -190,7 +190,7 @@ static void lay_down_rc_track_station(
 
 /** rct2: 0x0082492C */
 static void lay_down_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -355,7 +355,7 @@ static void lay_down_rc_track_25_deg_up(
 
 /** rct2: 0x0082493C */
 static void lay_down_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -471,7 +471,7 @@ static void lay_down_rc_track_60_deg_up(
 
 /** rct2: 0x0082494C */
 static void lay_down_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -636,7 +636,7 @@ static void lay_down_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x0082495C */
 static void lay_down_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -766,7 +766,7 @@ static void lay_down_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0082496C */
 static void lay_down_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -920,7 +920,7 @@ static void lay_down_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0082497C */
 static void lay_down_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1085,7 +1085,7 @@ static void lay_down_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0082498C */
 static void lay_down_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1093,7 +1093,7 @@ static void lay_down_rc_track_25_deg_down(
 
 /** rct2: 0x0082499C */
 static void lay_down_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1101,7 +1101,7 @@ static void lay_down_rc_track_60_deg_down(
 
 /** rct2: 0x008249AC */
 static void lay_down_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1109,7 +1109,7 @@ static void lay_down_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008249BC */
 static void lay_down_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1117,7 +1117,7 @@ static void lay_down_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008249CC */
 static void lay_down_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1125,7 +1125,7 @@ static void lay_down_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008249DC */
 static void lay_down_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1133,7 +1133,7 @@ static void lay_down_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008249EC */
 static void lay_down_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1502,7 +1502,7 @@ static void lay_down_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008249FC */
 static void lay_down_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1511,7 +1511,7 @@ static void lay_down_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x00824A0C */
 static void lay_down_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1592,7 +1592,7 @@ static void lay_down_rc_track_flat_to_left_bank(
 
 /** rct2: 0x00824A1C */
 static void lay_down_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1673,7 +1673,7 @@ static void lay_down_rc_track_flat_to_right_bank(
 
 /** rct2: 0x00824A2C */
 static void lay_down_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1754,7 +1754,7 @@ static void lay_down_rc_track_left_bank_to_flat(
 
 /** rct2: 0x00824A3C */
 static void lay_down_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1835,7 +1835,7 @@ static void lay_down_rc_track_right_bank_to_flat(
 
 /** rct2: 0x00824A4C */
 static void lay_down_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2205,7 +2205,7 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x00824A5C */
 static void lay_down_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2214,7 +2214,7 @@ static void lay_down_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x00824A6C */
 static void lay_down_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2326,7 +2326,7 @@ static void lay_down_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x00824A7C */
 static void lay_down_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2438,7 +2438,7 @@ static void lay_down_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x00824A8C */
 static void lay_down_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2550,7 +2550,7 @@ static void lay_down_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x00824A9C */
 static void lay_down_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2662,7 +2662,7 @@ static void lay_down_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x00824AAC */
 static void lay_down_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2670,7 +2670,7 @@ static void lay_down_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x00824ABC */
 static void lay_down_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2678,7 +2678,7 @@ static void lay_down_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x00824ACC */
 static void lay_down_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2686,7 +2686,7 @@ static void lay_down_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x00824ADC */
 static void lay_down_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2694,7 +2694,7 @@ static void lay_down_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x00824AEC */
 static void lay_down_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2771,7 +2771,7 @@ static void lay_down_rc_track_left_bank(
 
 /** rct2: 0x00824AFC */
 static void lay_down_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2779,7 +2779,7 @@ static void lay_down_rc_track_right_bank(
 
 /** rct2: 0x00824B0C */
 static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3123,7 +3123,7 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x00824B1C */
 static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3467,7 +3467,7 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x00824B2C */
 static void lay_down_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -3476,7 +3476,7 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x00824B3C */
 static void lay_down_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -3485,7 +3485,7 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x00824B4C */
 static void lay_down_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3812,7 +3812,7 @@ static void lay_down_rc_track_s_bend_left(
 
 /** rct2: 0x00824B5C */
 static void lay_down_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4139,7 +4139,7 @@ static void lay_down_rc_track_s_bend_right(
 
 /** rct2: 0x00824B6C */
 static void lay_down_rc_track_left_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4418,7 +4418,7 @@ static void lay_down_rc_track_left_vertical_loop(
 
 /** rct2: 0x00824B7C */
 static void lay_down_rc_track_right_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4653,7 +4653,7 @@ static void lay_down_rc_track_right_vertical_loop(
 
 /** rct2: 0x00824BBC */
 static void lay_down_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4892,7 +4892,7 @@ static void lay_down_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x00824BCC */
 static void lay_down_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4901,7 +4901,7 @@ static void lay_down_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x00824BDC */
 static void lay_down_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5146,7 +5146,7 @@ static void lay_down_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x00824BEC */
 static void lay_down_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5155,7 +5155,7 @@ static void lay_down_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x00824BFC */
 static void lay_down_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5326,7 +5326,7 @@ static void lay_down_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00824C0C */
 static void lay_down_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5503,7 +5503,7 @@ static void lay_down_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00824C1C */
 static void lay_down_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5512,7 +5512,7 @@ static void lay_down_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x00824C2C */
 static void lay_down_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5521,7 +5521,7 @@ static void lay_down_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x00824C9C */
 static void lay_down_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5743,7 +5743,7 @@ static void lay_down_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x00824CAC */
 static void lay_down_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5965,7 +5965,7 @@ static void lay_down_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x00824CBC */
 static void lay_down_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -5979,7 +5979,7 @@ static void lay_down_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x00824CCC */
 static void lay_down_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -5993,7 +5993,7 @@ static void lay_down_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x00824CDC */
 static void lay_down_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6339,7 +6339,7 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x00824CEC */
 static void lay_down_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6685,7 +6685,7 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x00824CFC */
 static void lay_down_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6699,7 +6699,7 @@ static void lay_down_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x00824D0C */
 static void lay_down_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6713,7 +6713,7 @@ static void lay_down_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x00824D3C */
 static void lay_down_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6791,7 +6791,7 @@ static void lay_down_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x00824D1C */
 static void lay_down_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6870,7 +6870,7 @@ static void lay_down_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x00824D2C */
 static void lay_down_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -6878,7 +6878,7 @@ static void lay_down_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x00824D4C */
 static void lay_down_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -6886,7 +6886,7 @@ static void lay_down_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x00824D5C */
 static void lay_down_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6947,7 +6947,7 @@ static void lay_down_rc_track_brakes(
 
 /** rct2: 0x00824D6C */
 static void lay_down_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7058,7 +7058,7 @@ static void lay_down_rc_track_on_ride_photo(
 
 /** rct2: 0x00824D8C */
 static void lay_down_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7372,7 +7372,7 @@ static void lay_down_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x00824D9C */
 static void lay_down_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7686,7 +7686,7 @@ static void lay_down_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x00824DAC */
 static void lay_down_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -7695,7 +7695,7 @@ static void lay_down_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x00824DBC */
 static void lay_down_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -7704,7 +7704,7 @@ static void lay_down_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x00824DCC */
 static void lay_down_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8019,7 +8019,7 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x00824DDC */
 static void lay_down_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8334,7 +8334,7 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x00824DEC */
 static void lay_down_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8343,7 +8343,7 @@ static void lay_down_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x00824DFC */
 static void lay_down_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8352,7 +8352,7 @@ static void lay_down_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x00824D7C */
 static void lay_down_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8644,7 +8644,7 @@ static void lay_down_rc_track_diag_flat(
 
 /** rct2: 0x00824E2C */
 static void lay_down_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8936,7 +8936,7 @@ static void lay_down_rc_track_diag_25_deg_up(
 
 /** rct2: 0x00824E8C */
 static void lay_down_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9172,7 +9172,7 @@ static void lay_down_rc_track_diag_60_deg_up(
 
 /** rct2: 0x00824E0C */
 static void lay_down_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9464,7 +9464,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x00824E6C */
 static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9700,7 +9700,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x00824E7C */
 static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9936,7 +9936,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00824E1C */
 static void lay_down_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10228,7 +10228,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x00824E5C */
 static void lay_down_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10464,7 +10464,7 @@ static void lay_down_rc_track_diag_25_deg_down(
 
 /** rct2: 0x00824EBC */
 static void lay_down_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10700,7 +10700,7 @@ static void lay_down_rc_track_diag_60_deg_down(
 
 /** rct2: 0x00824E3C */
 static void lay_down_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10929,7 +10929,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x00824E9C */
 static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11165,7 +11165,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x00824EAC */
 static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11401,7 +11401,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x00824E4C */
 static void lay_down_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11637,7 +11637,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x00824EEC */
 static void lay_down_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11807,7 +11807,7 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x00824EFC */
 static void lay_down_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11977,7 +11977,7 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x00824F0C */
 static void lay_down_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12147,7 +12147,7 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x00824F1C */
 static void lay_down_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12317,7 +12317,7 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x00824F4C */
 static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12486,7 +12486,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x00824F5C */
 static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12655,7 +12655,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x00824F2C */
 static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12824,7 +12824,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x00824F3C */
 static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12993,7 +12993,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x00824F6C */
 static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13155,7 +13155,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x00824F7C */
 static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13317,7 +13317,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x00824F8C */
 static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13486,7 +13486,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x00824F9C */
 static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13655,7 +13655,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x00824ECC */
 static void lay_down_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13822,7 +13822,7 @@ static void lay_down_rc_track_diag_left_bank(
 
 /** rct2: 0x00824EDC */
 static void lay_down_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13989,7 +13989,7 @@ static void lay_down_rc_track_diag_right_bank(
 
 /** rct2: 0x00824FAC */
 static void lay_down_rc_track_left_flyer_twist_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14101,7 +14101,7 @@ static void lay_down_rc_track_left_flyer_twist_up(
 
 /** rct2: 0x00824FBC */
 static void lay_down_rc_track_right_flyer_twist_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14211,7 +14211,7 @@ static void lay_down_rc_track_right_flyer_twist_up(
 
 /** rct2: 0x00824FCC */
 static void lay_down_rc_track_left_flyer_twist_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14323,7 +14323,7 @@ static void lay_down_rc_track_left_flyer_twist_down(
 
 /** rct2: 0x00824FDC */
 static void lay_down_rc_track_right_flyer_twist_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14433,7 +14433,7 @@ static void lay_down_rc_track_right_flyer_twist_down(
 
 /** rct2: 0x00824C3C */
 static void lay_down_rc_track_flyer_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14563,7 +14563,7 @@ static void lay_down_rc_track_flyer_half_loop_up(
 
 /** rct2: 0x00824C4C */
 static void lay_down_rc_track_flyer_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14693,7 +14693,7 @@ static void lay_down_rc_track_flyer_half_loop_down(
 
 /** rct2: 0x00824C5C */
 static void lay_down_rc_track_left_flyer_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14820,7 +14820,7 @@ static void lay_down_rc_track_left_flyer_corkscrew_up(
 
 /** rct2: 0x00824C6C */
 static void lay_down_rc_track_right_flyer_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14934,7 +14934,7 @@ static void lay_down_rc_track_right_flyer_corkscrew_up(
 
 /** rct2: 0x00824C7C */
 static void lay_down_rc_track_left_flyer_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15048,7 +15048,7 @@ static void lay_down_rc_track_left_flyer_corkscrew_down(
 
 /** rct2: 0x00824C8C */
 static void lay_down_rc_track_right_flyer_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_left_flyer_corkscrew_up(session, ride, 2 - trackSequence, (direction + 3) % 4, height, trackElement);
@@ -15056,7 +15056,7 @@ static void lay_down_rc_track_right_flyer_corkscrew_down(
 
 /** rct2: 0x00824FEC */
 static void lay_down_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -15113,7 +15113,7 @@ static void lay_down_rc_track_block_brakes(
 }
 
 static void lay_down_rc_track_left_quarter_banked_helix_large_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15297,7 +15297,7 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_up(
 }
 
 static void lay_down_rc_track_right_quarter_banked_helix_large_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15481,7 +15481,7 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_up(
 }
 
 static void lay_down_rc_track_left_quarter_banked_helix_large_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15665,7 +15665,7 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_down(
 }
 
 static void lay_down_rc_track_right_quarter_banked_helix_large_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _LimLauncherBlockBrakeImages[NumOrthogonalDirect
 
 /** rct2: 0x008A6D50, 0x008A6D60, 0x008A6D70 */
 static void lim_launched_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -58,7 +58,7 @@ static void lim_launched_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -66,7 +66,7 @@ static void lim_launched_rc_track_station(
 
 /** rct2: 0x008A65E0 */
 static void lim_launched_rc_track_left_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -329,7 +329,7 @@ static void lim_launched_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A65F0 */
 static void lim_launched_rc_track_right_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -546,7 +546,7 @@ static void lim_launched_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A6D10 */
 static void lim_launched_rc_track_left_twist_down_to_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -683,7 +683,7 @@ static void lim_launched_rc_track_left_twist_down_to_up(
 
 /** rct2: 0x008A6D20 */
 static void lim_launched_rc_track_right_twist_down_to_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -820,7 +820,7 @@ static void lim_launched_rc_track_right_twist_down_to_up(
 
 /** rct2: 0x008A6D30 */
 static void lim_launched_rc_track_left_twist_up_to_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -957,7 +957,7 @@ static void lim_launched_rc_track_left_twist_up_to_down(
 
 /** rct2: 0x008A6D40 */
 static void lim_launched_rc_track_right_twist_up_to_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1094,7 +1094,7 @@ static void lim_launched_rc_track_right_twist_up_to_down(
 
 /** rct2: 0x008A6CD0 */
 static void lim_launched_rc_track_left_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1206,7 +1206,7 @@ static void lim_launched_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A6CE0 */
 static void lim_launched_rc_track_right_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1319,7 +1319,7 @@ static void lim_launched_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A6CF0 */
 static void lim_launched_rc_track_left_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
@@ -1327,7 +1327,7 @@ static void lim_launched_rc_track_left_corkscrew_down(
 
 /** rct2: 0x008A6D00 */
 static void lim_launched_rc_track_right_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -1335,7 +1335,7 @@ static void lim_launched_rc_track_right_corkscrew_down(
 
 /** rct2: 0x008A6D80 */
 static void lim_launched_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1363,7 +1363,7 @@ static void lim_launched_rc_track_brakes(
 
 /** rct2: 0x008A6C10 */
 static void lim_launched_rc_track_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1404,7 +1404,7 @@ static void lim_launched_rc_track_90_deg_up(
 
 /** rct2: 0x008A6C20 */
 static void lim_launched_rc_track_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1412,7 +1412,7 @@ static void lim_launched_rc_track_90_deg_down(
 
 /** rct2: 0x008A6C30 */
 static void lim_launched_rc_track_60_deg_up_to_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1455,7 +1455,7 @@ static void lim_launched_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x008A6C40 */
 static void lim_launched_rc_track_90_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1463,7 +1463,7 @@ static void lim_launched_rc_track_90_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A6C50 */
 static void lim_launched_rc_track_90_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1501,7 +1501,7 @@ static void lim_launched_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A6C60 */
 static void lim_launched_rc_track_60_deg_down_to_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1545,7 +1545,7 @@ static void lim_launched_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x008A6C70 */
 static void lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1643,7 +1643,7 @@ static void lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
 
 /** rct2: 0x008A6C80 */
 static void lim_launched_rc_track_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
@@ -1652,7 +1652,7 @@ static void lim_launched_rc_track_inverted_flat_to_90_deg_quarter_loop_down(
 
 /** rct2: 0x008A6D90 */
 static void lim_launched_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -1671,7 +1671,7 @@ static void lim_launched_rc_track_block_brakes(
 }
 
 static void lim_launched_rc_track_left_quarter_turn_1_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1718,7 +1718,7 @@ static void lim_launched_rc_track_left_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008A6CA0 */
 static void lim_launched_rc_track_right_quarter_turn_1_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1765,7 +1765,7 @@ static void lim_launched_rc_track_right_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008A6CB0 */
 static void lim_launched_rc_track_left_quarter_turn_1_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_right_quarter_turn_1_90_deg_up(
@@ -1774,7 +1774,7 @@ static void lim_launched_rc_track_left_quarter_turn_1_90_deg_down(
 
 /** rct2: 0x008A6CC0 */
 static void lim_launched_rc_track_right_quarter_turn_1_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_left_quarter_turn_1_90_deg_up(

--- a/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
@@ -58,7 +58,7 @@ static void lim_launched_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
@@ -105,7 +105,7 @@ static void looping_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
@@ -26,7 +26,7 @@ static constexpr auto SPR_LOOPING_RC_FLAT_CHAINED_NW_SE = 15017;
 
 /** rct2: 0x008A6370 */
 static void looping_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -82,7 +82,7 @@ static void looping_rc_track_flat(
 }
 
 static void looping_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint32_t imageIdsFrictionWheels[4][2] = {
@@ -105,7 +105,7 @@ static void looping_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -113,7 +113,7 @@ static void looping_rc_track_station(
 
 /** rct2: 0x008A6380 */
 static void looping_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -183,7 +183,7 @@ static void looping_rc_track_25_deg_up(
 
 /** rct2: 0x008A6390 */
 static void looping_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -253,7 +253,7 @@ static void looping_rc_track_60_deg_up(
 
 /** rct2: 0x008A63A0 */
 static void looping_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -323,7 +323,7 @@ static void looping_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A63B0 */
 static void looping_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -401,7 +401,7 @@ static void looping_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A63C0 */
 static void looping_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -479,7 +479,7 @@ static void looping_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A63D0 */
 static void looping_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -549,7 +549,7 @@ static void looping_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A63E0 */
 static void looping_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -557,7 +557,7 @@ static void looping_rc_track_25_deg_down(
 
 /** rct2: 0x008A63F0 */
 static void looping_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -565,7 +565,7 @@ static void looping_rc_track_60_deg_down(
 
 /** rct2: 0x008A6400 */
 static void looping_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -573,7 +573,7 @@ static void looping_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A6410 */
 static void looping_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -581,7 +581,7 @@ static void looping_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A6420 */
 static void looping_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -589,7 +589,7 @@ static void looping_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A6430 */
 static void looping_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -597,7 +597,7 @@ static void looping_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A6440 */
 static void looping_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -761,7 +761,7 @@ static void looping_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A6450 */
 static void looping_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -770,7 +770,7 @@ static void looping_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A6460 */
 static void looping_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -808,7 +808,7 @@ static void looping_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A6470 */
 static void looping_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -846,7 +846,7 @@ static void looping_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A6480 */
 static void looping_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -884,7 +884,7 @@ static void looping_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A6490 */
 static void looping_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -922,7 +922,7 @@ static void looping_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A64A0 */
 static void looping_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1096,7 +1096,7 @@ static void looping_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A64B0 */
 static void looping_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1105,7 +1105,7 @@ static void looping_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008A64C0 */
 static void looping_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1150,7 +1150,7 @@ static void looping_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A64D0 */
 static void looping_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1195,7 +1195,7 @@ static void looping_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A64E0 */
 static void looping_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1240,7 +1240,7 @@ static void looping_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A64F0 */
 static void looping_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1285,7 +1285,7 @@ static void looping_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A6500 */
 static void looping_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1293,7 +1293,7 @@ static void looping_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A6510 */
 static void looping_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1301,7 +1301,7 @@ static void looping_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A6520 */
 static void looping_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1309,7 +1309,7 @@ static void looping_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A6530 */
 static void looping_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1317,7 +1317,7 @@ static void looping_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A6540 */
 static void looping_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1351,7 +1351,7 @@ static void looping_rc_track_left_bank(
 
 /** rct2: 0x008A6550 */
 static void looping_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1359,7 +1359,7 @@ static void looping_rc_track_right_bank(
 
 /** rct2: 0x008A6560 */
 static void looping_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1523,7 +1523,7 @@ static void looping_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6570 */
 static void looping_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1687,7 +1687,7 @@ static void looping_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6580 */
 static void looping_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1696,7 +1696,7 @@ static void looping_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A6590 */
 static void looping_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1705,7 +1705,7 @@ static void looping_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A65A0 */
 static void looping_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1840,7 +1840,7 @@ static void looping_rc_track_s_bend_left(
 
 /** rct2: 0x008A65B0 */
 static void looping_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1975,7 +1975,7 @@ static void looping_rc_track_s_bend_right(
 
 /** rct2: 0x008A65C0 */
 static void looping_rc_track_left_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2262,7 +2262,7 @@ static void looping_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A65D0 */
 static void looping_rc_track_right_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2517,7 +2517,7 @@ static void looping_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A6630 */
 static void looping_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2620,7 +2620,7 @@ static void looping_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A6640 */
 static void looping_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2629,7 +2629,7 @@ static void looping_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A6650 */
 static void looping_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2741,7 +2741,7 @@ static void looping_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A6660 */
 static void looping_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2750,7 +2750,7 @@ static void looping_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008A6670 */
 static void looping_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2829,7 +2829,7 @@ static void looping_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6680 */
 static void looping_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2915,7 +2915,7 @@ static void looping_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6690 */
 static void looping_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2924,7 +2924,7 @@ static void looping_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A66A0 */
 static void looping_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2933,7 +2933,7 @@ static void looping_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A66B0 */
 static void looping_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3151,7 +3151,7 @@ static void looping_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A66C0 */
 static void looping_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3369,7 +3369,7 @@ static void looping_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A66D0 */
 static void looping_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3383,7 +3383,7 @@ static void looping_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008A66E0 */
 static void looping_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3397,7 +3397,7 @@ static void looping_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008A66F0 */
 static void looping_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3739,7 +3739,7 @@ static void looping_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A6700 */
 static void looping_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4081,7 +4081,7 @@ static void looping_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A6710 */
 static void looping_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4095,7 +4095,7 @@ static void looping_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008A6720 */
 static void looping_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4109,7 +4109,7 @@ static void looping_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008A6750 */
 static void looping_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4146,7 +4146,7 @@ static void looping_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A6730 */
 static void looping_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4183,7 +4183,7 @@ static void looping_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A6740 */
 static void looping_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4191,7 +4191,7 @@ static void looping_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A6760 */
 static void looping_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4199,7 +4199,7 @@ static void looping_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A6770 */
 static void looping_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4231,7 +4231,7 @@ static void looping_rc_track_brakes(
 
 /** rct2: 0x008A6A40 */
 static void looping_rc_track_25_deg_up_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4272,7 +4272,7 @@ static void looping_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008A6A50 */
 static void looping_rc_track_25_deg_up_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4313,7 +4313,7 @@ static void looping_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008A6780 */
 static void looping_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4359,7 +4359,7 @@ static void looping_rc_track_on_ride_photo(
 
 /** rct2: 0x008A6A60 */
 static void looping_rc_track_25_deg_down_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4367,7 +4367,7 @@ static void looping_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x008A6A70 */
 static void looping_rc_track_25_deg_down_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4375,7 +4375,7 @@ static void looping_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x008A6860 */
 static void looping_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4514,7 +4514,7 @@ static void looping_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A6870 */
 static void looping_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4652,7 +4652,7 @@ static void looping_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A6880 */
 static void looping_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4661,7 +4661,7 @@ static void looping_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A6890 */
 static void looping_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4670,7 +4670,7 @@ static void looping_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A68A0 */
 static void looping_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4812,7 +4812,7 @@ static void looping_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A68B0 */
 static void looping_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4954,7 +4954,7 @@ static void looping_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A68C0 */
 static void looping_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4963,7 +4963,7 @@ static void looping_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A68D0 */
 static void looping_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4972,7 +4972,7 @@ static void looping_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A6790 */
 static void looping_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5118,7 +5118,7 @@ static void looping_rc_track_diag_flat(
 
 /** rct2: 0x008A67C0 */
 static void looping_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5264,7 +5264,7 @@ static void looping_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A67F0 */
 static void looping_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5410,7 +5410,7 @@ static void looping_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A67A0 */
 static void looping_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5556,7 +5556,7 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A67D0 */
 static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5702,7 +5702,7 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A67E0 */
 static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5848,7 +5848,7 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A67B0 */
 static void looping_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5994,7 +5994,7 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A6820 */
 static void looping_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6140,7 +6140,7 @@ static void looping_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A6850 */
 static void looping_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6286,7 +6286,7 @@ static void looping_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A6800 */
 static void looping_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6430,7 +6430,7 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A6830 */
 static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6576,7 +6576,7 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A6840 */
 static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6722,7 +6722,7 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A6810 */
 static void looping_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6868,7 +6868,7 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A6900 */
 static void looping_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6947,7 +6947,7 @@ static void looping_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A6910 */
 static void looping_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7026,7 +7026,7 @@ static void looping_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A6920 */
 static void looping_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7105,7 +7105,7 @@ static void looping_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A6930 */
 static void looping_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7184,7 +7184,7 @@ static void looping_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A6960 */
 static void looping_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7263,7 +7263,7 @@ static void looping_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A6970 */
 static void looping_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7342,7 +7342,7 @@ static void looping_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A6940 */
 static void looping_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7421,7 +7421,7 @@ static void looping_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A6950 */
 static void looping_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7500,7 +7500,7 @@ static void looping_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A6980 */
 static void looping_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7577,7 +7577,7 @@ static void looping_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A6990 */
 static void looping_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7654,7 +7654,7 @@ static void looping_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A69A0 */
 static void looping_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7733,7 +7733,7 @@ static void looping_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A69B0 */
 static void looping_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7812,7 +7812,7 @@ static void looping_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A68E0 */
 static void looping_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7888,7 +7888,7 @@ static void looping_rc_track_diag_left_bank(
 
 /** rct2: 0x008A68F0 */
 static void looping_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7964,7 +7964,7 @@ static void looping_rc_track_diag_right_bank(
 
 /** rct2: 0x008A6C00 */
 static void looping_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -7996,7 +7996,7 @@ static void looping_rc_track_block_brakes(
 
 /** rct2: 0x008A6BC0 */
 static void looping_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8078,7 +8078,7 @@ static void looping_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6BD0 */
 static void looping_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8167,7 +8167,7 @@ static void looping_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6BE0 */
 static void looping_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -8177,7 +8177,7 @@ static void looping_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A6BF0 */
 static void looping_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -8187,7 +8187,7 @@ static void looping_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A6B80 */
 static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8357,7 +8357,7 @@ static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6B90 */
 static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8527,7 +8527,7 @@ static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6BA0 */
 static void looping_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8537,7 +8537,7 @@ static void looping_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A6BB0 */
 static void looping_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8547,7 +8547,7 @@ static void looping_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A6A80 */
 static void looping_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8590,7 +8590,7 @@ static void looping_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A6A90 */
 static void looping_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8633,7 +8633,7 @@ static void looping_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A6AA0 */
 static void looping_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8676,7 +8676,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A6AB0 */
 static void looping_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8719,7 +8719,7 @@ static void looping_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A6AC0 */
 static void looping_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_banked_25_deg_up_to_25_deg_up(
@@ -8728,7 +8728,7 @@ static void looping_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A6AD0 */
 static void looping_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_banked_25_deg_up_to_25_deg_up(
@@ -8737,7 +8737,7 @@ static void looping_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A6AE0 */
 static void looping_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_right_banked_25_deg_up(
@@ -8746,7 +8746,7 @@ static void looping_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A6AF0 */
 static void looping_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_left_banked_25_deg_up(
@@ -8755,7 +8755,7 @@ static void looping_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A6B00 */
 static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8796,7 +8796,7 @@ static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A6B10 */
 static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8837,7 +8837,7 @@ static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A6B40 */
 static void looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8878,7 +8878,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008A6B50 */
 static void looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8919,7 +8919,7 @@ static void looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008A6B60 */
 static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -8928,7 +8928,7 @@ static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A6B70 */
 static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -8937,7 +8937,7 @@ static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A6B20 */
 static void looping_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -8946,7 +8946,7 @@ static void looping_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x008A6B30 */
 static void looping_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -8955,7 +8955,7 @@ static void looping_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x008A69C0 */
 static void looping_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8998,7 +8998,7 @@ static void looping_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A69D0 */
 static void looping_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9041,7 +9041,7 @@ static void looping_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A69E0 */
 static void looping_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9084,7 +9084,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A69F0 */
 static void looping_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9127,7 +9127,7 @@ static void looping_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A6A00 */
 static void looping_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9135,7 +9135,7 @@ static void looping_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A6A10 */
 static void looping_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9143,7 +9143,7 @@ static void looping_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A6A20 */
 static void looping_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9151,14 +9151,14 @@ static void looping_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x008A6A30 */
 static void looping_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void looping_rc_track_booster(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/MineRide.cpp
+++ b/src/openrct2/ride/coaster/MineRide.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008B08D0 */
 static void mine_ride_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -53,7 +53,7 @@ static void mine_ride_track_flat(
 }
 
 static void mine_ride_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -69,7 +69,7 @@ static void mine_ride_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -77,7 +77,7 @@ static void mine_ride_track_station(
 
 /** rct2: 0x008B08E0 */
 static void mine_ride_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -134,7 +134,7 @@ static void mine_ride_track_25_deg_up(
 
 /** rct2: 0x008B08F0 */
 static void mine_ride_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -191,7 +191,7 @@ static void mine_ride_track_flat_to_25_deg_up(
 
 /** rct2: 0x008B0900 */
 static void mine_ride_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -248,7 +248,7 @@ static void mine_ride_track_25_deg_up_to_flat(
 
 /** rct2: 0x008B0910 */
 static void mine_ride_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -256,7 +256,7 @@ static void mine_ride_track_25_deg_down(
 
 /** rct2: 0x008B0920 */
 static void mine_ride_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -264,7 +264,7 @@ static void mine_ride_track_flat_to_25_deg_down(
 
 /** rct2: 0x008B0930 */
 static void mine_ride_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -272,7 +272,7 @@ static void mine_ride_track_25_deg_down_to_flat(
 
 /** rct2: 0x008B0940 */
 static void mine_ride_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -450,7 +450,7 @@ static void mine_ride_track_left_quarter_turn_5(
 
 /** rct2: 0x008B0950 */
 static void mine_ride_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -459,7 +459,7 @@ static void mine_ride_track_right_quarter_turn_5(
 
 /** rct2: 0x008B0960 */
 static void mine_ride_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -513,7 +513,7 @@ static void mine_ride_track_flat_to_left_bank(
 
 /** rct2: 0x008B0970 */
 static void mine_ride_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -567,7 +567,7 @@ static void mine_ride_track_flat_to_right_bank(
 
 /** rct2: 0x008B0980 */
 static void mine_ride_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -621,7 +621,7 @@ static void mine_ride_track_left_bank_to_flat(
 
 /** rct2: 0x008B0990 */
 static void mine_ride_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -675,7 +675,7 @@ static void mine_ride_track_right_bank_to_flat(
 
 /** rct2: 0x008B09A0 */
 static void mine_ride_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -863,7 +863,7 @@ static void mine_ride_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008B09B0 */
 static void mine_ride_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -872,7 +872,7 @@ static void mine_ride_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008B09C0 */
 static void mine_ride_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -933,7 +933,7 @@ static void mine_ride_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008B09D0 */
 static void mine_ride_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -994,7 +994,7 @@ static void mine_ride_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008B09E0 */
 static void mine_ride_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1055,7 +1055,7 @@ static void mine_ride_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008B09F0 */
 static void mine_ride_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1116,7 +1116,7 @@ static void mine_ride_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008B0A00 */
 static void mine_ride_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1124,7 +1124,7 @@ static void mine_ride_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008B0A10 */
 static void mine_ride_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1132,7 +1132,7 @@ static void mine_ride_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008B0A20 */
 static void mine_ride_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1140,7 +1140,7 @@ static void mine_ride_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008B0A30 */
 static void mine_ride_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1148,7 +1148,7 @@ static void mine_ride_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008B0A40 */
 static void mine_ride_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1198,7 +1198,7 @@ static void mine_ride_track_left_bank(
 
 /** rct2: 0x008B0A50 */
 static void mine_ride_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1206,7 +1206,7 @@ static void mine_ride_track_right_bank(
 
 /** rct2: 0x008B0A60 */
 static void mine_ride_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1355,7 +1355,7 @@ static void mine_ride_track_s_bend_left(
 
 /** rct2: 0x008B0A70 */
 static void mine_ride_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1504,7 +1504,7 @@ static void mine_ride_track_s_bend_right(
 
 /** rct2: 0x008B0AB0 */
 static void mine_ride_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1621,7 +1621,7 @@ static void mine_ride_track_left_quarter_turn_3(
 
 /** rct2: 0x008B0AC0 */
 static void mine_ride_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1630,7 +1630,7 @@ static void mine_ride_track_right_quarter_turn_3(
 
 /** rct2: 0x008B0AD0 */
 static void mine_ride_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1756,7 +1756,7 @@ static void mine_ride_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008B0AE0 */
 static void mine_ride_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1765,7 +1765,7 @@ static void mine_ride_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008B0AF0 */
 static void mine_ride_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2011,7 +2011,7 @@ static void mine_ride_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008B0B00 */
 static void mine_ride_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2257,7 +2257,7 @@ static void mine_ride_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008B0B10 */
 static void mine_ride_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -2271,7 +2271,7 @@ static void mine_ride_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008B0B20 */
 static void mine_ride_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -2285,7 +2285,7 @@ static void mine_ride_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008B0B30 */
 static void mine_ride_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2655,7 +2655,7 @@ static void mine_ride_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008B0B40 */
 static void mine_ride_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3025,7 +3025,7 @@ static void mine_ride_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008B0B50 */
 static void mine_ride_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3039,7 +3039,7 @@ static void mine_ride_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008B0B60 */
 static void mine_ride_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3053,7 +3053,7 @@ static void mine_ride_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008B0B70 */
 static void mine_ride_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3099,7 +3099,7 @@ static void mine_ride_track_on_ride_photo(
 
 /** rct2: 0x008B0B90 */
 static void mine_ride_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3245,7 +3245,7 @@ static void mine_ride_track_left_eighth_to_diag(
 
 /** rct2: 0x008B0BA0 */
 static void mine_ride_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3390,7 +3390,7 @@ static void mine_ride_track_right_eighth_to_diag(
 
 /** rct2: 0x008B0BB0 */
 static void mine_ride_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -3399,7 +3399,7 @@ static void mine_ride_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008B0BC0 */
 static void mine_ride_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -3408,7 +3408,7 @@ static void mine_ride_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008B0BD0 */
 static void mine_ride_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3557,7 +3557,7 @@ static void mine_ride_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008B0BE0 */
 static void mine_ride_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3706,7 +3706,7 @@ static void mine_ride_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008B0BF0 */
 static void mine_ride_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -3715,7 +3715,7 @@ static void mine_ride_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008B0C00 */
 static void mine_ride_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -3724,7 +3724,7 @@ static void mine_ride_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008B0B80 */
 static void mine_ride_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3800,7 +3800,7 @@ static void mine_ride_track_diag_flat(
 
 /** rct2: 0x008B0C30 */
 static void mine_ride_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3876,7 +3876,7 @@ static void mine_ride_track_diag_25_deg_up(
 
 /** rct2: 0x008B0C10 */
 static void mine_ride_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3952,7 +3952,7 @@ static void mine_ride_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008B0C20 */
 static void mine_ride_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4028,7 +4028,7 @@ static void mine_ride_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008B0C60 */
 static void mine_ride_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4104,7 +4104,7 @@ static void mine_ride_track_diag_25_deg_down(
 
 /** rct2: 0x008B0C40 */
 static void mine_ride_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4178,7 +4178,7 @@ static void mine_ride_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008B0C50 */
 static void mine_ride_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4254,7 +4254,7 @@ static void mine_ride_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008B0C90 */
 static void mine_ride_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4333,7 +4333,7 @@ static void mine_ride_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008B0CA0 */
 static void mine_ride_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4412,7 +4412,7 @@ static void mine_ride_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008B0CB0 */
 static void mine_ride_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4491,7 +4491,7 @@ static void mine_ride_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008B0CC0 */
 static void mine_ride_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4570,7 +4570,7 @@ static void mine_ride_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008B0CF0 */
 static void mine_ride_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4649,7 +4649,7 @@ static void mine_ride_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008B0D00 */
 static void mine_ride_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4728,7 +4728,7 @@ static void mine_ride_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008B0CD0 */
 static void mine_ride_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4807,7 +4807,7 @@ static void mine_ride_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008B0CE0 */
 static void mine_ride_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4886,7 +4886,7 @@ static void mine_ride_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008B0D10 */
 static void mine_ride_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4963,7 +4963,7 @@ static void mine_ride_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008B0D20 */
 static void mine_ride_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5040,7 +5040,7 @@ static void mine_ride_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008B0D30 */
 static void mine_ride_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5119,7 +5119,7 @@ static void mine_ride_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008B0D40 */
 static void mine_ride_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5198,7 +5198,7 @@ static void mine_ride_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008B0C70 */
 static void mine_ride_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5274,7 +5274,7 @@ static void mine_ride_track_diag_left_bank(
 
 /** rct2: 0x008B0C80 */
 static void mine_ride_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/MineRide.cpp
+++ b/src/openrct2/ride/coaster/MineRide.cpp
@@ -69,7 +69,7 @@ static void mine_ride_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _MineTrainBlockBrakeImages[NumOrthogonalDirectio
 
 /** rct2: 0x0071BFA4 */
 static void mine_train_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -86,7 +86,7 @@ static void mine_train_rc_track_flat(
 
 /** rct2: 0x0071C154, 0x0071C164, 0x0071C174 */
 static void mine_train_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -113,7 +113,7 @@ static void mine_train_rc_track_station(
             height);
     }
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -121,7 +121,7 @@ static void mine_train_rc_track_station(
 
 /** rct2: 0x0071BFB4 */
 static void mine_train_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -190,7 +190,7 @@ static void mine_train_rc_track_25_deg_up(
 
 /** rct2: 0x0071BFC4 */
 static void mine_train_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -230,7 +230,7 @@ static void mine_train_rc_track_60_deg_up(
 
 /** rct2: 0x0071BFD4 */
 static void mine_train_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -299,7 +299,7 @@ static void mine_train_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x0071BFE4 */
 static void mine_train_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -343,7 +343,7 @@ static void mine_train_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0071BFF4 */
 static void mine_train_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -387,7 +387,7 @@ static void mine_train_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0071C004 */
 static void mine_train_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -456,7 +456,7 @@ static void mine_train_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0071C014 */
 static void mine_train_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -464,7 +464,7 @@ static void mine_train_rc_track_25_deg_down(
 
 /** rct2: 0x0071C024 */
 static void mine_train_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -472,7 +472,7 @@ static void mine_train_rc_track_60_deg_down(
 
 /** rct2: 0x0071C034 */
 static void mine_train_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -480,7 +480,7 @@ static void mine_train_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x0071C044 */
 static void mine_train_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -488,7 +488,7 @@ static void mine_train_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x0071C054 */
 static void mine_train_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -496,7 +496,7 @@ static void mine_train_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x0071C064 */
 static void mine_train_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -504,7 +504,7 @@ static void mine_train_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x0071C0B4 */
 static void mine_train_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -692,7 +692,7 @@ static void mine_train_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x0071C0C4 */
 static void mine_train_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -701,7 +701,7 @@ static void mine_train_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x0071C074 */
 static void mine_train_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -738,7 +738,7 @@ static void mine_train_rc_track_flat_to_left_bank(
 
 /** rct2: 0x0071C084 */
 static void mine_train_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -775,7 +775,7 @@ static void mine_train_rc_track_flat_to_right_bank(
 
 /** rct2: 0x0071C094 */
 static void mine_train_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -812,7 +812,7 @@ static void mine_train_rc_track_left_bank_to_flat(
 
 /** rct2: 0x0071C0A4 */
 static void mine_train_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -849,7 +849,7 @@ static void mine_train_rc_track_right_bank_to_flat(
 
 /** rct2: 0x0071C0D4 */
 static void mine_train_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1047,7 +1047,7 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x0071C0E4 */
 static void mine_train_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1056,7 +1056,7 @@ static void mine_train_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x0071C204 */
 static void mine_train_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1100,7 +1100,7 @@ static void mine_train_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x0071C214 */
 static void mine_train_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1144,7 +1144,7 @@ static void mine_train_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x0071C224 */
 static void mine_train_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1188,7 +1188,7 @@ static void mine_train_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x0071C234 */
 static void mine_train_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1232,7 +1232,7 @@ static void mine_train_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x0071C244 */
 static void mine_train_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1240,7 +1240,7 @@ static void mine_train_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x0071C254 */
 static void mine_train_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1248,7 +1248,7 @@ static void mine_train_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x0071C264 */
 static void mine_train_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1256,7 +1256,7 @@ static void mine_train_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x0071C274 */
 static void mine_train_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1264,7 +1264,7 @@ static void mine_train_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x0071C304 */
 static void mine_train_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1297,7 +1297,7 @@ static void mine_train_rc_track_left_bank(
 
 /** rct2: 0x0071C314 */
 static void mine_train_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1305,7 +1305,7 @@ static void mine_train_rc_track_right_bank(
 
 /** rct2: 0x0071C0F4 */
 static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1493,7 +1493,7 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x0071C104 */
 static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1681,7 +1681,7 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x0071C114 */
 static void mine_train_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1690,7 +1690,7 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x0071C124 */
 static void mine_train_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1699,7 +1699,7 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x0071C134 */
 static void mine_train_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1838,7 +1838,7 @@ static void mine_train_rc_track_s_bend_left(
 
 /** rct2: 0x0071C144 */
 static void mine_train_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1977,7 +1977,7 @@ static void mine_train_rc_track_s_bend_right(
 
 /** rct2: 0x0071C184 */
 static void mine_train_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2099,7 +2099,7 @@ static void mine_train_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x0071C194 */
 static void mine_train_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2108,7 +2108,7 @@ static void mine_train_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x0071C1A4 */
 static void mine_train_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2239,7 +2239,7 @@ static void mine_train_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x0071C1B4 */
 static void mine_train_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2248,7 +2248,7 @@ static void mine_train_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x0071C1C4 */
 static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2348,7 +2348,7 @@ static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0071C1D4 */
 static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2448,7 +2448,7 @@ static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0071C1E4 */
 static void mine_train_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2457,7 +2457,7 @@ static void mine_train_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x0071C1F4 */
 static void mine_train_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2466,7 +2466,7 @@ static void mine_train_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x0071C284 */
 static void mine_train_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2734,7 +2734,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x0071C294 */
 static void mine_train_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3002,7 +3002,7 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x0071C2A4 */
 static void mine_train_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3017,7 +3017,7 @@ static void mine_train_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x0071C2B4 */
 static void mine_train_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3032,7 +3032,7 @@ static void mine_train_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x0071C2C4 */
 static void mine_train_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3442,7 +3442,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x0071C2D4 */
 static void mine_train_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3840,7 +3840,7 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x0071C2E4 */
 static void mine_train_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3855,7 +3855,7 @@ static void mine_train_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x0071C2F4 */
 static void mine_train_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3870,7 +3870,7 @@ static void mine_train_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x0071C324 */
 static void mine_train_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3895,7 +3895,7 @@ static void mine_train_rc_track_brakes(
 
 /** rct2: 0x0071C334 */
 static void mine_train_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3929,7 +3929,7 @@ static void mine_train_rc_track_on_ride_photo(
 
 /** rct2: 0x0071C354 */
 static void mine_train_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4074,7 +4074,7 @@ static void mine_train_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x0071C364 */
 static void mine_train_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4218,7 +4218,7 @@ static void mine_train_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x0071C374 */
 static void mine_train_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4227,7 +4227,7 @@ static void mine_train_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x0071C384 */
 static void mine_train_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4236,7 +4236,7 @@ static void mine_train_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x0071C394 */
 static void mine_train_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4384,7 +4384,7 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x0071C3A4 */
 static void mine_train_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4532,7 +4532,7 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x0071C3B4 */
 static void mine_train_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4541,7 +4541,7 @@ static void mine_train_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x0071C3C4 */
 static void mine_train_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4550,7 +4550,7 @@ static void mine_train_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x0071C344 */
 static void mine_train_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4704,7 +4704,7 @@ static void mine_train_rc_track_diag_flat(
 
 /** rct2: 0x0071C414 */
 static void mine_train_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4858,7 +4858,7 @@ static void mine_train_rc_track_diag_25_deg_up(
 
 /** rct2: 0x0071C474 */
 static void mine_train_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4936,7 +4936,7 @@ static void mine_train_rc_track_diag_60_deg_up(
 
 /** rct2: 0x0071C3F4 */
 static void mine_train_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5090,7 +5090,7 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x0071C454 */
 static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5168,7 +5168,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0071C464 */
 static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5246,7 +5246,7 @@ static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0071C404 */
 static void mine_train_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5400,7 +5400,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x0071C444 */
 static void mine_train_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5554,7 +5554,7 @@ static void mine_train_rc_track_diag_25_deg_down(
 
 /** rct2: 0x0071C4A4 */
 static void mine_train_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5632,7 +5632,7 @@ static void mine_train_rc_track_diag_60_deg_down(
 
 /** rct2: 0x0071C424 */
 static void mine_train_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5784,7 +5784,7 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x0071C484 */
 static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5862,7 +5862,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x0071C494 */
 static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5940,7 +5940,7 @@ static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x0071C434 */
 static void mine_train_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6094,7 +6094,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x0071C4D4 */
 static void mine_train_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6175,7 +6175,7 @@ static void mine_train_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x0071C4B4 */
 static void mine_train_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6256,7 +6256,7 @@ static void mine_train_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x0071C4C4 */
 static void mine_train_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6337,7 +6337,7 @@ static void mine_train_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x0071C4E4 */
 static void mine_train_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6418,7 +6418,7 @@ static void mine_train_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x0071C514 */
 static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6499,7 +6499,7 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x0071C524 */
 static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6580,7 +6580,7 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x0071C4F4 */
 static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6661,7 +6661,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x0071C504 */
 static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6742,7 +6742,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x0071C534 */
 static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6818,7 +6818,7 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x0071C544 */
 static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6894,7 +6894,7 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x0071C554 */
 static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6975,7 +6975,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x0071C564 */
 static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7056,7 +7056,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x0071C3D4 */
 static void mine_train_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7138,7 +7138,7 @@ static void mine_train_rc_track_diag_left_bank(
 
 /** rct2: 0x0071C3E4 */
 static void mine_train_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7220,7 +7220,7 @@ static void mine_train_rc_track_diag_right_bank(
 
 /** rct2: 0x0071C574 */
 static void mine_train_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -113,7 +113,7 @@ static void mine_train_rc_track_station(
             height);
     }
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _MiniRCBlockBrakeImages[NumOrthogonalDirections]
 
 /** rct2: 0x008A4ABC */
 static void mini_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -110,7 +110,7 @@ static void mini_rc_track_flat(
 }
 
 static void mini_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -136,7 +136,7 @@ static void mini_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -144,7 +144,7 @@ static void mini_rc_track_station(
 
 /** rct2: 0x008A4ACC */
 static void mini_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -246,7 +246,7 @@ static void mini_rc_track_25_deg_up(
 
 /** rct2: 0x008A4ADC */
 static void mini_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -303,7 +303,7 @@ static void mini_rc_track_60_deg_up(
 
 /** rct2: 0x008A4AEC */
 static void mini_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -405,7 +405,7 @@ static void mini_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A4AFC */
 static void mini_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -466,7 +466,7 @@ static void mini_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A4B0C */
 static void mini_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -527,7 +527,7 @@ static void mini_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A4B1C */
 static void mini_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -629,7 +629,7 @@ static void mini_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A4B2C */
 static void mini_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -637,7 +637,7 @@ static void mini_rc_track_25_deg_down(
 
 /** rct2: 0x008A4B3C */
 static void mini_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -645,7 +645,7 @@ static void mini_rc_track_60_deg_down(
 
 /** rct2: 0x008A4B4C */
 static void mini_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -653,7 +653,7 @@ static void mini_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A4B5C */
 static void mini_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -661,7 +661,7 @@ static void mini_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A4B6C */
 static void mini_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -669,7 +669,7 @@ static void mini_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A4B7C */
 static void mini_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -677,7 +677,7 @@ static void mini_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A4B8C */
 static void mini_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -855,7 +855,7 @@ static void mini_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A4B9C */
 static void mini_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -864,7 +864,7 @@ static void mini_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A4BAC */
 static void mini_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -918,7 +918,7 @@ static void mini_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A4BBC */
 static void mini_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -972,7 +972,7 @@ static void mini_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A4BCC */
 static void mini_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1026,7 +1026,7 @@ static void mini_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A4BDC */
 static void mini_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1080,7 +1080,7 @@ static void mini_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A4BEC */
 static void mini_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1268,7 +1268,7 @@ static void mini_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A4BFC */
 static void mini_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1277,7 +1277,7 @@ static void mini_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008A4C0C */
 static void mini_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1338,7 +1338,7 @@ static void mini_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A4C1C */
 static void mini_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1399,7 +1399,7 @@ static void mini_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A4C2C */
 static void mini_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1460,7 +1460,7 @@ static void mini_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A4C3C */
 static void mini_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1521,7 +1521,7 @@ static void mini_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A4C4C */
 static void mini_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1529,7 +1529,7 @@ static void mini_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A4C5C */
 static void mini_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1537,7 +1537,7 @@ static void mini_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A4C6C */
 static void mini_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1545,7 +1545,7 @@ static void mini_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A4C7C */
 static void mini_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1553,7 +1553,7 @@ static void mini_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A4C8C */
 static void mini_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1603,7 +1603,7 @@ static void mini_rc_track_left_bank(
 
 /** rct2: 0x008A4C9C */
 static void mini_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1611,7 +1611,7 @@ static void mini_rc_track_right_bank(
 
 /** rct2: 0x008A4CAC */
 static void mini_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1789,7 +1789,7 @@ static void mini_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A4CBC */
 static void mini_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1967,7 +1967,7 @@ static void mini_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A4CCC */
 static void mini_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1976,7 +1976,7 @@ static void mini_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A4CDC */
 static void mini_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1985,7 +1985,7 @@ static void mini_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A4CEC */
 static void mini_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2134,7 +2134,7 @@ static void mini_rc_track_s_bend_left(
 
 /** rct2: 0x008A4CFC */
 static void mini_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2283,7 +2283,7 @@ static void mini_rc_track_s_bend_right(
 
 /** rct2: 0x008A4D3C */
 static void mini_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2400,7 +2400,7 @@ static void mini_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A4D4C */
 static void mini_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2409,7 +2409,7 @@ static void mini_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A4D5C */
 static void mini_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2535,7 +2535,7 @@ static void mini_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A4D6C */
 static void mini_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2544,7 +2544,7 @@ static void mini_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008A4D7C */
 static void mini_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2637,7 +2637,7 @@ static void mini_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A4D8C */
 static void mini_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2730,7 +2730,7 @@ static void mini_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A4D9C */
 static void mini_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2739,7 +2739,7 @@ static void mini_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A4DAC */
 static void mini_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2748,7 +2748,7 @@ static void mini_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A4DBC */
 static void mini_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2994,7 +2994,7 @@ static void mini_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A4DCC */
 static void mini_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3240,7 +3240,7 @@ static void mini_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A4DDC */
 static void mini_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3254,7 +3254,7 @@ static void mini_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008A4DEC */
 static void mini_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3268,7 +3268,7 @@ static void mini_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008A4DFC */
 static void mini_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3638,7 +3638,7 @@ static void mini_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A4E0C */
 static void mini_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4008,7 +4008,7 @@ static void mini_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A4E1C */
 static void mini_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4022,7 +4022,7 @@ static void mini_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008A4E2C */
 static void mini_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4036,7 +4036,7 @@ static void mini_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008A4E5C */
 static void mini_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4073,7 +4073,7 @@ static void mini_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A4E3C */
 static void mini_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4110,7 +4110,7 @@ static void mini_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A4E4C */
 static void mini_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4118,7 +4118,7 @@ static void mini_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A4E6C */
 static void mini_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4126,7 +4126,7 @@ static void mini_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A4E7C */
 static void mini_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4160,7 +4160,7 @@ static void mini_rc_track_brakes(
 
 /** rct2: 0x008A50CC */
 static void mini_rc_track_25_deg_up_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4217,7 +4217,7 @@ static void mini_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008A50DC */
 static void mini_rc_track_25_deg_up_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4274,7 +4274,7 @@ static void mini_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008A4E8C */
 static void mini_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4320,7 +4320,7 @@ static void mini_rc_track_on_ride_photo(
 
 /** rct2: 0x008A50EC */
 static void mini_rc_track_25_deg_down_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4328,7 +4328,7 @@ static void mini_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x008A50FC */
 static void mini_rc_track_25_deg_down_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4336,7 +4336,7 @@ static void mini_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x008A4EAC */
 static void mini_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4482,7 +4482,7 @@ static void mini_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A4EBC */
 static void mini_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4627,7 +4627,7 @@ static void mini_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A4ECC */
 static void mini_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4636,7 +4636,7 @@ static void mini_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A4EDC */
 static void mini_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4645,7 +4645,7 @@ static void mini_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A4EEC */
 static void mini_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4794,7 +4794,7 @@ static void mini_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A4EFC */
 static void mini_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4943,7 +4943,7 @@ static void mini_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A4F0C */
 static void mini_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4952,7 +4952,7 @@ static void mini_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A4F1C */
 static void mini_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4961,7 +4961,7 @@ static void mini_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A4E9C */
 static void mini_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5107,7 +5107,7 @@ static void mini_rc_track_diag_flat(
 
 /** rct2: 0x008A4F4C */
 static void mini_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5253,7 +5253,7 @@ static void mini_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A4FAC */
 static void mini_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5329,7 +5329,7 @@ static void mini_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A4F2C */
 static void mini_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5475,7 +5475,7 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A4F8C */
 static void mini_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5551,7 +5551,7 @@ static void mini_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A4F9C */
 static void mini_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5627,7 +5627,7 @@ static void mini_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A4F3C */
 static void mini_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5773,7 +5773,7 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A4F7C */
 static void mini_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5919,7 +5919,7 @@ static void mini_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A4FDC */
 static void mini_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5995,7 +5995,7 @@ static void mini_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A4F5C */
 static void mini_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6139,7 +6139,7 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A4FBC */
 static void mini_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6215,7 +6215,7 @@ static void mini_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A4FCC */
 static void mini_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6291,7 +6291,7 @@ static void mini_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A4F6C */
 static void mini_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6437,7 +6437,7 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A500C */
 static void mini_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6516,7 +6516,7 @@ static void mini_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A501C */
 static void mini_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6595,7 +6595,7 @@ static void mini_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A502C */
 static void mini_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6674,7 +6674,7 @@ static void mini_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A503C */
 static void mini_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6753,7 +6753,7 @@ static void mini_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A506C */
 static void mini_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6832,7 +6832,7 @@ static void mini_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A507C */
 static void mini_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6911,7 +6911,7 @@ static void mini_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A504C */
 static void mini_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6990,7 +6990,7 @@ static void mini_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A505C */
 static void mini_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7069,7 +7069,7 @@ static void mini_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A508C */
 static void mini_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7146,7 +7146,7 @@ static void mini_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A509C */
 static void mini_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7223,7 +7223,7 @@ static void mini_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A50AC */
 static void mini_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7302,7 +7302,7 @@ static void mini_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A50BC */
 static void mini_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7381,7 +7381,7 @@ static void mini_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A4FEC */
 static void mini_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7457,7 +7457,7 @@ static void mini_rc_track_diag_left_bank(
 
 /** rct2: 0x008A4FFC */
 static void mini_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7533,7 +7533,7 @@ static void mini_rc_track_diag_right_bank(
 
 /** rct2: 0x008A530C */
 static void mini_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -7567,7 +7567,7 @@ static void mini_rc_track_block_brakes(
 
 /** rct2: 0x008A510C */
 static void mini_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7663,7 +7663,7 @@ static void mini_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A511C */
 static void mini_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7759,7 +7759,7 @@ static void mini_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A512C */
 static void mini_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7769,7 +7769,7 @@ static void mini_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A513C */
 static void mini_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7778,7 +7778,7 @@ static void mini_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A514C */
 static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7962,7 +7962,7 @@ static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A515C */
 static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8146,7 +8146,7 @@ static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A516C */
 static void mini_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8156,7 +8156,7 @@ static void mini_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A517C */
 static void mini_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8165,7 +8165,7 @@ static void mini_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A518C */
 static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8224,7 +8224,7 @@ static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A519C */
 static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8283,7 +8283,7 @@ static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A51AC */
 static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8342,7 +8342,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A51BC */
 static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8401,7 +8401,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A51CC */
 static void mini_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8409,7 +8409,7 @@ static void mini_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A51DC */
 static void mini_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8417,7 +8417,7 @@ static void mini_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A51EC */
 static void mini_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8425,7 +8425,7 @@ static void mini_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A51FC */
 static void mini_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8433,7 +8433,7 @@ static void mini_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A520C */
 static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8490,7 +8490,7 @@ static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A521C */
 static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8547,7 +8547,7 @@ static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A524C */
 static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8604,7 +8604,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008A525C */
 static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8661,7 +8661,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008A526C */
 static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -8670,7 +8670,7 @@ static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A527C */
 static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -8679,7 +8679,7 @@ static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A522C */
 static void mini_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -8688,7 +8688,7 @@ static void mini_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x008A523C */
 static void mini_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -8697,7 +8697,7 @@ static void mini_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x008A528C */
 static void mini_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8756,7 +8756,7 @@ static void mini_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A529C */
 static void mini_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8815,7 +8815,7 @@ static void mini_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A52AC */
 static void mini_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8874,7 +8874,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A52BC */
 static void mini_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8933,7 +8933,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A52CC */
 static void mini_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8941,7 +8941,7 @@ static void mini_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A52DC */
 static void mini_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8949,7 +8949,7 @@ static void mini_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A52EC */
 static void mini_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8957,14 +8957,14 @@ static void mini_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x008A52FC */
 static void mini_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void mini_rc_track_left_curved_lift_hill(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9056,7 +9056,7 @@ static void mini_rc_track_left_curved_lift_hill(
 }
 
 static void mini_rc_track_right_curved_lift_hill(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9148,7 +9148,7 @@ static void mini_rc_track_right_curved_lift_hill(
 }
 
 static void mini_rc_track_booster(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     // These offsets could be moved to the g2.dat file when that supports offsets.

--- a/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
@@ -136,7 +136,7 @@ static void mini_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008AFE9C */
 static void mini_suspended_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -81,7 +81,7 @@ static void mini_suspended_rc_track_flat(
 
 /** rct2: 0x008AFF4C, 0x008AFF5C, 0x008AFF6C */
 static void mini_suspended_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -99,7 +99,7 @@ static void mini_suspended_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24, 0, 2,
         height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_1);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -107,7 +107,7 @@ static void mini_suspended_rc_track_station(
 
 /** rct2: 0x008AFEAC */
 static void mini_suspended_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -201,7 +201,7 @@ static void mini_suspended_rc_track_25_deg_up(
 
 /** rct2: 0x008AFEBC */
 static void mini_suspended_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -295,7 +295,7 @@ static void mini_suspended_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AFECC */
 static void mini_suspended_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -389,7 +389,7 @@ static void mini_suspended_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AFEDC */
 static void mini_suspended_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_suspended_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -397,7 +397,7 @@ static void mini_suspended_rc_track_25_deg_down(
 
 /** rct2: 0x008AFEEC */
 static void mini_suspended_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_suspended_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -405,7 +405,7 @@ static void mini_suspended_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AFEFC */
 static void mini_suspended_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_suspended_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -413,7 +413,7 @@ static void mini_suspended_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008AFF0C */
 static void mini_suspended_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -600,7 +600,7 @@ static void mini_suspended_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AFF1C */
 static void mini_suspended_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -609,7 +609,7 @@ static void mini_suspended_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008AFF2C */
 static void mini_suspended_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -790,7 +790,7 @@ static void mini_suspended_rc_track_s_bend_left(
 
 /** rct2: 0x008AFF3C */
 static void mini_suspended_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -971,7 +971,7 @@ static void mini_suspended_rc_track_s_bend_right(
 
 /** rct2: 0x008AFF7C */
 static void mini_suspended_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1101,7 +1101,7 @@ static void mini_suspended_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AFF8C */
 static void mini_suspended_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1110,7 +1110,7 @@ static void mini_suspended_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008AFFAC */
 static void mini_suspended_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1284,7 +1284,7 @@ static void mini_suspended_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008AFFBC */
 static void mini_suspended_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1458,7 +1458,7 @@ static void mini_suspended_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008AFFCC */
 static void mini_suspended_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1467,7 +1467,7 @@ static void mini_suspended_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008AFFDC */
 static void mini_suspended_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1476,7 +1476,7 @@ static void mini_suspended_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008AFF9C */
 static void mini_suspended_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1615,7 +1615,7 @@ static void mini_suspended_rc_track_diag_flat(
 
 /** rct2: 0x008B000C */
 static void mini_suspended_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1754,7 +1754,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008AFFEC */
 static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1893,7 +1893,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AFFFC */
 static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2032,7 +2032,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008B003C */
 static void mini_suspended_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2171,7 +2171,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008B001C */
 static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2307,7 +2307,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008B002C */
 static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
@@ -99,7 +99,7 @@ static void mini_suspended_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 1, height + 24, 0, 2,
         height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
+    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_1);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -149,23 +149,23 @@ static void multi_dimension_rc_track_station(
     bool hasFence;
     if (direction == 0 || direction == 2)
     {
-        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, stationObj, height);
         }
         else
         {
-            hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, session->CurrentRotation);
+            hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
             track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, stationObj, height);
         }
 
         if (direction == 0 || direction == 2)
         {
-            hasFence = track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation);
+            hasFence = track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
             track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, stationObj, height);
         }
         else
         {
-            hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
+            hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
             track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, stationObj, height);
         }
 

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -151,23 +151,23 @@ static void multi_dimension_rc_track_station(
     {
         hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, stationObj, height);
-        }
-        else
-        {
-            hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, session->CurrentRotation);
-            track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, stationObj, height);
-        }
+    }
+    else
+    {
+        hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, stationObj, height);
+    }
 
-        if (direction == 0 || direction == 2)
-        {
-            hasFence = track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation);
-            track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, stationObj, height);
-        }
-        else
-        {
-            hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
-            track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, stationObj, height);
-        }
+    if (direction == 0 || direction == 2)
+    {
+        hasFence = track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, stationObj, height);
+    }
+    else
+    {
+        hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, stationObj, height);
+    }
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -145,14 +145,12 @@ static void multi_dimension_rc_track_station(
     }
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
 
-    if (ride != nullptr)
+    const auto stationObj = ride->GetStationObject();
+    bool hasFence;
+    if (direction == 0 || direction == 2)
     {
-        auto stationObj = ride->GetStationObject();
-        bool hasFence;
-        if (direction == 0 || direction == 2)
-        {
-            hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
-            track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, stationObj, height);
+        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, stationObj, height);
         }
         else
         {
@@ -170,7 +168,6 @@ static void multi_dimension_rc_track_station(
             hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
             track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, stationObj, height);
         }
-    }
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -145,7 +145,7 @@ static void multi_dimension_rc_track_station(
     }
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
 
-    const auto stationObj = ride.GetStationObject();
+    const auto* stationObj = ride.GetStationObject();
     bool hasFence;
     if (direction == 0 || direction == 2)
     {

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -35,7 +35,7 @@ static constexpr const uint32_t MULTI_DIM_INVERTED_BLOCK_BRAKE_NW_SE_CLOSED = 26
 
 /** rct2: 0x00792D88 */
 static void multi_dimension_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -119,7 +119,7 @@ static void multi_dimension_rc_track_flat(
 
 /** rct2: 0x00792F98, 0x00792FA8, 0x00792FB8 */
 static void multi_dimension_rc_track_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[NumOrthogonalDirections][3] = {
@@ -145,27 +145,27 @@ static void multi_dimension_rc_track_station(
     }
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 11);
 
-    const auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride.GetStationObject();
     bool hasFence;
     if (direction == 0 || direction == 2)
     {
-        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, stationObj, height);
         }
         else
         {
-            hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+            hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, session->CurrentRotation);
             track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, stationObj, height);
         }
 
         if (direction == 0 || direction == 2)
         {
-            hasFence = track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+            hasFence = track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation);
             track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, stationObj, height);
         }
         else
         {
-            hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+            hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
             track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, stationObj, height);
         }
 
@@ -176,7 +176,7 @@ static void multi_dimension_rc_track_station(
 
 /** rct2: 0x00792D98 */
 static void multi_dimension_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -311,7 +311,7 @@ static void multi_dimension_rc_track_25_deg_up(
 
 /** rct2: 0x00792DA8 */
 static void multi_dimension_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -392,7 +392,7 @@ static void multi_dimension_rc_track_60_deg_up(
 
 /** rct2: 0x00792DB8 */
 static void multi_dimension_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -527,7 +527,7 @@ static void multi_dimension_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x00792DC8 */
 static void multi_dimension_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -618,7 +618,7 @@ static void multi_dimension_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x00792DD8 */
 static void multi_dimension_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -733,7 +733,7 @@ static void multi_dimension_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00792DE8 */
 static void multi_dimension_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -868,7 +868,7 @@ static void multi_dimension_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x00792DF8 */
 static void multi_dimension_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -876,7 +876,7 @@ static void multi_dimension_rc_track_25_deg_down(
 
 /** rct2: 0x00792E08 */
 static void multi_dimension_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -884,7 +884,7 @@ static void multi_dimension_rc_track_60_deg_down(
 
 /** rct2: 0x00792E18 */
 static void multi_dimension_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -892,7 +892,7 @@ static void multi_dimension_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x00792E28 */
 static void multi_dimension_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -900,7 +900,7 @@ static void multi_dimension_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x00792E38 */
 static void multi_dimension_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -908,7 +908,7 @@ static void multi_dimension_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x00792E48 */
 static void multi_dimension_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -916,7 +916,7 @@ static void multi_dimension_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x00792E58 */
 static void multi_dimension_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1283,7 +1283,7 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x00792E68 */
 static void multi_dimension_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1292,7 +1292,7 @@ static void multi_dimension_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x00792E78 */
 static void multi_dimension_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1372,7 +1372,7 @@ static void multi_dimension_rc_track_flat_to_left_bank(
 
 /** rct2: 0x00792E88 */
 static void multi_dimension_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1452,7 +1452,7 @@ static void multi_dimension_rc_track_flat_to_right_bank(
 
 /** rct2: 0x00792E98 */
 static void multi_dimension_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1532,7 +1532,7 @@ static void multi_dimension_rc_track_left_bank_to_flat(
 
 /** rct2: 0x00792EA8 */
 static void multi_dimension_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1612,7 +1612,7 @@ static void multi_dimension_rc_track_right_bank_to_flat(
 
 /** rct2: 0x00792EB8 */
 static void multi_dimension_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1980,7 +1980,7 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x00792EC8 */
 static void multi_dimension_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1990,7 +1990,7 @@ static void multi_dimension_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x00792ED8 */
 static void multi_dimension_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2101,7 +2101,7 @@ static void multi_dimension_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x00792EE8 */
 static void multi_dimension_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2212,7 +2212,7 @@ static void multi_dimension_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x00792EF8 */
 static void multi_dimension_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2323,7 +2323,7 @@ static void multi_dimension_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x00792F08 */
 static void multi_dimension_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2434,7 +2434,7 @@ static void multi_dimension_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x00792F18 */
 static void multi_dimension_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2442,7 +2442,7 @@ static void multi_dimension_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x00792F28 */
 static void multi_dimension_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2450,7 +2450,7 @@ static void multi_dimension_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x00792F38 */
 static void multi_dimension_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2458,7 +2458,7 @@ static void multi_dimension_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x00792F48 */
 static void multi_dimension_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2466,7 +2466,7 @@ static void multi_dimension_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x00792F58 */
 static void multi_dimension_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2542,7 +2542,7 @@ static void multi_dimension_rc_track_left_bank(
 
 /** rct2: 0x00792F68 */
 static void multi_dimension_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2550,7 +2550,7 @@ static void multi_dimension_rc_track_right_bank(
 
 /** rct2: 0x00792F78 */
 static void multi_dimension_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2865,7 +2865,7 @@ static void multi_dimension_rc_track_s_bend_left(
 
 /** rct2: 0x00792F88 */
 static void multi_dimension_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3180,7 +3180,7 @@ static void multi_dimension_rc_track_s_bend_right(
 
 /** rct2: 0x00792FC8 */
 static void multi_dimension_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3417,7 +3417,7 @@ static void multi_dimension_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x00792FD8 */
 static void multi_dimension_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3426,7 +3426,7 @@ static void multi_dimension_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x00792FE8 */
 static void multi_dimension_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3669,7 +3669,7 @@ static void multi_dimension_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x00792FF8 */
 static void multi_dimension_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3678,7 +3678,7 @@ static void multi_dimension_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x00793008 */
 static void multi_dimension_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3894,7 +3894,7 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x00793018 */
 static void multi_dimension_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4110,7 +4110,7 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x00793028 */
 static void multi_dimension_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -4125,7 +4125,7 @@ static void multi_dimension_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x00793038 */
 static void multi_dimension_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -4140,7 +4140,7 @@ static void multi_dimension_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x00793048 */
 static void multi_dimension_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4480,7 +4480,7 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x00793058 */
 static void multi_dimension_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4820,7 +4820,7 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x00793068 */
 static void multi_dimension_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4835,7 +4835,7 @@ static void multi_dimension_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x00793078 */
 static void multi_dimension_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4850,7 +4850,7 @@ static void multi_dimension_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x00793088 */
 static void multi_dimension_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4910,7 +4910,7 @@ static void multi_dimension_rc_track_brakes(
 
 /** rct2: 0x00793098 */
 static void multi_dimension_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5021,7 +5021,7 @@ static void multi_dimension_rc_track_on_ride_photo(
 
 /** rct2: 0x00793328 */
 static void multi_dimension_rc_track_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5102,7 +5102,7 @@ static void multi_dimension_rc_track_90_deg_up(
 
 /** rct2: 0x00793338 */
 static void multi_dimension_rc_track_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5110,7 +5110,7 @@ static void multi_dimension_rc_track_90_deg_down(
 
 /** rct2: 0x00793348 */
 static void multi_dimension_rc_track_60_deg_up_to_90_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5199,7 +5199,7 @@ static void multi_dimension_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x00793358 */
 static void multi_dimension_rc_track_90_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5207,7 +5207,7 @@ static void multi_dimension_rc_track_90_deg_down_to_60_deg_down(
 
 /** rct2: 0x00793368 */
 static void multi_dimension_rc_track_90_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5288,7 +5288,7 @@ static void multi_dimension_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x00793378 */
 static void multi_dimension_rc_track_60_deg_down_to_90_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5375,7 +5375,7 @@ static void multi_dimension_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x007930B8 */
 static void multi_dimension_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5680,7 +5680,7 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x007930C8 */
 static void multi_dimension_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5985,7 +5985,7 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x007930D8 */
 static void multi_dimension_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5994,7 +5994,7 @@ static void multi_dimension_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x007930E8 */
 static void multi_dimension_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6003,7 +6003,7 @@ static void multi_dimension_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x007930F8 */
 static void multi_dimension_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6309,7 +6309,7 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x00793108 */
 static void multi_dimension_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6615,7 +6615,7 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x00793118 */
 static void multi_dimension_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6624,7 +6624,7 @@ static void multi_dimension_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x00793128 */
 static void multi_dimension_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6633,7 +6633,7 @@ static void multi_dimension_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x007930A8 */
 static void multi_dimension_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6925,7 +6925,7 @@ static void multi_dimension_rc_track_diag_flat(
 
 /** rct2: 0x00793158 */
 static void multi_dimension_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7217,7 +7217,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
 
 /** rct2: 0x007931B8 */
 static void multi_dimension_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7383,7 +7383,7 @@ static void multi_dimension_rc_track_diag_60_deg_up(
 
 /** rct2: 0x00793138 */
 static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7675,7 +7675,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x00793198 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7841,7 +7841,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x007931A8 */
 static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8007,7 +8007,7 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00793148 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8299,7 +8299,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x00793188 */
 static void multi_dimension_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8535,7 +8535,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
 
 /** rct2: 0x007931E8 */
 static void multi_dimension_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8701,7 +8701,7 @@ static void multi_dimension_rc_track_diag_60_deg_down(
 
 /** rct2: 0x00793168 */
 static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8933,7 +8933,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x007931C8 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9099,7 +9099,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x007931D8 */
 static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9265,7 +9265,7 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x00793178 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9501,7 +9501,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x00793218 */
 static void multi_dimension_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9671,7 +9671,7 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x00793228 */
 static void multi_dimension_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9841,7 +9841,7 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x00793238 */
 static void multi_dimension_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10011,7 +10011,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x00793248 */
 static void multi_dimension_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10181,7 +10181,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x00793278 */
 static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10350,7 +10350,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x00793288 */
 static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10519,7 +10519,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x00793258 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10688,7 +10688,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x00793268 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10857,7 +10857,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x00793298 */
 static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11019,7 +11019,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x007932A8 */
 static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11181,7 +11181,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x007932B8 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11350,7 +11350,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x007932C8 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11519,7 +11519,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x007931F8 */
 static void multi_dimension_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11686,7 +11686,7 @@ static void multi_dimension_rc_track_diag_left_bank(
 
 /** rct2: 0x00793208 */
 static void multi_dimension_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11853,7 +11853,7 @@ static void multi_dimension_rc_track_diag_right_bank(
 
 /** rct2: 0x007932D8 */
 static void multi_dimension_rc_track_left_flyer_twist_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11965,7 +11965,7 @@ static void multi_dimension_rc_track_left_flyer_twist_up(
 
 /** rct2: 0x007932E8 */
 static void multi_dimension_rc_track_right_flyer_twist_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12075,7 +12075,7 @@ static void multi_dimension_rc_track_right_flyer_twist_up(
 
 /** rct2: 0x007932F8 */
 static void multi_dimension_rc_track_left_flyer_twist_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12187,7 +12187,7 @@ static void multi_dimension_rc_track_left_flyer_twist_down(
 
 /** rct2: 0x00793308 */
 static void multi_dimension_rc_track_right_flyer_twist_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12297,7 +12297,7 @@ static void multi_dimension_rc_track_right_flyer_twist_down(
 
 /** rct2: 0x00793398 */
 static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12496,7 +12496,7 @@ static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_lo
 
 /** rct2: 0x00793318 */
 static void multi_dimension_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -12547,7 +12547,7 @@ static void multi_dimension_rc_track_block_brakes(
 
 /** rct2: 0x00793388 */
 static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12742,7 +12742,7 @@ static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter
 
 /** rct2: 0x00793398 */
 static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12941,7 +12941,7 @@ static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
 
 /** rct2: 0x00793388 */
 static void multi_dimension_rc_track_multidim_inverted_90_deg_up_to_flat_quarter_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())

--- a/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
@@ -250,7 +250,6 @@ static void paint_reverse_freefall_rc_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 5, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
@@ -196,7 +196,7 @@ static constexpr const uint32_t reverse_freefall_rc_track_pieces_vertical_suppor
 };
 
 static void paint_reverse_freefall_rc_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction & 1)
@@ -218,7 +218,7 @@ static void paint_reverse_freefall_rc_flat(
 }
 
 static void paint_reverse_freefall_rc_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -250,14 +250,14 @@ static void paint_reverse_freefall_rc_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 5, trackElement);
+    track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 5, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
 static void paint_reverse_freefall_rc_slope(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     TESTPAINT_IGNORE_ALL();
@@ -352,7 +352,7 @@ static void paint_reverse_freefall_rc_slope(
 }
 
 static void paint_reverse_freefall_rc_vertical(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t supportsImageId, trackImageId;
@@ -383,7 +383,7 @@ static void paint_reverse_freefall_rc_vertical(
 }
 
 static void paint_reverse_freefall_rc_onride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {

--- a/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
@@ -250,7 +250,7 @@ static void paint_reverse_freefall_rc_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-        track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 5, trackElement);
+    track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 5, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -47,7 +47,7 @@ void vehicle_visual_reverser(
 
 /** rct2: 0x0086E65C */
 static void reverser_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -92,7 +92,7 @@ static void reverser_rc_track_flat(
 }
 
 static void reverser_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -108,7 +108,7 @@ static void reverser_rc_track_station(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 27, 2, height, 0, 2,
         height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -116,7 +116,7 @@ static void reverser_rc_track_station(
 
 /** rct2: 0x0086E66C */
 static void reverser_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -185,7 +185,7 @@ static void reverser_rc_track_25_deg_up(
 
 /** rct2: 0x0086E67C */
 static void reverser_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -254,7 +254,7 @@ static void reverser_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x0086E68C */
 static void reverser_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -323,7 +323,7 @@ static void reverser_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0086E69C */
 static void reverser_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     reverser_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -331,7 +331,7 @@ static void reverser_rc_track_25_deg_down(
 
 /** rct2: 0x0086E6AC */
 static void reverser_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     reverser_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -339,7 +339,7 @@ static void reverser_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x0086E6BC */
 static void reverser_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     reverser_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -347,7 +347,7 @@ static void reverser_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x0086E6CC */
 static void reverser_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -528,7 +528,7 @@ static void reverser_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x0086E6DC */
 static void reverser_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -537,7 +537,7 @@ static void reverser_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x0086E6EC */
 static void reverser_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -676,7 +676,7 @@ static void reverser_rc_track_s_bend_left(
 
 /** rct2: 0x0086E6FC */
 static void reverser_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -815,7 +815,7 @@ static void reverser_rc_track_s_bend_right(
 
 /** rct2: 0x0086E73C */
 static void reverser_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -922,7 +922,7 @@ static void reverser_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x0086E74C */
 static void reverser_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -931,7 +931,7 @@ static void reverser_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x0086E75C */
 static void reverser_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -956,7 +956,7 @@ static void reverser_rc_track_brakes(
 
 /** rct2: 0x0086E76C */
 static void reverser_rc_track_left_reverser(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1141,7 +1141,7 @@ static void reverser_rc_track_left_reverser(
 
 /** rct2: 0x0086E77C */
 static void reverser_rc_track_right_reverser(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -108,7 +108,7 @@ static void reverser_rc_track_station(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 27, 2, height, 0, 2,
         height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
@@ -152,7 +152,7 @@ static void side_friction_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 27, 2, height, 0, 2, height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
@@ -67,7 +67,7 @@ constexpr int32_t SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_3_A = 21879;
 
 /** rct2: 0x0077839C */
 static void side_friction_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -139,7 +139,7 @@ static void side_friction_rc_track_flat(
 
 /** rct2: 0x007784AC, 0x007784BC, 0x007784CC */
 static void side_friction_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -152,7 +152,7 @@ static void side_friction_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction] | session->TrackColours[SCHEME_TRACK], 0, 0, 32, 27, 2, height, 0, 2, height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -160,7 +160,7 @@ static void side_friction_rc_track_station(
 
 /** rct2: 0x007783AC */
 static void side_friction_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -245,7 +245,7 @@ static void side_friction_rc_track_25_deg_up(
 
 /** rct2: 0x007783CC */
 static void side_friction_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -330,7 +330,7 @@ static void side_friction_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x007783FC */
 static void side_friction_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -415,7 +415,7 @@ static void side_friction_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0077840C */
 static void side_friction_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -423,7 +423,7 @@ static void side_friction_rc_track_25_deg_down(
 
 /** rct2: 0x0077842C */
 static void side_friction_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -431,7 +431,7 @@ static void side_friction_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x0077845C */
 static void side_friction_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -439,7 +439,7 @@ static void side_friction_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x0077846C */
 static void side_friction_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -680,7 +680,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x0077847C */
 static void side_friction_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -689,7 +689,7 @@ static void side_friction_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x0077848C */
 static void side_friction_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -876,7 +876,7 @@ static void side_friction_rc_track_s_bend_left(
 
 /** rct2: 0x0077849C */
 static void side_friction_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1063,7 +1063,7 @@ static void side_friction_rc_track_s_bend_right(
 
 /** rct2: 0x007784DC */
 static void side_friction_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1206,7 +1206,7 @@ static void side_friction_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x007784EC */
 static void side_friction_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1215,7 +1215,7 @@ static void side_friction_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x007784FC */
 static void side_friction_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1244,7 +1244,7 @@ static void side_friction_rc_track_brakes(
 
 /** rct2: 0x007785DC */
 static void side_friction_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1437,7 +1437,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x007785EC */
 static void side_friction_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1629,7 +1629,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x007785FC */
 static void side_friction_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1638,7 +1638,7 @@ static void side_friction_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x0077860C */
 static void side_friction_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1647,7 +1647,7 @@ static void side_friction_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x0077850C */
 static void side_friction_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1813,7 +1813,7 @@ static void side_friction_rc_track_diag_flat(
 
 /** rct2: 0x0077853C */
 static void side_friction_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1979,7 +1979,7 @@ static void side_friction_rc_track_diag_25_deg_up(
 
 /** rct2: 0x0077851C */
 static void side_friction_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2145,7 +2145,7 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x0077852C */
 static void side_friction_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2311,7 +2311,7 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x0077859C */
 static void side_friction_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2477,7 +2477,7 @@ static void side_friction_rc_track_diag_25_deg_down(
 
 /** rct2: 0x0077857C */
 static void side_friction_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2638,7 +2638,7 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x0077858C */
 static void side_friction_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2803,7 +2803,7 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
 }
 
 static void side_friction_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -2862,14 +2862,14 @@ static void side_friction_rc_track_60_deg_up(
 }
 
 static void side_friction_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void side_friction_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -2925,14 +2925,14 @@ static void side_friction_rc_track_25_deg_up_to_60_deg_up(
 }
 
 static void side_friction_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void side_friction_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -2988,14 +2988,14 @@ static void side_friction_rc_track_60_deg_up_to_25_deg_up(
 }
 
 static void side_friction_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void side_friction_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3080,14 +3080,14 @@ static void side_friction_rc_track_diag_60_deg_up(
 }
 
 static void side_friction_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_diag_60_deg_up(session, ride, 3 - trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3176,7 +3176,7 @@ static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
 }
 
 static void side_friction_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
@@ -3184,7 +3184,7 @@ static void side_friction_rc_track_diag_25_deg_down_to_60_deg_down(
 };
 
 static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3271,7 +3271,7 @@ static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
 }
 
 static void side_friction_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_diag_25_deg_up_to_60_deg_up(

--- a/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
@@ -27,7 +27,7 @@
 namespace SingleRailRC
 {
     static void TrackFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -91,7 +91,7 @@ namespace SingleRailRC
     }
 
     static void TrackStation(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         static constexpr const uint32_t imageIds[4][3] = {
@@ -117,14 +117,14 @@ namespace SingleRailRC
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 28, 2, height - 2, 0, 2,
             height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-        track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 4, 7);
+        track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 4, 7);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 32, 0x20);
     }
 
     static void Track25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -203,7 +203,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -282,7 +282,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -361,7 +361,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpTo60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -452,7 +452,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegUpTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -543,7 +543,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -622,49 +622,49 @@ namespace SingleRailRC
     }
 
     static void Track25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownTo60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDownTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpTo60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -704,14 +704,14 @@ namespace SingleRailRC
     }
 
     static void Track90DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegUpTo90DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -760,14 +760,14 @@ namespace SingleRailRC
     }
 
     static void Track90DegDownTo60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpTo90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegUpTo60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -808,7 +808,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegDownTo90DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -851,7 +851,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -979,7 +979,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -987,7 +987,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn5(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1188,7 +1188,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn5(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1196,7 +1196,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftEighthToDiag(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1361,7 +1361,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightEighthToDiag(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1526,7 +1526,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftEighthToOrthogonal(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1534,7 +1534,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightEighthToOrthogonal(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1542,7 +1542,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1699,7 +1699,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1856,7 +1856,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2013,7 +2013,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2170,7 +2170,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2327,7 +2327,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2482,7 +2482,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2639,7 +2639,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2796,7 +2796,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpTo60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2953,7 +2953,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegUpTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3110,7 +3110,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3267,7 +3267,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownTo60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3424,7 +3424,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegDownTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3581,7 +3581,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3624,7 +3624,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3667,21 +3667,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3731,7 +3731,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3781,7 +3781,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3831,7 +3831,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3881,35 +3881,35 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3946,14 +3946,14 @@ namespace SingleRailRC
     }
 
     static void TrackRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackDiagFlatToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4040,7 +4040,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4127,7 +4127,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBankToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4214,7 +4214,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBankToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4301,7 +4301,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBankTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4388,7 +4388,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBankTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4475,7 +4475,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4562,7 +4562,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4649,7 +4649,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBankTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4734,7 +4734,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBankTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4819,7 +4819,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4906,7 +4906,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4993,7 +4993,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5076,7 +5076,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5159,7 +5159,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Bank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5295,7 +5295,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Bank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5303,7 +5303,7 @@ namespace SingleRailRC
     }
 
     static void TrackBankedLeftQuarterTurn5(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5512,7 +5512,7 @@ namespace SingleRailRC
     }
 
     static void TrackBankedRightQuarterTurn5(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -5520,7 +5520,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftEighthBankToDiag(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5685,7 +5685,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightEighthBankToDiag(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5850,7 +5850,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftEighthBankToOrthogonal(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5858,7 +5858,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightEighthBankToOrthogonal(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5866,7 +5866,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5964,7 +5964,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6068,7 +6068,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -6076,7 +6076,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -6084,7 +6084,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn525DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6285,7 +6285,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn525DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6486,7 +6486,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn525DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -6494,7 +6494,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn525DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -6502,7 +6502,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn160DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6546,7 +6546,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn160DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6590,21 +6590,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn160DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightQuarterTurn160DegUp(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightQuarterTurn160DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftQuarterTurn160DegUp(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
     }
 
     static void TrackLeftQuarterTurn190DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6656,7 +6656,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn190DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6708,21 +6708,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn190DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightQuarterTurn190DegUp(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightQuarterTurn190DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftQuarterTurn190DegUp(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
     }
 
     static void Track25DegUpToLeftBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6774,7 +6774,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToRightBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6826,7 +6826,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegUpTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6878,7 +6878,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBanked25DegUpTo25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6930,35 +6930,35 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegDownTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownTo25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToLeftBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToRightBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7006,7 +7006,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedFlatToRightBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7054,7 +7054,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegUpToLeftBankedFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7102,7 +7102,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBanked25DegUpToRightBankedFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7150,35 +7150,35 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpToRightBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankedFlatToRightBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpToLeftBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBanked25DegDownToLeftBankedFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBankedFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownToRightBankedFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBankedFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegUpLeftBanked(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7226,7 +7226,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpRightBanked(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7274,21 +7274,21 @@ namespace SingleRailRC
     }
 
     static void Track25DegDownLeftBanked(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpRightBanked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownRightBanked(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpLeftBanked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatToLeftBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7340,7 +7340,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToRightBanked25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7392,7 +7392,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegUpToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7444,7 +7444,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBanked25DegUpToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7496,35 +7496,35 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToLeftBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatToRightBanked25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBanked25DegDownToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7622,7 +7622,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7726,7 +7726,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7734,7 +7734,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7742,7 +7742,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedQuarterTurn525DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7943,7 +7943,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedQuarterTurn525DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8144,7 +8144,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedQuarterTurn525DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8152,7 +8152,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedQuarterTurn525DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8160,7 +8160,7 @@ namespace SingleRailRC
     }
 
     static void TrackSBendLeft(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8314,7 +8314,7 @@ namespace SingleRailRC
     }
 
     static void TrackSBendRight(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8468,7 +8468,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixUpSmall(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8735,7 +8735,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightHalfBankedHelixUpSmall(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9002,7 +9002,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixDownSmall(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 4)
@@ -9015,7 +9015,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightHalfBankedHelixDownSmall(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 4)
@@ -9028,7 +9028,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixUpLarge(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9440,7 +9440,7 @@ namespace SingleRailRC
         }
     }
     static void TrackRightHalfBankedHelixUpLarge(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9865,7 +9865,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixDownLarge(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 7)
@@ -9878,7 +9878,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightHalfBankedHelixDownLarge(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 7)
@@ -9891,7 +9891,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBarrelRollUpToDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10072,7 +10072,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBarrelRollUpToDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10253,21 +10253,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBarrelRollDownToUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBarrelRollDownToUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackHalfLoopUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10408,14 +10408,14 @@ namespace SingleRailRC
     }
 
     static void TrackHalfLoopDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackHalfLoopUp(session, ride, 3 - trackSequence, direction, height, trackElement);
     }
 
     static void TrackBrakes(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -10444,7 +10444,7 @@ namespace SingleRailRC
     }
 
     static void TrackOnRidePhoto(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -10501,7 +10501,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo60DegUpLongBase(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10670,7 +10670,7 @@ namespace SingleRailRC
         }
     }
     static void Track60DegUpToFlatLongBase(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10840,21 +10840,21 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo60DegDownLongBase(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpToFlatLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDownToFlatLongBase(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo60DegUpLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackBlockBrakes(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -10883,7 +10883,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftCorkscrewUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11000,7 +11000,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightCorkscrewUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11115,21 +11115,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftCorkscrewDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightCorkscrewUp(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightCorkscrewDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftCorkscrewUp(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
     }
 
     static void Track90DegToInvertedFlatQuarterLoopUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11238,14 +11238,14 @@ namespace SingleRailRC
     }
 
     static void TrackInvertedFlatTo90DegQuarterLoopDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track90DegToInvertedFlatQuarterLoopUp(session, ride, 2 - trackSequence, direction, height, trackElement);
     }
 
     static void TrackLeftBankToLeftQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11347,7 +11347,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankToRightQuarterTurn3Tile25DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11449,7 +11449,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDownToLeftBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11551,7 +11551,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDownToRightBank(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11653,7 +11653,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftLargeHalfLoopUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11925,7 +11925,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightLargeHalfLoopUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -12197,21 +12197,21 @@ namespace SingleRailRC
     }
 
     static void TrackRightLargeHalfLoopDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightLargeHalfLoopUp(session, ride, 6 - trackSequence, direction, height, trackElement);
     }
 
     static void TrackLeftLargeHalfLoopDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftLargeHalfLoopUp(session, ride, 6 - trackSequence, direction, height, trackElement);
     }
 
     static void TrackFlatTo60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -12320,7 +12320,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegUpToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -12415,21 +12415,21 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDownToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackDiagFlatTo60DegUp(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -12586,7 +12586,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegUpToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -12743,7 +12743,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatTo60DegDown(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -12900,7 +12900,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegDownToFlat(
-        paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)

--- a/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
@@ -117,7 +117,7 @@ namespace SingleRailRC
             session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 28, 2, height - 2, 0, 2,
             height);
         track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-        track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 4, 7);
+        track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 4, 7);
         paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
         paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
         paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _StandUpBlockBrakeImages[NumOrthogonalDirections
 
 /** rct2: 0x008A7114 */
 static void stand_up_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -89,7 +89,7 @@ static void stand_up_rc_track_flat(
 
 /** rct2: 0x008A7384, 0x008A7394, 0x008A73A4 */
 static void stand_up_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -115,7 +115,7 @@ static void stand_up_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -123,7 +123,7 @@ static void stand_up_rc_track_station(
 
 /** rct2: 0x008A7124 */
 static void stand_up_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -193,7 +193,7 @@ static void stand_up_rc_track_25_deg_up(
 
 /** rct2: 0x008A7134 */
 static void stand_up_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -263,7 +263,7 @@ static void stand_up_rc_track_60_deg_up(
 
 /** rct2: 0x008A7144 */
 static void stand_up_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -333,7 +333,7 @@ static void stand_up_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A7154 */
 static void stand_up_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -411,7 +411,7 @@ static void stand_up_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A7164 */
 static void stand_up_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -489,7 +489,7 @@ static void stand_up_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7174 */
 static void stand_up_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -559,7 +559,7 @@ static void stand_up_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A7184 */
 static void stand_up_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -567,7 +567,7 @@ static void stand_up_rc_track_25_deg_down(
 
 /** rct2: 0x008A7194 */
 static void stand_up_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -575,7 +575,7 @@ static void stand_up_rc_track_60_deg_down(
 
 /** rct2: 0x008A71A4 */
 static void stand_up_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -583,7 +583,7 @@ static void stand_up_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A71B4 */
 static void stand_up_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -591,7 +591,7 @@ static void stand_up_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A71C4 */
 static void stand_up_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -599,7 +599,7 @@ static void stand_up_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A71D4 */
 static void stand_up_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -607,7 +607,7 @@ static void stand_up_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A71E4 */
 static void stand_up_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -764,7 +764,7 @@ static void stand_up_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A71F4 */
 static void stand_up_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -773,7 +773,7 @@ static void stand_up_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A7204 */
 static void stand_up_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -807,7 +807,7 @@ static void stand_up_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A7214 */
 static void stand_up_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -841,7 +841,7 @@ static void stand_up_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A7224 */
 static void stand_up_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -875,7 +875,7 @@ static void stand_up_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A7234 */
 static void stand_up_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -909,7 +909,7 @@ static void stand_up_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A7244 */
 static void stand_up_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1083,7 +1083,7 @@ static void stand_up_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A7254 */
 static void stand_up_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1092,7 +1092,7 @@ static void stand_up_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008A7264 */
 static void stand_up_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1133,7 +1133,7 @@ static void stand_up_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A7274 */
 static void stand_up_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1174,7 +1174,7 @@ static void stand_up_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A7284 */
 static void stand_up_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1215,7 +1215,7 @@ static void stand_up_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A7294 */
 static void stand_up_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1256,7 +1256,7 @@ static void stand_up_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A72A4 */
 static void stand_up_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1264,7 +1264,7 @@ static void stand_up_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A72B4 */
 static void stand_up_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1272,7 +1272,7 @@ static void stand_up_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A72C4 */
 static void stand_up_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1280,7 +1280,7 @@ static void stand_up_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A72D4 */
 static void stand_up_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1288,7 +1288,7 @@ static void stand_up_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A72E4 */
 static void stand_up_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1322,7 +1322,7 @@ static void stand_up_rc_track_left_bank(
 
 /** rct2: 0x008A72F4 */
 static void stand_up_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1330,7 +1330,7 @@ static void stand_up_rc_track_right_bank(
 
 /** rct2: 0x008A7304 */
 static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1618,7 +1618,7 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7314 */
 static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1906,7 +1906,7 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7324 */
 static void stand_up_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1915,7 +1915,7 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A7334 */
 static void stand_up_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1924,7 +1924,7 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A7344 */
 static void stand_up_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2059,7 +2059,7 @@ static void stand_up_rc_track_s_bend_left(
 
 /** rct2: 0x008A7354 */
 static void stand_up_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2194,7 +2194,7 @@ static void stand_up_rc_track_s_bend_right(
 
 /** rct2: 0x008A7364 */
 static void stand_up_rc_track_left_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2451,7 +2451,7 @@ static void stand_up_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A7374 */
 static void stand_up_rc_track_right_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2676,7 +2676,7 @@ static void stand_up_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A73B4 */
 static void stand_up_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2776,7 +2776,7 @@ static void stand_up_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A73C4 */
 static void stand_up_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2785,7 +2785,7 @@ static void stand_up_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A73D4 */
 static void stand_up_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2897,7 +2897,7 @@ static void stand_up_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A73E4 */
 static void stand_up_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2906,7 +2906,7 @@ static void stand_up_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008A73F4 */
 static void stand_up_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3041,7 +3041,7 @@ static void stand_up_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7404 */
 static void stand_up_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3188,7 +3188,7 @@ static void stand_up_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7414 */
 static void stand_up_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3197,7 +3197,7 @@ static void stand_up_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A7424 */
 static void stand_up_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3206,7 +3206,7 @@ static void stand_up_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A7434 */
 static void stand_up_rc_track_half_loop_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3332,7 +3332,7 @@ static void stand_up_rc_track_half_loop_up(
 
 /** rct2: 0x008A7444 */
 static void stand_up_rc_track_half_loop_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, trackElement);
@@ -3340,7 +3340,7 @@ static void stand_up_rc_track_half_loop_down(
 
 /** rct2: 0x008A7454 */
 static void stand_up_rc_track_left_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3452,7 +3452,7 @@ static void stand_up_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A7464 */
 static void stand_up_rc_track_right_corkscrew_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3565,7 +3565,7 @@ static void stand_up_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A7474 */
 static void stand_up_rc_track_left_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
@@ -3573,7 +3573,7 @@ static void stand_up_rc_track_left_corkscrew_down(
 
 /** rct2: 0x008A7484 */
 static void stand_up_rc_track_right_corkscrew_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -3581,7 +3581,7 @@ static void stand_up_rc_track_right_corkscrew_down(
 
 /** rct2: 0x008A7734 */
 static void stand_up_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3799,7 +3799,7 @@ static void stand_up_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A7744 */
 static void stand_up_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4017,7 +4017,7 @@ static void stand_up_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A7754 */
 static void stand_up_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -4031,7 +4031,7 @@ static void stand_up_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008A7764 */
 static void stand_up_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -4045,7 +4045,7 @@ static void stand_up_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008A76F4 */
 static void stand_up_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4387,7 +4387,7 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A7704 */
 static void stand_up_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4729,7 +4729,7 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A7714 */
 static void stand_up_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4743,7 +4743,7 @@ static void stand_up_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008A7724 */
 static void stand_up_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4757,7 +4757,7 @@ static void stand_up_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008A7494 */
 static void stand_up_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4785,7 +4785,7 @@ static void stand_up_rc_track_brakes(
 
 /** rct2: 0x008A74A4 */
 static void stand_up_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4827,7 +4827,7 @@ static void stand_up_rc_track_on_ride_photo(
 
 /** rct2: 0x008A74B4 */
 static void stand_up_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4966,7 +4966,7 @@ static void stand_up_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A74C4 */
 static void stand_up_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5104,7 +5104,7 @@ static void stand_up_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A74D4 */
 static void stand_up_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5113,7 +5113,7 @@ static void stand_up_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A74E4 */
 static void stand_up_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5122,7 +5122,7 @@ static void stand_up_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A76A4 */
 static void stand_up_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5264,7 +5264,7 @@ static void stand_up_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A76B4 */
 static void stand_up_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5405,7 +5405,7 @@ static void stand_up_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A76C4 */
 static void stand_up_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5414,7 +5414,7 @@ static void stand_up_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A76D4 */
 static void stand_up_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5423,7 +5423,7 @@ static void stand_up_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A74F4 */
 static void stand_up_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5569,7 +5569,7 @@ static void stand_up_rc_track_diag_flat(
 
 /** rct2: 0x008A7524 */
 static void stand_up_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5715,7 +5715,7 @@ static void stand_up_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A7584 */
 static void stand_up_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5861,7 +5861,7 @@ static void stand_up_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A7504 */
 static void stand_up_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6007,7 +6007,7 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A7564 */
 static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6153,7 +6153,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A7574 */
 static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6299,7 +6299,7 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7514 */
 static void stand_up_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6445,7 +6445,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A7554 */
 static void stand_up_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6591,7 +6591,7 @@ static void stand_up_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A75B4 */
 static void stand_up_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6737,7 +6737,7 @@ static void stand_up_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A7534 */
 static void stand_up_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6881,7 +6881,7 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A7594 */
 static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7027,7 +7027,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A75A4 */
 static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7173,7 +7173,7 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A7544 */
 static void stand_up_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7319,7 +7319,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A75E4 */
 static void stand_up_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7398,7 +7398,7 @@ static void stand_up_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A75F4 */
 static void stand_up_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7477,7 +7477,7 @@ static void stand_up_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A7604 */
 static void stand_up_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7556,7 +7556,7 @@ static void stand_up_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A7614 */
 static void stand_up_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7635,7 +7635,7 @@ static void stand_up_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A7644 */
 static void stand_up_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7714,7 +7714,7 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A7654 */
 static void stand_up_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7793,7 +7793,7 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A7624 */
 static void stand_up_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7872,7 +7872,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A7634 */
 static void stand_up_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7951,7 +7951,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A7664 */
 static void stand_up_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8028,7 +8028,7 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A7674 */
 static void stand_up_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8105,7 +8105,7 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A7684 */
 static void stand_up_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8184,7 +8184,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A7694 */
 static void stand_up_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8263,7 +8263,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A75C4 */
 static void stand_up_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8339,7 +8339,7 @@ static void stand_up_rc_track_diag_left_bank(
 
 /** rct2: 0x008A75D4 */
 static void stand_up_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8415,7 +8415,7 @@ static void stand_up_rc_track_diag_right_bank(
 
 /** rct2: 0x008A76E4 */
 static void stand_up_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();

--- a/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
@@ -115,7 +115,7 @@ static void stand_up_rc_track_station(
     PaintAddImageAsParentRotated(
         session, direction, imageIds[direction][1] | session->TrackColours[SCHEME_MISC], 0, 0, 32, 32, 1, height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -87,7 +87,7 @@ static void steeplechase_track_station(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 6, 32, 20, 3, height, 0, 0,
         height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008A59A8 */
 static void steeplechase_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -70,7 +70,7 @@ static void steeplechase_track_flat(
 }
 
 static void steeplechase_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -87,7 +87,7 @@ static void steeplechase_track_station(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 6, 32, 20, 3, height, 0, 0,
         height);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -95,7 +95,7 @@ static void steeplechase_track_station(
 
 /** rct2: 0x008A59B8 */
 static void steeplechase_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -173,7 +173,7 @@ static void steeplechase_track_25_deg_up(
 
 /** rct2: 0x008A59C8 */
 static void steeplechase_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -251,7 +251,7 @@ static void steeplechase_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A59D8 */
 static void steeplechase_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -329,7 +329,7 @@ static void steeplechase_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A59E8 */
 static void steeplechase_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     steeplechase_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -337,7 +337,7 @@ static void steeplechase_track_25_deg_down(
 
 /** rct2: 0x008A59F8 */
 static void steeplechase_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     steeplechase_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -345,7 +345,7 @@ static void steeplechase_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A5A08 */
 static void steeplechase_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     steeplechase_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -353,7 +353,7 @@ static void steeplechase_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A5A18 */
 static void steeplechase_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -524,7 +524,7 @@ static void steeplechase_track_left_quarter_turn_5(
 
 /** rct2: 0x008A5A28 */
 static void steeplechase_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -533,7 +533,7 @@ static void steeplechase_track_right_quarter_turn_5(
 
 /** rct2: 0x008A5A38 */
 static void steeplechase_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -682,7 +682,7 @@ static void steeplechase_track_s_bend_left(
 
 /** rct2: 0x008A5A48 */
 static void steeplechase_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -831,7 +831,7 @@ static void steeplechase_track_s_bend_right(
 
 /** rct2: 0x008A5A88 */
 static void steeplechase_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -945,7 +945,7 @@ static void steeplechase_track_left_quarter_turn_3(
 
 /** rct2: 0x008A5A98 */
 static void steeplechase_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -954,7 +954,7 @@ static void steeplechase_track_right_quarter_turn_3(
 
 /** rct2: 0x008A5AA8 */
 static void steeplechase_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -981,7 +981,7 @@ static void steeplechase_track_brakes(
 
 /** rct2: 0x008A5AD8 */
 static void steeplechase_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1127,7 +1127,7 @@ static void steeplechase_track_left_eighth_to_diag(
 
 /** rct2: 0x008A5AE8 */
 static void steeplechase_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1272,7 +1272,7 @@ static void steeplechase_track_right_eighth_to_diag(
 
 /** rct2: 0x008A5AF8 */
 static void steeplechase_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1281,7 +1281,7 @@ static void steeplechase_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A5B08 */
 static void steeplechase_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1290,7 +1290,7 @@ static void steeplechase_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A5AC8 */
 static void steeplechase_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1436,7 +1436,7 @@ static void steeplechase_track_diag_flat(
 
 /** rct2: 0x008A5B38 */
 static void steeplechase_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1582,7 +1582,7 @@ static void steeplechase_track_diag_25_deg_up(
 
 /** rct2: 0x008A5B18 */
 static void steeplechase_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1728,7 +1728,7 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A5B28 */
 static void steeplechase_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1874,7 +1874,7 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A5B68 */
 static void steeplechase_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2020,7 +2020,7 @@ static void steeplechase_track_diag_25_deg_down(
 
 /** rct2: 0x008A5B48 */
 static void steeplechase_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2164,7 +2164,7 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A5B58 */
 static void steeplechase_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2310,7 +2310,7 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A5AB8 */
 static void steeplechase_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008A8958 */
 static void suspended_swinging_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -73,7 +73,7 @@ static void suspended_swinging_rc_track_flat(
 
 /** rct2: 0x008A8AA8, 0x008A8AB8, 0x008A8AC8 */
 static void suspended_swinging_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -92,7 +92,7 @@ static void suspended_swinging_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -100,7 +100,7 @@ static void suspended_swinging_rc_track_station(
 
 /** rct2: 0x008A8968 */
 static void suspended_swinging_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -194,7 +194,7 @@ static void suspended_swinging_rc_track_25_deg_up(
 
 /** rct2: 0x008A8978 */
 static void suspended_swinging_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -235,7 +235,7 @@ static void suspended_swinging_rc_track_60_deg_up(
 
 /** rct2: 0x008A8988 */
 static void suspended_swinging_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -329,7 +329,7 @@ static void suspended_swinging_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A8998 */
 static void suspended_swinging_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -376,7 +376,7 @@ static void suspended_swinging_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A89A8 */
 static void suspended_swinging_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -482,7 +482,7 @@ static void suspended_swinging_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A89B8 */
 static void suspended_swinging_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -576,7 +576,7 @@ static void suspended_swinging_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A89C8 */
 static void suspended_swinging_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -584,7 +584,7 @@ static void suspended_swinging_rc_track_25_deg_down(
 
 /** rct2: 0x008A89D8 */
 static void suspended_swinging_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -592,7 +592,7 @@ static void suspended_swinging_rc_track_60_deg_down(
 
 /** rct2: 0x008A89E8 */
 static void suspended_swinging_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -600,7 +600,7 @@ static void suspended_swinging_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A89F8 */
 static void suspended_swinging_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -608,7 +608,7 @@ static void suspended_swinging_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A8A08 */
 static void suspended_swinging_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -616,7 +616,7 @@ static void suspended_swinging_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A8A18 */
 static void suspended_swinging_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -624,7 +624,7 @@ static void suspended_swinging_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A8A28 */
 static void suspended_swinging_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -804,7 +804,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A8A38 */
 static void suspended_swinging_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -813,7 +813,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A8A48 */
 static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -979,7 +979,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A8A58 */
 static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1145,7 +1145,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A8A68 */
 static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1155,7 +1155,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A8A78 */
 static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1165,7 +1165,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A8A88 */
 static void suspended_swinging_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1324,7 +1324,7 @@ static void suspended_swinging_rc_track_s_bend_left(
 
 /** rct2: 0x008A8A98 */
 static void suspended_swinging_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1483,7 +1483,7 @@ static void suspended_swinging_rc_track_s_bend_right(
 
 /** rct2: 0x008A8AD8 */
 static void suspended_swinging_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1602,7 +1602,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A8AE8 */
 static void suspended_swinging_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1611,7 +1611,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A8AF8 */
 static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1698,7 +1698,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A8B08 */
 static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1785,7 +1785,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A8B18 */
 static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1795,7 +1795,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A8B28 */
 static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1805,7 +1805,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A8B38 */
 static void suspended_swinging_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1837,7 +1837,7 @@ static void suspended_swinging_rc_track_brakes(
 
 /** rct2: 0x008A8B48 */
 static void suspended_swinging_rc_track_left_quarter_helix_large_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2022,7 +2022,7 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_up(
 
 /** rct2: 0x008A8B58 */
 static void suspended_swinging_rc_track_right_quarter_helix_large_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2207,7 +2207,7 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_up(
 
 /** rct2: 0x008A8B68 */
 static void suspended_swinging_rc_track_left_quarter_helix_large_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2392,7 +2392,7 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_down(
 
 /** rct2: 0x008A8B78 */
 static void suspended_swinging_rc_track_right_quarter_helix_large_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2577,7 +2577,7 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_down(
 
 /** rct2: 0x008A8B88 */
 static void suspended_swinging_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2740,7 +2740,7 @@ static void suspended_swinging_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A8B98 */
 static void suspended_swinging_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2903,7 +2903,7 @@ static void suspended_swinging_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A8BA8 */
 static void suspended_swinging_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -2912,7 +2912,7 @@ static void suspended_swinging_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A8BB8 */
 static void suspended_swinging_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -2921,7 +2921,7 @@ static void suspended_swinging_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A8BC8 */
 static void suspended_swinging_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3060,7 +3060,7 @@ static void suspended_swinging_rc_track_diag_flat(
 
 /** rct2: 0x008A8BF8 */
 static void suspended_swinging_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3199,7 +3199,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A8C58 */
 static void suspended_swinging_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3282,7 +3282,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A8BD8 */
 static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3421,7 +3421,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A8C38 */
 static void suspended_swinging_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3504,7 +3504,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A8C48 */
 static void suspended_swinging_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3587,7 +3587,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A8BE8 */
 static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3726,7 +3726,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A8C28 */
 static void suspended_swinging_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3865,7 +3865,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A8C88 */
 static void suspended_swinging_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3927,7 +3927,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A8C08 */
 static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4063,7 +4063,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A8C68 */
 static void suspended_swinging_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4146,7 +4146,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A8C78 */
 static void suspended_swinging_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4229,7 +4229,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A8C18 */
 static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4368,7 +4368,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A8B38 */
 static void suspended_swinging_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
@@ -92,7 +92,7 @@ static void suspended_swinging_rc_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 29, 0, 6,
         height + 29);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 0);
-    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -222,7 +222,7 @@ void vehicle_visual_virginia_reel(
 
 /** rct2: 0x00811264 */
 static void paint_virginia_reel_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_flat;
@@ -251,7 +251,7 @@ static void paint_virginia_reel_track_flat(
 
 /** rct2: 0x00811274 */
 static void paint_virginia_reel_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_25_deg_up;
@@ -303,7 +303,7 @@ static void paint_virginia_reel_track_25_deg_up(
 
 /** rct2: 0x00811294 */
 static void paint_virginia_reel_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_flat_to_25_deg_up;
@@ -350,7 +350,7 @@ static void paint_virginia_reel_track_flat_to_25_deg_up(
 
 /** rct2: 0x00811294 */
 static void paint_virginia_reel_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_25_deg_up_to_flat;
@@ -402,7 +402,7 @@ static void paint_virginia_reel_track_25_deg_up_to_flat(
 
 /** rct2: 0x008112A4 */
 static void paint_virginia_reel_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_virginia_reel_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -410,7 +410,7 @@ static void paint_virginia_reel_track_25_deg_down(
 
 /** rct2: 0x008112B4 */
 static void paint_virginia_reel_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_virginia_reel_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -418,7 +418,7 @@ static void paint_virginia_reel_track_flat_to_25_deg_down(
 
 /** rct2: 0x008112C4 */
 static void paint_virginia_reel_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_virginia_reel_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -426,7 +426,7 @@ static void paint_virginia_reel_track_25_deg_down_to_flat(
 
 /** rct2: 0x008112D4, 0x008112E4, 0x008112F4 */
 static void paint_virginia_reel_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -453,7 +453,7 @@ static void paint_virginia_reel_station(
     }
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -468,7 +468,7 @@ static constexpr const uint8_t virginia_reel_left_quarter_turn_supports[] = {
 
 /** rct2: 0x00811304 */
 static void paint_virginia_reel_track_left_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -503,7 +503,7 @@ static constexpr const uint8_t virginia_reel_right_quarter_turn_3_tiles_to_left_
 
 /** rct2: 0x00811314 */
 static void paint_virginia_reel_track_right_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = virginia_reel_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
@@ -513,7 +513,7 @@ static void paint_virginia_reel_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x00811324 */
 static void paint_virginia_reel_track_left_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
@@ -546,7 +546,7 @@ static void paint_virginia_reel_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x00811334 */
 static void paint_virginia_reel_track_right_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_virginia_reel_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -453,7 +453,7 @@ static void paint_virginia_reel_station(
     }
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/WildMouse.cpp
+++ b/src/openrct2/ride/coaster/WildMouse.cpp
@@ -165,7 +165,7 @@ static constexpr const uint32_t _wild_mouse_block_brakes_image_ids[NumOrthogonal
 
 /** rct2: 0x0078B1E4 */
 static void wild_mouse_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -189,7 +189,7 @@ static void wild_mouse_track_flat(
 }
 
 static void wild_mouse_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t baseImageIds[4] = {
@@ -217,7 +217,7 @@ static void wild_mouse_track_station(
             height, 0, 0, height);
     }
     track_paint_util_draw_station_metal_supports(session, direction, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -225,7 +225,7 @@ static void wild_mouse_track_station(
 
 /** rct2: 0x0078B1F4 */
 static void wild_mouse_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -257,7 +257,7 @@ static void wild_mouse_track_25_deg_up(
 
 /** rct2: 0x0078B204 */
 static void wild_mouse_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -303,7 +303,7 @@ static void wild_mouse_track_60_deg_up(
 
 /** rct2: 0x0078B214 */
 static void wild_mouse_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -335,7 +335,7 @@ static void wild_mouse_track_flat_to_25_deg_up(
 
 /** rct2: 0x0078B224 */
 static void wild_mouse_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -382,7 +382,7 @@ static void wild_mouse_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0078B234 */
 static void wild_mouse_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -429,7 +429,7 @@ static void wild_mouse_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0078B244 */
 static void wild_mouse_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -461,7 +461,7 @@ static void wild_mouse_track_25_deg_up_to_flat(
 
 /** rct2: 0x0078B254 */
 static void wild_mouse_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -469,7 +469,7 @@ static void wild_mouse_track_25_deg_down(
 
 /** rct2: 0x0078B264 */
 static void wild_mouse_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -477,7 +477,7 @@ static void wild_mouse_track_60_deg_down(
 
 /** rct2: 0x0078B274 */
 static void wild_mouse_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -485,7 +485,7 @@ static void wild_mouse_track_flat_to_25_deg_down(
 
 /** rct2: 0x0078B284 */
 static void wild_mouse_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -493,7 +493,7 @@ static void wild_mouse_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x0078B294 */
 static void wild_mouse_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -501,14 +501,14 @@ static void wild_mouse_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x0078B2A4 */
 static void wild_mouse_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void wild_mouse_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb imageIds[4][3] = {
@@ -564,7 +564,7 @@ static void wild_mouse_track_right_quarter_turn_3(
 }
 
 static void wild_mouse_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb imageIds[4][2] = {
@@ -623,7 +623,7 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_down(
 }
 
 static void wild_mouse_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -632,7 +632,7 @@ static void wild_mouse_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0078B314 */
 static void wild_mouse_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb imageIds[4][2] = {
@@ -701,7 +701,7 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0078B324 */
 static void wild_mouse_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -709,7 +709,7 @@ static void wild_mouse_track_left_quarter_turn_3_25_deg_down(
 }
 
 static void wild_mouse_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -718,7 +718,7 @@ static void wild_mouse_track_left_quarter_turn_3(
 
 /** rct2: 0x0078B394 */
 static void wild_mouse_track_left_quarter_turn_1(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -753,7 +753,7 @@ static void wild_mouse_track_left_quarter_turn_1(
 
 /** rct2: 0x0078B3A4 */
 static void wild_mouse_track_right_quarter_turn_1(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_left_quarter_turn_1(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -761,7 +761,7 @@ static void wild_mouse_track_right_quarter_turn_1(
 
 /** rct2: 0x0078B354 */
 static void wild_mouse_track_flat_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -808,7 +808,7 @@ static void wild_mouse_track_flat_to_60_deg_up(
 
 /** rct2: 0x0078B364 */
 static void wild_mouse_track_60_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -862,7 +862,7 @@ static void wild_mouse_track_60_deg_up_to_flat(
 
 /** rct2: 0x0078B374 */
 static void wild_mouse_track_flat_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_60_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -870,7 +870,7 @@ static void wild_mouse_track_flat_to_60_deg_down(
 
 /** rct2: 0x0078B384 */
 static void wild_mouse_track_60_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_flat_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -878,7 +878,7 @@ static void wild_mouse_track_60_deg_down_to_flat(
 
 /** rct2: 0x0078B344 */
 static void wild_mouse_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = _wild_mouse_brakes_image_ids[direction] | session->TrackColours[SCHEME_TRACK];
@@ -895,7 +895,7 @@ static void wild_mouse_track_brakes(
 
 /** rct2: 0x0078B3C4 */
 static void wild_mouse_track_rotation_control_toggle(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -919,7 +919,7 @@ static void wild_mouse_track_rotation_control_toggle(
 
 /** rct2: 0x0078B3B4 */
 static void wild_mouse_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();

--- a/src/openrct2/ride/coaster/WildMouse.cpp
+++ b/src/openrct2/ride/coaster/WildMouse.cpp
@@ -217,7 +217,7 @@ static void wild_mouse_track_station(
             height, 0, 0, height);
     }
     track_paint_util_draw_station_metal_supports(session, direction, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -438,7 +438,7 @@ static void wooden_rc_track_paint_bb(paint_session* session, const sprite_bb_2* 
 
 /** rct2: 0x008AC568 */
 static void wooden_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -465,7 +465,7 @@ static void wooden_rc_track_flat(
 }
 
 static void wooden_rc_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t stationImageIds[4][2] = {
@@ -491,7 +491,7 @@ static void wooden_rc_track_station(
             height);
     }
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -499,7 +499,7 @@ static void wooden_rc_track_station(
 
 /** rct2: 0x008AC578 */
 static void wooden_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][4] = {
@@ -584,7 +584,7 @@ static void wooden_rc_track_25_deg_up(
 
 /** rct2: 0x008AC588 */
 static void wooden_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -621,7 +621,7 @@ static void wooden_rc_track_60_deg_up(
 
 /** rct2: 0x008AC598 */
 static void wooden_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][4] = {
@@ -706,7 +706,7 @@ static void wooden_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AC5A8 */
 static void wooden_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -765,7 +765,7 @@ static void wooden_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AC5B8 */
 static void wooden_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -824,7 +824,7 @@ static void wooden_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AC5C8 */
 static void wooden_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][4] = {
@@ -909,7 +909,7 @@ static void wooden_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AC5D8 */
 static void wooden_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -917,7 +917,7 @@ static void wooden_rc_track_25_deg_down(
 
 /** rct2: 0x008AC5E8 */
 static void wooden_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -925,7 +925,7 @@ static void wooden_rc_track_60_deg_down(
 
 /** rct2: 0x008AC5F8 */
 static void wooden_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -933,7 +933,7 @@ static void wooden_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AC608 */
 static void wooden_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -941,7 +941,7 @@ static void wooden_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AC618 */
 static void wooden_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -949,14 +949,14 @@ static void wooden_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008AC628 */
 static void wooden_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void wooden_rc_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[2][4][7] = {
@@ -1338,7 +1338,7 @@ static void wooden_rc_track_right_quarter_turn_5(
 }
 
 static void wooden_rc_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1347,7 +1347,7 @@ static void wooden_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AC658 */
 static void wooden_rc_track_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1392,7 +1392,7 @@ static void wooden_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AC668 */
 static void wooden_rc_track_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1437,7 +1437,7 @@ static void wooden_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008AC678 */
 static void wooden_rc_track_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_flat_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1445,14 +1445,14 @@ static void wooden_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008AC688 */
 static void wooden_rc_track_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_flat_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void wooden_rc_track_banked_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[2][4][7] = {
@@ -1834,7 +1834,7 @@ static void wooden_rc_track_banked_right_quarter_turn_5(
 }
 
 static void wooden_rc_track_banked_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1843,7 +1843,7 @@ static void wooden_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008AC6B8 */
 static void wooden_rc_track_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1895,7 +1895,7 @@ static void wooden_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AC6C8 */
 static void wooden_rc_track_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1947,7 +1947,7 @@ static void wooden_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AC6D8 */
 static void wooden_rc_track_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1999,7 +1999,7 @@ static void wooden_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AC6E8 */
 static void wooden_rc_track_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -2051,7 +2051,7 @@ static void wooden_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AC6F8 */
 static void wooden_rc_track_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2059,7 +2059,7 @@ static void wooden_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008AC708 */
 static void wooden_rc_track_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2067,7 +2067,7 @@ static void wooden_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008AC718 */
 static void wooden_rc_track_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2075,7 +2075,7 @@ static void wooden_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008AC728 */
 static void wooden_rc_track_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2083,7 +2083,7 @@ static void wooden_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008AC738 */
 static void wooden_rc_track_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -2103,7 +2103,7 @@ static void wooden_rc_track_left_bank(
 
 /** rct2: 0x008AC748 */
 static void wooden_rc_track_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2111,7 +2111,7 @@ static void wooden_rc_track_right_bank(
 
 /** rct2: 0x008AC758 */
 static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2412,7 +2412,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AC768 */
 static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2713,7 +2713,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AC778 */
 static void wooden_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2722,7 +2722,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008AC788 */
 static void wooden_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2731,7 +2731,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008AC798 */
 static void wooden_rc_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2950,7 +2950,7 @@ static void wooden_rc_track_s_bend_left(
 
 /** rct2: 0x008AC7A8 */
 static void wooden_rc_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3169,7 +3169,7 @@ static void wooden_rc_track_s_bend_right(
 
 /** rct2: 0x008ACE18 */
 static void wooden_rc_track_left_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3426,7 +3426,7 @@ static void wooden_rc_track_left_vertical_loop(
 
 /** rct2: 0x008ACE28 */
 static void wooden_rc_track_right_vertical_loop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3651,7 +3651,7 @@ static void wooden_rc_track_right_vertical_loop(
 
 /** rct2: 0x008AC7E8 */
 static void wooden_rc_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3821,7 +3821,7 @@ static void wooden_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AC7F8 */
 static void wooden_rc_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3830,7 +3830,7 @@ static void wooden_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008AC808 */
 static void wooden_rc_track_left_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4000,7 +4000,7 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008AC818 */
 static void wooden_rc_track_right_quarter_turn_3_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4009,7 +4009,7 @@ static void wooden_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008AC828 */
 static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4140,7 +4140,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AC838 */
 static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4271,7 +4271,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AC848 */
 static void wooden_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4280,7 +4280,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008AC858 */
 static void wooden_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4289,7 +4289,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008ACAB8 */
 static void wooden_rc_track_left_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4665,7 +4665,7 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008ACAC8 */
 static void wooden_rc_track_right_half_banked_helix_up_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5041,7 +5041,7 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008ACAD8 */
 static void wooden_rc_track_left_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -5055,7 +5055,7 @@ static void wooden_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008ACAE8 */
 static void wooden_rc_track_right_half_banked_helix_down_small(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -5069,7 +5069,7 @@ static void wooden_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008ACAF8 */
 static void wooden_rc_track_left_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5661,7 +5661,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008ACB08 */
 static void wooden_rc_track_right_half_banked_helix_up_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6253,7 +6253,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008ACB18 */
 static void wooden_rc_track_left_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6267,7 +6267,7 @@ static void wooden_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008ACB28 */
 static void wooden_rc_track_right_half_banked_helix_down_large(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6281,7 +6281,7 @@ static void wooden_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008ACB98 */
 static void wooden_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -6334,7 +6334,7 @@ static void wooden_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008ACB78 */
 static void wooden_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -6387,7 +6387,7 @@ static void wooden_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008ACB88 */
 static void wooden_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -6395,7 +6395,7 @@ static void wooden_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008ACBA8 */
 static void wooden_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -6403,7 +6403,7 @@ static void wooden_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008AC868 */
 static void wooden_rc_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -6423,7 +6423,7 @@ static void wooden_rc_track_brakes(
 
 /** rct2: 0x008ACC78 */
 static void wooden_rc_track_25_deg_up_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -6479,7 +6479,7 @@ static void wooden_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008ACC88 */
 static void wooden_rc_track_25_deg_up_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -6535,7 +6535,7 @@ static void wooden_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008AC878 */
 static void wooden_rc_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -6574,7 +6574,7 @@ static void wooden_rc_track_on_ride_photo(
 
 /** rct2: 0x008ACC98 */
 static void wooden_rc_track_25_deg_down_left_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -6582,7 +6582,7 @@ static void wooden_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x008ACCA8 */
 static void wooden_rc_track_25_deg_down_right_banked(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -6590,7 +6590,7 @@ static void wooden_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x008ACE08 */
 static void wooden_rc_track_water_splash(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const bool transparent = gConfigGeneral.transparent_water || (session->ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE);
@@ -7007,7 +7007,7 @@ static void wooden_rc_track_water_splash(
 
 /** rct2: 0x008AC958 */
 static void wooden_rc_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7240,7 +7240,7 @@ static void wooden_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008AC968 */
 static void wooden_rc_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7471,7 +7471,7 @@ static void wooden_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008AC978 */
 static void wooden_rc_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -7480,7 +7480,7 @@ static void wooden_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008AC988 */
 static void wooden_rc_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -7489,7 +7489,7 @@ static void wooden_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008AC998 */
 static void wooden_rc_track_left_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7722,7 +7722,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008AC9A8 */
 static void wooden_rc_track_right_eighth_bank_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7953,7 +7953,7 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008AC9B8 */
 static void wooden_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -7962,7 +7962,7 @@ static void wooden_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008AC9C8 */
 static void wooden_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -7971,7 +7971,7 @@ static void wooden_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008AC888 */
 static void wooden_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8173,7 +8173,7 @@ static void wooden_rc_track_diag_flat(
 
 /** rct2: 0x008AC8B8 */
 static void wooden_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8375,7 +8375,7 @@ static void wooden_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008AC8E8 */
 static void wooden_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8477,7 +8477,7 @@ static void wooden_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008AC898 */
 static void wooden_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8679,7 +8679,7 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AC8C8 */
 static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8781,7 +8781,7 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AC8D8 */
 static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8883,7 +8883,7 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AC8A8 */
 static void wooden_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9085,7 +9085,7 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AC918 */
 static void wooden_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9287,7 +9287,7 @@ static void wooden_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008AC948 */
 static void wooden_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9389,7 +9389,7 @@ static void wooden_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008AC8F8 */
 static void wooden_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9586,7 +9586,7 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008AC928 */
 static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9688,7 +9688,7 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AC938 */
 static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9790,7 +9790,7 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008AC908 */
 static void wooden_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9992,7 +9992,7 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008ACA18 */
 static void wooden_rc_track_diag_flat_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10094,7 +10094,7 @@ static void wooden_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008AC9F8 */
 static void wooden_rc_track_diag_flat_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10196,7 +10196,7 @@ static void wooden_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008ACA08 */
 static void wooden_rc_track_diag_left_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10298,7 +10298,7 @@ static void wooden_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008ACA28 */
 static void wooden_rc_track_diag_right_bank_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10400,7 +10400,7 @@ static void wooden_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008ACA58 */
 static void wooden_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10502,7 +10502,7 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008ACA68 */
 static void wooden_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10604,7 +10604,7 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008ACA38 */
 static void wooden_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10706,7 +10706,7 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008ACA48 */
 static void wooden_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10808,7 +10808,7 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008ACA78 */
 static void wooden_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10905,7 +10905,7 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008ACA88 */
 static void wooden_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11002,7 +11002,7 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008ACA98 */
 static void wooden_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11104,7 +11104,7 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008ACAA8 */
 static void wooden_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11206,7 +11206,7 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008AC9D8 */
 static void wooden_rc_track_diag_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11308,7 +11308,7 @@ static void wooden_rc_track_diag_left_bank(
 
 /** rct2: 0x008AC9E8 */
 static void wooden_rc_track_diag_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11410,7 +11410,7 @@ static void wooden_rc_track_diag_right_bank(
 
 /** rct2: 0x008ACB38 */
 static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11541,7 +11541,7 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ACB48 */
 static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11672,7 +11672,7 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ACB58 */
 static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11803,7 +11803,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
 
 /** rct2: 0x008ACB68 */
 static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11934,7 +11934,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
 
 /** rct2: 0x008ACDF8 */
 static void wooden_rc_track_block_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const auto brakeImg = trackElement.BlockBrakeClosed() ? _wooden_rc_block_brakes_image_ids[direction][1]
@@ -11949,7 +11949,7 @@ static void wooden_rc_track_block_brakes(
 
 /** rct2: 0x008ACCB8 */
 static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12080,7 +12080,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ACCC8 */
 static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12211,7 +12211,7 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ACCD8 */
 static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -12221,7 +12221,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008ACCE8 */
 static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -12231,7 +12231,7 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008ACC38 */
 static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12532,7 +12532,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008ACC48 */
 static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12833,7 +12833,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008ACC58 */
 static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -12843,7 +12843,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008ACC68 */
 static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -12853,7 +12853,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008ACCF8 */
 static void wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -12901,7 +12901,7 @@ static void wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ACD08 */
 static void wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -12949,7 +12949,7 @@ static void wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ACD18 */
 static void wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -12997,7 +12997,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ACD28 */
 static void wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13045,7 +13045,7 @@ static void wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ACD38 */
 static void wooden_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
@@ -13054,7 +13054,7 @@ static void wooden_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x008ACD48 */
 static void wooden_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -13062,7 +13062,7 @@ static void wooden_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x008ACD58 */
 static void wooden_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
@@ -13071,7 +13071,7 @@ static void wooden_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008ACD68 */
 static void wooden_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -13079,7 +13079,7 @@ static void wooden_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008ACD78 */
 static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13135,7 +13135,7 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ACD88 */
 static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13191,7 +13191,7 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ACD98 */
 static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13247,7 +13247,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008ACDA8 */
 static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13303,7 +13303,7 @@ static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008ACDB8 */
 static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -13312,7 +13312,7 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008ACDC8 */
 static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -13321,7 +13321,7 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008ACDD8 */
 static void wooden_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -13330,7 +13330,7 @@ static void wooden_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x008ACDE8 */
 static void wooden_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -13339,7 +13339,7 @@ static void wooden_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x008ACBB8 */
 static void wooden_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13395,7 +13395,7 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ACBC8 */
 static void wooden_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13451,7 +13451,7 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ACBD8 */
 static void wooden_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13507,7 +13507,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008ACBE8 */
 static void wooden_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13563,7 +13563,7 @@ static void wooden_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008ACBF8 */
 static void wooden_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -13571,7 +13571,7 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008ACC08 */
 static void wooden_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -13579,7 +13579,7 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008ACC18 */
 static void wooden_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -13587,14 +13587,14 @@ static void wooden_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x008ACC28 */
 static void wooden_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void wooden_rc_track_booster(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -491,7 +491,7 @@ static void wooden_rc_track_station(
             height);
     }
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station_2(session, ride, direction, height, trackElement, 9, 11);
+    track_paint_util_draw_station_2(session, *ride, direction, height, trackElement, 9, 11);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/ride/coaster/WoodenWildMouse.cpp
@@ -122,7 +122,7 @@ enum
 
 /** rct2: 0x008A5464 */
 static void wooden_wild_mouse_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -146,7 +146,7 @@ static void wooden_wild_mouse_track_flat(
 }
 
 static void wooden_wild_mouse_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -163,7 +163,7 @@ static void wooden_wild_mouse_track_station(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 6, 32, 20, 1, height, 0, 0,
         height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -171,7 +171,7 @@ static void wooden_wild_mouse_track_station(
 
 /** rct2: 0x008A5474 */
 static void wooden_wild_mouse_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -210,7 +210,7 @@ static void wooden_wild_mouse_track_25_deg_up(
 
 /** rct2: 0x008A5484 */
 static void wooden_wild_mouse_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -257,7 +257,7 @@ static void wooden_wild_mouse_track_60_deg_up(
 
 /** rct2: 0x008A5494 */
 static void wooden_wild_mouse_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -296,7 +296,7 @@ static void wooden_wild_mouse_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A54A4 */
 static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -346,7 +346,7 @@ static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(
 }
 
 static void wooden_wild_mouse_track_60_deg_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -397,7 +397,7 @@ static void wooden_wild_mouse_track_60_deg_to_25_deg_up(
 
 /** rct2: 0x008A54C4 */
 static void wooden_wild_mouse_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -436,7 +436,7 @@ static void wooden_wild_mouse_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A54D4 */
 static void wooden_wild_mouse_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -444,7 +444,7 @@ static void wooden_wild_mouse_track_25_deg_down(
 
 /** rct2: 0x008A54E4 */
 static void wooden_wild_mouse_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -452,7 +452,7 @@ static void wooden_wild_mouse_track_60_deg_down(
 
 /** rct2: 0x008A54F4 */
 static void wooden_wild_mouse_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -460,7 +460,7 @@ static void wooden_wild_mouse_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A5504 */
 static void wooden_wild_mouse_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_60_deg_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -468,7 +468,7 @@ static void wooden_wild_mouse_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A5514 */
 static void wooden_wild_mouse_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -476,14 +476,14 @@ static void wooden_wild_mouse_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A5524 */
 static void wooden_wild_mouse_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void wooden_wild_mouse_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb imageIds[4][3] = {
@@ -540,7 +540,7 @@ static void wooden_wild_mouse_track_right_quarter_turn_3(
 }
 
 static void wooden_wild_mouse_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -548,7 +548,7 @@ static void wooden_wild_mouse_track_left_quarter_turn_3(
 }
 
 static void wooden_wild_mouse_track_left_quarter_turn_1(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -583,7 +583,7 @@ static void wooden_wild_mouse_track_left_quarter_turn_1(
 
 /** rct2: 0x008A55D4 */
 static void wooden_wild_mouse_track_right_quarter_turn_1(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_left_quarter_turn_1(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -591,7 +591,7 @@ static void wooden_wild_mouse_track_right_quarter_turn_1(
 
 /** rct2: 0x008A55E4 */
 static void wooden_wild_mouse_track_flat_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -641,7 +641,7 @@ static void wooden_wild_mouse_track_flat_to_60_deg_up(
 
 /** rct2: 0x008A55F4 */
 static void wooden_wild_mouse_track_60_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -691,7 +691,7 @@ static void wooden_wild_mouse_track_60_deg_up_to_flat(
 
 /** rct2: 0x008A5604 */
 static void wooden_wild_mouse_track_flat_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_60_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -699,7 +699,7 @@ static void wooden_wild_mouse_track_flat_to_60_deg_down(
 
 /** rct2: 0x008A5614 */
 static void wooden_wild_mouse_track_60_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_flat_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);

--- a/src/openrct2/ride/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/ride/coaster/WoodenWildMouse.cpp
@@ -163,7 +163,7 @@ static void wooden_wild_mouse_track_station(
         session, direction, imageIds[direction][0] | session->TrackColours[SCHEME_TRACK], 0, 6, 32, 20, 1, height, 0, 0,
         height);
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -372,7 +372,7 @@ static void paint_car_ride_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -157,7 +157,7 @@ static constexpr const uint32_t car_ride_track_pieces_quarter_turn_3_tiles[4][3]
 
 /** rct2: 0x006F72C8 */
 static void paint_car_ride_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = car_ride_track_pieces_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -188,7 +188,7 @@ static void paint_car_ride_track_flat(
 
 /** rct2: 0x006F72D8 */
 static void paint_car_ride_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = car_ride_track_pieces_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -226,7 +226,7 @@ static void paint_car_ride_track_25_deg_up(
 
 /** rct2: 0x006F72E8 */
 static void paint_car_ride_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = car_ride_track_pieces_flat_to_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -264,7 +264,7 @@ static void paint_car_ride_track_flat_to_25_deg_up(
 
 /** rct2: 0x006F72F8 */
 static void paint_car_ride_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = car_ride_track_pieces_25_deg_up_to_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -302,7 +302,7 @@ static void paint_car_ride_track_25_deg_up_to_flat(
 
 /** rct2: 0x006F7308 */
 static void paint_car_ride_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_car_ride_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -310,7 +310,7 @@ static void paint_car_ride_track_25_deg_down(
 
 /** rct2: 0x006F7318 */
 static void paint_car_ride_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_car_ride_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -318,7 +318,7 @@ static void paint_car_ride_track_flat_to_25_deg_down(
 
 /** rct2: 0x006F7328 */
 static void paint_car_ride_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_car_ride_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -326,7 +326,7 @@ static void paint_car_ride_track_25_deg_down_to_flat(
 
 /** rct2: 0x006F7338, 0x006F7348, 0x006F7358 */
 static void paint_car_ride_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -372,7 +372,7 @@ static void paint_car_ride_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -380,7 +380,7 @@ static void paint_car_ride_station(
 
 /** rct2: 0x006F7378 */
 static void paint_car_ride_track_right_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -417,7 +417,7 @@ static void paint_car_ride_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x006F7368 */
 static void paint_car_ride_track_left_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -426,7 +426,7 @@ static void paint_car_ride_track_left_quarter_turn_3_tiles(
 
 /** rct2: 0x006F7388 */
 static void paint_car_ride_track_left_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = car_ride_track_pieces_left_quarter_turn_1_tile[direction] | session->TrackColours[SCHEME_TRACK];
@@ -457,7 +457,7 @@ static void paint_car_ride_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x006F7398 */
 static void paint_car_ride_track_right_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_car_ride_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);
@@ -465,7 +465,7 @@ static void paint_car_ride_track_right_quarter_turn_1_tile(
 
 /** rct2: 0x006F73A8 */
 static void paint_car_ride_track_spinning_tunnel(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = car_ride_track_pieces_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -498,7 +498,7 @@ static void paint_car_ride_track_spinning_tunnel(
 
 /** rct2: 0x006F73B8 */
 static void paint_car_ride_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = car_ride_track_pieces_60_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -547,7 +547,7 @@ static void paint_car_ride_track_60_deg_up(
 
 /** rct2: 0x006F73C8 */
 static void paint_car_ride_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = car_ride_track_pieces_25_deg_up_to_60_deg_up[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -603,7 +603,7 @@ static void paint_car_ride_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x006F73D8 */
 static void paint_car_ride_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = car_ride_track_pieces_60_deg_up_to_25_deg_up[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -659,7 +659,7 @@ static void paint_car_ride_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x006F73E8 */
 static void paint_car_ride_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_car_ride_track_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -667,7 +667,7 @@ static void paint_car_ride_track_60_deg_down(
 
 /** rct2: 0x006F73F8 */
 static void paint_car_ride_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_car_ride_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -675,7 +675,7 @@ static void paint_car_ride_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x006F7408 */
 static void paint_car_ride_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_car_ride_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -683,7 +683,7 @@ static void paint_car_ride_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x006F7418 */
 static void paint_car_ride_track_log_bumps(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = car_ride_track_pieces_log_bumps[direction] | session->TrackColours[SCHEME_TRACK];

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -16,22 +16,22 @@
 #include "../Track.h"
 #include "../TrackPaint.h"
 
-static void PaintCircusTent(paint_session* session, const Ride* ride, uint8_t direction, int8_t al, int8_t cl, uint16_t height)
+static void PaintCircusTent(paint_session* session, const Ride& ride, uint8_t direction, int8_t al, int8_t cl, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    auto rideEntry = ride->GetRideEntry();
+    auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
         return;
 
-    auto vehicle = GetEntity<Vehicle>(ride->vehicles[0]);
-    if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+    auto vehicle = GetEntity<Vehicle>(ride.vehicles[0]);
+    if (ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
     {
         session->InteractionType = ViewportInteractionItem::Entity;
         session->CurrentlyDrawnItem = vehicle;
     }
 
-    auto imageTemplate = ImageId(0, ride->vehicle_colours[0].Body, ride->vehicle_colours[0].Trim);
+    auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session->TrackColours[SCHEME_MISC];
     if (imageFlags != IMAGE_TYPE_REMAP)
     {
@@ -47,7 +47,7 @@ static void PaintCircusTent(paint_session* session, const Ride* ride, uint8_t di
 }
 
 static void PaintCircus(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -56,12 +56,12 @@ static void PaintCircus(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_SUPPORTS], height,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_SUPPORTS], height,
         fenceSpritesRope, session->CurrentRotation);
 
     switch (trackSequence)

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -60,9 +60,9 @@ static void PaintCircus(
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_SUPPORTS], height,
-            fenceSpritesRope, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_SUPPORTS], height,
+        fenceSpritesRope, session->CurrentRotation);
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -20,9 +20,6 @@ static void PaintCircusTent(paint_session* session, const Ride* ride, uint8_t di
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    if (ride == nullptr)
-        return;
-
     auto rideEntry = ride->GetRideEntry();
     if (rideEntry == nullptr)
         return;
@@ -59,18 +56,13 @@ static void PaintCircus(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_SUPPORTS], height,
             fenceSpritesRope, session->CurrentRotation);
-    }
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -90,18 +90,13 @@ static void PaintCrookedHouse(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
             fenceSpritesRope, session->CurrentRotation);
-    }
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -94,9 +94,9 @@ static void PaintCrookedHouse(
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
-            fenceSpritesRope, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session->CurrentRotation);
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -81,7 +81,7 @@ static void PaintCrookedHouseStructure(
 }
 
 static void PaintCrookedHouse(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -90,12 +90,12 @@ static void PaintCrookedHouse(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
         session->CurrentRotation);
 
     switch (trackSequence)

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -60,9 +60,9 @@ static void paint_dodgems(
         uint32_t imageId = SPR_DODGEMS_FLOOR | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 1, 1, height });
 
-            track_paint_util_paint_fences(
-                session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_SUPPORTS], height,
-                dodgems_fence_sprites, session->CurrentRotation);
+        track_paint_util_paint_fences(
+            session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_SUPPORTS], height,
+            dodgems_fence_sprites, session->CurrentRotation);
 
         switch (direction)
         {

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -53,21 +53,16 @@ static void paint_dodgems(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
         uint32_t imageId = SPR_DODGEMS_FLOOR | session->TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 1, 1, height });
 
-        if (ride != nullptr)
-        {
             track_paint_util_paint_fences(
                 session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_SUPPORTS], height,
                 dodgems_fence_sprites, session->CurrentRotation);
-        }
 
         switch (direction)
         {

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -44,7 +44,7 @@ static void paint_dodgems_roof(paint_session* session, int32_t height, int32_t o
 }
 
 static void paint_dodgems(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_4x4[direction][trackSequence];
@@ -53,7 +53,7 @@ static void paint_dodgems(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
@@ -61,7 +61,7 @@ static void paint_dodgems(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 1, 1, height });
 
         track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_SUPPORTS], height,
+            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_SUPPORTS], height,
             dodgems_fence_sprites, session->CurrentRotation);
 
         switch (direction)

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -135,23 +135,23 @@ static void PaintFerrisWheel(
     uint8_t rotation = session->CurrentRotation;
     uint32_t colourFlags = session->TrackColours[SCHEME_MISC];
 
-        if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, rotation))
-        {
-            imageId = SPR_FENCE_ROPE_NW | colourFlags;
-            PaintAddImageAsChild(session, imageId, 0, 0, 32, 1, 7, height, 0, 2, height + 2);
+    if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, *ride, rotation))
+    {
+        imageId = SPR_FENCE_ROPE_NW | colourFlags;
+        PaintAddImageAsChild(session, imageId, 0, 0, 32, 1, 7, height, 0, 2, height + 2);
         }
-        if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, rotation))
+        if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, *ride, rotation))
         {
             imageId = SPR_FENCE_ROPE_NE | colourFlags;
             PaintAddImageAsChild(session, imageId, 0, 0, 1, 32, 7, height, 2, 0, height + 2);
         }
-        if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, rotation))
+        if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, *ride, rotation))
         {
             // Bound box is slightly different from track_paint_util_paint_fences
             imageId = SPR_FENCE_ROPE_SE | colourFlags;
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 3 });
         }
-        if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, rotation))
+        if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, *ride, rotation))
         {
             imageId = SPR_FENCE_ROPE_SW | colourFlags;
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 30, 0, height + 2 });

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -127,17 +127,14 @@ static void PaintFerrisWheel(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     uint32_t imageId;
     uint8_t rotation = session->CurrentRotation;
     uint32_t colourFlags = session->TrackColours[SCHEME_MISC];
-    if (ride != nullptr)
-    {
+
         if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, rotation))
         {
             imageId = SPR_FENCE_ROPE_NW | colourFlags;
@@ -159,7 +156,6 @@ static void PaintFerrisWheel(
             imageId = SPR_FENCE_ROPE_SW | colourFlags;
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 30, 0, height + 2 });
         }
-    }
 
     switch (relativeTrackSequence)
     {

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -139,23 +139,23 @@ static void PaintFerrisWheel(
     {
         imageId = SPR_FENCE_ROPE_NW | colourFlags;
         PaintAddImageAsChild(session, imageId, 0, 0, 32, 1, 7, height, 0, 2, height + 2);
-        }
-        if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, rotation))
-        {
-            imageId = SPR_FENCE_ROPE_NE | colourFlags;
-            PaintAddImageAsChild(session, imageId, 0, 0, 1, 32, 7, height, 2, 0, height + 2);
-        }
-        if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, rotation))
-        {
-            // Bound box is slightly different from track_paint_util_paint_fences
-            imageId = SPR_FENCE_ROPE_SE | colourFlags;
-            PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 3 });
-        }
-        if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, rotation))
-        {
-            imageId = SPR_FENCE_ROPE_SW | colourFlags;
-            PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 30, 0, height + 2 });
-        }
+    }
+    if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, rotation))
+    {
+        imageId = SPR_FENCE_ROPE_NE | colourFlags;
+        PaintAddImageAsChild(session, imageId, 0, 0, 1, 32, 7, height, 2, 0, height + 2);
+    }
+    if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, rotation))
+    {
+        // Bound box is slightly different from track_paint_util_paint_fences
+        imageId = SPR_FENCE_ROPE_SE | colourFlags;
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 3 });
+    }
+    if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, rotation))
+    {
+        imageId = SPR_FENCE_ROPE_SW | colourFlags;
+        PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 30, 0, height + 2 });
+    }
 
     switch (relativeTrackSequence)
     {

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -110,7 +110,7 @@ static void PaintFerrisWheelStructure(
 }
 
 static void PaintFerrisWheel(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
@@ -127,7 +127,7 @@ static void PaintFerrisWheel(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
@@ -135,23 +135,23 @@ static void PaintFerrisWheel(
     uint8_t rotation = session->CurrentRotation;
     uint32_t colourFlags = session->TrackColours[SCHEME_MISC];
 
-    if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, *ride, rotation))
+    if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, rotation))
     {
         imageId = SPR_FENCE_ROPE_NW | colourFlags;
         PaintAddImageAsChild(session, imageId, 0, 0, 32, 1, 7, height, 0, 2, height + 2);
         }
-        if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, *ride, rotation))
+        if (edges & EDGE_NE && track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, rotation))
         {
             imageId = SPR_FENCE_ROPE_NE | colourFlags;
             PaintAddImageAsChild(session, imageId, 0, 0, 1, 32, 7, height, 2, 0, height + 2);
         }
-        if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, *ride, rotation))
+        if (edges & EDGE_SE && track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, rotation))
         {
             // Bound box is slightly different from track_paint_util_paint_fences
             imageId = SPR_FENCE_ROPE_SE | colourFlags;
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 3 });
         }
-        if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, *ride, rotation))
+        if (edges & EDGE_SW && track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, rotation))
         {
             imageId = SPR_FENCE_ROPE_SW | colourFlags;
             PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 32, 7 }, { 30, 0, height + 2 });
@@ -160,16 +160,16 @@ static void PaintFerrisWheel(
     switch (relativeTrackSequence)
     {
         case 1:
-            PaintFerrisWheelStructure(session, *ride, direction, 48, height);
+            PaintFerrisWheelStructure(session, ride, direction, 48, height);
             break;
         case 2:
-            PaintFerrisWheelStructure(session, *ride, direction, 16, height);
+            PaintFerrisWheelStructure(session, ride, direction, 16, height);
             break;
         case 0:
-            PaintFerrisWheelStructure(session, *ride, direction, -16, height);
+            PaintFerrisWheelStructure(session, ride, direction, -16, height);
             break;
         case 3:
-            PaintFerrisWheelStructure(session, *ride, direction, -48, height);
+            PaintFerrisWheelStructure(session, ride, direction, -48, height);
             break;
     }
 

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -35,7 +35,7 @@ static constexpr const uint32_t flying_saucers_fence_sprites[] = {
  * rct2: 0x008873D8
  */
 static void paint_flying_saucers(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_4x4[direction][trackSequence];
@@ -44,7 +44,7 @@ static void paint_flying_saucers(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
@@ -53,7 +53,7 @@ static void paint_flying_saucers(
     }
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
         flying_saucers_fence_sprites, session->CurrentRotation);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -44,9 +44,7 @@ static void paint_flying_saucers(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
@@ -54,12 +52,9 @@ static void paint_flying_saucers(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 1, 1, height });
     }
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
             flying_saucers_fence_sprites, session->CurrentRotation);
-    }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -52,9 +52,9 @@ static void paint_flying_saucers(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 30, 30, 1 }, { 1, 1, height });
     }
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
-            flying_saucers_fence_sprites, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
+        flying_saucers_fence_sprites, session->CurrentRotation);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -177,7 +177,7 @@ static uint8_t get_tunnel_doors_image_straight_flat(const TrackElement& trackEle
 
 /** rct2: 0x00770BEC */
 static void paint_ghost_train_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = ghost_train_track_pieces_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -199,7 +199,7 @@ static void paint_ghost_train_track_flat(
 
 /** rct2: 0x00770BFC */
 static void paint_ghost_train_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = ghost_train_track_pieces_25_deg_up[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -236,7 +236,7 @@ static void paint_ghost_train_track_25_deg_up(
 
 /** rct2: 0x00770C0C */
 static void paint_ghost_train_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isBackwards = trackElement.GetTrackType() == TrackElemType::Down25ToFlat;
@@ -283,7 +283,7 @@ static void paint_ghost_train_track_flat_to_25_deg_up(
 }
 
 static void paint_ghost_train_track_25_deg_up_to_flat_shared(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = ghost_train_track_pieces_25_deg_up_to_flat[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -304,7 +304,7 @@ static void paint_ghost_train_track_25_deg_up_to_flat_shared(
 
 /** rct2: 0x00770C1C */
 static void paint_ghost_train_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_ghost_train_track_25_deg_up_to_flat_shared(session, ride, trackSequence, direction, height, trackElement);
@@ -328,7 +328,7 @@ static void paint_ghost_train_track_25_deg_up_to_flat(
 
 /** rct2: 0x00770C2C */
 static void paint_ghost_train_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_ghost_train_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -336,7 +336,7 @@ static void paint_ghost_train_track_25_deg_down(
 
 /** rct2: 0x00770C3C */
 static void paint_ghost_train_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_ghost_train_track_25_deg_up_to_flat_shared(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -360,7 +360,7 @@ static void paint_ghost_train_track_flat_to_25_deg_down(
 
 /** rct2: 0x00770C4C */
 static void paint_ghost_train_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_ghost_train_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -368,7 +368,7 @@ static void paint_ghost_train_track_25_deg_down_to_flat(
 
 /** rct2: 0x00770C5C, 0x00770C6C, 0x00770C7C */
 static void paint_ghost_train_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -399,7 +399,7 @@ static void paint_ghost_train_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -407,7 +407,7 @@ static void paint_ghost_train_station(
 
 /** rct2: 0x00770C9C */
 static void paint_ghost_train_track_right_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -448,7 +448,7 @@ static void paint_ghost_train_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x00770CAC */
 static void paint_ghost_train_track_left_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -457,7 +457,7 @@ static void paint_ghost_train_track_left_quarter_turn_3_tiles(
 
 /** rct2: 0x00770CAC */
 static void paint_ghost_train_track_left_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isBackwards = trackElement.GetTrackType() == TrackElemType::RightQuarterTurn1Tile;
@@ -484,7 +484,7 @@ static void paint_ghost_train_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x00770CBC */
 static void paint_ghost_train_track_right_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_ghost_train_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);
@@ -492,7 +492,7 @@ static void paint_ghost_train_track_right_quarter_turn_1_tile(
 
 /** rct2: 0x00770CCC */
 static void paint_ghost_train_track_spinning_tunnel(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = ghost_train_track_pieces_spinning_tunnel_track[direction] | session->TrackColours[SCHEME_TRACK];
@@ -512,7 +512,7 @@ static void paint_ghost_train_track_spinning_tunnel(
 
 /** rct2: 0x00770CDC */
 static void paint_ghost_train_track_brakes(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = ghost_train_track_pieces_brakes[direction] | session->TrackColours[SCHEME_TRACK];

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -399,7 +399,7 @@ static void paint_ghost_train_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -35,9 +35,6 @@ static void PaintHauntedHouseStructure(
 
     uint8_t frameNum = 0;
 
-    if (ride == nullptr)
-        return;
-
     auto rideEntry = ride->GetRideEntry();
     if (rideEntry == nullptr)
         return;
@@ -80,18 +77,13 @@ static void PaintHauntedHouse(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
             fenceSpritesRope, session->CurrentRotation);
-    }
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -29,18 +29,18 @@ static constexpr haunted_house_bound_box haunted_house_data[] = {
 };
 
 static void PaintHauntedHouseStructure(
-    paint_session* session, const Ride* ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint8_t part, uint16_t height)
+    paint_session* session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint8_t part, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
     uint8_t frameNum = 0;
 
-    auto rideEntry = ride->GetRideEntry();
+    auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
         return;
 
-    auto vehicle = GetEntity<Vehicle>(ride->vehicles[0]);
-    if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+    auto vehicle = GetEntity<Vehicle>(ride.vehicles[0]);
+    if (ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
     {
         session->InteractionType = ViewportInteractionItem::Entity;
         session->CurrentlyDrawnItem = vehicle;
@@ -68,7 +68,7 @@ static void PaintHauntedHouseStructure(
 }
 
 static void PaintHauntedHouse(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -77,12 +77,12 @@ static void PaintHauntedHouse(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
         session->CurrentRotation);
 
     switch (trackSequence)

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -81,9 +81,9 @@ static void PaintHauntedHouse(
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
-            fenceSpritesRope, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session->CurrentRotation);
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/gentle/Maze.cpp
+++ b/src/openrct2/ride/gentle/Maze.cpp
@@ -47,7 +47,7 @@ enum
  * rct: 0x004ACF4A
  */
 static void maze_paint_setup(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint16_t maze_entry = trackElement.GetMazeEntry();
@@ -63,7 +63,7 @@ static void maze_paint_setup(
     paint_util_set_segment_support_height(session, SEGMENTS_ALL & ~SEGMENT_C4, 0xFFFF, 0);
 
     int32_t base_image_id = 0;
-    switch (ride->track_colour[0].supports)
+    switch (ride.track_colour[0].supports)
     {
         case 0:
             base_image_id = SPR_MAZE_BASE_BRICK;

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -101,7 +101,7 @@ static void PaintCarousel(
 }
 
 static void PaintMerryGoRound(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -110,33 +110,33 @@ static void PaintMerryGoRound(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
         session->CurrentRotation);
 
     switch (trackSequence)
     {
         case 1:
-            PaintCarousel(session, *ride, direction, 32, 32, height);
+            PaintCarousel(session, ride, direction, 32, 32, height);
             break;
         case 3:
-            PaintCarousel(session, *ride, direction, 32, -32, height);
+            PaintCarousel(session, ride, direction, 32, -32, height);
             break;
         case 5:
-            PaintCarousel(session, *ride, direction, 0, -32, height);
+            PaintCarousel(session, ride, direction, 0, -32, height);
             break;
         case 6:
-            PaintCarousel(session, *ride, direction, -32, 32, height);
+            PaintCarousel(session, ride, direction, -32, 32, height);
             break;
         case 7:
-            PaintCarousel(session, *ride, direction, -32, -32, height);
+            PaintCarousel(session, ride, direction, -32, -32, height);
             break;
         case 8:
-            PaintCarousel(session, *ride, direction, -32, 0, height);
+            PaintCarousel(session, ride, direction, -32, 0, height);
             break;
     }
 

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -110,18 +110,13 @@ static void PaintMerryGoRound(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
             fenceSpritesRope, session->CurrentRotation);
-    }
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -114,9 +114,9 @@ static void PaintMerryGoRound(
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
-            fenceSpritesRope, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session->CurrentRotation);
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -675,7 +675,7 @@ static void paint_mini_golf_station(
     paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    const auto stationObj = ride.GetStationObject();
+    const auto* stationObj = ride.GetStationObject();
     uint32_t imageId;
     bool hasFence;
 

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -675,10 +675,7 @@ static void paint_mini_golf_station(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (ride == nullptr)
-        return;
-
-    auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride->GetStationObject();
     uint32_t imageId;
     bool hasFence;
 

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -684,7 +684,7 @@ static void paint_mini_golf_station(
 
     if (direction & 1)
     {
-        hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_MINI_GOLF_FLAT_FENCE_BACK_NW_SE | session->TrackColours[SCHEME_MISC];
@@ -692,7 +692,7 @@ static void paint_mini_golf_station(
         }
 
         bool hasSWFence = track_paint_util_has_fence(
-            EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
+            EDGE_SW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_MINI_GOLF_FLAT_FENCE_FRONT_NW_SE | session->TrackColours[SCHEME_MISC];
@@ -707,7 +707,7 @@ static void paint_mini_golf_station(
     }
     else
     {
-        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_MINI_GOLF_FLAT_FENCE_BACK_SW_NE | session->TrackColours[SCHEME_MISC];
@@ -715,7 +715,7 @@ static void paint_mini_golf_station(
         }
 
         bool hasSEFence = track_paint_util_has_fence(
-            EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation);
+            EDGE_SE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_MINI_GOLF_FLAT_FENCE_FRONT_SW_NE | session->TrackColours[SCHEME_MISC];

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -484,7 +484,7 @@ static bool mini_golf_paint_util_should_draw_fence(paint_session* session, const
 
 /** rct2: 0x0087F10C */
 static void paint_mini_golf_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -531,7 +531,7 @@ static void paint_mini_golf_track_flat(
 
 /** rct2: 0x0087F11C */
 static void paint_mini_golf_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -570,7 +570,7 @@ static void paint_mini_golf_track_25_deg_up(
 
 /** rct2: 0x0087F12C */
 static void paint_mini_golf_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -609,7 +609,7 @@ static void paint_mini_golf_track_flat_to_25_deg_up(
 
 /** rct2: 0x0087F13C */
 static void paint_mini_golf_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -648,7 +648,7 @@ static void paint_mini_golf_track_25_deg_up_to_flat(
 
 /** rct2: 0x0087F14C */
 static void paint_mini_golf_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_mini_golf_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -656,7 +656,7 @@ static void paint_mini_golf_track_25_deg_down(
 
 /** rct2: 0x0087F15C */
 static void paint_mini_golf_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_mini_golf_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -664,7 +664,7 @@ static void paint_mini_golf_track_flat_to_25_deg_down(
 
 /** rct2: 0x0087F16C */
 static void paint_mini_golf_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_mini_golf_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -672,10 +672,10 @@ static void paint_mini_golf_track_25_deg_down_to_flat(
 
 /** rct2: 0x0087F17C, 0x0087F18C, 0x0087F19C */
 static void paint_mini_golf_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    const auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride.GetStationObject();
     uint32_t imageId;
     bool hasFence;
 
@@ -684,7 +684,7 @@ static void paint_mini_golf_station(
 
     if (direction & 1)
     {
-        hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_MINI_GOLF_FLAT_FENCE_BACK_NW_SE | session->TrackColours[SCHEME_MISC];
@@ -692,7 +692,7 @@ static void paint_mini_golf_station(
         }
 
         bool hasSWFence = track_paint_util_has_fence(
-            EDGE_SW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+            EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_MINI_GOLF_FLAT_FENCE_FRONT_NW_SE | session->TrackColours[SCHEME_MISC];
@@ -707,7 +707,7 @@ static void paint_mini_golf_station(
     }
     else
     {
-        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_MINI_GOLF_FLAT_FENCE_BACK_SW_NE | session->TrackColours[SCHEME_MISC];
@@ -715,7 +715,7 @@ static void paint_mini_golf_station(
         }
 
         bool hasSEFence = track_paint_util_has_fence(
-            EDGE_SE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+            EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation);
         if (hasFence)
         {
             imageId = SPR_MINI_GOLF_FLAT_FENCE_FRONT_SW_NE | session->TrackColours[SCHEME_MISC];
@@ -736,7 +736,7 @@ static void paint_mini_golf_station(
 
 /** rct2: 0x0087F1AC */
 static void paint_mini_golf_track_left_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -816,7 +816,7 @@ static void paint_mini_golf_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x0087F1BC */
 static void paint_mini_golf_track_right_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_mini_golf_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);
@@ -878,7 +878,7 @@ static void paint_mini_golf_hole_ab(
 
 /** rct2: 0x0087F1CC */
 static void paint_mini_golf_hole_a(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_mini_golf_hole_ab(session, trackSequence, direction, height, mini_golf_track_sprites_hole_a);
@@ -886,7 +886,7 @@ static void paint_mini_golf_hole_a(
 
 /** rct2: 0x0087F1DC */
 static void paint_mini_golf_hole_b(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_mini_golf_hole_ab(session, trackSequence, direction, height, mini_golf_track_sprites_hole_b);
@@ -894,7 +894,7 @@ static void paint_mini_golf_hole_b(
 
 /** rct2: 0x0087F1EC */
 static void paint_mini_golf_hole_c(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -965,7 +965,7 @@ static void paint_mini_golf_hole_c(
 
 /** rct2: 0x0087F1FC */
 static void paint_mini_golf_hole_d(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -1058,7 +1058,7 @@ static void paint_mini_golf_hole_d(
 
 /** rct2: 0x0087F1FC */
 static void paint_mini_golf_hole_e(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -48,7 +48,7 @@ static void paint_mini_helicopters_track_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -18,7 +18,7 @@
 
 /** rct2: 0x */
 static void paint_mini_helicopters_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -48,7 +48,7 @@ static void paint_mini_helicopters_track_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -56,7 +56,7 @@ static void paint_mini_helicopters_track_station(
 
 /** rct2: 0x0081F348 */
 static void paint_mini_helicopters_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -88,7 +88,7 @@ static void paint_mini_helicopters_track_flat(
 
 /** rct2: 0x0081F368 */
 static void paint_mini_helicopters_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -129,7 +129,7 @@ static void paint_mini_helicopters_track_flat_to_25_deg_up(
 
 /** rct2: 0x0081F358 */
 static void paint_mini_helicopters_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -170,7 +170,7 @@ static void paint_mini_helicopters_track_25_deg_up(
 
 /** rct2: 0x0081F378 */
 static void paint_mini_helicopters_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -211,7 +211,7 @@ static void paint_mini_helicopters_track_25_deg_up_to_flat(
 
 /** rct2: 0x */
 static void paint_mini_helicopters_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_mini_helicopters_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -219,7 +219,7 @@ static void paint_mini_helicopters_track_flat_to_25_deg_down(
 
 /** rct2: 0x0081F388 */
 static void paint_mini_helicopters_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_mini_helicopters_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -227,7 +227,7 @@ static void paint_mini_helicopters_track_25_deg_down(
 
 /** rct2: 0x0081F3A8 */
 static void paint_mini_helicopters_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_mini_helicopters_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -235,7 +235,7 @@ static void paint_mini_helicopters_track_25_deg_down_to_flat(
 
 /** rct2: 0x0081F3E8 */
 static void paint_mini_helicopters_track_left_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -273,7 +273,7 @@ static constexpr const uint8_t mini_helicopters_right_quarter_turn_3_tiles_to_le
 
 /** rct2: 0x0081F3F8 */
 static void paint_mini_helicopters_track_right_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mini_helicopters_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
@@ -283,7 +283,7 @@ static void paint_mini_helicopters_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x0081F408 */
 static void paint_mini_helicopters_track_left_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
@@ -298,7 +298,7 @@ static void paint_mini_helicopters_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x0081F418 */
 static void paint_mini_helicopters_track_right_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_mini_helicopters_track_left_quarter_turn_1_tile(

--- a/src/openrct2/ride/gentle/MonorailCycles.cpp
+++ b/src/openrct2/ride/gentle/MonorailCycles.cpp
@@ -235,7 +235,7 @@ static void paint_monorail_cycles_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/gentle/MonorailCycles.cpp
+++ b/src/openrct2/ride/gentle/MonorailCycles.cpp
@@ -178,7 +178,7 @@ static paint_struct* paint_monorail_cycles_util_7c(
 
 /** rct2: 0x0088AD48 */
 static void paint_monorail_cycles_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = monorail_cycles_track_pieces_flat[(direction & 1)] | session->TrackColours[SCHEME_TRACK];
@@ -205,7 +205,7 @@ static void paint_monorail_cycles_track_flat(
 
 /** rct2: 0x0088ADD8 */
 static void paint_monorail_cycles_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -235,7 +235,7 @@ static void paint_monorail_cycles_station(
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
     }
 
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -243,7 +243,7 @@ static void paint_monorail_cycles_station(
 
 /** rct2: 0x0088AD88 */
 static void paint_monorail_cycles_track_left_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -281,7 +281,7 @@ static constexpr const uint8_t monorail_cycles_right_quarter_turn_3_tiles_to_lef
 
 /** rct2: 0x0088AD98 */
 static void paint_monorail_cycles_track_right_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = monorail_cycles_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
@@ -305,7 +305,7 @@ static constexpr const int8_t monorail_cycles_track_right_quarter_turn_5_tiles_s
 
 /** rct2: 0x0088ADB8 */
 static void paint_monorail_cycles_track_right_quarter_turn_5_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -421,7 +421,7 @@ static void paint_monorail_cycles_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x0088ADA8 */
 static void paint_monorail_cycles_track_left_quarter_turn_5_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -431,7 +431,7 @@ static void paint_monorail_cycles_track_left_quarter_turn_5_tiles(
 
 /** rct2: 0x0088ADC8 */
 static void paint_monorail_cycles_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -540,7 +540,7 @@ static void paint_monorail_cycles_track_s_bend_left(
 
 /** rct2: 0x*/
 static void paint_monorail_cycles_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -83,7 +83,7 @@ void vehicle_visual_observation_tower(
 
 /** rct2: 0x0070DD6C */
 static void paint_observation_tower_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -93,13 +93,13 @@ static void paint_observation_tower_base(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(
         session, edges, session->TrackColours[SCHEME_SUPPORTS], height, floorSpritesMetalB, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, position, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height, fenceSpritesMetalB,
+        session, edges, position, trackElement, ride, session->TrackColours[SCHEME_TRACK], height, fenceSpritesMetalB,
         session->CurrentRotation);
 
     if (trackSequence == 0)
@@ -159,7 +159,7 @@ static void paint_observation_tower_base(
 
 /** rct2: 0x0070DD7C */
 static void paint_observation_tower_section(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -93,19 +93,14 @@ static void paint_observation_tower_base(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(
         session, edges, session->TrackColours[SCHEME_SUPPORTS], height, floorSpritesMetalB, stationObject);
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, position, trackElement, ride, session->TrackColours[SCHEME_TRACK], height, fenceSpritesMetalB,
             session->CurrentRotation);
-    }
 
     if (trackSequence == 0)
     {

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -98,9 +98,9 @@ static void paint_observation_tower_base(
     track_paint_util_paint_floor(
         session, edges, session->TrackColours[SCHEME_SUPPORTS], height, floorSpritesMetalB, stationObject);
 
-        track_paint_util_paint_fences(
-            session, edges, position, trackElement, ride, session->TrackColours[SCHEME_TRACK], height, fenceSpritesMetalB,
-            session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, position, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height, fenceSpritesMetalB,
+        session->CurrentRotation);
 
     if (trackSequence == 0)
     {

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -106,12 +106,12 @@ static void paint_space_rings(
     switch (trackSequence)
     {
         case 7:
-            if (track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session->CurrentRotation))
+            if (track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, session->CurrentRotation))
             {
                 imageId = SPR_SPACE_RINGS_FENCE_SW | session->TrackColours[SCHEME_MISC];
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 28, 7 }, { 29, 0, height + 2 });
             }
-            if (track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, session->CurrentRotation))
+            if (track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, session->CurrentRotation))
             {
                 imageId = SPR_SPACE_RINGS_FENCE_SE | session->TrackColours[SCHEME_MISC];
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 2 });

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -119,7 +119,7 @@ static void paint_space_rings(
             break;
         default:
             track_paint_util_paint_fences(
-                session, edges, position, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
+                session, edges, position, trackElement, *ride, session->TrackColours[SCHEME_MISC], height,
                 space_rings_fence_sprites, session->CurrentRotation);
             break;
     }

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -34,21 +34,21 @@ static constexpr const uint32_t space_rings_fence_sprites[] = {
 
 /** rct2: 0x00768A3B */
 static void paint_space_rings_structure(
-    paint_session* session, const Ride* ride, uint8_t direction, uint32_t segment, int32_t height)
+    paint_session* session, const Ride& ride, uint8_t direction, uint32_t segment, int32_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
     uint32_t vehicleIndex = (segment - direction) & 0x3;
 
-    if (ride->num_stations == 0 || vehicleIndex < ride->num_vehicles)
+    if (ride.num_stations == 0 || vehicleIndex < ride.num_vehicles)
     {
-        rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+        rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
 
         int32_t frameNum = direction;
 
         uint32_t baseImageId = rideEntry->vehicles[0].base_image_id;
-        auto vehicle = GetEntity<Vehicle>(ride->vehicles[vehicleIndex]);
-        if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+        auto vehicle = GetEntity<Vehicle>(ride.vehicles[vehicleIndex]);
+        if (ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
         {
             session->InteractionType = ViewportInteractionItem::Entity;
             session->CurrentlyDrawnItem = vehicle;
@@ -56,7 +56,7 @@ static void paint_space_rings_structure(
         }
 
         uint32_t imageColourFlags = session->TrackColours[SCHEME_MISC];
-        if ((ride->colour_scheme_type & 3) != RIDE_COLOUR_SCHEME_DIFFERENT_PER_TRAIN)
+        if ((ride.colour_scheme_type & 3) != RIDE_COLOUR_SCHEME_DIFFERENT_PER_TRAIN)
         {
             vehicleIndex = 0;
         }
@@ -64,7 +64,7 @@ static void paint_space_rings_structure(
         if (imageColourFlags == IMAGE_TYPE_REMAP)
         {
             imageColourFlags = SPRITE_ID_PALETTE_COLOUR_2(
-                ride->vehicle_colours[vehicleIndex].Body, ride->vehicle_colours[vehicleIndex].Trim);
+                ride.vehicle_colours[vehicleIndex].Body, ride.vehicle_colours[vehicleIndex].Trim);
         }
 
         uint32_t imageId = (baseImageId + frameNum) | imageColourFlags;
@@ -88,7 +88,7 @@ static void paint_space_rings_structure(
 
 /** rct2: 0x00767C40 */
 static void paint_space_rings(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -100,18 +100,18 @@ static void paint_space_rings(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     switch (trackSequence)
     {
         case 7:
-            if (track_paint_util_has_fence(EDGE_SW, position, trackElement, *ride, session->CurrentRotation))
+            if (track_paint_util_has_fence(EDGE_SW, position, trackElement, ride, session->CurrentRotation))
             {
                 imageId = SPR_SPACE_RINGS_FENCE_SW | session->TrackColours[SCHEME_MISC];
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 28, 7 }, { 29, 0, height + 2 });
             }
-            if (track_paint_util_has_fence(EDGE_SE, position, trackElement, *ride, session->CurrentRotation))
+            if (track_paint_util_has_fence(EDGE_SE, position, trackElement, ride, session->CurrentRotation))
             {
                 imageId = SPR_SPACE_RINGS_FENCE_SE | session->TrackColours[SCHEME_MISC];
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 2 });
@@ -119,7 +119,7 @@ static void paint_space_rings(
             break;
         default:
             track_paint_util_paint_fences(
-                session, edges, position, trackElement, *ride, session->TrackColours[SCHEME_MISC], height,
+                session, edges, position, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
                 space_rings_fence_sprites, session->CurrentRotation);
             break;
     }

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -91,9 +91,6 @@ static void paint_space_rings(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (ride == nullptr)
-        return;
-
     trackSequence = track_map_3x3[direction][trackSequence];
 
     int32_t edges = edges_3x3[trackSequence];

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -209,9 +209,9 @@ static void paint_spiral_slide(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
     }
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
-            spiral_slide_fence_sprites, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
+        spiral_slide_fence_sprites, session->CurrentRotation);
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -48,7 +48,7 @@ enum
 };
 
 static void spiral_slide_paint_tile_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id = 0;
@@ -66,7 +66,7 @@ static void spiral_slide_paint_tile_right(
 }
 
 static void spiral_slide_paint_tile_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id = 0;
@@ -84,7 +84,7 @@ static void spiral_slide_paint_tile_left(
 }
 
 static void spiral_slide_paint_tile_front(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t image_id = 0;
@@ -122,9 +122,9 @@ static void spiral_slide_paint_tile_front(
     }
 
     rct_drawpixelinfo* dpi = &session->DPI;
-    if (dpi->zoom_level <= ZoomLevel{ 0 } && ride->slide_in_use != 0)
+    if (dpi->zoom_level <= ZoomLevel{ 0 } && ride.slide_in_use != 0)
     {
-        uint8_t slide_progress = ride->spiral_slide_progress;
+        uint8_t slide_progress = ride.spiral_slide_progress;
         if (slide_progress != 0)
         {
             slide_progress--;
@@ -170,7 +170,7 @@ static void spiral_slide_paint_tile_front(
                 boundingBox.x = 8;
             }
 
-            image_id = (offset + slide_progress) | (ride->slide_peep_t_shirt_colour << 19) | (1 << 29);
+            image_id = (offset + slide_progress) | (ride.slide_peep_t_shirt_colour << 19) | (1 << 29);
 
             PaintAddImageAsChild(
                 session, image_id, 16, 16, boundingBox.x, boundingBox.y, boundingBox.z, height, boundingBoxOffset.x,
@@ -190,7 +190,7 @@ static constexpr const uint32_t spiral_slide_fence_sprites[] = {
  * rct: 0x007485C8
  */
 static void paint_spiral_slide(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_2x2[direction][trackSequence];
@@ -200,7 +200,7 @@ static void paint_spiral_slide(
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
     // Base
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
@@ -210,7 +210,7 @@ static void paint_spiral_slide(
     }
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
         spiral_slide_fence_sprites, session->CurrentRotation);
 
     switch (trackSequence)

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -89,9 +89,6 @@ static void spiral_slide_paint_tile_front(
 {
     uint32_t image_id = 0;
 
-    if (ride == nullptr)
-        return;
-
     if (direction == 1)
     {
         image_id = SPIRAL_SLIDE_INSIDE_R1 | session->TrackColours[SCHEME_TRACK];
@@ -203,9 +200,7 @@ static void paint_spiral_slide(
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
     // Base
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
@@ -214,12 +209,9 @@ static void paint_spiral_slide(
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
     }
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
             spiral_slide_fence_sprites, session->CurrentRotation);
-    }
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -23,9 +23,6 @@ static void PaintFacility(
 {
     bool hasSupports = wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_3]);
 
-    if (ride == nullptr)
-        return;
-
     auto rideEntry = ride->GetRideEntry();
     if (rideEntry == nullptr)
         return;

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -18,12 +18,12 @@
 #include "../TrackPaint.h"
 
 static void PaintFacility(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool hasSupports = wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_3]);
 
-    auto rideEntry = ride->GetRideEntry();
+    auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
         return;
 

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -23,9 +23,6 @@ static void PaintShop(
 {
     bool hasSupports = wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_3]);
 
-    if (ride == nullptr)
-        return;
-
     auto rideEntry = ride->GetRideEntry();
     if (rideEntry == nullptr)
         return;

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -18,12 +18,12 @@
 #include "../TrackPaint.h"
 
 static void PaintShop(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool hasSupports = wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_3]);
 
-    auto rideEntry = ride->GetRideEntry();
+    auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
         return;
 

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -17,21 +17,21 @@
 #include "../TrackPaint.h"
 
 static void Paint3dCinemaDome(
-    paint_session* session, const Ride* ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    paint_session* session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    auto rideEntry = ride->GetRideEntry();
+    auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
         return;
 
-    if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && ride->vehicles[0] != SPRITE_INDEX_NULL)
+    if (ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && ride.vehicles[0] != SPRITE_INDEX_NULL)
     {
         session->InteractionType = ViewportInteractionItem::Entity;
-        session->CurrentlyDrawnItem = GetEntity<Vehicle>(ride->vehicles[0]);
+        session->CurrentlyDrawnItem = GetEntity<Vehicle>(ride.vehicles[0]);
     }
 
-    auto imageTemplate = ImageId(0, ride->vehicle_colours[0].Body, ride->vehicle_colours[0].Trim);
+    auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session->TrackColours[SCHEME_MISC];
     if (imageFlags != IMAGE_TYPE_REMAP)
     {
@@ -50,7 +50,7 @@ static void Paint3dCinemaDome(
  * rct2: 0x0076574C
  */
 static void Paint3dCinema(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -59,12 +59,12 @@ static void Paint3dCinema(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
         session->CurrentRotation);
 
     switch (trackSequence)

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -63,9 +63,9 @@ static void Paint3dCinema(
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
-            fenceSpritesRope, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session->CurrentRotation);
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -21,9 +21,6 @@ static void Paint3dCinemaDome(
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    if (ride == nullptr)
-        return;
-
     auto rideEntry = ride->GetRideEntry();
     if (rideEntry == nullptr)
         return;
@@ -62,18 +59,13 @@ static void Paint3dCinema(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
             fenceSpritesRope, session->CurrentRotation);
-    }
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -89,7 +89,7 @@ static void PaintEnterpriseStructure(
 }
 
 static void PaintEnterprise(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_4x4[direction][trackSequence];
@@ -98,52 +98,52 @@ static void PaintEnterprise(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
-        fenceSpritesRope, session->CurrentRotation);
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height, fenceSpritesRope,
+        session->CurrentRotation);
 
     switch (trackSequence)
     {
         case 5:
-            PaintEnterpriseStructure(session, *ride, 16, 16, height, trackElement);
+            PaintEnterpriseStructure(session, ride, 16, 16, height, trackElement);
             break;
         case 6:
-            PaintEnterpriseStructure(session, *ride, 16, -16, height, trackElement);
+            PaintEnterpriseStructure(session, ride, 16, -16, height, trackElement);
             break;
         case 10:
-            PaintEnterpriseStructure(session, *ride, -16, -16, height, trackElement);
+            PaintEnterpriseStructure(session, ride, -16, -16, height, trackElement);
             break;
         case 9:
-            PaintEnterpriseStructure(session, *ride, -16, 16, height, trackElement);
+            PaintEnterpriseStructure(session, ride, -16, 16, height, trackElement);
             break;
 
         case 0:
-            PaintEnterpriseStructure(session, *ride, 48, 48, height, trackElement);
+            PaintEnterpriseStructure(session, ride, 48, 48, height, trackElement);
             break;
         case 3:
-            PaintEnterpriseStructure(session, *ride, 48, -48, height, trackElement);
+            PaintEnterpriseStructure(session, ride, 48, -48, height, trackElement);
             break;
         case 15:
-            PaintEnterpriseStructure(session, *ride, -48, -48, height, trackElement);
+            PaintEnterpriseStructure(session, ride, -48, -48, height, trackElement);
             break;
         case 12:
-            PaintEnterpriseStructure(session, *ride, -48, 48, height, trackElement);
+            PaintEnterpriseStructure(session, ride, -48, 48, height, trackElement);
             break;
 
         case 7:
-            PaintEnterpriseStructure(session, *ride, 16, -48, height, trackElement);
+            PaintEnterpriseStructure(session, ride, 16, -48, height, trackElement);
             break;
         case 11:
-            PaintEnterpriseStructure(session, *ride, -16, -48, height, trackElement);
+            PaintEnterpriseStructure(session, ride, -16, -48, height, trackElement);
             break;
         case 14:
-            PaintEnterpriseStructure(session, *ride, -48, -16, height, trackElement);
+            PaintEnterpriseStructure(session, ride, -48, -16, height, trackElement);
             break;
         case 13:
-            PaintEnterpriseStructure(session, *ride, -48, 16, height, trackElement);
+            PaintEnterpriseStructure(session, ride, -48, 16, height, trackElement);
             break;
     }
 

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -92,9 +92,6 @@ static void PaintEnterprise(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (ride == nullptr)
-        return;
-
     trackSequence = track_map_4x4[direction][trackSequence];
 
     int32_t edges = edges_4x4[trackSequence];

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -102,8 +102,8 @@ static void PaintEnterprise(
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height, fenceSpritesRope,
-        session->CurrentRotation);
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
+        fenceSpritesRope, session->CurrentRotation);
 
     switch (trackSequence)
     {

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -348,10 +348,7 @@ static void paint_go_karts_station(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (ride == nullptr)
-        return;
-
-    auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride->GetStationObject();
 
     bool hasFence;
     uint32_t imageId;

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -126,7 +126,7 @@ static constexpr const uint32_t go_karts_track_pieces_25_deg_up_to_flat[4][2] = 
 
 /** rct2: 0x0074A748 */
 static void paint_go_karts_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -159,7 +159,7 @@ static void paint_go_karts_track_flat(
 
 /** rct2: 0x0074A758 */
 static void paint_go_karts_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -213,7 +213,7 @@ static void paint_go_karts_track_25_deg_up(
 
 /** rct2: 0x0074A768 */
 static void paint_go_karts_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -267,7 +267,7 @@ static void paint_go_karts_track_flat_to_25_deg_up(
 
 /** rct2: 0x */
 static void paint_go_karts_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -321,7 +321,7 @@ static void paint_go_karts_track_25_deg_up_to_flat(
 
 /** rct2: 0x0074A788 */
 static void paint_go_karts_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_go_karts_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -329,7 +329,7 @@ static void paint_go_karts_track_25_deg_down(
 
 /** rct2: 0x0074A798 */
 static void paint_go_karts_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_go_karts_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -337,7 +337,7 @@ static void paint_go_karts_track_flat_to_25_deg_down(
 
 /** rct2: 0x0074A7A8 */
 static void paint_go_karts_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_go_karts_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -345,10 +345,10 @@ static void paint_go_karts_track_25_deg_down_to_flat(
 
 /** rct2: 0x */
 static void paint_go_karts_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    const auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride.GetStationObject();
 
     bool hasFence;
     uint32_t imageId;
@@ -371,12 +371,12 @@ static void paint_go_karts_station(
 
     if (direction == 0 || direction == 2)
     {
-        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, stationObj, height);
     }
     else
     {
-        hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, stationObj, height);
     }
 
@@ -396,12 +396,12 @@ static void paint_go_karts_station(
 
     if (direction == 0 || direction == 2)
     {
-        hasFence = track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, stationObj, height);
     }
     else
     {
-        hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, stationObj, height);
     }
 
@@ -454,7 +454,7 @@ static void paint_go_karts_station(
 
 /** rct2: 0x0074A7E8 */
 static void paint_go_karts_track_left_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -524,7 +524,7 @@ static void paint_go_karts_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x0074A7F8 */
 static void paint_go_karts_track_right_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_go_karts_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -348,7 +348,7 @@ static void paint_go_karts_station(
     paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    const auto stationObj = ride.GetStationObject();
+    const auto* stationObj = ride.GetStationObject();
 
     bool hasFence;
     uint32_t imageId;

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -371,12 +371,12 @@ static void paint_go_karts_station(
 
     if (direction == 0 || direction == 2)
     {
-        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_NW, hasFence, stationObj, height);
     }
     else
     {
-        hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_NE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_NE, hasFence, stationObj, height);
     }
 
@@ -396,12 +396,12 @@ static void paint_go_karts_station(
 
     if (direction == 0 || direction == 2)
     {
-        hasFence = track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_SE, hasFence, stationObj, height);
     }
     else
     {
-        hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
+        hasFence = track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
         track_paint_util_draw_station_covers(session, EDGE_SW, hasFence, stationObj, height);
     }
 

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -85,7 +85,7 @@ void vehicle_visual_launched_freefall(
 
 /** rct2: 0x006FD1F8 */
 static void paint_launched_freefall_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -94,13 +94,13 @@ static void paint_launched_freefall_base(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(
         session, edges, session->TrackColours[SCHEME_SUPPORTS], height, floorSpritesMetal, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
         fenceSpritesMetal, session->CurrentRotation);
 
     if (trackSequence == 0)
@@ -159,7 +159,7 @@ static void paint_launched_freefall_base(
 
 /** rct2: 0x006FD208 */
 static void paint_launched_freefall_tower_section(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -99,9 +99,9 @@ static void paint_launched_freefall_base(
     track_paint_util_paint_floor(
         session, edges, session->TrackColours[SCHEME_SUPPORTS], height, floorSpritesMetal, stationObject);
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
-            fenceSpritesMetal, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
+        fenceSpritesMetal, session->CurrentRotation);
 
     if (trackSequence == 0)
     {

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -94,19 +94,14 @@ static void paint_launched_freefall_base(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(
         session, edges, session->TrackColours[SCHEME_SUPPORTS], height, floorSpritesMetal, stationObject);
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
             fenceSpritesMetal, session->CurrentRotation);
-    }
 
     if (trackSequence == 0)
     {

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -251,9 +251,7 @@ static void PaintMagicCarpet(
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             }
-            const StationObject* stationObject = nullptr;
-            if (ride != nullptr)
-                stationObject = ride->GetStationObject();
+            const StationObject* stationObject = ride->GetStationObject();
 
             if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
             {
@@ -263,8 +261,6 @@ static void PaintMagicCarpet(
             break;
     }
 
-    if (ride != nullptr)
-    {
         switch (relativeTrackSequence)
         {
             case 3:
@@ -280,7 +276,6 @@ static void PaintMagicCarpet(
                 PaintMagicCarpetStructure(session, *ride, direction, 48, height);
                 break;
         }
-    }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 176, 0x20);

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -261,21 +261,21 @@ static void PaintMagicCarpet(
             break;
     }
 
-        switch (relativeTrackSequence)
-        {
-            case 3:
-                PaintMagicCarpetStructure(session, ride, direction, -48, height);
-                break;
-            case 0:
-                PaintMagicCarpetStructure(session, ride, direction, -16, height);
-                break;
-            case 2:
-                PaintMagicCarpetStructure(session, ride, direction, 16, height);
-                break;
-            case 1:
-                PaintMagicCarpetStructure(session, ride, direction, 48, height);
-                break;
-        }
+    switch (relativeTrackSequence)
+    {
+        case 3:
+            PaintMagicCarpetStructure(session, ride, direction, -48, height);
+            break;
+        case 0:
+            PaintMagicCarpetStructure(session, ride, direction, -16, height);
+            break;
+        case 2:
+            PaintMagicCarpetStructure(session, ride, direction, 16, height);
+            break;
+        case 1:
+            PaintMagicCarpetStructure(session, ride, direction, 48, height);
+            break;
+    }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 176, 0x20);

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -227,7 +227,7 @@ static void PaintMagicCarpetStructure(
 }
 
 static void PaintMagicCarpet(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
@@ -251,7 +251,7 @@ static void PaintMagicCarpet(
                 metal_a_supports_paint_setup(
                     session, METAL_SUPPORTS_TUBES, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
             }
-            const StationObject* stationObject = ride->GetStationObject();
+            const StationObject* stationObject = ride.GetStationObject();
 
             if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
             {
@@ -264,16 +264,16 @@ static void PaintMagicCarpet(
         switch (relativeTrackSequence)
         {
             case 3:
-                PaintMagicCarpetStructure(session, *ride, direction, -48, height);
+                PaintMagicCarpetStructure(session, ride, direction, -48, height);
                 break;
             case 0:
-                PaintMagicCarpetStructure(session, *ride, direction, -16, height);
+                PaintMagicCarpetStructure(session, ride, direction, -16, height);
                 break;
             case 2:
-                PaintMagicCarpetStructure(session, *ride, direction, 16, height);
+                PaintMagicCarpetStructure(session, ride, direction, 16, height);
                 break;
             case 1:
-                PaintMagicCarpetStructure(session, *ride, direction, 48, height);
+                PaintMagicCarpetStructure(session, ride, direction, 48, height);
                 break;
         }
 

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -111,14 +111,10 @@ static void PaintMotionSimulator(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_SUPPORTS], height,
             fenceSpritesRope, session->CurrentRotation);
@@ -135,7 +131,6 @@ static void PaintMotionSimulator(
                 PaintMotionSimulatorVehicle(session, *ride, -16, -16, direction, height, trackElement);
                 break;
         }
-    }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 128, 0x20);

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -102,7 +102,7 @@ static void PaintMotionSimulatorVehicle(
 }
 
 static void PaintMotionSimulator(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_2x2[direction][trackSequence];
@@ -111,24 +111,24 @@ static void PaintMotionSimulator(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_SUPPORTS], height,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_SUPPORTS], height,
         fenceSpritesRope, session->CurrentRotation);
 
     switch (trackSequence)
     {
         case 1:
-            PaintMotionSimulatorVehicle(session, *ride, 16, -16, direction, height, trackElement);
+            PaintMotionSimulatorVehicle(session, ride, 16, -16, direction, height, trackElement);
             break;
         case 2:
-            PaintMotionSimulatorVehicle(session, *ride, -16, 16, direction, height, trackElement);
+            PaintMotionSimulatorVehicle(session, ride, -16, 16, direction, height, trackElement);
             break;
         case 3:
-            PaintMotionSimulatorVehicle(session, *ride, -16, -16, direction, height, trackElement);
+            PaintMotionSimulatorVehicle(session, ride, -16, -16, direction, height, trackElement);
             break;
     }
 

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -115,22 +115,22 @@ static void PaintMotionSimulator(
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_SUPPORTS], height,
-            fenceSpritesRope, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_SUPPORTS], height,
+        fenceSpritesRope, session->CurrentRotation);
 
-        switch (trackSequence)
-        {
-            case 1:
-                PaintMotionSimulatorVehicle(session, *ride, 16, -16, direction, height, trackElement);
-                break;
-            case 2:
-                PaintMotionSimulatorVehicle(session, *ride, -16, 16, direction, height, trackElement);
-                break;
-            case 3:
-                PaintMotionSimulatorVehicle(session, *ride, -16, -16, direction, height, trackElement);
-                break;
-        }
+    switch (trackSequence)
+    {
+        case 1:
+            PaintMotionSimulatorVehicle(session, *ride, 16, -16, direction, height, trackElement);
+            break;
+        case 2:
+            PaintMotionSimulatorVehicle(session, *ride, -16, 16, direction, height, trackElement);
+            break;
+        case 3:
+            PaintMotionSimulatorVehicle(session, *ride, -16, -16, direction, height, trackElement);
+            break;
+    }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 128, 0x20);

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -112,9 +112,9 @@ static void paint_roto_drop_base(
     track_paint_util_paint_floor(
         session, edges, session->TrackColours[SCHEME_SUPPORTS], height, floorSpritesMetalB, stationObject);
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
-            fenceSpritesMetalB, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
+        fenceSpritesMetalB, session->CurrentRotation);
 
     if (trackSequence == 0)
     {

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -98,7 +98,7 @@ void vehicle_visual_roto_drop(
 
 /** rct2: 0x00886194 */
 static void paint_roto_drop_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -107,13 +107,13 @@ static void paint_roto_drop_base(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(
         session, edges, session->TrackColours[SCHEME_SUPPORTS], height, floorSpritesMetalB, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
         fenceSpritesMetalB, session->CurrentRotation);
 
     if (trackSequence == 0)
@@ -177,7 +177,7 @@ static void paint_roto_drop_base(
 
 /** rct2: 0x008861A4 */
 static void paint_roto_drop_tower_section(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -107,19 +107,14 @@ static void paint_roto_drop_base(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(
         session, edges, session->TrackColours[SCHEME_SUPPORTS], height, floorSpritesMetalB, stationObject);
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
             fenceSpritesMetalB, session->CurrentRotation);
-    }
 
     if (trackSequence == 0)
     {

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -141,9 +141,7 @@ static void PaintSwingingInverterShip(
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
     uint32_t imageId;
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     if (relativeTrackSequence != 1 && relativeTrackSequence != 3)
     {
@@ -185,8 +183,6 @@ static void PaintSwingingInverterShip(
         }
     }
 
-    if (ride != nullptr)
-    {
         switch (relativeTrackSequence)
         {
             case 1:
@@ -202,7 +198,6 @@ static void PaintSwingingInverterShip(
                 PaintSwingingInverterShipStructure(session, *ride, direction, -48, height + 7);
                 break;
         }
-    }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 176, 0x20);

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -135,13 +135,13 @@ static void PaintSwingingInverterShipStructure(
 }
 
 static void PaintSwingingInverterShip(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];
     uint32_t imageId;
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     if (relativeTrackSequence != 1 && relativeTrackSequence != 3)
     {
@@ -186,16 +186,16 @@ static void PaintSwingingInverterShip(
         switch (relativeTrackSequence)
         {
             case 1:
-                PaintSwingingInverterShipStructure(session, *ride, direction, 48, height + 7);
+                PaintSwingingInverterShipStructure(session, ride, direction, 48, height + 7);
                 break;
             case 2:
-                PaintSwingingInverterShipStructure(session, *ride, direction, 16, height + 7);
+                PaintSwingingInverterShipStructure(session, ride, direction, 16, height + 7);
                 break;
             case 0:
-                PaintSwingingInverterShipStructure(session, *ride, direction, -16, height + 7);
+                PaintSwingingInverterShipStructure(session, ride, direction, -16, height + 7);
                 break;
             case 3:
-                PaintSwingingInverterShipStructure(session, *ride, direction, -48, height + 7);
+                PaintSwingingInverterShipStructure(session, ride, direction, -48, height + 7);
                 break;
         }
 

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -183,21 +183,21 @@ static void PaintSwingingInverterShip(
         }
     }
 
-        switch (relativeTrackSequence)
-        {
-            case 1:
-                PaintSwingingInverterShipStructure(session, ride, direction, 48, height + 7);
-                break;
-            case 2:
-                PaintSwingingInverterShipStructure(session, ride, direction, 16, height + 7);
-                break;
-            case 0:
-                PaintSwingingInverterShipStructure(session, ride, direction, -16, height + 7);
-                break;
-            case 3:
-                PaintSwingingInverterShipStructure(session, ride, direction, -48, height + 7);
-                break;
-        }
+    switch (relativeTrackSequence)
+    {
+        case 1:
+            PaintSwingingInverterShipStructure(session, ride, direction, 48, height + 7);
+            break;
+        case 2:
+            PaintSwingingInverterShipStructure(session, ride, direction, 16, height + 7);
+            break;
+        case 0:
+            PaintSwingingInverterShipStructure(session, ride, direction, -16, height + 7);
+            break;
+        case 3:
+            PaintSwingingInverterShipStructure(session, ride, direction, -48, height + 7);
+            break;
+    }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 176, 0x20);

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -162,7 +162,7 @@ static void PaintSwingingShipStructure(
 }
 
 static void PaintSwingingShip(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_1x5[direction][trackSequence];
@@ -170,7 +170,7 @@ static void PaintSwingingShip(
     uint32_t imageId;
     bool hasFence;
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     if (relativeTrackSequence == 1 || relativeTrackSequence == 4)
     {
@@ -208,7 +208,7 @@ static void PaintSwingingShip(
             if (relativeTrackSequence != 1 && relativeTrackSequence != 4)
             {
                 hasFence = track_paint_util_has_fence(
-                    EDGE_NE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+                    EDGE_NE, session->MapPosition, trackElement, ride, session->CurrentRotation);
                 if (relativeTrackSequence == 2)
                 {
                     imageId = (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_NW_SE : SPR_STATION_PLATFORM_BEGIN_NW_SE)
@@ -226,7 +226,7 @@ static void PaintSwingingShip(
                 PaintAddImageAsParent(session, imageId, { 24, 0, height + 9 }, { 8, 32, 1 });
 
                 hasFence = track_paint_util_has_fence(
-                    EDGE_SW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+                    EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
                 if (relativeTrackSequence == 3)
                 {
                     if (hasFence)
@@ -255,7 +255,7 @@ static void PaintSwingingShip(
             if (relativeTrackSequence != 1 && relativeTrackSequence != 4)
             {
                 hasFence = track_paint_util_has_fence(
-                    EDGE_NW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+                    EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
                 if (relativeTrackSequence == 2)
                 {
                     imageId = (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_SW_NE : SPR_STATION_PLATFORM_BEGIN_SW_NE)
@@ -273,7 +273,7 @@ static void PaintSwingingShip(
                 PaintAddImageAsParent(session, imageId, { 0, 24, height + 9 }, { 32, 8, 1 });
 
                 hasFence = track_paint_util_has_fence(
-                    EDGE_SE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
+                    EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation);
                 if (relativeTrackSequence == 3)
                 {
                     if (hasFence)
@@ -301,19 +301,19 @@ static void PaintSwingingShip(
     switch (relativeTrackSequence)
     {
         case 1:
-            PaintSwingingShipStructure(session, *ride, direction, 64, height);
+            PaintSwingingShipStructure(session, ride, direction, 64, height);
             break;
         case 2:
-            PaintSwingingShipStructure(session, *ride, direction, 32, height);
+            PaintSwingingShipStructure(session, ride, direction, 32, height);
             break;
         case 0:
-            PaintSwingingShipStructure(session, *ride, direction, 0, height);
+            PaintSwingingShipStructure(session, ride, direction, 0, height);
             break;
         case 3:
-            PaintSwingingShipStructure(session, *ride, direction, -32, height);
+            PaintSwingingShipStructure(session, ride, direction, -32, height);
             break;
         case 4:
-            PaintSwingingShipStructure(session, *ride, direction, -64, height);
+            PaintSwingingShipStructure(session, ride, direction, -64, height);
             break;
     }
 

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -208,7 +208,7 @@ static void PaintSwingingShip(
             if (relativeTrackSequence != 1 && relativeTrackSequence != 4)
             {
                 hasFence = track_paint_util_has_fence(
-                    EDGE_NE, session->MapPosition, trackElement, ride, session->CurrentRotation);
+                    EDGE_NE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
                 if (relativeTrackSequence == 2)
                 {
                     imageId = (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_NW_SE : SPR_STATION_PLATFORM_BEGIN_NW_SE)
@@ -226,7 +226,7 @@ static void PaintSwingingShip(
                 PaintAddImageAsParent(session, imageId, { 24, 0, height + 9 }, { 8, 32, 1 });
 
                 hasFence = track_paint_util_has_fence(
-                    EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation);
+                    EDGE_SW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
                 if (relativeTrackSequence == 3)
                 {
                     if (hasFence)
@@ -255,7 +255,7 @@ static void PaintSwingingShip(
             if (relativeTrackSequence != 1 && relativeTrackSequence != 4)
             {
                 hasFence = track_paint_util_has_fence(
-                    EDGE_NW, session->MapPosition, trackElement, ride, session->CurrentRotation);
+                    EDGE_NW, session->MapPosition, trackElement, *ride, session->CurrentRotation);
                 if (relativeTrackSequence == 2)
                 {
                     imageId = (hasFence ? SPR_STATION_PLATFORM_BEGIN_FENCED_SW_NE : SPR_STATION_PLATFORM_BEGIN_SW_NE)
@@ -273,7 +273,7 @@ static void PaintSwingingShip(
                 PaintAddImageAsParent(session, imageId, { 0, 24, height + 9 }, { 32, 8, 1 });
 
                 hasFence = track_paint_util_has_fence(
-                    EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation);
+                    EDGE_SE, session->MapPosition, trackElement, *ride, session->CurrentRotation);
                 if (relativeTrackSequence == 3)
                 {
                     if (hasFence)

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -165,17 +165,12 @@ static void PaintSwingingShip(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (ride == nullptr)
-        return;
-
     uint8_t relativeTrackSequence = track_map_1x5[direction][trackSequence];
 
     uint32_t imageId;
     bool hasFence;
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     if (relativeTrackSequence == 1 || relativeTrackSequence == 4)
     {

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -186,7 +186,7 @@ static void PaintTopSpinVehicle(
 }
 
 static void PaintTopSpin(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -195,33 +195,33 @@ static void PaintTopSpin(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
     track_paint_util_paint_fences(
-        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
         session->CurrentRotation);
 
     switch (trackSequence)
     {
         case 1:
-            PaintTopSpinVehicle(session, 32, 32, *ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, 32, 32, ride, direction, height, trackElement);
             break;
         case 3:
-            PaintTopSpinVehicle(session, 32, -32, *ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, 32, -32, ride, direction, height, trackElement);
             break;
         case 5:
-            PaintTopSpinVehicle(session, 0, -32, *ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, 0, -32, ride, direction, height, trackElement);
             break;
         case 6:
-            PaintTopSpinVehicle(session, -32, 32, *ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, -32, 32, ride, direction, height, trackElement);
             break;
         case 7:
-            PaintTopSpinVehicle(session, -32, -32, *ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, -32, -32, ride, direction, height, trackElement);
             break;
         case 8:
-            PaintTopSpinVehicle(session, -32, 0, *ride, direction, height, trackElement);
+            PaintTopSpinVehicle(session, -32, 0, ride, direction, height, trackElement);
             break;
     }
 

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -199,31 +199,31 @@ static void PaintTopSpin(
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
-            fenceSpritesRope, session->CurrentRotation);
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height, fenceSpritesRope,
+        session->CurrentRotation);
 
-        switch (trackSequence)
-        {
-            case 1:
-                PaintTopSpinVehicle(session, 32, 32, *ride, direction, height, trackElement);
-                break;
-            case 3:
-                PaintTopSpinVehicle(session, 32, -32, *ride, direction, height, trackElement);
-                break;
-            case 5:
-                PaintTopSpinVehicle(session, 0, -32, *ride, direction, height, trackElement);
-                break;
-            case 6:
-                PaintTopSpinVehicle(session, -32, 32, *ride, direction, height, trackElement);
-                break;
-            case 7:
-                PaintTopSpinVehicle(session, -32, -32, *ride, direction, height, trackElement);
-                break;
-            case 8:
-                PaintTopSpinVehicle(session, -32, 0, *ride, direction, height, trackElement);
-                break;
-        }
+    switch (trackSequence)
+    {
+        case 1:
+            PaintTopSpinVehicle(session, 32, 32, *ride, direction, height, trackElement);
+            break;
+        case 3:
+            PaintTopSpinVehicle(session, 32, -32, *ride, direction, height, trackElement);
+            break;
+        case 5:
+            PaintTopSpinVehicle(session, 0, -32, *ride, direction, height, trackElement);
+            break;
+        case 6:
+            PaintTopSpinVehicle(session, -32, 32, *ride, direction, height, trackElement);
+            break;
+        case 7:
+            PaintTopSpinVehicle(session, -32, -32, *ride, direction, height, trackElement);
+            break;
+        case 8:
+            PaintTopSpinVehicle(session, -32, 0, *ride, direction, height, trackElement);
+            break;
+    }
 
     int32_t cornerSegments = 0;
     switch (trackSequence)

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -195,14 +195,10 @@ static void PaintTopSpin(
 
     wooden_a_supports_paint_setup(session, direction & 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = nullptr;
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride->GetStationObject();
 
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_TRACK], height, floorSpritesCork, stationObject);
 
-    if (ride != nullptr)
-    {
         track_paint_util_paint_fences(
             session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
             fenceSpritesRope, session->CurrentRotation);
@@ -228,7 +224,6 @@ static void PaintTopSpin(
                 PaintTopSpinVehicle(session, -32, 0, *ride, direction, height, trackElement);
                 break;
         }
-    }
 
     int32_t cornerSegments = 0;
     switch (trackSequence)

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -84,9 +84,6 @@ static void paint_twist(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (ride == nullptr)
-        return;
-
     trackSequence = track_map_3x3[direction][trackSequence];
 
     const uint8_t edges = edges_3x3[trackSequence];

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -111,7 +111,7 @@ static void paint_twist(
             break;
         default:
             track_paint_util_paint_fences(
-                session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
+                session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height,
                 fenceSpritesRope, session->CurrentRotation);
             break;
     }

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -98,12 +98,12 @@ static void paint_twist(
     switch (trackSequence)
     {
         case 7:
-            if (track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation))
+            if (track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, *ride, session->CurrentRotation))
             {
                 imageId = SPR_FENCE_ROPE_SW | session->TrackColours[SCHEME_MISC];
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 28, 7 }, { 29, 0, height + 3 });
             }
-            if (track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation))
+            if (track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, *ride, session->CurrentRotation))
             {
                 imageId = SPR_FENCE_ROPE_SE | session->TrackColours[SCHEME_MISC];
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 3 });

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -20,11 +20,11 @@
 
 /** rct2: 0x0076E5C9 */
 static void paint_twist_structure(
-    paint_session* session, const Ride* ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    paint_session* session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
 {
     const TileElement* savedTileElement = static_cast<const TileElement*>(session->CurrentlyDrawnItem);
 
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
     Vehicle* vehicle = nullptr;
 
     if (rideEntry == nullptr)
@@ -34,9 +34,9 @@ static void paint_twist_structure(
 
     height += 7;
 
-    if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && ride->vehicles[0] != SPRITE_INDEX_NULL)
+    if (ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && ride.vehicles[0] != SPRITE_INDEX_NULL)
     {
-        vehicle = GetEntity<Vehicle>(ride->vehicles[0]);
+        vehicle = GetEntity<Vehicle>(ride.vehicles[0]);
 
         session->InteractionType = ViewportInteractionItem::Entity;
         session->CurrentlyDrawnItem = vehicle;
@@ -51,7 +51,7 @@ static void paint_twist_structure(
     }
 
     auto imageFlags = session->TrackColours[SCHEME_MISC];
-    auto imageTemplate = ImageId(0, ride->vehicle_colours[0].Body, ride->vehicle_colours[0].Trim);
+    auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     if (imageFlags != IMAGE_TYPE_REMAP)
     {
         imageTemplate = ImageId::FromUInt32(imageFlags);
@@ -63,7 +63,7 @@ static void paint_twist_structure(
     PaintAddImageAsParent(
         session, imageId, { xOffset, yOffset, height }, { 24, 24, 48 }, { xOffset + 16, yOffset + 16, height });
 
-    if (session->DPI.zoom_level < ZoomLevel{ 1 } && ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
+    if (session->DPI.zoom_level < ZoomLevel{ 1 } && ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
     {
         for (int32_t i = 0; i < vehicle->num_peeps; i += 2)
         {
@@ -81,7 +81,7 @@ static void paint_twist_structure(
 
 /** rct2: 0x0076D858 */
 static void paint_twist(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -92,18 +92,18 @@ static void paint_twist(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_MISC]);
 
-    const StationObject* stationObject = ride->GetStationObject();
+    const StationObject* stationObject = ride.GetStationObject();
     track_paint_util_paint_floor(session, edges, session->TrackColours[SCHEME_MISC], height, floorSpritesCork, stationObject);
 
     switch (trackSequence)
     {
         case 7:
-            if (track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, *ride, session->CurrentRotation))
+            if (track_paint_util_has_fence(EDGE_SW, session->MapPosition, trackElement, ride, session->CurrentRotation))
             {
                 imageId = SPR_FENCE_ROPE_SW | session->TrackColours[SCHEME_MISC];
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 28, 7 }, { 29, 0, height + 3 });
             }
-            if (track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, *ride, session->CurrentRotation))
+            if (track_paint_util_has_fence(EDGE_SE, session->MapPosition, trackElement, ride, session->CurrentRotation))
             {
                 imageId = SPR_FENCE_ROPE_SE | session->TrackColours[SCHEME_MISC];
                 PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 7 }, { 0, 29, height + 3 });
@@ -111,7 +111,7 @@ static void paint_twist(
             break;
         default:
             track_paint_util_paint_fences(
-                session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_MISC], height,
+                session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_MISC], height,
                 fenceSpritesRope, session->CurrentRotation);
             break;
     }

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -112,7 +112,7 @@ static void chairlift_paint_util_draw_supports(paint_session* session, int32_t s
 }
 
 static const TrackElement* chairlift_paint_util_map_get_track_element_at_from_ride_fuzzy(
-    int32_t x, int32_t y, int32_t z, const Ride* ride)
+    int32_t x, int32_t y, int32_t z, const Ride& ride)
 {
     const TileElement* tileElement = map_get_first_element_at(CoordsXY{ x, y });
     if (tileElement == nullptr)
@@ -124,7 +124,7 @@ static const TrackElement* chairlift_paint_util_map_get_track_element_at_from_ri
     {
         if (tileElement->GetType() != TileElementType::Track)
             continue;
-        if (tileElement->GetRideIndex() != ride->id)
+        if (tileElement->GetRideIndex() != ride.id)
             continue;
         if (tileElement->base_height != z && tileElement->base_height != z - 1)
             continue;
@@ -136,7 +136,7 @@ static const TrackElement* chairlift_paint_util_map_get_track_element_at_from_ri
 };
 
 static bool chairlift_paint_util_is_first_track(
-    const Ride* ride, const TrackElement& trackElement, const CoordsXY& pos, track_type_t trackType)
+    const Ride& ride, const TrackElement& trackElement, const CoordsXY& pos, track_type_t trackType)
 {
     if (trackElement.GetTrackType() != TrackElemType::BeginStation)
     {
@@ -156,7 +156,7 @@ static bool chairlift_paint_util_is_first_track(
 }
 
 static bool chairlift_paint_util_is_last_track(
-    const Ride* ride, const TrackElement& trackElement, const CoordsXY& pos, track_type_t trackType)
+    const Ride& ride, const TrackElement& trackElement, const CoordsXY& pos, track_type_t trackType)
 {
     if (trackElement.GetTrackType() != TrackElemType::EndStation)
     {
@@ -176,7 +176,7 @@ static bool chairlift_paint_util_is_last_track(
 }
 
 static void chairlift_paint_station_ne_sw(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const CoordsXY pos = session->MapPosition;
@@ -186,7 +186,7 @@ static void chairlift_paint_station_ne_sw(
     bool isStart = chairlift_paint_util_is_first_track(ride, trackElement, pos, trackType);
     bool isEnd = chairlift_paint_util_is_last_track(ride, trackElement, pos, trackType);
 
-    const auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride.GetStationObject();
 
     wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_MISC]);
 
@@ -199,7 +199,7 @@ static void chairlift_paint_station_ne_sw(
     imageId = SPR_FLOOR_METAL | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
 
-    bool hasFence = track_paint_util_has_fence(EDGE_NW, pos, trackElement, *ride, session->CurrentRotation);
+    bool hasFence = track_paint_util_has_fence(EDGE_NW, pos, trackElement, ride, session->CurrentRotation);
     if (hasFence)
     {
         imageId = SPR_FENCE_METAL_NW | session->TrackColours[SCHEME_TRACK];
@@ -213,7 +213,7 @@ static void chairlift_paint_station_ne_sw(
         PaintAddImageAsChild(session, imageId, 0, 0, 1, 28, 7, height, 2, 2, height + 4);
     }
 
-    hasFence = track_paint_util_has_fence(EDGE_SE, pos, trackElement, *ride, session->CurrentRotation);
+    hasFence = track_paint_util_has_fence(EDGE_SE, pos, trackElement, ride, session->CurrentRotation);
     if (hasFence)
     {
         imageId = SPR_FENCE_METAL_SE | session->TrackColours[SCHEME_TRACK];
@@ -228,7 +228,7 @@ static void chairlift_paint_station_ne_sw(
         imageId = SPR_FENCE_METAL_SW | session->TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 1, 28, 27 }, { 30, 2, height + 4 });
 
-        imageId = chairlift_bullwheel_frames[ride->chairlift_bullwheel_rotation / 16384] | session->TrackColours[SCHEME_TRACK];
+        imageId = chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384] | session->TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
         imageId = SPR_CHAIRLIFT_STATION_END_CAP_NE | session->TrackColours[SCHEME_TRACK];
@@ -238,7 +238,7 @@ static void chairlift_paint_station_ne_sw(
     }
     else if ((direction == 2 && isStart) || (direction == 0 && isEnd))
     {
-        imageId = chairlift_bullwheel_frames[ride->chairlift_bullwheel_rotation / 16384] | session->TrackColours[SCHEME_TRACK];
+        imageId = chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384] | session->TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
         imageId = SPR_CHAIRLIFT_STATION_END_CAP_SW | session->TrackColours[SCHEME_TRACK];
@@ -266,7 +266,7 @@ static void chairlift_paint_station_ne_sw(
 }
 
 static void chairlift_paint_station_se_nw(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const CoordsXY pos = session->MapPosition;
@@ -276,7 +276,7 @@ static void chairlift_paint_station_se_nw(
     bool isStart = chairlift_paint_util_is_first_track(ride, trackElement, pos, trackType);
     bool isEnd = chairlift_paint_util_is_last_track(ride, trackElement, pos, trackType);
 
-    const auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride.GetStationObject();
 
     wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_MISC]);
 
@@ -289,7 +289,7 @@ static void chairlift_paint_station_se_nw(
     imageId = SPR_FLOOR_METAL | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
 
-    bool hasFence = track_paint_util_has_fence(EDGE_NE, pos, trackElement, *ride, session->CurrentRotation);
+    bool hasFence = track_paint_util_has_fence(EDGE_NE, pos, trackElement, ride, session->CurrentRotation);
     if (hasFence)
     {
         imageId = SPR_FENCE_METAL_NE | session->TrackColours[SCHEME_TRACK];
@@ -303,7 +303,7 @@ static void chairlift_paint_station_se_nw(
         PaintAddImageAsChild(session, imageId, 0, 0, 28, 1, 7, height, 2, 2, height + 4);
     }
 
-    hasFence = track_paint_util_has_fence(EDGE_SW, pos, trackElement, *ride, session->CurrentRotation);
+    hasFence = track_paint_util_has_fence(EDGE_SW, pos, trackElement, ride, session->CurrentRotation);
     if (hasFence)
     {
         imageId = SPR_FENCE_METAL_SW | session->TrackColours[SCHEME_TRACK];
@@ -315,7 +315,7 @@ static void chairlift_paint_station_se_nw(
     bool drawLeftColumn = true;
     if ((direction == 1 && isStart) || (direction == 3 && isEnd))
     {
-        imageId = chairlift_bullwheel_frames[ride->chairlift_bullwheel_rotation / 16384] | session->TrackColours[SCHEME_TRACK];
+        imageId = chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384] | session->TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
         imageId = SPR_CHAIRLIFT_STATION_END_CAP_SE | session->TrackColours[SCHEME_TRACK];
@@ -328,7 +328,7 @@ static void chairlift_paint_station_se_nw(
         imageId = SPR_FENCE_METAL_SE | session->TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 28, 1, 27 }, { 2, 30, height + 4 });
 
-        imageId = chairlift_bullwheel_frames[ride->chairlift_bullwheel_rotation / 16384] | session->TrackColours[SCHEME_TRACK];
+        imageId = chairlift_bullwheel_frames[ride.chairlift_bullwheel_rotation / 16384] | session->TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 4, 4, 26 }, { 14, 14, height + 4 });
 
         imageId = SPR_CHAIRLIFT_STATION_END_CAP_NW | session->TrackColours[SCHEME_TRACK];
@@ -358,7 +358,7 @@ static void chairlift_paint_station_se_nw(
 
 /** rct2: 0x00744068 */
 static void chairlift_paint_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction % 2)
@@ -372,7 +372,7 @@ static void chairlift_paint_station(
 }
 
 static void chairlift_paint_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -395,7 +395,7 @@ static void chairlift_paint_flat(
 
 /** rct2: 0x00743FD8 */
 static void chairlift_paint_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -433,7 +433,7 @@ static void chairlift_paint_25_deg_up(
 
 /** rct2: 0x00743FD8 */
 static void chairlift_paint_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -488,7 +488,7 @@ static void chairlift_paint_flat_to_25_deg_up(
 
 /** rct2: 0x00743FF8 */
 static void chairlift_paint_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -543,7 +543,7 @@ static void chairlift_paint_25_deg_up_to_flat(
 
 /** rct2: 0x00744008 */
 static void chairlift_paint_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     chairlift_paint_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -551,7 +551,7 @@ static void chairlift_paint_25_deg_down(
 
 /** rct2: 0x00744018 */
 static void chairlift_paint_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     chairlift_paint_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -559,7 +559,7 @@ static void chairlift_paint_flat_to_25_deg_down(
 
 /** rct2: 0x00744028 */
 static void chairlift_paint_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     chairlift_paint_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -567,7 +567,7 @@ static void chairlift_paint_25_deg_down_to_flat(
 
 /** rct2: 0x00744038 */
 static void chairlift_paint_left_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -634,7 +634,7 @@ static void chairlift_paint_left_quarter_turn_1_tile(
 
 /** rct2: 0x00744048 */
 static void chairlift_paint_right_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     chairlift_paint_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -186,7 +186,7 @@ static void chairlift_paint_station_ne_sw(
     bool isStart = chairlift_paint_util_is_first_track(ride, trackElement, pos, trackType);
     bool isEnd = chairlift_paint_util_is_last_track(ride, trackElement, pos, trackType);
 
-    const auto stationObj = ride.GetStationObject();
+    const auto* stationObj = ride.GetStationObject();
 
     wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_MISC]);
 
@@ -276,7 +276,7 @@ static void chairlift_paint_station_se_nw(
     bool isStart = chairlift_paint_util_is_first_track(ride, trackElement, pos, trackType);
     bool isEnd = chairlift_paint_util_is_last_track(ride, trackElement, pos, trackType);
 
-    const auto stationObj = ride.GetStationObject();
+    const auto* stationObj = ride.GetStationObject();
 
     wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_MISC]);
 

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -179,9 +179,6 @@ static void chairlift_paint_station_ne_sw(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (ride == nullptr)
-        return;
-
     const CoordsXY pos = session->MapPosition;
     auto trackType = trackElement.GetTrackType();
     uint32_t imageId;
@@ -189,7 +186,7 @@ static void chairlift_paint_station_ne_sw(
     bool isStart = chairlift_paint_util_is_first_track(ride, trackElement, pos, trackType);
     bool isEnd = chairlift_paint_util_is_last_track(ride, trackElement, pos, trackType);
 
-    auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride->GetStationObject();
 
     wooden_a_supports_paint_setup(session, 0, 0, height, session->TrackColours[SCHEME_MISC]);
 
@@ -272,9 +269,6 @@ static void chairlift_paint_station_se_nw(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (ride == nullptr)
-        return;
-
     const CoordsXY pos = session->MapPosition;
     auto trackType = trackElement.GetTrackType();
     uint32_t imageId;
@@ -282,7 +276,7 @@ static void chairlift_paint_station_se_nw(
     bool isStart = chairlift_paint_util_is_first_track(ride, trackElement, pos, trackType);
     bool isEnd = chairlift_paint_util_is_last_track(ride, trackElement, pos, trackType);
 
-    auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride->GetStationObject();
 
     wooden_a_supports_paint_setup(session, 1, 0, height, session->TrackColours[SCHEME_MISC]);
 

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -199,7 +199,7 @@ static void chairlift_paint_station_ne_sw(
     imageId = SPR_FLOOR_METAL | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
 
-    bool hasFence = track_paint_util_has_fence(EDGE_NW, pos, trackElement, ride, session->CurrentRotation);
+    bool hasFence = track_paint_util_has_fence(EDGE_NW, pos, trackElement, *ride, session->CurrentRotation);
     if (hasFence)
     {
         imageId = SPR_FENCE_METAL_NW | session->TrackColours[SCHEME_TRACK];
@@ -213,7 +213,7 @@ static void chairlift_paint_station_ne_sw(
         PaintAddImageAsChild(session, imageId, 0, 0, 1, 28, 7, height, 2, 2, height + 4);
     }
 
-    hasFence = track_paint_util_has_fence(EDGE_SE, pos, trackElement, ride, session->CurrentRotation);
+    hasFence = track_paint_util_has_fence(EDGE_SE, pos, trackElement, *ride, session->CurrentRotation);
     if (hasFence)
     {
         imageId = SPR_FENCE_METAL_SE | session->TrackColours[SCHEME_TRACK];
@@ -289,7 +289,7 @@ static void chairlift_paint_station_se_nw(
     imageId = SPR_FLOOR_METAL | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
 
-    bool hasFence = track_paint_util_has_fence(EDGE_NE, pos, trackElement, ride, session->CurrentRotation);
+    bool hasFence = track_paint_util_has_fence(EDGE_NE, pos, trackElement, *ride, session->CurrentRotation);
     if (hasFence)
     {
         imageId = SPR_FENCE_METAL_NE | session->TrackColours[SCHEME_TRACK];
@@ -303,7 +303,7 @@ static void chairlift_paint_station_se_nw(
         PaintAddImageAsChild(session, imageId, 0, 0, 28, 1, 7, height, 2, 2, height + 4);
     }
 
-    hasFence = track_paint_util_has_fence(EDGE_SW, pos, trackElement, ride, session->CurrentRotation);
+    hasFence = track_paint_util_has_fence(EDGE_SW, pos, trackElement, *ride, session->CurrentRotation);
     if (hasFence)
     {
         imageId = SPR_FENCE_METAL_SW | session->TrackColours[SCHEME_TRACK];

--- a/src/openrct2/ride/transport/Lift.cpp
+++ b/src/openrct2/ride/transport/Lift.cpp
@@ -47,7 +47,7 @@ static void paint_lift_cage(paint_session* session, int8_t index, uint32_t colou
 
 /** rct2: 0x0076C6CC */
 static void paint_lift_base(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -77,12 +77,9 @@ static void paint_lift_base(
     uint32_t imageId = SPR_FLOOR_METAL_B | session->TrackColours[SCHEME_SUPPORTS];
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
 
-    if (ride != nullptr)
-    {
-        track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
-            fenceSpritesMetalB, session->CurrentRotation);
-    }
+    track_paint_util_paint_fences(
+        session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
+        fenceSpritesMetalB, session->CurrentRotation);
 
     int32_t blockedSegments = 0;
     switch (trackSequence)
@@ -119,7 +116,7 @@ static void paint_lift_base(
 
 /** rct2: 0x0076C6DC */
 static void paint_lift_tower_section(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/transport/Lift.cpp
+++ b/src/openrct2/ride/transport/Lift.cpp
@@ -80,7 +80,7 @@ static void paint_lift_base(
     if (ride != nullptr)
     {
         track_paint_util_paint_fences(
-            session, edges, session->MapPosition, trackElement, ride, session->TrackColours[SCHEME_TRACK], height,
+            session, edges, session->MapPosition, trackElement, *ride, session->TrackColours[SCHEME_TRACK], height,
             fenceSpritesMetalB, session->CurrentRotation);
     }
 

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -624,7 +624,7 @@ static uint32_t miniature_railway_track_to_grooved_indent(
 
 /** rct2: 0x008AD0C0 */
 static void paint_miniature_railway_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool paintAsGravel = false;
@@ -703,7 +703,7 @@ static void paint_miniature_railway_track_flat(
 
 /** rct2: 0x008AD170, 0x008AD180, 0x008AD190 */
 static void paint_miniature_railway_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -718,7 +718,7 @@ static void paint_miniature_railway_station(
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
-    track_paint_util_draw_station_3(session, *ride, direction, height + 2, height, trackElement);
+    track_paint_util_draw_station_3(session, ride, direction, height + 2, height, trackElement);
     // covers shouldn't be offset by +2
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -727,7 +727,7 @@ static void paint_miniature_railway_station(
 
 /** rct2: 0x008AD0D0 */
 static void paint_miniature_railway_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = miniature_railway_track_pieces_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -758,7 +758,7 @@ static void paint_miniature_railway_track_25_deg_up(
 
 /** rct2: 0x008AD0E0 */
 static void paint_miniature_railway_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = miniature_railway_track_pieces_flat_to_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -789,7 +789,7 @@ static void paint_miniature_railway_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AD0F0 */
 static void paint_miniature_railway_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = miniature_railway_track_pieces_25_deg_up_to_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -820,7 +820,7 @@ static void paint_miniature_railway_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AD100 */
 static void paint_miniature_railway_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_miniature_railway_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -828,7 +828,7 @@ static void paint_miniature_railway_track_25_deg_down(
 
 /** rct2: 0x008AD110 */
 static void paint_miniature_railway_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_miniature_railway_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -836,7 +836,7 @@ static void paint_miniature_railway_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AD120 */
 static void paint_miniature_railway_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_miniature_railway_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -979,7 +979,7 @@ static constexpr const int8_t miniature_railway_right_quarter_turn_5_tiles_sprit
 
 /** rct2: 0x008AD140 */
 static void paint_miniature_railway_track_right_quarter_turn_5_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (right_quarter_turn_5_supports_type[direction][trackSequence] != -1)
@@ -1068,7 +1068,7 @@ static void paint_miniature_railway_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x008AD130 */
 static void paint_miniature_railway_track_left_quarter_turn_5_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1100,7 +1100,7 @@ static constexpr const uint32_t miniature_railway_s_bend_left_tiles_track_floor[
 
 /** rct2: 0x8AD150 */
 static void paint_miniature_railway_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -1209,7 +1209,7 @@ static constexpr const uint32_t miniature_railway_s_bend_right_tiles_track_floor
 
 /** rct2: 0x008AD160 */
 static void paint_miniature_railway_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -1342,7 +1342,7 @@ static constexpr const CoordsXYZ miniature_railway_right_quarter_turn_3_tile_bou
 
 /** rct2: 0x008AD1B0 */
 static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isSupported = false;
@@ -1408,7 +1408,7 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x008AD1A0 */
 static void paint_miniature_railway_track_left_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1515,7 +1515,7 @@ static constexpr const CoordsXY miniature_railway_track_floor_pieces_left_eight_
 
 /** rct2: 0x008AD1C0 */
 static void paint_miniature_railway_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t supportType[4][5] = {
@@ -1677,7 +1677,7 @@ static constexpr const CoordsXY miniature_railway_track_floor_pieces_right_eight
 
 /** rct2: 0x008AD1D0 */
 static void paint_miniature_railway_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t supportType[4][5] = {
@@ -1749,7 +1749,7 @@ static void paint_miniature_railway_track_right_eighth_to_diag(
 
 /** rct2: 0x008AD1E0 */
 static void paint_miniature_railway_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1758,7 +1758,7 @@ static void paint_miniature_railway_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008AD1F0 */
 static void paint_miniature_railway_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1807,7 +1807,7 @@ static constexpr const floor_desc floors[] = {
 
 /** rct2: 0x008AD200 */
 static void miniature_railway_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isSupported = false;
@@ -1878,7 +1878,7 @@ static bool wooden_supports_paint_setup(
 
 /** rct2: 0x008AD230 */
 static void miniature_railway_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     // TODO: The supports are inconsistent for different rotations
@@ -1958,7 +1958,7 @@ static void miniature_railway_track_diag_25_deg_up(
 
 /** rct2: 0x008AD210 */
 static void miniature_railway_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool hasSupports = false;
@@ -2008,7 +2008,7 @@ static void miniature_railway_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AD220 */
 static void miniature_railway_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t supportOffsets[][4] = {
@@ -2084,7 +2084,7 @@ static void miniature_railway_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AD260 */
 static void miniature_railway_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t supportOffsets[][4] = {
@@ -2159,7 +2159,7 @@ static void miniature_railway_track_diag_25_deg_down(
 
 /** rct2: 0x008AD240 */
 static void miniature_railway_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t supportOffsets[][4] = {
@@ -2232,7 +2232,7 @@ static void miniature_railway_track_diag_flat_to_25_deg_down(
 }
 
 static void miniature_railway_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool hasSupports = false;

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -718,7 +718,7 @@ static void paint_miniature_railway_station(
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
-    track_paint_util_draw_station_3(session, ride, direction, height + 2, height, trackElement);
+    track_paint_util_draw_station_3(session, *ride, direction, height + 2, height, trackElement);
     // covers shouldn't be offset by +2
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -524,7 +524,7 @@ static void paint_monorail_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -436,7 +436,7 @@ static constexpr const uint32_t monorail_track_pieces_diag_25_deg_up[4] = {
 
 /** rct2: 0x008AE1AC */
 static void paint_monorail_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = monorail_track_pieces_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -471,14 +471,13 @@ static void paint_monorail_track_flat(
 
 /** rct2: 0x008AE25C, 0x008AE26C, 0x008AE27C */
 static void paint_monorail_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
     const StationObject* stationObject = nullptr;
 
-    if (ride != nullptr)
-        stationObject = ride->GetStationObject();
+    stationObject = ride.GetStationObject();
 
     if (stationObject == nullptr || !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
@@ -524,7 +523,7 @@ static void paint_monorail_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 7, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 32, 0x20);
@@ -532,7 +531,7 @@ static void paint_monorail_station(
 
 /** rct2: 0x008AE1BC */
 static void paint_monorail_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = monorail_track_pieces_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -574,7 +573,7 @@ static void paint_monorail_track_25_deg_up(
 
 /** rct2: 0x008AE1CC */
 static void paint_monorail_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = monorail_track_pieces_flat_to_25_deg_up[direction] | session->TrackColours[SCHEME_TRACK];
@@ -616,7 +615,7 @@ static void paint_monorail_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AE1DC */
 static void paint_monorail_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = monorail_track_pieces_25_deg_up_to_flat[direction] | session->TrackColours[SCHEME_TRACK];
@@ -658,7 +657,7 @@ static void paint_monorail_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AE1EC */
 static void paint_monorail_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_monorail_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -666,7 +665,7 @@ static void paint_monorail_track_25_deg_down(
 
 /** rct2: 0x008AE1FC */
 static void paint_monorail_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_monorail_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -674,7 +673,7 @@ static void paint_monorail_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AE20C */
 static void paint_monorail_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_monorail_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -682,7 +681,7 @@ static void paint_monorail_track_25_deg_down_to_flat(
 
 /** rct2: 0x008AE22C */
 static void paint_monorail_track_right_quarter_turn_5_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -745,7 +744,7 @@ static void paint_monorail_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x008AE21C */
 static void paint_monorail_track_left_quarter_turn_5_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -754,7 +753,7 @@ static void paint_monorail_track_left_quarter_turn_5_tiles(
 
 /** rct2: 0x */
 static void paint_monorail_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -858,7 +857,7 @@ static void paint_monorail_track_s_bend_left(
 
 /** rct2: 0x008AE24C */
 static void paint_monorail_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -962,7 +961,7 @@ static void paint_monorail_track_s_bend_right(
 
 /** rct2: 0x008AE29C */
 static void paint_monorail_track_right_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -999,7 +998,7 @@ static void paint_monorail_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x008AE28C */
 static void paint_monorail_track_left_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1012,7 +1011,7 @@ static constexpr const int8_t paint_monorail_eighth_to_diag_index[] = {
 
 /** rct2: 0x008AE31C */
 static void paint_monorail_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     int8_t index = paint_monorail_eighth_to_diag_index[trackSequence];
@@ -1080,7 +1079,7 @@ static void paint_monorail_track_left_eighth_to_diag(
 
 /** rct2: 0x008AE32C */
 static void paint_monorail_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     int8_t index = paint_monorail_eighth_to_diag_index[trackSequence];
@@ -1148,7 +1147,7 @@ static void paint_monorail_track_right_eighth_to_diag(
 
 /** rct2: 0x008AE33C */
 static void paint_monorail_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -1158,7 +1157,7 @@ static void paint_monorail_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008AE34C */
 static void paint_monorail_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -1189,7 +1188,7 @@ static constexpr const int32_t monorail_diag_blocked_segments[] = {
 
 /** rct2: 0x008AE2AC */
 static void paint_monorail_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1212,7 +1211,7 @@ static void paint_monorail_track_diag_flat(
 
 /** rct2: 0x008AE2DC */
 static void paint_monorail_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1235,7 +1234,7 @@ static void paint_monorail_track_diag_25_deg_up(
 
 /** rct2: 0x008AE2BC */
 static void paint_monorail_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1258,7 +1257,7 @@ static void paint_monorail_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AE2CC */
 static void paint_monorail_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1281,7 +1280,7 @@ static void paint_monorail_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AE30C */
 static void paint_monorail_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1304,7 +1303,7 @@ static void paint_monorail_track_diag_25_deg_down(
 
 /** rct2: 0x008AE2EC */
 static void paint_monorail_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1328,7 +1327,7 @@ static void paint_monorail_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008AE2FC */
 static void paint_monorail_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])

--- a/src/openrct2/ride/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/ride/transport/SuspendedMonorail.cpp
@@ -72,7 +72,7 @@ static void suspended_monorail_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 32, 0, 6,
         height + 32);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);

--- a/src/openrct2/ride/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/ride/transport/SuspendedMonorail.cpp
@@ -21,7 +21,7 @@
 
 /** rct2: 0x008636F4 */
 static void suspended_monorail_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -53,7 +53,7 @@ static void suspended_monorail_track_flat(
 
 /** rct2: 0x008637A4, 0x008637B4, 0x008637C4 */
 static void suspended_monorail_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -72,7 +72,7 @@ static void suspended_monorail_track_station(
         session, direction, imageIds[direction][2] | session->TrackColours[SCHEME_SUPPORTS], 0, 6, 32, 20, 3, height + 32, 0, 6,
         height + 32);
     track_paint_util_draw_station_metal_supports_2(session, direction, height, session->TrackColours[SCHEME_SUPPORTS], 3);
-    track_paint_util_draw_station_inverted(session, *ride, direction, height, trackElement, STATION_VARIANT_TALL);
+    track_paint_util_draw_station_inverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
     paint_util_set_general_support_height(session, height + 48, 0x20);
@@ -80,7 +80,7 @@ static void suspended_monorail_track_station(
 
 /** rct2: 0x00863704 */
 static void suspended_monorail_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -145,7 +145,7 @@ static void suspended_monorail_track_25_deg_up(
 
 /** rct2: 0x00863714 */
 static void suspended_monorail_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -210,7 +210,7 @@ static void suspended_monorail_track_flat_to_25_deg_up(
 
 /** rct2: 0x00863724 */
 static void suspended_monorail_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -275,7 +275,7 @@ static void suspended_monorail_track_25_deg_up_to_flat(
 
 /** rct2: 0x00863734 */
 static void suspended_monorail_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_monorail_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -283,7 +283,7 @@ static void suspended_monorail_track_25_deg_down(
 
 /** rct2: 0x00863744 */
 static void suspended_monorail_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_monorail_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -291,7 +291,7 @@ static void suspended_monorail_track_flat_to_25_deg_down(
 
 /** rct2: 0x00863754 */
 static void suspended_monorail_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_monorail_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -299,7 +299,7 @@ static void suspended_monorail_track_25_deg_down_to_flat(
 
 /** rct2: 0x00863764 */
 static void suspended_monorail_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -479,7 +479,7 @@ static void suspended_monorail_track_left_quarter_turn_5(
 
 /** rct2: 0x00863774 */
 static void suspended_monorail_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -488,7 +488,7 @@ static void suspended_monorail_track_right_quarter_turn_5(
 
 /** rct2: 0x00863784 */
 static void suspended_monorail_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -659,7 +659,7 @@ static void suspended_monorail_track_s_bend_left(
 
 /** rct2: 0x00863794 */
 static void suspended_monorail_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -830,7 +830,7 @@ static void suspended_monorail_track_s_bend_right(
 
 /** rct2: 0x008637D4 */
 static void suspended_monorail_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -949,7 +949,7 @@ static void suspended_monorail_track_left_quarter_turn_3(
 
 /** rct2: 0x008637E4 */
 static void suspended_monorail_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -958,7 +958,7 @@ static void suspended_monorail_track_right_quarter_turn_3(
 
 /** rct2: 0x00863864 */
 static void suspended_monorail_track_left_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1121,7 +1121,7 @@ static void suspended_monorail_track_left_eighth_to_diag(
 
 /** rct2: 0x00863874 */
 static void suspended_monorail_track_right_eighth_to_diag(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1284,7 +1284,7 @@ static void suspended_monorail_track_right_eighth_to_diag(
 
 /** rct2: 0x00863884 */
 static void suspended_monorail_track_left_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1293,7 +1293,7 @@ static void suspended_monorail_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x00863894 */
 static void suspended_monorail_track_right_eighth_to_orthogonal(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1302,7 +1302,7 @@ static void suspended_monorail_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008637F4 */
 static void suspended_monorail_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1385,7 +1385,7 @@ static void suspended_monorail_track_diag_flat(
 
 /** rct2: 0x00863824 */
 static void suspended_monorail_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1468,7 +1468,7 @@ static void suspended_monorail_track_diag_25_deg_up(
 
 /** rct2: 0x00863804 */
 static void suspended_monorail_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1551,7 +1551,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x00863814 */
 static void suspended_monorail_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1634,7 +1634,7 @@ static void suspended_monorail_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x00863854 */
 static void suspended_monorail_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1717,7 +1717,7 @@ static void suspended_monorail_track_diag_25_deg_down(
 
 /** rct2: 0x00863834 */
 static void suspended_monorail_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1797,7 +1797,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x00863844 */
 static void suspended_monorail_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/water/BoatHire.cpp
+++ b/src/openrct2/ride/water/BoatHire.cpp
@@ -32,7 +32,7 @@ enum
 
 /** rct2: 0x008B0E40 */
 static void paint_boat_hire_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -62,22 +62,22 @@ static void paint_boat_hire_track_flat(
 
 /** rct2: 0x008B0E50 */
 static void paint_boat_hire_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    const auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride.GetStationObject();
 
     if (direction & 1)
     {
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
         track_paint_util_draw_pier(
-            session, *ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
+            session, ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
     }
     else
     {
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
         track_paint_util_draw_pier(
-            session, *ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
+            session, ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
     }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -86,7 +86,7 @@ static void paint_boat_hire_station(
 
 /** rct2: 0x008B0E80 */
 static void paint_boat_hire_track_left_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -130,7 +130,7 @@ static void paint_boat_hire_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x008B0E90 */
 static void paint_boat_hire_track_right_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_boat_hire_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);

--- a/src/openrct2/ride/water/BoatHire.cpp
+++ b/src/openrct2/ride/water/BoatHire.cpp
@@ -65,7 +65,7 @@ static void paint_boat_hire_station(
     paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    const auto stationObj = ride.GetStationObject();
+    const auto* stationObj = ride.GetStationObject();
 
     if (direction & 1)
     {

--- a/src/openrct2/ride/water/BoatHire.cpp
+++ b/src/openrct2/ride/water/BoatHire.cpp
@@ -65,10 +65,7 @@ static void paint_boat_hire_station(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (ride == nullptr)
-        return;
-
-    auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride->GetStationObject();
 
     if (direction & 1)
     {

--- a/src/openrct2/ride/water/BoatHire.cpp
+++ b/src/openrct2/ride/water/BoatHire.cpp
@@ -71,13 +71,13 @@ static void paint_boat_hire_station(
     {
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
         track_paint_util_draw_pier(
-            session, ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
+            session, *ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
     }
     else
     {
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
         track_paint_util_draw_pier(
-            session, ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
+            session, *ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
     }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/water/DingySlide.cpp
+++ b/src/openrct2/ride/water/DingySlide.cpp
@@ -349,7 +349,7 @@ enum
 };
 
 static void dinghy_slide_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -387,7 +387,7 @@ static void dinghy_slide_track_flat(
 }
 
 static void dinghy_slide_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -408,7 +408,7 @@ static void dinghy_slide_track_station(
     metal_a_supports_paint_setup(
         session, METAL_SUPPORTS_TUBES, 8 - (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, ride, direction, height, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -417,7 +417,7 @@ static void dinghy_slide_track_station(
 }
 
 static void dinghy_slide_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -462,7 +462,7 @@ static void dinghy_slide_track_25_deg_up(
 }
 
 static void dinghy_slide_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -498,7 +498,7 @@ static void dinghy_slide_track_60_deg_up(
 }
 
 static void dinghy_slide_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -543,7 +543,7 @@ static void dinghy_slide_track_flat_to_25_deg_up(
 }
 
 static void dinghy_slide_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -579,7 +579,7 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up(
 }
 
 static void dinghy_slide_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -615,7 +615,7 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up(
 }
 
 static void dinghy_slide_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -660,42 +660,42 @@ static void dinghy_slide_track_25_deg_up_to_flat(
 }
 
 static void dinghy_slide_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_right_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb imageIds[4][5] = {
@@ -823,7 +823,7 @@ static void dinghy_slide_track_right_quarter_turn_5(
 }
 
 static void dinghy_slide_track_left_quarter_turn_5(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -831,14 +831,14 @@ static void dinghy_slide_track_left_quarter_turn_5(
 }
 
 static void dinghy_slide_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -941,7 +941,7 @@ static void dinghy_slide_track_s_bend_left(
 }
 
 static void dinghy_slide_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1042,7 +1042,7 @@ static void dinghy_slide_track_s_bend_right(
 }
 
 static void dinghy_slide_track_right_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb imageIds[4][3] = {
@@ -1123,7 +1123,7 @@ static void dinghy_slide_track_right_quarter_turn_3(
 }
 
 static void dinghy_slide_track_left_quarter_turn_3(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1131,7 +1131,7 @@ static void dinghy_slide_track_left_quarter_turn_3(
 }
 
 static void dinghy_slide_track_flat_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1160,7 +1160,7 @@ static void dinghy_slide_track_flat_covered(
 }
 
 static void dinghy_slide_track_25_deg_up_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1196,7 +1196,7 @@ static void dinghy_slide_track_25_deg_up_covered(
 }
 
 static void dinghy_slide_track_60_deg_up_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1232,7 +1232,7 @@ static void dinghy_slide_track_60_deg_up_covered(
 }
 
 static void dinghy_slide_track_flat_to_25_deg_up_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1268,7 +1268,7 @@ static void dinghy_slide_track_flat_to_25_deg_up_covered(
 }
 
 static void dinghy_slide_track_25_deg_up_to_60_deg_up_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1304,7 +1304,7 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up_covered(
 }
 
 static void dinghy_slide_track_60_deg_up_to_25_deg_up_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1340,7 +1340,7 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up_covered(
 }
 
 static void dinghy_slide_track_25_deg_up_to_flat_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1376,42 +1376,42 @@ static void dinghy_slide_track_25_deg_up_to_flat_covered(
 }
 
 static void dinghy_slide_track_25_deg_down_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_60_deg_down_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_60_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_flat_to_25_deg_down_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up_to_flat_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_60_deg_down_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_60_deg_up_to_25_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_flat_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_flat_to_25_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_right_quarter_turn_5_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb imageIds[4][5] = {
@@ -1539,7 +1539,7 @@ static void dinghy_slide_track_right_quarter_turn_5_covered(
 }
 
 static void dinghy_slide_track_left_quarter_turn_5_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1547,7 +1547,7 @@ static void dinghy_slide_track_left_quarter_turn_5_covered(
 }
 
 static void dinghy_slide_track_s_bend_left_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1650,7 +1650,7 @@ static void dinghy_slide_track_s_bend_left_covered(
 }
 
 static void dinghy_slide_track_s_bend_right_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1751,7 +1751,7 @@ static void dinghy_slide_track_s_bend_right_covered(
 }
 
 static void dinghy_slide_track_right_quarter_turn_3_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb imageIds[4][3] = {
@@ -1832,7 +1832,7 @@ static void dinghy_slide_track_right_quarter_turn_3_covered(
 }
 
 static void dinghy_slide_track_left_quarter_turn_3_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1840,7 +1840,7 @@ static void dinghy_slide_track_left_quarter_turn_3_covered(
 }
 
 static void dinghy_slide_track_60_deg_down_to_25_deg_down_covered(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up_to_60_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);

--- a/src/openrct2/ride/water/DingySlide.cpp
+++ b/src/openrct2/ride/water/DingySlide.cpp
@@ -408,7 +408,7 @@ static void dinghy_slide_track_station(
     metal_a_supports_paint_setup(
         session, METAL_SUPPORTS_TUBES, 8 - (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-    track_paint_util_draw_station(session, ride, direction, height, trackElement);
+    track_paint_util_draw_station(session, *ride, direction, height, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 

--- a/src/openrct2/ride/water/LogFlume.cpp
+++ b/src/openrct2/ride/water/LogFlume.cpp
@@ -161,7 +161,7 @@ static constexpr const uint32_t LogFlumeTrackFlatImageIds[4][2] = {
 };
 
 static void paint_log_flume_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = LogFlumeTrackFlatImageIds[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -182,7 +182,7 @@ static void paint_log_flume_track_flat(
 }
 
 static void paint_log_flume_track_station(
-    paint_session* session, const Ride* ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = LogFlumeTrackFlatImageIds[direction][0] | session->TrackColours[SCHEME_TRACK];
@@ -209,7 +209,7 @@ static void paint_log_flume_track_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station_3(session, *ride, direction, height + 2, height, trackElement);
+    track_paint_util_draw_station_3(session, ride, direction, height + 2, height, trackElement);
     // Covers shouldn't be offset by +2
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -219,7 +219,7 @@ static void paint_log_flume_track_station(
 }
 
 static void paint_log_flume_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -254,7 +254,7 @@ static void paint_log_flume_track_25_deg_up(
 }
 
 static void paint_log_flume_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -289,7 +289,7 @@ static void paint_log_flume_track_flat_to_25_deg_up(
 }
 
 static void paint_log_flume_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -324,7 +324,7 @@ static void paint_log_flume_track_25_deg_up_to_flat(
 }
 
 static void paint_log_flume_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -359,7 +359,7 @@ static void paint_log_flume_track_25_deg_down(
 }
 
 static void paint_log_flume_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -394,7 +394,7 @@ static void paint_log_flume_track_flat_to_25_deg_down(
 }
 
 static void paint_log_flume_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -429,7 +429,7 @@ static void paint_log_flume_track_25_deg_down_to_flat(
 }
 
 static void paint_log_flume_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -532,7 +532,7 @@ static void paint_log_flume_track_s_bend_left(
 }
 
 static void paint_log_flume_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -633,7 +633,7 @@ static void paint_log_flume_track_s_bend_right(
 }
 
 static void paint_log_flume_track_left_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -712,7 +712,7 @@ static void paint_log_flume_track_left_quarter_turn_3_tiles(
 }
 
 static void paint_log_flume_track_right_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -791,7 +791,7 @@ static void paint_log_flume_track_right_quarter_turn_3_tiles(
 }
 
 static void paint_log_flume_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = SPR_STATION_BASE_D | IMAGE_TYPE_REMAP;
@@ -822,7 +822,7 @@ static void paint_log_flume_track_on_ride_photo(
 }
 
 static void paint_log_flume_track_reverser(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {

--- a/src/openrct2/ride/water/LogFlume.cpp
+++ b/src/openrct2/ride/water/LogFlume.cpp
@@ -209,7 +209,7 @@ static void paint_log_flume_track_station(
         metal_a_supports_paint_setup(session, METAL_SUPPORTS_BOXED, 8, 0, height, session->TrackColours[SCHEME_SUPPORTS]);
     }
 
-    track_paint_util_draw_station_3(session, ride, direction, height + 2, height, trackElement);
+    track_paint_util_draw_station_3(session, *ride, direction, height + 2, height, trackElement);
     // Covers shouldn't be offset by +2
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -277,7 +277,7 @@ void vehicle_visual_river_rapids(
 
 /** rct2: 0x00757650 */
 static void paint_river_rapids_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -320,11 +320,11 @@ static void paint_river_rapids_track_flat(
 
 /** rct2: 0x007576C0 */
 static void paint_river_rapids_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_flat(session, ride, trackSequence, direction, height, trackElement);
-    track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 12, trackElement);
+    track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 12, trackElement);
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 
@@ -507,7 +507,7 @@ static void paint_river_rapids_track_25_deg_to_flat_b(
 
 /** rct2: 0x00757660 */
 static void paint_river_rapids_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg(session, direction, height, river_rapids_track_pieces_25_deg_up);
@@ -515,7 +515,7 @@ static void paint_river_rapids_track_25_deg_up(
 
 /** rct2: 0x00757670 */
 static void paint_river_rapids_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg_to_flat_b(session, direction, height, river_rapids_track_pieces_flat_to_25_deg_up);
@@ -523,7 +523,7 @@ static void paint_river_rapids_track_flat_to_25_deg_up(
 
 /** rct2: 0x00757680 */
 static void paint_river_rapids_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg_to_flat_a(session, direction, height, river_rapids_track_pieces_25_deg_up_to_flat);
@@ -531,7 +531,7 @@ static void paint_river_rapids_track_25_deg_up_to_flat(
 
 /** rct2: 0x00757690 */
 static void paint_river_rapids_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg(session, (direction + 2) % 4, height, river_rapids_track_pieces_25_deg_down);
@@ -539,7 +539,7 @@ static void paint_river_rapids_track_25_deg_down(
 
 /** rct2: 0x007576A0 */
 static void paint_river_rapids_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg_to_flat_a(
@@ -548,7 +548,7 @@ static void paint_river_rapids_track_flat_to_25_deg_down(
 
 /** rct2: 0x007576B0 */
 static void paint_river_rapids_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg_to_flat_b(
@@ -557,7 +557,7 @@ static void paint_river_rapids_track_25_deg_down_to_flat(
 
 /** rct2: 0x007576F0 */
 static void paint_river_rapids_track_left_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -613,7 +613,7 @@ static void paint_river_rapids_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x00757700 */
 static void paint_river_rapids_track_right_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -670,7 +670,7 @@ static void paint_river_rapids_track_right_quarter_turn_1_tile(
 
 /** rct2: 0x00757710 */
 static void paint_river_rapids_track_waterfall(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -733,7 +733,7 @@ static void paint_river_rapids_track_waterfall(
 
 /** rct2: 0x00757720 */
 static void paint_river_rapids_track_rapids(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -774,7 +774,7 @@ static void paint_river_rapids_track_rapids(
 
 /** rct2: 0x00757740 */
 static void paint_river_rapids_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_flat(session, ride, trackSequence, direction, height, trackElement);
@@ -784,7 +784,7 @@ static void paint_river_rapids_track_on_ride_photo(
 
 /** rct2: 0x */
 static void paint_river_rapids_track_whirlpool(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -324,7 +324,6 @@ static void paint_river_rapids_station(
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_flat(session, ride, trackSequence, direction, height, trackElement);
-    if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 12, trackElement);
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -324,7 +324,7 @@ static void paint_river_rapids_station(
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_flat(session, ride, trackSequence, direction, height, trackElement);
-        track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 12, trackElement);
+    track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 12, trackElement);
     paint_util_set_general_support_height(session, height + 32, 0x20);
 }
 

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -800,7 +800,6 @@ static void paint_splash_boats_station(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-    if (ride != nullptr)
         track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 7, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -800,7 +800,7 @@ static void paint_splash_boats_station(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-        track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 7, trackElement);
+    track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 7, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -475,7 +475,7 @@ static constexpr const sprite_bb RiverRaftsRightQuarterTurn5_Side[4][5] = {
 };
 
 static void paint_splash_boats_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = SplashBoats25DegUpImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -499,7 +499,7 @@ static void paint_splash_boats_track_25_deg_up(
 }
 
 static void paint_splash_boats_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = SplashBoats60DegUpImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -524,7 +524,7 @@ static void paint_splash_boats_track_60_deg_up(
 }
 
 static void paint_splash_boats_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = SplashBoatsFlatTo25DegUpImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -548,7 +548,7 @@ static void paint_splash_boats_track_flat_to_25_deg_up(
 }
 
 static void paint_splash_boats_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = SplashBoats25DegUpToFlatImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -572,7 +572,7 @@ static void paint_splash_boats_track_25_deg_up_to_flat(
 }
 
 static void paint_splash_boats_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = SplashBoats25DegUpTo60DegUpImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -597,7 +597,7 @@ static void paint_splash_boats_track_25_deg_up_to_60_deg_up(
 }
 
 static void paint_splash_boats_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = SplashBoats60DegUpTo25DegUpImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -622,7 +622,7 @@ static void paint_splash_boats_track_60_deg_up_to_25_deg_up(
 }
 
 static void paint_splash_boats_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = SplashBoats25DegDownImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -648,14 +648,14 @@ static void paint_splash_boats_track_25_deg_down(
 }
 
 static void paint_splash_boats_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_splash_boats_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void paint_splash_boats_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = SplashBoatsFlatTo25DegDownImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -681,21 +681,21 @@ static void paint_splash_boats_track_flat_to_25_deg_down(
 }
 
 static void paint_splash_boats_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_splash_boats_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void paint_splash_boats_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_splash_boats_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void paint_splash_boats_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId = SplashBoats25DegDownToFlatImageId[direction] | session->TrackColours[SCHEME_TRACK];
@@ -733,7 +733,7 @@ static void paint_splash_boats_track_25_deg_down_to_flat(
 /** Start of elements originally from River Rafts */
 /** rct2: 0x0089B170 */
 static void paint_splash_boats_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint32_t imageId;
@@ -776,7 +776,7 @@ static void paint_splash_boats_track_flat(
 
 /** rct2: 0x0089B1A0 */
 static void paint_splash_boats_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction & 1)
@@ -800,7 +800,7 @@ static void paint_splash_boats_station(
 
     wooden_a_supports_paint_setup(session, (direction & 1), 0, height, session->TrackColours[SCHEME_SUPPORTS]);
 
-    track_paint_util_draw_narrow_station_platform(session, *ride, direction, height, 7, trackElement);
+    track_paint_util_draw_narrow_station_platform(session, ride, direction, height, 7, trackElement);
 
     paint_util_push_tunnel_rotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -810,7 +810,7 @@ static void paint_splash_boats_station(
 
 /** rct2: 0x0089B1D0 */
 static void paint_splash_boats_track_left_quarter_turn_5_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
@@ -891,7 +891,7 @@ static void paint_splash_boats_track_left_quarter_turn_5_tiles(
 
 /** rct2: 0x0089B1D0 */
 static void paint_splash_boats_track_right_quarter_turn_5_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
@@ -972,7 +972,7 @@ static void paint_splash_boats_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x0089B180 */
 static void paint_splash_boats_track_s_bend_left(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1070,7 +1070,7 @@ static void paint_splash_boats_track_s_bend_left(
 
 /** rct2: 0x0089B190 */
 static void paint_splash_boats_track_s_bend_right(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1167,7 +1167,7 @@ static void paint_splash_boats_track_s_bend_right(
 }
 
 static void paint_splash_boats_track_on_ride_photo(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -79,7 +79,7 @@ static void submarine_ride_paint_track_station(
     paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    const auto stationObj = ride.GetStationObject();
+    const auto* stationObj = ride.GetStationObject();
     int32_t heightLower = height - 16;
     uint32_t imageId;
 

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -79,10 +79,7 @@ static void submarine_ride_paint_track_station(
     paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    if (ride == nullptr)
-        return;
-
-    auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride->GetStationObject();
     int32_t heightLower = height - 16;
     uint32_t imageId;
 

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -76,10 +76,10 @@ void vehicle_visual_submarine(
 }
 
 static void submarine_ride_paint_track_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    const auto stationObj = ride->GetStationObject();
+    const auto stationObj = ride.GetStationObject();
     int32_t heightLower = height - 16;
     uint32_t imageId;
 
@@ -90,7 +90,7 @@ static void submarine_ride_paint_track_station(
 
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
         track_paint_util_draw_pier(
-            session, *ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
+            session, ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
     }
     else
     {
@@ -99,7 +99,7 @@ static void submarine_ride_paint_track_station(
 
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
         track_paint_util_draw_pier(
-            session, *ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
+            session, ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
     }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -107,7 +107,7 @@ static void submarine_ride_paint_track_station(
 }
 
 static void submarine_ride_paint_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     int32_t heightLower = height - 16;
@@ -139,7 +139,7 @@ static void submarine_ride_paint_track_flat(
 }
 
 static void submarine_ride_paint_track_left_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -177,7 +177,7 @@ static constexpr const uint8_t submarine_ride_right_quarter_turn_3_tiles_to_left
     0,
 };
 static void submarine_ride_paint_track_right_quarter_turn_3_tiles(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = submarine_ride_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
@@ -186,7 +186,7 @@ static void submarine_ride_paint_track_right_quarter_turn_3_tiles(
 }
 
 static void submarine_ride_paint_track_left_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
@@ -200,7 +200,7 @@ static void submarine_ride_paint_track_left_quarter_turn_1_tile(
 }
 
 static void submarine_ride_paint_track_right_quarter_turn_1_tile(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     submarine_ride_paint_track_left_quarter_turn_1_tile(

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -90,7 +90,7 @@ static void submarine_ride_paint_track_station(
 
         paint_util_push_tunnel_right(session, height, TUNNEL_SQUARE_FLAT);
         track_paint_util_draw_pier(
-            session, ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
+            session, *ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
     }
     else
     {
@@ -99,7 +99,7 @@ static void submarine_ride_paint_track_station(
 
         paint_util_push_tunnel_left(session, height, TUNNEL_SQUARE_FLAT);
         track_paint_util_draw_pier(
-            session, ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
+            session, *ride, stationObj, session->MapPosition, direction, height, trackElement, session->CurrentRotation);
     }
 
     paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/water/WaterCoaster.cpp
+++ b/src/openrct2/ride/water/WaterCoaster.cpp
@@ -14,7 +14,7 @@
 #include "../coaster/JuniorRollerCoaster.h"
 
 static void water_rc_track_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -24,7 +24,7 @@ static void water_rc_track_flat(
 }
 
 static void water_rc_track_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -34,7 +34,7 @@ static void water_rc_track_25_deg_up(
 }
 
 static void water_rc_track_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -44,7 +44,7 @@ static void water_rc_track_flat_to_25_deg_up(
 }
 
 static void water_rc_track_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -54,28 +54,28 @@ static void water_rc_track_25_deg_up_to_flat(
 }
 
 static void water_rc_track_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void water_rc_track_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void water_rc_track_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void water_rc_track_diag_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -85,7 +85,7 @@ static void water_rc_track_diag_flat(
 }
 
 static void water_rc_track_diag_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -95,7 +95,7 @@ static void water_rc_track_diag_25_deg_up(
 }
 
 static void water_rc_track_diag_flat_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -105,7 +105,7 @@ static void water_rc_track_diag_flat_to_25_deg_up(
 }
 
 static void water_rc_track_diag_25_deg_up_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -115,7 +115,7 @@ static void water_rc_track_diag_25_deg_up_to_flat(
 }
 
 static void water_rc_track_diag_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -125,7 +125,7 @@ static void water_rc_track_diag_25_deg_down(
 }
 
 static void water_rc_track_diag_flat_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -135,7 +135,7 @@ static void water_rc_track_diag_flat_to_25_deg_down(
 }
 
 static void water_rc_track_diag_25_deg_down_to_flat(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -145,21 +145,21 @@ static void water_rc_track_diag_25_deg_down_to_flat(
 }
 
 static void water_rc_track_station(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_station(session, ride, trackSequence, direction, height, trackElement, RIDE_TYPE_WATER_COASTER);
 }
 
 static void water_rc_track_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_60_deg_up(session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_25_deg_up_to_60_deg_up(
@@ -167,7 +167,7 @@ static void water_rc_track_25_deg_up_to_60_deg_up(
 }
 
 static void water_rc_track_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_60_deg_up_to_25_deg_up(
@@ -175,21 +175,21 @@ static void water_rc_track_60_deg_up_to_25_deg_up(
 }
 
 static void water_rc_track_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void water_rc_track_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void water_rc_track_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -198,7 +198,7 @@ static void water_rc_track_60_deg_down_to_25_deg_down(
 // 5 tile turns
 
 static void water_rc_track_left_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
@@ -206,7 +206,7 @@ static void water_rc_track_left_quarter_turn_5_tiles_25_deg_up(
 }
 
 static void water_rc_track_right_quarter_turn_5_tiles_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
@@ -218,7 +218,7 @@ static constexpr const uint8_t water_rc_left_quarter_turn_5_tiles_to_right_turn_
 };
 
 static void water_rc_track_left_quarter_turn_5_tiles_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_right_quarter_turn_5_tiles_25_deg_up(
@@ -227,7 +227,7 @@ static void water_rc_track_left_quarter_turn_5_tiles_25_deg_down(
 }
 
 static void water_rc_track_right_quarter_turn_5_tiles_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_left_quarter_turn_5_tiles_25_deg_up(
@@ -238,7 +238,7 @@ static void water_rc_track_right_quarter_turn_5_tiles_25_deg_down(
 // 3 tile turns
 
 static void water_rc_track_right_quarter_turn_3_tiles_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
@@ -246,7 +246,7 @@ static void water_rc_track_right_quarter_turn_3_tiles_25_deg_up(
 }
 
 static void water_rc_track_right_quarter_turn_3_tiles_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
@@ -261,7 +261,7 @@ static constexpr const uint8_t water_rc_left_quarter_turn_3_tiles_to_right_turn_
 };
 
 static void water_rc_track_left_quarter_turn_3_tiles_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = water_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
@@ -270,7 +270,7 @@ static void water_rc_track_left_quarter_turn_3_tiles_25_deg_up(
 }
 
 static void water_rc_track_left_quarter_turn_3_tiles_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = water_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
@@ -279,7 +279,7 @@ static void water_rc_track_left_quarter_turn_3_tiles_25_deg_down(
 }
 
 static void water_rc_track_diag_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_60_deg_up(
@@ -287,7 +287,7 @@ static void water_rc_track_diag_60_deg_up(
 }
 
 static void water_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
@@ -295,7 +295,7 @@ static void water_rc_track_diag_25_deg_up_to_60_deg_up(
 }
 
 static void water_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
@@ -303,7 +303,7 @@ static void water_rc_track_diag_60_deg_up_to_25_deg_up(
 }
 
 static void water_rc_track_diag_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_60_deg_down(
@@ -311,7 +311,7 @@ static void water_rc_track_diag_60_deg_down(
 }
 
 static void water_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
@@ -319,7 +319,7 @@ static void water_rc_track_diag_25_deg_down_to_60_deg_down(
 }
 
 static void water_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session* session, const Ride* ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    paint_session* session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(


### PR DESCRIPTION
`ride` was always guaranteed to be set before attempting to call the paint function anyway, so turn it into a reference so we have one fewer thing to consider.