### PR TITLE
Prevent underground view during title sequence

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,6 +20,7 @@
 - Improved: [#16258] Increased image limit in the engine.
 - Improved: [#16408] Improve --version cli option to report more compatibility information.
 - Change: [#16077] When importing SV6 files, the RCT1 land types are only added when they were actually used.
+- Change: [#16424] Following an entity in the title sequence no longer toggles underground view when it's underground.
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#15830] Objects with RCT1 images are very glitchy if OpenRCT2 is not linked to an RCT1 install.
 - Fix: [#15998] Cannot set map size to the actual maximum.

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -665,10 +665,13 @@ void viewport_update_sprite_follow(rct_window* window)
         {
             return;
         }
-        int32_t height = (tile_element_height({ sprite->x, sprite->y })) - 16;
-        int32_t underground = sprite->z < height;
 
-        viewport_set_underground_flag(underground, window, window->viewport);
+        if (!(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
+        {
+            int32_t height = (tile_element_height({ sprite->x, sprite->y })) - 16;
+            int32_t underground = sprite->z < height;
+            viewport_set_underground_flag(underground, window, window->viewport);
+        }
 
         auto centreLoc = centre_2d_coordinates(sprite->GetLocation(), window->viewport);
         if (centreLoc.has_value())


### PR DESCRIPTION
This change allows creating underground monorails or other rides to pan the camera.