### PR TITLE
Fix #16327: Crash supplying a bad signature size in the auth packet

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -29,6 +29,7 @@
 - Fix: [#16087] The Looping Roller Coaster booster is now always drawn correctly.
 - Fix: [#16162] Go Karts speeds are not correctly randomised, they only go very fast or very slow.
 - Fix: [#16188] Medium-size banked turns on the Twister and Vertical Roller Coaster have incorrect support placement (partly original bug). 
+- Fix: [#16327] Crash on malformed network packet.
 
 0.3.5.1 (2021-11-21)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -2559,6 +2559,15 @@ void NetworkBase::Server_Handle_AUTH(NetworkConnection& connection, NetworkPacke
         {
             try
             {
+                // RSA technically supports keys up to 65536 bits, so this is the
+                // maximum signature size for now.
+                constexpr auto MaxRSASignatureSizeInBytes = 8192;
+
+                if (sigsize == 0 || sigsize > MaxRSASignatureSizeInBytes)
+                {
+                    throw std::runtime_error("Invalid signature size");
+                }
+
                 std::vector<uint8_t> signature;
                 signature.resize(sigsize);
 


### PR DESCRIPTION
No network version bump required

Closes #16327