### PR TITLE
Enable std::filesystem for Android

### DIFF
--- a/src/openrct2/core/FileSystem.hpp
+++ b/src/openrct2/core/FileSystem.hpp
@@ -20,7 +20,7 @@
 #elif defined(__APPLE__) // XCode has the header, but reports error when included.
 #    define HAVE_STD_FILESYSTEM 0
 #elif defined(__ANDROID__)
-#    define HAVE_STD_FILESYSTEM 0
+#    define HAVE_STD_FILESYSTEM 1
 #elif defined(__has_include) // For GCC/Clang check if the header exists.
 #    if __has_include(<filesystem>)
 #        define HAVE_STD_FILESYSTEM 1


### PR DESCRIPTION
NDK r22 introduced support for std::filesystem, so re-enable it: https://android.googlesource.com/platform/ndk/+/master/docs/Roadmap.md#ndk-r22