### PR TITLE
Fix #16324: Real time ticks advancing every millisecond

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1031,13 +1031,10 @@ namespace OpenRCT2
 
             // Real Time.
             _realtimeAccumulator = std::min(_realtimeAccumulator + deltaTime, GAME_UPDATE_MAX_THRESHOLD);
-
-            // The game works with milliseconds as integers so we need to compensate.
-            constexpr auto _1Ms = 1.0f / 1000.0f;
-            while (_realtimeAccumulator >= _1Ms)
+            while (_realtimeAccumulator >= GAME_UPDATE_TIME_MS)
             {
                 gCurrentRealTimeTicks++;
-                _realtimeAccumulator -= _1Ms;
+                _realtimeAccumulator -= GAME_UPDATE_TIME_MS;
             }
         }
 


### PR DESCRIPTION
Small mistake, I confused the ticks with real-time.

Closes #16324