### PR TITLE
Wrap vehicle colors when there are more than 32 trains

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#15998] Cannot set map size to the actual maximum.
 - Fix: [#16007] Scenario Editor "Entry Price" appears to the right of the value field.
 - Fix: [#16008] Tile Inspector can select elements from last tile without reselecting it.
+- Fix: [#16024] Go-Karts with more thant 32 vehicles do not color themselves correctly.
 - Fix: [#16063] Object Selection preview for objects with glass is broken.
 - Fix: [#16075] Exporting track designs saves scenery in incorrect locations.
 - Fix: [#16087] The Looping Roller Coaster booster is now always drawn correctly.

--- a/src/openrct2/actions/TrackDesignAction.cpp
+++ b/src/openrct2/actions/TrackDesignAction.cpp
@@ -259,7 +259,7 @@ GameActions::Result TrackDesignAction::Execute() const
 
     for (size_t i = 0; i <= MAX_VEHICLES_PER_RIDE; i++)
     {
-        auto tdIndex = std::min(i, std::size(_td.vehicle_colours) - 1);
+        auto tdIndex = i % std::size(_td.vehicle_colours);
         ride->vehicle_colours[i].Body = _td.vehicle_colours[tdIndex].body_colour;
         ride->vehicle_colours[i].Trim = _td.vehicle_colours[tdIndex].trim_colour;
         ride->vehicle_colours[i].Ternary = _td.vehicle_additional_colour[tdIndex];

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -41,7 +41,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2164,10 +2164,11 @@ void ride_set_vehicle_colours_to_random_preset(Ride* ride, uint8_t preset_index)
     else
     {
         ride->colour_scheme_type = RIDE_COLOUR_SCHEME_DIFFERENT_PER_TRAIN;
-        uint32_t count = std::min(presetList->count, static_cast<uint8_t>(32));
+        uint32_t count = presetList->count;
         for (uint32_t i = 0; i < count; i++)
         {
-            VehicleColour* preset = &presetList->list[i];
+            auto index = i % static_cast<uint8_t>(32);
+            VehicleColour* preset = &presetList->list[index];
             ride->vehicle_colours[i] = *preset;
         }
     }


### PR DESCRIPTION
Closes #16024

These changes were tested with the Go Karts rides, both premade ones and player created ones.
Let me know if there are more tests I should do with these changes.
