### PR TITLE
Refactor out DidPassSurface

### DIFF
--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -210,11 +210,13 @@ struct PaintSessionCore
     tunnel_entry RightTunnels[TUNNEL_MAX_COUNT];
     uint8_t RightTunnelCount;
     uint8_t VerticalTunnelHeight;
-    bool DidPassSurface;
-    uint8_t Unk141E9DB;
+    uint8_t Flags;
     uint16_t WaterHeight;
     uint32_t TrackColours[4];
 };
+
+// 16544
+static constexpr size_t SizeOfPaintSessionCore = sizeof(PaintSessionCore);
 
 struct paint_session : public PaintSessionCore
 {

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -185,6 +185,7 @@ public:
 
 struct PaintSessionCore
 {
+    paint_struct PaintHead;
     paint_struct* Quadrants[MaxPaintQuadrants];
     paint_struct* LastPS;
     paint_string_struct* PSStringHead;
@@ -194,29 +195,25 @@ struct PaintSessionCore
     const void* CurrentlyDrawnItem;
     const TileElement* PathElementOnSameHeight;
     const TileElement* TrackElementOnSameHeight;
-    paint_struct PaintHead;
+    paint_struct* WoodenSupportsPrependTo;
+    CoordsXY SpritePosition;
+    CoordsXY MapPosition;
     uint32_t ViewFlags;
     uint32_t QuadrantBackIndex;
     uint32_t QuadrantFrontIndex;
-    CoordsXY SpritePosition;
-    ViewportInteractionItem InteractionType;
-    uint8_t CurrentRotation;
+    uint32_t TrackColours[4];
     support_height SupportSegments[9];
     support_height Support;
-    paint_struct* WoodenSupportsPrependTo;
-    CoordsXY MapPosition;
+    uint16_t WaterHeight;
     tunnel_entry LeftTunnels[TUNNEL_MAX_COUNT];
-    uint8_t LeftTunnelCount;
     tunnel_entry RightTunnels[TUNNEL_MAX_COUNT];
+    uint8_t LeftTunnelCount;
     uint8_t RightTunnelCount;
     uint8_t VerticalTunnelHeight;
+    uint8_t CurrentRotation;
     uint8_t Flags;
-    uint16_t WaterHeight;
-    uint32_t TrackColours[4];
+    ViewportInteractionItem InteractionType;
 };
-
-// 16544
-static constexpr size_t SizeOfPaintSessionCore = sizeof(PaintSessionCore);
 
 struct paint_session : public PaintSessionCore
 {

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -157,6 +157,7 @@ paint_session* Painter::CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags
     session->QuadrantBackIndex = std::numeric_limits<uint32_t>::max();
     session->QuadrantFrontIndex = 0;
     session->PaintEntryChain = _paintStructPool.Create();
+    session->Flags = 0;
 
     std::fill(std::begin(session->Quadrants), std::end(session->Quadrants), nullptr);
     session->LastPS = nullptr;

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -477,7 +477,7 @@ bool wooden_a_supports_paint_setup(
         return false;
     }
 
-    if (!(session.Unk141E9DB & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
     {
         return false;
     }
@@ -636,7 +636,7 @@ bool wooden_b_supports_paint_setup(
         return false;
     }
 
-    if (!(session.Unk141E9DB & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
     {
         return false;
     }
@@ -806,7 +806,7 @@ bool metal_a_supports_paint_setup(
         return false;
     }
 
-    if (!(session.Unk141E9DB & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
     {
         return false;
     }
@@ -1005,7 +1005,7 @@ bool metal_b_supports_paint_setup(
         return false; // AND
     }
 
-    if (!(session.Unk141E9DB & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
     {
         return false; // AND
     }
@@ -1185,7 +1185,7 @@ bool path_a_supports_paint_setup(
         return false;
     }
 
-    if (!(session.Unk141E9DB & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
     {
         return false;
     }
@@ -1335,7 +1335,7 @@ bool path_b_supports_paint_setup(
         return false; // AND
     }
 
-    if (!(session.Unk141E9DB & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
     {
         return false; // AND
     }

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -477,7 +477,7 @@ bool wooden_a_supports_paint_setup(
         return false;
     }
 
-    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
         return false;
     }
@@ -636,7 +636,7 @@ bool wooden_b_supports_paint_setup(
         return false;
     }
 
-    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
         return false;
     }
@@ -806,7 +806,7 @@ bool metal_a_supports_paint_setup(
         return false;
     }
 
-    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
         return false;
     }
@@ -1005,7 +1005,7 @@ bool metal_b_supports_paint_setup(
         return false; // AND
     }
 
-    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
         return false; // AND
     }
@@ -1185,7 +1185,7 @@ bool path_a_supports_paint_setup(
         return false;
     }
 
-    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
         return false;
     }
@@ -1335,7 +1335,7 @@ bool path_b_supports_paint_setup(
         return false; // AND
     }
 
-    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
         return false; // AND
     }

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -1099,7 +1099,7 @@ void path_paint_box_support(
         surfaceBaseImageIndex += byte_98D6E0[edi];
     }
 
-    const bool hasPassedSurface = (session.Flags & PaintSessionFlags::IsPassedSurface) != 0;
+    const bool hasPassedSurface = (session.Flags & PaintSessionFlags::PassedSurface) != 0;
     if (!hasPassedSurface)
     {
         boundBoxOffset.x = 3;
@@ -1239,7 +1239,7 @@ void path_paint_pole_support(
     }
 
     // Below Surface
-    const bool hasPassedSurface = (session.Flags & PaintSessionFlags::IsPassedSurface) != 0;
+    const bool hasPassedSurface = (session.Flags & PaintSessionFlags::PassedSurface) != 0;
     if (!hasPassedSurface)
     {
         boundBoxOffset.x = 3;

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -1099,7 +1099,8 @@ void path_paint_box_support(
         surfaceBaseImageIndex += byte_98D6E0[edi];
     }
 
-    if (!session.DidPassSurface)
+    const bool hasPassedSurface = (session.Flags & PaintSessionFlags::IsPassedSurface) != 0;
+    if (!hasPassedSurface)
     {
         boundBoxOffset.x = 3;
         boundBoxOffset.y = 3;
@@ -1120,7 +1121,7 @@ void path_paint_box_support(
         }
     }
 
-    if (!hasSupports || !session.DidPassSurface)
+    if (!hasSupports || !hasPassedSurface)
     {
         PaintAddImageAsParent(
             session, imageTemplate.WithIndex(surfaceBaseImageIndex), { 0, 0, height }, { boundBoxSize, 0 },
@@ -1238,7 +1239,8 @@ void path_paint_pole_support(
     }
 
     // Below Surface
-    if (!session.DidPassSurface)
+    const bool hasPassedSurface = (session.Flags & PaintSessionFlags::IsPassedSurface) != 0;
+    if (!hasPassedSurface)
     {
         boundBoxOffset.x = 3;
         boundBoxOffset.y = 3;
@@ -1259,7 +1261,7 @@ void path_paint_pole_support(
         }
     }
 
-    if (!hasSupports || !session.DidPassSurface)
+    if (!hasSupports || !hasPassedSurface)
     {
         PaintAddImageAsParent(
             session, imageTemplate.WithIndex(surfaceBaseImageIndex), { 0, 0, height }, { boundBoxSize.x, boundBoxSize.y, 0 },

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -978,7 +978,7 @@ void PaintSurface(paint_session& session, uint8_t direction, uint16_t height, co
 
     rct_drawpixelinfo* dpi = &session.DPI;
     session.InteractionType = ViewportInteractionItem::Terrain;
-    session.DidPassSurface = true;
+    session.Flags |= PaintSessionFlags::IsPassedSurface;
     session.SurfaceElement = reinterpret_cast<const TileElement*>(&tileElement);
 
     const auto zoomLevel = dpi->zoom_level;
@@ -1414,7 +1414,6 @@ void PaintSurface(paint_session& session, uint8_t direction, uint16_t height, co
     }
 
     session.InteractionType = ViewportInteractionItem::Terrain;
-    session.Unk141E9DB |= PaintSessionFlags::IsPassedSurface;
 
     switch (surfaceShape)
     {

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -978,7 +978,7 @@ void PaintSurface(paint_session& session, uint8_t direction, uint16_t height, co
 
     rct_drawpixelinfo* dpi = &session.DPI;
     session.InteractionType = ViewportInteractionItem::Terrain;
-    session.Flags |= PaintSessionFlags::IsPassedSurface;
+    session.Flags |= PaintSessionFlags::PassedSurface;
     session.SurfaceElement = reinterpret_cast<const TileElement*>(&tileElement);
 
     const auto zoomLevel = dpi->zoom_level;

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -56,7 +56,7 @@ void tile_element_paint_setup(paint_session& session, const CoordsXY& mapCoords,
     {
         paint_util_set_segment_support_height(session, SEGMENTS_ALL, 0xFFFF, 0);
         paint_util_force_set_general_support_height(session, -1, 0);
-        session.Unk141E9DB = isTrackPiecePreview ? PaintSessionFlags::IsTrackPiecePreview : 0;
+        session.Flags = isTrackPiecePreview ? PaintSessionFlags::IsTrackPiecePreview : 0;
         session.WaterHeight = 0xFFFF;
 
         PaintTileElementBase(session, mapCoords);
@@ -218,7 +218,8 @@ static void PaintTileElementBase(paint_session& session, const CoordsXY& origCoo
 
     session.SpritePosition.x = coords.x;
     session.SpritePosition.y = coords.y;
-    session.DidPassSurface = false;
+    session.Flags &= ~PaintSessionFlags::IsPassedSurface;
+
     int32_t previousBaseZ = 0;
     do
     {

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -218,7 +218,7 @@ static void PaintTileElementBase(paint_session& session, const CoordsXY& origCoo
 
     session.SpritePosition.x = coords.x;
     session.SpritePosition.y = coords.y;
-    session.Flags &= ~PaintSessionFlags::IsPassedSurface;
+    session.Flags &= ~PaintSessionFlags::PassedSurface;
 
     int32_t previousBaseZ = 0;
     do

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -73,9 +73,8 @@ enum
 
 namespace PaintSessionFlags
 {
-    // Unsure as to why this exists and DidPassSurface
-    constexpr uint8_t IsPassedSurface = 1;
-    constexpr uint8_t IsTrackPiecePreview = 2;
+    constexpr uint8_t PassedSurface = 1u << 0;
+    constexpr uint8_t IsTrackPiecePreview = 1u << 1;
 } // namespace PaintSessionFlags
 
 #ifdef __TESTPAINT__

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -783,7 +783,7 @@ bool track_paint_util_draw_station_covers_2(
         return false;
     }
 
-    if (!(session.Flags & (PaintSessionFlags::IsPassedSurface | PaintSessionFlags::IsTrackPiecePreview)))
+    if (!(session.Flags & (PaintSessionFlags::PassedSurface | PaintSessionFlags::IsTrackPiecePreview)))
     {
         return false;
     }

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -783,7 +783,7 @@ bool track_paint_util_draw_station_covers_2(
         return false;
     }
 
-    if (!(session.Unk141E9DB & (PaintSessionFlags::IsPassedSurface | PaintSessionFlags::IsTrackPiecePreview)))
+    if (!(session.Flags & (PaintSessionFlags::IsPassedSurface | PaintSessionFlags::IsTrackPiecePreview)))
     {
         return false;
     }

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -462,7 +462,7 @@ static paint_struct* mini_golf_paint_util_7c(
 
 static bool mini_golf_paint_util_should_draw_fence(paint_session& session, const TrackElement& trackElement)
 {
-    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
+    if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
         // Should be above ground (have passed surface rendering)
         return false;

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -462,7 +462,7 @@ static paint_struct* mini_golf_paint_util_7c(
 
 static bool mini_golf_paint_util_should_draw_fence(paint_session& session, const TrackElement& trackElement)
 {
-    if (!session.DidPassSurface)
+    if (!(session.Flags & PaintSessionFlags::IsPassedSurface))
     {
         // Should be above ground (have passed surface rendering)
         return false;


### PR DESCRIPTION
I removed the member as we can use the flags variable for this information instead. I also re-ordered the struct members to save a few bytes. I did some testing with underground tracks and loaded a few parks, I did not notice any difference, it should be logically the same just with a different variable now.