### PR TITLE
Fix #16061: Incorrect colours in minimap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,9 @@ set(TITLE_SEQUENCE_VERSION "0.1.2c")
 set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v${TITLE_SEQUENCE_VERSION}/title-sequences.zip")
 set(TITLE_SEQUENCE_SHA1 "304d13a126c15bf2c86ff13b81a2f2cc1856ac8d")
 
-set(OBJECTS_VERSION "1.2.4")
+set(OBJECTS_VERSION "1.2.5")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
-set(OBJECTS_SHA1 "c82605035f120188b7334a781a786ced9588e9af")
+set(OBJECTS_SHA1 "cc1db6abf7d6f7bdf6dbcbca782548a2c3af27ad")
 
 set(REPLAYS_VERSION "0.0.62")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -46,8 +46,8 @@
     <GtestSha1>058b9df80244c03f1633cb06e9f70471a29ebb8e</GtestSha1>
     <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.1.2c/title-sequences.zip</TitleSequencesUrl>
     <TitleSequencesSha1>304d13a126c15bf2c86ff13b81a2f2cc1856ac8d</TitleSequencesSha1>
-    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.2.4/objects.zip</ObjectsUrl>
-    <ObjectsSha1>c82605035f120188b7334a781a786ced9588e9af</ObjectsSha1>
+    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.2.5/objects.zip</ObjectsUrl>
+    <ObjectsSha1>cc1db6abf7d6f7bdf6dbcbca782548a2c3af27ad</ObjectsSha1>
     <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.62/replays.zip</ReplaysUrl>
     <ReplaysSha1>0B234FA152AFA49F5204ADA97CBAAE39A538961B</ReplaysSha1>
   </PropertyGroup>

--- a/shell.nix
+++ b/shell.nix
@@ -15,8 +15,8 @@ let
   objects-src = pkgs.fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "objects";
-    rev = "v1.2.4";
-    sha256 = "d01e5f1d2c95ba8ee295c457ae6215c048728ab07adc3db58a08f3cf2b1fa179";
+    rev = "v1.2.5";
+    sha256 = "e6b1f6985e38966672450e9c17473c730562f3f340fe07c93df618f3a8e809bb";
   };
 
   title-sequences-src = pkgs.fetchFromGitHub {

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -29,6 +29,7 @@
 #include <openrct2/entity/Staff.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
+#include <openrct2/object/TerrainSurfaceObject.h>
 #include <openrct2/ride/RideData.h>
 #include <openrct2/ride/Track.h>
 #include <openrct2/ride/TrainManager.h>
@@ -1380,22 +1381,6 @@ static void MapWindowDecreaseMapSize()
 }
 
 static constexpr const uint16_t WaterColour = MapColour(PALETTE_INDEX_195);
-static constexpr const uint16_t TerrainColour[] = {
-    MapColour(PALETTE_INDEX_73),                     // TERRAIN_GRASS
-    MapColour(PALETTE_INDEX_40),                     // TERRAIN_SAND
-    MapColour(PALETTE_INDEX_108),                    // TERRAIN_DIRT
-    MapColour(PALETTE_INDEX_12),                     // TERRAIN_ROCK
-    MapColour(PALETTE_INDEX_62),                     // TERRAIN_MARTIAN
-    MapColour2(PALETTE_INDEX_10, PALETTE_INDEX_16),  // TERRAIN_CHECKERBOARD
-    MapColour2(PALETTE_INDEX_73, PALETTE_INDEX_108), // TERRAIN_GRASS_CLUMPS
-    MapColour(PALETTE_INDEX_141),                    // TERRAIN_ICE
-    MapColour2(PALETTE_INDEX_172, PALETTE_INDEX_10), // TERRAIN_GRID_RED
-    MapColour2(PALETTE_INDEX_54, PALETTE_INDEX_10),  // TERRAIN_GRID_YELLOW
-    MapColour2(PALETTE_INDEX_162, PALETTE_INDEX_10), // TERRAIN_GRID_BLUE
-    MapColour2(PALETTE_INDEX_102, PALETTE_INDEX_10), // TERRAIN_GRID_GREEN
-    MapColour(PALETTE_INDEX_111),                    // TERRAIN_SAND_DARK
-    MapColour(PALETTE_INDEX_222),                    // TERRAIN_SAND_LIGHT
-};
 
 static constexpr const uint16_t ElementTypeMaskColour[] = {
     0xFFFF, // TILE_ELEMENT_TYPE_SURFACE
@@ -1424,7 +1409,12 @@ static uint16_t MapWindowGetPixelColourPeep(const CoordsXY& c)
     auto* surfaceElement = map_get_surface_element_at(c);
     if (surfaceElement == nullptr)
         return 0;
-    uint16_t colour = TerrainColour[surfaceElement->GetSurfaceStyle()];
+
+    uint16_t colour = MapColour(PALETTE_INDEX_0);
+    const auto* surfaceObject = surfaceElement->GetSurfaceStyleObject();
+    if (surfaceObject != nullptr)
+        colour = MapColour2(surfaceObject->MapColours[0], surfaceObject->MapColours[1]);
+
     if (surfaceElement->GetWaterHeight() > 0)
         colour = WaterColour;
 

--- a/src/openrct2/interface/Colour.h
+++ b/src/openrct2/interface/Colour.h
@@ -13,6 +13,8 @@
 
 #include <string_view>
 
+using PaletteIndex = uint8_t;
+
 /**
  * Colour IDs as used by the colour dropdown, NOT palette indices.
  */
@@ -65,7 +67,7 @@ enum
     COLOUR_LIGHT_WATER = 10
 };
 
-enum : uint8_t
+enum : PaletteIndex
 {
     PALETTE_INDEX_0 = 0,     // Transparent
     PALETTE_INDEX_10 = 10,   // Black (0-dark), Dark grey (0)

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -94,6 +94,16 @@ void TerrainSurfaceObject::ReadJson(IReadObjectContext* context, json_t& root)
               { "smoothWithOther", TERRAIN_SURFACE_FLAGS::SMOOTH_WITH_OTHER },
               { "canGrow", TERRAIN_SURFACE_FLAGS::CAN_GROW } });
 
+        const auto mapColours = properties["mapColours"];
+        const bool mapColoursAreValid = mapColours.is_array() && mapColours.size() == std::size(MapColours);
+        for (size_t i = 0; i < std::size(MapColours); i++)
+        {
+            if (mapColoursAreValid)
+                MapColours[i] = mapColours[i];
+            else
+                MapColours[i] = PALETTE_INDEX_0;
+        }
+
         for (auto& el : properties["special"])
         {
             if (el.is_object())

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -53,7 +53,7 @@ public:
     uint8_t Rotations{};
     money32 Price{};
     TERRAIN_SURFACE_FLAGS Flags{};
-    uint8_t MapColours[2];
+    PaletteIndex MapColours[2];
 
     void ReadJson(IReadObjectContext* context, json_t& root) override;
     void Load() override;

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -53,7 +53,7 @@ public:
     uint8_t Rotations{};
     money32 Price{};
     TERRAIN_SURFACE_FLAGS Flags{};
-    PaletteIndex MapColours[2];
+    PaletteIndex MapColours[2]{};
 
     void ReadJson(IReadObjectContext* context, json_t& root) override;
     void Load() override;

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -53,6 +53,7 @@ public:
     uint8_t Rotations{};
     money32 Price{};
     TERRAIN_SURFACE_FLAGS Flags{};
+    uint8_t MapColours[2];
 
     void ReadJson(IReadObjectContext* context, json_t& root) override;
     void Load() override;


### PR DESCRIPTION
Requires an object release before merging. The accompanying object changing are here: https://github.com/OpenRCT2/objects/commit/6cabf489aaa31bcca014e1240f91ac2d88d72997

Besides showing the wrong colours, the old code also frequently read beyond the end of the array. The new code should be very robust against that sort of thing, only continuing if exactly two colours have been specified and falling back to 0 otherwise.