### PR TITLE
Change rct2_path into a C++ string

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -772,9 +772,10 @@ namespace OpenRCT2
             if (String::IsNullOrEmpty(gCustomRCT2DataPath))
             {
                 // Check install directory
-                if (gConfigGeneral.rct2_path == nullptr || !platform_original_game_data_exists(gConfigGeneral.rct2_path))
+                if (gConfigGeneral.rct2_path.empty() || !platform_original_game_data_exists(gConfigGeneral.rct2_path.c_str()))
                 {
-                    log_verbose("install directory does not exist or invalid directory selected, %s", gConfigGeneral.rct2_path);
+                    log_verbose(
+                        "install directory does not exist or invalid directory selected, %s", gConfigGeneral.rct2_path.c_str());
                     if (!config_find_or_browse_install_directory())
                     {
                         utf8 path[MAX_PATH];

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -174,7 +174,7 @@ std::unique_ptr<IPlatformEnvironment> OpenRCT2::CreatePlatformEnvironment()
     }
     if (String::IsNullOrEmpty(gCustomRCT2DataPath))
     {
-        env->SetBasePath(DIRBASE::RCT2, String::ToStd(gConfigGeneral.rct2_path));
+        env->SetBasePath(DIRBASE::RCT2, gConfigGeneral.rct2_path);
     }
 
     // Log base paths

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -379,7 +379,7 @@ static exitcode_t HandleCommandSetRCT2(CommandLineArgEnumerator* enumerator)
     auto configPath = env->GetFilePath(OpenRCT2::PATHID::CONFIG);
     config_set_defaults();
     config_open(configPath.c_str());
-    String::DiscardDuplicate(&gConfigGeneral.rct2_path, path);
+    gConfigGeneral.rct2_path = std::string(path);
     if (config_save(configPath.c_str()))
     {
         Console::WriteFormat("Updating RCT2 path to '%s'.", path);

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -829,7 +829,7 @@ bool config_find_or_browse_install_directory()
     std::string path = Config::FindRCT2Path();
     if (!path.empty())
     {
-        gConfigGeneral.rct2_path = std::string(path);
+        gConfigGeneral.rct2_path = path;
     }
     else
     {
@@ -920,7 +920,7 @@ bool config_find_or_browse_install_directory()
                 {
                     return false;
                 }
-                gConfigGeneral.rct2_path = std::string(installPath);
+                gConfigGeneral.rct2_path = installPath;
 
                 if (platform_original_game_data_exists(installPath.c_str()))
                 {

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -162,7 +162,7 @@ namespace Config
             model->fullscreen_height = reader->GetInt32("fullscreen_height", -1);
             model->fullscreen_width = reader->GetInt32("fullscreen_width", -1);
             model->rct1_path = reader->GetCString("rct1_path", nullptr);
-            model->rct2_path = reader->GetCString("game_path", nullptr);
+            model->rct2_path = reader->GetString("game_path", "");
             model->landscape_smoothing = reader->GetBoolean("landscape_smoothing", true);
             model->language = reader->GetEnum<int32_t>("language", platform_get_locale_language(), Enum_LanguageEnum);
             model->measurement_format = reader->GetEnum<MeasurementFormat>(
@@ -798,7 +798,6 @@ bool config_save(const utf8* path)
 void config_release()
 {
     SafeFree(gConfigGeneral.rct1_path);
-    SafeFree(gConfigGeneral.rct2_path);
     SafeFree(gConfigGeneral.custom_currency_symbol);
     SafeFree(gConfigGeneral.last_save_game_directory);
     SafeFree(gConfigGeneral.last_save_landscape_directory);
@@ -830,8 +829,7 @@ bool config_find_or_browse_install_directory()
     std::string path = Config::FindRCT2Path();
     if (!path.empty())
     {
-        Memory::Free(gConfigGeneral.rct2_path);
-        gConfigGeneral.rct2_path = String::Duplicate(path.c_str());
+        gConfigGeneral.rct2_path = std::string(path);
     }
     else
     {
@@ -922,8 +920,7 @@ bool config_find_or_browse_install_directory()
                 {
                     return false;
                 }
-                Memory::Free(gConfigGeneral.rct2_path);
-                gConfigGeneral.rct2_path = String::Duplicate(installPath.c_str());
+                gConfigGeneral.rct2_path = std::string(installPath);
 
                 if (platform_original_game_data_exists(installPath.c_str()))
                 {

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -26,7 +26,7 @@ struct GeneralConfiguration
 {
     // Paths
     utf8* rct1_path;
-    utf8* rct2_path;
+    std::string rct2_path{};
 
     // Display
     int32_t default_display;

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -26,7 +26,7 @@ struct GeneralConfiguration
 {
     // Paths
     utf8* rct1_path;
-    std::string rct2_path{};
+    std::string rct2_path;
 
     // Display
     int32_t default_display;


### PR DESCRIPTION
Older config strings still use C strings, which means complicated memory management and footguns, or at least for mediocre developers like me. Hence why I want to change these to C++ strings.

I would like this to receive thorough scrutiny, as memory management is still a bit of a black box for me.