### PR TITLE
Fix #15943: Crash accessing unset w->focus

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1663,7 +1663,7 @@ static void WindowRideInitViewport(rct_window* w)
     w->focus = focus;
 
     // rct2: 0x006aec9c only used here so brought it into the function
-    if (w->viewport == nullptr && !ride->overall_view.IsNull())
+    if (w->viewport == nullptr && !ride->overall_view.IsNull() && w->focus.has_value())
     {
         const auto& view_widget = w->widgets[WIDX_VIEWPORT];
 


### PR DESCRIPTION
Crash happened on line 1674, throwing `std::_Throw_bad_optional_access`.