### PR TITLE
Enable std::filesystem for Android

### DIFF
--- a/src/openrct2-ui/input/ShortcutManager.cpp
+++ b/src/openrct2-ui/input/ShortcutManager.cpp
@@ -194,7 +194,7 @@ void ShortcutManager::LoadUserBindings()
 {
     try
     {
-        auto path = u8path(_env->GetFilePath(PATHID::CONFIG_SHORTCUTS));
+        auto path = fs::u8path(_env->GetFilePath(PATHID::CONFIG_SHORTCUTS));
         if (fs::exists(path))
         {
             LoadUserBindings(path);
@@ -204,7 +204,7 @@ void ShortcutManager::LoadUserBindings()
             try
             {
                 Console::WriteLine("Importing legacy shortcuts...");
-                auto legacyPath = u8path(_env->GetFilePath(PATHID::CONFIG_SHORTCUTS_LEGACY));
+                auto legacyPath = fs::u8path(_env->GetFilePath(PATHID::CONFIG_SHORTCUTS_LEGACY));
                 if (fs::exists(legacyPath))
                 {
                     LoadLegacyBindings(legacyPath);
@@ -315,7 +315,7 @@ void ShortcutManager::SaveUserBindings()
 {
     try
     {
-        auto path = u8path(_env->GetFilePath(PATHID::CONFIG_SHORTCUTS));
+        auto path = fs::u8path(_env->GetFilePath(PATHID::CONFIG_SHORTCUTS));
         SaveUserBindings(path);
     }
     catch (const std::exception& e)

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -66,7 +66,7 @@ public:
     const std::string GetChangelogText()
     {
         auto path = GetChangelogPath();
-        auto fs = std::ifstream(u8path(path), std::ios::in);
+        auto fs = std::ifstream(fs::u8path(path), std::ios::in);
         if (!fs.is_open())
         {
             throw std::runtime_error("Unable to open " + path);

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -582,7 +582,7 @@ namespace OpenRCT2
             {
                 if (String::Equals(Path::GetExtension(path), ".sea", true))
                 {
-                    auto data = DecryptSea(u8path(path));
+                    auto data = DecryptSea(fs::u8path(path));
                     auto ms = MemoryStream(data.data(), data.size(), MEMORY_ACCESS::READ);
                     if (!LoadParkFromStream(&ms, path, loadTitleScreenOnFail, asScenario))
                     {

--- a/src/openrct2/core/File.cpp
+++ b/src/openrct2/core/File.cpp
@@ -25,7 +25,7 @@ namespace File
 {
     bool Exists(u8string_view path)
     {
-        fs::path file = u8path(path);
+        fs::path file = fs::u8path(path);
         log_verbose("Checking if file exists: %s", u8string(path).c_str());
         std::error_code ec;
         const auto result = fs::exists(file, ec);
@@ -41,27 +41,27 @@ namespace File
         }
 
         std::error_code ec;
-        const auto result = fs::copy_file(u8path(srcPath), u8path(dstPath), ec);
+        const auto result = fs::copy_file(fs::u8path(srcPath), fs::u8path(dstPath), ec);
         return result && ec.value() == 0;
     }
 
     bool Delete(u8string_view path)
     {
         std::error_code ec;
-        const auto result = fs::remove(u8path(path), ec);
+        const auto result = fs::remove(fs::u8path(path), ec);
         return result && ec.value() == 0;
     }
 
     bool Move(u8string_view srcPath, u8string_view dstPath)
     {
         std::error_code ec;
-        fs::rename(u8path(srcPath), u8path(dstPath), ec);
+        fs::rename(fs::u8path(srcPath), fs::u8path(dstPath), ec);
         return ec.value() == 0;
     }
 
     std::vector<uint8_t> ReadAllBytes(u8string_view path)
     {
-        std::ifstream fs(u8path(u8string(path)), std::ios::in | std::ios::binary);
+        std::ifstream fs(fs::u8path(u8string(path)), std::ios::in | std::ios::binary);
         if (!fs.is_open())
         {
             throw IOException("Unable to open " + u8string(path));

--- a/src/openrct2/core/FileStream.cpp
+++ b/src/openrct2/core/FileStream.cpp
@@ -110,7 +110,7 @@ namespace OpenRCT2
         _fileSize = _filelengthi64(_fileno(_file));
 #else
         std::error_code ec;
-        _fileSize = fs::file_size(u8path(path), ec);
+        _fileSize = fs::file_size(fs::u8path(path), ec);
 #endif
 
         _ownsFilePtr = true;

--- a/src/openrct2/core/FileSystem.hpp
+++ b/src/openrct2/core/FileSystem.hpp
@@ -57,9 +57,3 @@ namespace fs = ghc::filesystem;
 #endif
 
 #undef HAVE_STD_FILESYSTEM // Not needed any more, don't make it public.
-
-#ifdef __ANDROID__
-#    define u8path(path) fs::u8path(std::string(path))
-#else
-#    define u8path(path) fs::u8path(path)
-#endif

--- a/src/openrct2/core/FileSystem.hpp
+++ b/src/openrct2/core/FileSystem.hpp
@@ -20,7 +20,7 @@
 #elif defined(__APPLE__) // XCode has the header, but reports error when included.
 #    define HAVE_STD_FILESYSTEM 0
 #elif defined(__ANDROID__)
-#    define HAVE_STD_FILESYSTEM 0
+#    define HAVE_STD_FILESYSTEM 1
 #elif defined(__has_include) // For GCC/Clang check if the header exists.
 #    if __has_include(<filesystem>)
 #        define HAVE_STD_FILESYSTEM 1

--- a/src/openrct2/core/Imaging.cpp
+++ b/src/openrct2/core/Imaging.cpp
@@ -312,7 +312,7 @@ namespace Imaging
                 return ReadFromFile(path, GetImageFormatFromPath(path));
             default:
             {
-                std::ifstream fs(u8path(path), std::ios::binary);
+                std::ifstream fs(fs::u8path(path), std::ios::binary);
                 return ReadFromStream(fs, format);
             }
         }
@@ -333,7 +333,7 @@ namespace Imaging
                 break;
             case IMAGE_FORMAT::PNG:
             {
-                std::ofstream fs(u8path(path), std::ios::binary);
+                std::ofstream fs(fs::u8path(path), std::ios::binary);
                 WritePng(fs, image);
                 break;
             }

--- a/src/openrct2/core/Path.cpp
+++ b/src/openrct2/core/Path.cpp
@@ -50,7 +50,7 @@ namespace Path
 
     u8string GetDirectory(u8string_view path)
     {
-        return u8path(path).parent_path().u8string();
+        return fs::u8path(path).parent_path().u8string();
     }
 
     void CreateDirectory(u8string_view path)
@@ -61,34 +61,34 @@ namespace Path
     bool DirectoryExists(u8string_view path)
     {
         std::error_code ec;
-        const auto result = fs::is_directory(u8path(path), ec);
+        const auto result = fs::is_directory(fs::u8path(path), ec);
         return result && ec.value() == 0;
     }
 
     u8string GetFileName(u8string_view path)
     {
-        return u8path(path).filename().u8string();
+        return fs::u8path(path).filename().u8string();
     }
 
     u8string GetFileNameWithoutExtension(u8string_view path)
     {
-        return u8path(path).stem().u8string();
+        return fs::u8path(path).stem().u8string();
     }
 
     u8string GetExtension(u8string_view path)
     {
-        return u8path(path).extension().u8string();
+        return fs::u8path(path).extension().u8string();
     }
 
     u8string WithExtension(u8string_view path, u8string_view newExtension)
     {
-        return u8path(path).replace_extension(u8path(newExtension)).u8string();
+        return fs::u8path(path).replace_extension(fs::u8path(newExtension)).u8string();
     }
 
     u8string GetAbsolute(u8string_view relative)
     {
         std::error_code ec;
-        return fs::absolute(u8path(relative), ec).u8string();
+        return fs::absolute(fs::u8path(relative), ec).u8string();
     }
 
     bool Equals(u8string_view a, u8string_view b)
@@ -104,7 +104,7 @@ namespace Path
     bool DeleteDirectory(u8string_view path)
     {
         std::error_code ec;
-        const auto result = fs::remove_all(u8path(path), ec);
+        const auto result = fs::remove_all(fs::u8path(path), ec);
         return (result > 0) && ec.value() == 0;
     }
 } // namespace Path

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -773,7 +773,7 @@ static std::string ResolveFilenameForCapture(const fs::path& filename)
         return *path;
     }
 
-    auto screenshotDirectory = u8path(screenshot_get_directory());
+    auto screenshotDirectory = fs::u8path(screenshot_get_directory());
     auto screenshotPath = fs::absolute(screenshotDirectory / filename);
 
     // Check the filename isn't attempting to leave the screenshot directory for security

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -1085,7 +1085,7 @@ void NetworkBase::BeginChatLog()
     auto env = GetContext().GetPlatformEnvironment();
     auto directory = env->GetDirectoryPath(DIRBASE::USER, DIRID::LOG_CHAT);
     _chatLogPath = BeginLog(directory, "", _chatLogFilenameFormat);
-    _chat_log_fs.open(u8path(_chatLogPath), std::ios::out | std::ios::app);
+    _chat_log_fs.open(fs::u8path(_chatLogPath), std::ios::out | std::ios::app);
 }
 
 void NetworkBase::AppendChatLog(std::string_view s)
@@ -1106,7 +1106,7 @@ void NetworkBase::BeginServerLog()
     auto env = GetContext().GetPlatformEnvironment();
     auto directory = env->GetDirectoryPath(DIRBASE::USER, DIRID::LOG_SERVER);
     _serverLogPath = BeginLog(directory, ServerName, _serverLogFilenameFormat);
-    _server_log_fs.open(u8path(_serverLogPath), std::ios::out | std::ios::app | std::ios::binary);
+    _server_log_fs.open(fs::u8path(_serverLogPath), std::ios::out | std::ios::app | std::ios::binary);
 
     // Log server start event
     utf8 logMessage[256];

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -176,7 +176,7 @@ private:
     {
         if (String::Equals(Path::GetExtension(path), ".sea", true))
         {
-            auto data = DecryptSea(u8path(path));
+            auto data = DecryptSea(fs::u8path(path));
             auto ms = std::make_unique<MemoryStream>();
             // Need to copy the data into MemoryStream as the overload will borrow instead of copy.
             ms->Write(data.data(), data.size());

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -116,7 +116,7 @@ namespace OpenRCT2::Scripting
             try
             {
                 CaptureOptions captureOptions;
-                captureOptions.Filename = u8path(AsOrDefault(options["filename"], ""));
+                captureOptions.Filename = fs::u8path(AsOrDefault(options["filename"], ""));
                 captureOptions.Rotation = options["rotation"].as_int() & 3;
                 captureOptions.Zoom = ZoomLevel(options["zoom"].as_int());
                 captureOptions.Transparent = AsOrDefault(options["transparent"], false);


### PR DESCRIPTION
NDK r22 introduced support for std::filesystem, so re-enable it: https://android.googlesource.com/platform/ndk/+/master/docs/Roadmap.md#ndk-r22

Requires the Android updates from https://github.com/OpenRCT2/OpenRCT2/pull/16107 to work.