### PR TITLE
Update manpages

### DIFF
--- a/distribution/man/openrct2-cli.6
+++ b/distribution/man/openrct2-cli.6
@@ -1,0 +1,127 @@
+.Dd December 19, 2021
+.Dt OPENRCT2-CLI 6
+.Os
+.Sh NAME
+.Nm openrct2-cli
+.Nd Headless server mode for OpenRCT2
+.sp
+.Sh SYNOPSIS
+.Nm
+.Op Fl h | -help
+.Op Fl v | -version
+.Op Fl -verbose
+.sp
+.Nm
+.Ar host
+uri
+.Op Fl -address Ar address
+.Op Fl -port Ar port
+.Op Fl -password Ar password
+.sp
+.Sh DESCRIPTION
+OpenRCT2 supports a headless mode where the game will run as a console application with no UI.
+This is useful for running dedicated game servers.
+.sp
+Several objects are available in OpenRCT2's scripting interface that can be modified from its CLI:
+.sp
+\(bu \fBcheats\fR Enable/disable various cheats
+.sp
+\(bu \fBclimate\fR Modify the climate and weather
+.sp
+\(bu \fBconsole\fR Options for interacting with the stdout console
+.sp
+\(bu \fBcontext\fR Core API for use by plugins
+.sp
+\(bu \fBdate\fR Getting or setting the in-game date
+.sp
+\(bu \fBmap\fR Manipulation of the map
+.sp
+\(bu \fBnetwork\fR Management of the server or interacting with clients
+.sp
+\(bu \fBpark\fR APIs for the park and its management
+.sp
+\(bu \fBscenario\fR Information about the current scenario
+.sp
+\(bu \fBtitleSequenceManager\fR Create and edit title sequences (only available to clients that are
+not running in headless mode)
+.sp
+\(bu \fBui\fR APIs for controlling the user interface (only available to clients that are not running
+in headless mode)
+.sp
+For further information about OpenRCT2, its options and capabilities, please refer to
+the \fB openrct2(6) \fR manpage.
+.sp
+.Sh OPTIONS
+.Bl -tag -width "-openrct2-data-path path "
+.sp
+.It Fl h | -help
+Print a summary of all options to stdout and exit.
+.sp
+.It Fl v | -version
+Show version information and exit.
+.sp
+.It Fl n | -no-install
+Do not install scenario if passed.
+.sp
+.It Fl a | -all
+Show help for all commands.
+.sp
+.It Fl -about
+Show information about
+.Nm .
+.sp
+.It Fl -verbose
+Print diagnostic information to stdout.
+.sp
+.It Fl -port Ar port
+Port to use for hosting or joining a server; if not specified, the default port of 11753 will be used.
+.sp
+.It Fl -address Ar address
+Address to bind to when hosting a server.
+.sp
+.It Fl -password Ar password
+Password needed to join the server.
+.sp
+.It Fl -user-data-path Ar path
+Path to the user data directory (containing
+.Pa config.ini )
+.sp
+.It Fl -openrct2-data-path Ar path
+Path to the OpenRCT2 data directory (containing
+.Pa languages )
+.sp
+.It Fl -rct1-data-path Ar path
+Path to the RollerCoaster Tycoon 1 data directory (containing
+.Pa data/csg1.dat )
+.sp
+.It Fl -rct2-data-path Ar path
+Path to the RollerCoaster Tycoon 2 data directory (containing
+.Pa data/g1.dat )
+.El
+.sp
+.Sh NOTES
+With multiplayer, you might run into some bugs that do not occur in single player mode.
+If that happens, please report it on GitHub if the issue hasn't been reported already,
+and please say if the bug only occurs on multiplayer games.
+.sp
+In order for the server to successfully accept clients, the port must be open for the server's own
+firewall and any router's firewall the computer is behind. Additionally if the server is behind a
+router with NAT enabled, the router must be configured to have the port forwarded to the server's
+local address.
+.sp
+.Sh EXAMPLES
+.Bl -tag -width "openrct2-cli host ./my_park.sv6 --port 11753 "
+.It openrct2-cli host ./my_park.sv6 --port 11753
+Run a headless server for a saved park.
+.It \fB$\fR network.players[1].group = 0
+From the CLI for a multiplayer server, set the first user to join as an admin
+.It \fB$\fR cheats["disableAllBreakdowns"] = true
+From the CLI, enable the cheat to disable all ride breakdowns
+.El
+.sp
+.Sh SEE ALSO
+openrct2(6)
+.sp
+.Lk https://openrct2.io "Official site"
+.sp
+.Lk https://github.com/OpenRCT2/OpenRCT2 "GitHub"

--- a/distribution/man/openrct2.6
+++ b/distribution/man/openrct2.6
@@ -1,19 +1,9 @@
-.Dd May 31, 2017
+.Dd December 19, 2021
 .Dt OPENRCT2 6
 .Os
 .Sh NAME
 .Nm openrct2
 .Nd An open source re-implementation of \(lqRollerCoaster Tycoon 2\(rq.
-.sp
-.Sh DESCRIPTION
-OpenRCT2 is an open-source re-implementation of RollerCoaster Tycoon 2 (RCT2).
-The gameplay revolves around building and maintaining an amusement park
-containing attractions, shops and facilities. The player must try to make a
-profit and maintain a good park reputation whilst keeping the guests happy.
-OpenRCT2 allows for both scenario and sandbox play. Scenarios require the
-player to complete a certain objective in a set time limit whilst sandbox
-allows the player to build a more flexible park with optionally no
-restrictions or finance.
 .sp
 .Sh SYNOPSIS
 .Nm
@@ -27,6 +17,7 @@ restrictions or finance.
 .Op uri
 .Nm
 .Ar intro
+.sp
 .Nm
 .Ar host
 uri
@@ -39,6 +30,7 @@ uri
 hostname
 .Op Fl -port Ar port
 .Op Fl -password Ar password
+.sp
 .Nm
 .Ar set-rct2
 path
@@ -48,6 +40,7 @@ source
 destination
 .Nm
 .Ar scan-objects
+path
 .Nm
 .Ar handle-uri
 openrct2://.../
@@ -56,34 +49,80 @@ openrct2://.../
 .Ar screenshot
 file output_image width height
 .Op x y zoom rotation
+.Op options
 .Nm
 .Ar screenshot
 file output_image
 .Ar giant
 zoom rotation
+.Op options
 .sp
 .Nm
 .Ar sprite append
 spritefile input
 .Op x_offset y_offset
-.Op Fl m | -mode Ar default|closest|dithering
+.Op options
 .Nm
 .Ar sprite build
 spritefile json_path
 .Op silent
+.Op options
 .Nm
 .Ar sprite create
 spritefile
+.Op options
 .Nm
 .Ar sprite details
 spritefile
 .Op idx
+.Op options
 .Nm
 .Ar sprite export
 spritefile idx output
+.Op options
 .Nm
 .Ar sprite exportall
 spritefile output_directory
+.Op options
+.Nm
+.Ar sprite exportalldat
+dat_identifier output_directory
+.Op options
+.sp
+.Nm
+.Ar benchgfx
+parkfile ticks
+.Nm
+.Ar benchspritesort
+.Op file
+.Op options
+.Nm
+.Ar benchsimulate
+.Op file
+.Op options
+.Nm
+.Ar simulate
+parkfile ticks
+.sp
+.Sh DESCRIPTION
+OpenRCT2 is an open-source re-implementation of RollerCoaster Tycoon 2 (RCT2).
+The gameplay revolves around building and maintaining an amusement park
+containing attractions, shops and facilities. The player must try to make a profit
+and maintain a good park reputation whilst keeping the guests happy. OpenRCT2
+allows for both scenario and sandbox play. Scenarios require the player to complete
+a certain objective in a set time limit whilst sandbox allows the player to build a
+more flexible park with optionally no restrictions or finance.
+.sp
+RollerCoaster Tycoon 2 was originally written by Chris Sawyer in x86 assembly and
+is the sequel to RollerCoaster Tycoon. The engine was based on Transport Tycoon,
+an older game which also has an equivalent open-source project, OpenTTD. OpenRCT2
+attempts to provide everything from RCT2 as well as many improvements and
+additional features, some of these include support for modern platforms, an improved
+interface, improved guest and staff AI, more editing tools, increased limits, and
+cooperative multiplayer. It also re-introduces mechanics from RollerCoaster Tycoon that
+were not present in RollerCoaster Tycoon 2. Some of those include; mountain tool
+in-game, the \(lqhave fun\(rq objective, launched coasters (not passing-through the
+station) and several buttons on the toolbar.
 .sp
 .Sh OPTIONS
 .Bl -tag -width "-openrct2-data-path path "
@@ -93,6 +132,9 @@ Print a summary of all options to stdout and exit.
 .sp
 .It Fl v | -version
 Show version information and exit.
+.sp
+.It Fl n | -no-install
+Do not install scenario if passed.
 .sp
 .It Fl a | -all
 Show help for all commands.
@@ -110,7 +152,7 @@ run
 without a graphical window.
 .sp
 .It Fl -port Ar port
-Port to use for hosting or joining a server.
+Port to use for hosting or joining a server; if not specified, the default port of 11753 will be used.
 .sp
 .It Fl -address Ar address
 Address to bind to when hosting a server.
@@ -127,35 +169,108 @@ Path to the OpenRCT2 data directory (containing
 .Pa languages )
 .sp
 .It Fl -rct1-data-path Ar path
-path to the RollerCoaster Tycoon 1 data directory (containing
+Path to the RollerCoaster Tycoon 1 data directory (containing
 .Pa data/csg1.dat )
 .sp
 .It Fl -rct2-data-path Ar path
 Path to the RollerCoaster Tycoon 2 data directory (containing
 .Pa data/g1.dat )
 .El
+.sp
+Options specific to screenshots:
+.Bl -tag -width "-fix-vandalism "
+.sp
+.It Fl -weather Ar 0-6
+Weather to be used (0 = default, 1 = sunny, ..., 6 = thunder).
+.sp
+.It Fl -no-peeps
+Hide peeps.
+.sp
+.It Fl -no-sprites
+Hide all sprites (e.g. balloons, vehicles, guests).
+.sp
+.It Fl -clear-grass
+Set all grass to be clear of weeds.
+.sp
+.It Fl -mowed-grass
+Set all grass to be mowed.
+.sp
+.It Fl -water-plants
+Water plants for the screenshot.
+.sp
+.It Fl -fix-vandalism
+Fix vandalism for the screenshot.
+.sp
+.It Fl -remove-litter
+Remove litter for the screenshot.
+.sp
+.It Fl -tidy-up-park
+Clear grass, water plants, fix vandalism and remove litter.
+.sp
+.It Fl -transparent
+Make the background transparent.
+.El
+.sp
+Options specific to sprite commands:
+.Bl -tag -width "m | --mode Ar mode "
+.sp
+.It Fl m | -mode Ar mode
+The type of sprite conversion (default, closest, or dithering).
+.El
+.sp
+Options specific to benchmark commands:
+.Bl -tag -width "-benchmark_report_aggregates_only Ar {true|false} "
+.sp
+.It Fl -benchmark_list_tests Ar {true|false}
+.It Fl -benchmark_filter Ar regex
+.It Fl -benchmark_min_time Ar min_time
+.It Fl -benchmark_repetitions Ar num_repetitions
+.It Fl -benchmark_report_aggregates_only Ar {true|false}
+.It Fl -benchmark_format Ar <console|json|csv>
+.It Fl -benchmark_out Ar filename
+.It Fl -benchmark_out_format Ar <json|console|csv>
+.It Fl -benchmark_color Ar {auto|true|false}
+.It Fl -benchmark_counters_tabular Ar {true|false}
+.It Fl -v Ar verbosity
+.El
+.sp
+.Sh FILES
+On UNIX systems, OpenRCT2 stores user configuration, data, and cache in
+\fB$XDG_CONFIG_HOME/OpenRCT2\fR, falling back to \fB~/.config/OpenRCT2\fR if
+XDG_CONFIG_HOME is not set in the environment.
+.sp
+.Sh NOTES
+Playing OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bought
+at either Steam or GOG.com. If you have the original RollerCoaster Tycoon and its expansion
+packs, you can point OpenRCT2 to these in order to play the original scenarios.
+.sp
+OpenRCT2 allows custom scripts (also known as plug-ins) to be written and executed in
+the game providing additional behaviour on top of the vanilla experience. This can range
+from extra windows providing information about the park to entire new multiplayer game
+modes.
+.sp
+Version 0.4.0 of OpenRCT2 introduced a new park save format that allows for higher limits and
+more features than the original RollerCoaster Tycoon 2. Old .SV4 and .SV6 files will continue to
+work - forever. The only thing changed is that you can no longer save to .SV6, it will now be
+saved as .park.
+.sp
 .Sh EXAMPLES
 .Bl -tag -width "openrct2 https://openrct2.io/files/SnowyPark.sv6 "
 .It openrct2 ./my_park.sv6
 Open a saved park.
+.It openrct2 ./SnowyPark.sc6
+Install and open a scenario.
+.It openrct2 ./ShuttleLoop.td6
+Install a track.
 .It openrct2 https://openrct2.io/files/SnowyPark.sv6
 Download and open a saved park.
 .It openrct2 host ./my_park.sv6 --port 11753 --headless
 Run a headless server for a saved park.
 .El
+.sp
 .Sh SEE ALSO
+openrct2-cli(6)
+.sp
 .Lk https://openrct2.io "Official site"
 .sp
 .Lk https://github.com/OpenRCT2/OpenRCT2 "GitHub"
-.Sh HISTORY
-RollerCoaster Tycoon 2 was originally written by Chris Sawyer in x86 assembly
-and is the sequel to RollerCoaster Tycoon. The engine was based on
-Transport Tycoon, an older game which also has an equivalent open-source
-project, OpenTTD. OpenRCT2 attempts to provide everything from RCT2 as well as
-many improvements and additional features, some of these include support for
-modern platforms, an improved interface, improved guest and staff AI, more
-editing tools, increased limits, and cooperative multiplayer. It also
-re-introduces mechanics from RollerCoaster Tycoon that were not present in
-RollerCoaster Tycoon 2. Some of those include; mountain tool in-game, the
-"have fun" objective, launched coasters (not passing-through the station) and
-several buttons on the toolbar.


### PR DESCRIPTION
This PR updates the existing manpage for `openrct2` and adds one for `openrct2-cli`. New content was mostly pulled from the wiki pages. As the v0.4.0 release is going to be a particularly big milestone with the NSF, I thought it would be worthwhile to update the manpages. This is a partial fix for #13708.

One issue needs to be resolved before merging -- the existing manpage and `src/openrct2/cmdline/RootCommands.cpp` refer to a file that's no longer available online: https://openrct2.io/files/SnowyPark.sv6. A relatively quick search didn't find that particular saved park available online, so we should update the example with a working link.