### PR TITLE
Refactor tile access to be continuous when iterating

### DIFF
--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -951,9 +951,9 @@ namespace OpenRCT2
 
         void UpdateTrackElementsRideType()
         {
-            for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
+            for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
             {
-                for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
+                for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
                 {
                     TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y });
                     if (tileElement == nullptr)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5581,9 +5581,9 @@ void determine_ride_entrance_and_exit_locations()
             // Search the map to find it. Skip the outer ring of invisible tiles.
             bool alreadyFoundEntrance = false;
             bool alreadyFoundExit = false;
-            for (int32_t x = 1; x < MAXIMUM_MAP_SIZE_TECHNICAL - 1; x++)
+            for (int32_t y = 1; y < MAXIMUM_MAP_SIZE_TECHNICAL - 1; y++)
             {
-                for (int32_t y = 1; y < MAXIMUM_MAP_SIZE_TECHNICAL - 1; y++)
+                for (int32_t x = 1; x < MAXIMUM_MAP_SIZE_TECHNICAL - 1; x++)
                 {
                     TileElement* tileElement = map_get_first_element_at(TileCoordsXY{ x, y });
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -305,17 +305,17 @@ int32_t tile_element_iterator_next(tile_element_iterator* it)
         return 1;
     }
 
-    if (it->x < (MAXIMUM_MAP_SIZE_TECHNICAL - 1))
+    if (it->y < (MAXIMUM_MAP_SIZE_TECHNICAL - 1))
     {
-        it->x++;
+        it->y++;
         it->element = map_get_first_element_at(TileCoordsXY{ it->x, it->y });
         return 1;
     }
 
-    if (it->y < (MAXIMUM_MAP_SIZE_TECHNICAL - 1))
+    if (it->x < (MAXIMUM_MAP_SIZE_TECHNICAL - 1))
     {
-        it->x = 0;
-        it->y++;
+        it->y = 0;
+        it->x++;
         it->element = map_get_first_element_at(TileCoordsXY{ it->x, it->y });
         return 1;
     }
@@ -469,9 +469,9 @@ void map_count_remaining_land_rights()
     gLandRemainingOwnershipSales = 0;
     gLandRemainingConstructionSales = 0;
 
-    for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
+    for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
     {
-        for (int32_t y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
+        for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
             auto* surfaceElement = map_get_surface_element_at(TileCoordsXY{ x, y }.ToCoordsXY());
             // Surface elements are sometimes hacked out to save some space for other map elements

--- a/test/tests/TileElementsView.cpp
+++ b/test/tests/TileElementsView.cpp
@@ -116,9 +116,9 @@ template<typename T> bool CompareLists(const CoordsXY& pos)
 
 template<typename T> void CheckMapTiles()
 {
-    for (int x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; ++x)
+    for (int y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; ++y)
     {
-        for (int y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; ++y)
+        for (int x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; ++x)
         {
             auto pos = TileCoordsXY(x, y).ToCoordsXY();
 


### PR DESCRIPTION
In order to get continuous memory access the iteration over the to tiles need to start by y first. There have been some mixed uses which I corrected. There should be a minor performance gain.