### PR TITLE
Improve support for .park files in title sequence

### DIFF
--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -465,6 +465,7 @@ private:
         News::InitQueue();
         load_palette();
         gScreenAge = 0;
+        gGamePaused = false;
         gGameSpeed = 1;
     }
 

--- a/src/openrct2/ParkImporter.cpp
+++ b/src/openrct2/ParkImporter.cpp
@@ -23,24 +23,33 @@ namespace ParkImporter
     {
         std::unique_ptr<IParkImporter> parkImporter;
         std::string extension = Path::GetExtension(hintPath);
-        if (ExtensionIsRCT1(extension))
+        auto* context = OpenRCT2::GetContext();
+        if (ExtensionIsOpenRCT2ParkFile(extension))
+        {
+            parkImporter = CreateParkFile(context->GetObjectRepository());
+        }
+        else if (ExtensionIsRCT1(extension))
         {
             parkImporter = CreateS4();
         }
         else
         {
-            auto context = OpenRCT2::GetContext();
             parkImporter = CreateS6(context->GetObjectRepository());
         }
         return parkImporter;
     }
 
-    bool ExtensionIsRCT1(const std::string& extension)
+    bool ExtensionIsOpenRCT2ParkFile(std::string_view extension)
+    {
+        return String::Equals(extension, ".park", true);
+    }
+
+    bool ExtensionIsRCT1(std::string_view extension)
     {
         return String::Equals(extension, ".sc4", true) || String::Equals(extension, ".sv4", true);
     }
 
-    bool ExtensionIsScenario(const std::string& extension)
+    bool ExtensionIsScenario(std::string_view extension)
     {
         return String::Equals(extension, ".sc4", true) || String::Equals(extension, ".sc6", true)
             || String::Equals(extension, ".sea", true);

--- a/src/openrct2/ParkImporter.h
+++ b/src/openrct2/ParkImporter.h
@@ -64,8 +64,9 @@ namespace ParkImporter
     [[nodiscard]] std::unique_ptr<IParkImporter> CreateS6(IObjectRepository& objectRepository);
     [[nodiscard]] std::unique_ptr<IParkImporter> CreateParkFile(IObjectRepository& objectRepository);
 
-    bool ExtensionIsRCT1(const std::string& extension);
-    bool ExtensionIsScenario(const std::string& extension);
+    bool ExtensionIsOpenRCT2ParkFile(std::string_view extension);
+    bool ExtensionIsRCT1(std::string_view extension);
+    bool ExtensionIsScenario(std::string_view extension);
 } // namespace ParkImporter
 
 class ObjectLoadException : public std::exception

--- a/src/openrct2/title/TitleSequence.cpp
+++ b/src/openrct2/title/TitleSequence.cpp
@@ -309,7 +309,7 @@ static std::vector<std::string> GetSaves(IZipArchive* zip)
     {
         auto name = zip->GetFileName(i);
         auto ext = Path::GetExtension(name);
-        if (String::Equals(ext, ".sv6", true) || String::Equals(ext, ".sc6", true))
+        if (String::Equals(ext, ".sv6", true) || String::Equals(ext, ".sc6", true) || String::Equals(ext, ".park", true))
         {
             saves.push_back(std::move(name));
         }


### PR DESCRIPTION
There were a few more issues that I bumped into, which this PR resolves:

 - When loading .park files from the title sequence editor, they would be loaded as if they were RCT2 files, resulting in exceptions
 - .park files were not properly listed when reloading the title sequence (this also partly fixes the sequence editor plug-in: the items show up, but the names are empty)
 - .park files can be paused, causing the title sequence to hang