### PR TITLE
Parkinfo object query

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.2 (in development)
 ------------------------------------------------------------------------
 - Feature: [#13634] Add ability to sell merchandise in random colours.
+- Feature: [#16283] Added parkinfo command line tool to list objects in a save file. 
 - Feature: [#16662] Show a warning message when g2.dat is mismatched.
 - Feature: [#17107] Ride operating settings can be set via text input.
 - Improved: [#15358] Park and scenario names can now contain up to 128 characters.

--- a/src/openrct2/cmdline/CommandLine.hpp
+++ b/src/openrct2/cmdline/CommandLine.hpp
@@ -120,6 +120,7 @@ namespace CommandLine
     extern const CommandLineCommand BenchSpriteSortCommands[];
     extern const CommandLineCommand BenchUpdateCommands[];
     extern const CommandLineCommand SimulateCommands[];
+    extern const CommandLineCommand ParkInfoCommands[];
 
     extern const CommandLineExample RootExamples[];
 

--- a/src/openrct2/cmdline/ParkInfoCommands.cpp
+++ b/src/openrct2/cmdline/ParkInfoCommands.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2021 OpenRCT2 developers
+ * Copyright (c) 2014-2022 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -89,9 +89,9 @@ static exitcode_t HandleObjectsInfo(CommandLineArgEnumerator* argEnumerator)
     Console::WriteLine();
 
     const std::array<std::string, 17> typeToName = {
-        "Ride",        "SmallScenery", "LargeScenery", "Walls",           "Banners",          "Paths",
-        "PathBits",    "SceneryGroup", "ParkEntrance", "Water",           "ScenarioText",     "TerrainSurface",
-        "TerrainEdge", "Station",      "Music",        "FootpathSurface", "FootpathRailings",
+        "Ride",          "SmallScenery", "LargeScenery", "Walls",           "Banners",          "Paths",
+        "PathAdditions", "SceneryGroup", "ParkEntrance", "Water",           "ScenarioText",     "TerrainSurface",
+        "TerrainEdge",   "Station",      "Music",        "FootpathSurface", "FootpathRailings",
     };
     const std::array<std::string, 9> sourceGameToName = {
         "Custom", "WackyWorlds", "TimeTwister", "OpenRCT2Official", "RCT1", "AddedAttractions", "LoopyLandscapes", "", "RCT2",

--- a/src/openrct2/cmdline/ParkInfoCommands.cpp
+++ b/src/openrct2/cmdline/ParkInfoCommands.cpp
@@ -1,0 +1,122 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2021 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#include "../Context.h"
+#include "../ParkImporter.h"
+#include "../core/Console.hpp"
+#include "../core/Path.hpp"
+#include "../object/ObjectRepository.h"
+#include "CommandLine.hpp"
+
+// clang-format off
+static constexpr const CommandLineOptionDefinition NoOptions[]
+{
+    OptionTableEnd
+};
+
+static exitcode_t HandleObjectsInfo(CommandLineArgEnumerator *argEnumerator);
+
+const CommandLineCommand CommandLine::ParkInfoCommands[]{
+    // Main commands
+    DefineCommand("objects", "<savefile> <output directory>", NoOptions, HandleObjectsInfo),
+
+    CommandTableEnd
+};
+// clang-format on
+
+static exitcode_t HandleObjectsInfo(CommandLineArgEnumerator* argEnumerator)
+{
+    exitcode_t result = CommandLine::HandleCommandDefault();
+    if (result != EXITCODE_CONTINUE)
+    {
+        return result;
+    }
+
+    // Get the source path
+    const utf8* rawSourcePath;
+    if (!argEnumerator->TryPopString(&rawSourcePath))
+    {
+        Console::Error::WriteLine("Expected a source save file path.");
+        return EXITCODE_FAIL;
+    }
+
+    utf8 sourcePath[MAX_PATH];
+    Path::GetAbsolute(sourcePath, sizeof(sourcePath), rawSourcePath);
+
+    // Get the destination path
+    // const utf8* rawDestinationPath;
+    // if (!argEnumerator->TryPopString(&rawDestinationPath))
+    //{
+    //    Console::Error::WriteLine("Expected an output directory.");
+    //    return EXITCODE_FAIL;
+    //}
+
+    // utf8 directory[MAX_PATH];
+    // Path::GetDirectory(directory, MAX_PATH, rawDestinationPath);
+    // if (!Path::DirectoryExists(directory))
+    //{
+    //    Console::Error::WriteLine("Output directory does not exist. Creating...");
+    //    Path::CreateDirectory(directory);
+    //    if (!Path::DirectoryExists(directory))
+    //    {
+    //        Console::Error::WriteLine("Output directory failed to create.");
+    //        return EXITCODE_FAIL;
+    //    }
+    //}
+
+    auto context = OpenRCT2::CreateContext();
+    context->Initialise();
+
+    auto importer = ParkImporter::Create(sourcePath);
+    auto loadResult = importer->LoadSavedGame(sourcePath);
+
+    for (auto& objType : {
+             ObjectType::Ride,
+             ObjectType::SmallScenery,
+             ObjectType::LargeScenery,
+             ObjectType::Walls,
+             ObjectType::Banners,
+             ObjectType::Paths,
+             ObjectType::PathBits,
+             ObjectType::SceneryGroup,
+             ObjectType::ParkEntrance,
+             ObjectType::Water,
+             ObjectType::ScenarioText,
+             ObjectType::TerrainSurface,
+             ObjectType::TerrainEdge,
+             ObjectType::Station,
+             ObjectType::Music,
+             ObjectType::FootpathSurface,
+             ObjectType::FootpathRailings,
+         })
+    {
+        auto& list = loadResult.RequiredObjects.GetList(objType);
+        Console::WriteLine("ObjectType: %d, Number of Objects: %d", EnumValue(objType), list.size());
+        for (auto& obj : list)
+        {
+            if (obj.Generation == ObjectGeneration::JSON && obj.Identifier.size() == 0)
+            {
+                Console::WriteLine("Empty object. Likely Circus Music.");
+                continue;
+            }
+            auto* ori = OpenRCT2::GetContext()->GetObjectRepository().FindObject(obj);
+            if (ori->GetFirstSourceGame() != ObjectSourceGame::Custom)
+            {
+                Console::Write("Official Object: ");
+            }
+            else
+            {
+                Console::Write("Custom Object: ");
+            }
+            std::string name{ obj.GetName() };
+            Console::WriteLine(name.c_str());
+        }
+    }
+    return EXITCODE_OK;
+}

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -144,6 +144,7 @@ const CommandLineCommand CommandLine::RootCommands[]
     DefineSubCommand("benchspritesort", CommandLine::BenchSpriteSortCommands  ),
     DefineSubCommand("benchsimulate",   CommandLine::BenchUpdateCommands      ),
     DefineSubCommand("simulate",        CommandLine::SimulateCommands         ),
+    DefineSubCommand("parkinfo",        CommandLine::ParkInfoCommands         ),
     CommandTableEnd
 };
 

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -645,6 +645,7 @@
     <ClCompile Include="cmdline/BenchUpdate.cpp" />
     <ClCompile Include="cmdline\CommandLine.cpp" />
     <ClCompile Include="cmdline\ConvertCommand.cpp" />
+    <ClCompile Include="cmdline\ParkInfoCommands.cpp" />
     <ClCompile Include="cmdline\RootCommands.cpp" />
     <ClCompile Include="cmdline\ScreenshotCommands.cpp" />
     <ClCompile Include="cmdline\SimulateCommands.cpp" />

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -64,7 +64,7 @@ int32_t object_entry_group_encoding[] = {
 ObjectList::const_iterator::const_iterator(const ObjectList* parent, bool end)
 {
     _parent = parent;
-    _subList = end ? _parent->_subLists.size() : 0;
+    _subList = _parent->_subLists.size();
     _index = 0;
 }
 

--- a/src/openrct2/object/ObjectList.cpp
+++ b/src/openrct2/object/ObjectList.cpp
@@ -64,7 +64,7 @@ int32_t object_entry_group_encoding[] = {
 ObjectList::const_iterator::const_iterator(const ObjectList* parent, bool end)
 {
     _parent = parent;
-    _subList = _parent->_subLists.size();
+    _subList = end ? _parent->_subLists.size() : 0;
     _index = 0;
 }
 


### PR DESCRIPTION
This should ultimately be for #15968. 
~~Very much a WiP.~~

~~At present bpb would output https://gist.github.com/duncanspumpkin/268ed21112f9715d8e9cdb3434659d64
Will probably have to create a new mock ObjectRepo class to be able to output the objects to the desired location.~~

~~Notes: Context required to be able to import s4 and s6. So if export of objects wanted need to create a mock Context and mock ObjectRepo. Need to be able to load the whole object to be able to verify if object is official or custom as json identifier's are not storing this info.~~

I've decided that making it unpack objects to a specified directory is too awkward to do atm so instead this will just output all the in use objects and their identifier. This is useful for people wanting to check what objects are in use in a park.

This is a typical output from the tool.
https://gist.github.com/duncanspumpkin/2694cbaff93af31ba5e9400dc71ba17c