### PR TITLE
Potential Fix #14696: Ghost Stations created in Shuttle mode

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Improved: [#16251] Plugin API handles null values better.
 - Improved: [#16258] Increased image limit in the engine.
 - Change: [#16077] When importing SV6 files, the RCT1 land types are only added when they were actually used.
+- Fix: [#14696] Ghost Stations created under certain simulation conditions in Shuttle mode
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#15830] Objects with RCT1 images are very glitchy if OpenRCT2 is not linked to an RCT1 install.
 - Fix: [#15998] Cannot set map size to the actual maximum.

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3951,6 +3951,16 @@ bool Ride::Test(RideStatus newStatus, bool isApplying)
         }
     }
 
+    if (mode == RideMode::Shuttle)
+    {
+        rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
+        if (w != nullptr && _rideConstructionState != RideConstructionState::State0
+            && _currentRideIndex == trackElement.element->AsTrack()->GetRideIndex())
+        {
+            ride_construction_invalidate_current_track();
+        }
+    }
+
     if (isApplying)
         ride_set_start_finish_points(id, &trackElement);
 


### PR DESCRIPTION
I believe this a potential fix for #14696. I did some investigation, and believe there are a few parts to the issue:
1. The station logic "rebuilds" the station whenever a station piece is modified. This effectively re-assigns the begin/middle/end designations. The station numbering is handled by the station end pieces - whenever one is removed, the counter decrements, and when one is added, it increments. Normally, when removing the front piece of a station (the current end), the end will be removed and re-added, and the numbering is all happy. In this bug, we increment stationId _without_ decrementing it first...because the station end...isn't an end? When I stepped through in the debugger, the piece that should have been an end was in fact a middle, due to:
2. The ghost piece at the front of construction counts as a "station end", but it needs to be removed correctly. When TrackRemoveAction removes a ghost, it does not handle the station logic above: https://github.com/OpenRCT2/OpenRCT2/blob/c7851983e40bd6ac1e85f0c0a799eb6afef573f8/src/openrct2/actions/TrackRemoveAction.cpp#L410 skips `track_remove_station_element`, where the station tracking is performed.

So, either that logic is not correct (@duncanspumpkin or @manuelVo can you weigh in here? #13309 changed this logic last...and I don't fully understand why the current set of conditionals is present, nor why it caused desyncs)

Or...the ghost piece should be removed elsewhere when simulating. If the current track piece is a ghost (new end station piece), they are removed by `ride_construction_invalidate_current_track`. This is invoked in `Test`...for only some ride modes! An invocation of that function is hiding in the checks present for continuous circuit, blocked section, and station to station mode rides. But, not other ride types.

After adding a section for Shuttle mode, the steps presented in the linked issue can no longer reliably recreate the ghost station issue.

I'll admit that this section of the code is rather new to me, so I have two questions:
1. Is this even the right place to address the issue, or should we resolve the handling of ghost station elements in TrackRemoveAction so that it is impossible to remove a ghost station element without re-assigning beginning/middle/end? Or add checks to `ValidateStations` to ensure each station has a beginning and an end (and resolve if needed)?
2. If we try the proposed change here, should we even have a ride mode check? Or just always invalidate when simulating? I think I've seen reports of this issue popping up for other ride types that don't fit within the ride modes where we currently invalidate, so I'm not actually sure that the conditional is appropriate here.