### PR TITLE
Fix "Can't remove this" error when trying to remove rotated rides

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -23,6 +23,7 @@
 - Change: [#16424] Following an entity in the title sequence no longer toggles underground view when it's underground.
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#15830] Objects with RCT1 images are very glitchy if OpenRCT2 is not linked to an RCT1 install.
+- Fix: [#15947, #15960] Removing a flat ride results in an error message and duplicate structures.
 - Fix: [#15998] Cannot set map size to the actual maximum.
 - Fix: [#16007] Scenario Editor "Entry Price" appears to the right of the value field.
 - Fix: [#16008] Tile Inspector can select elements from last tile without reselecting it.

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1586,6 +1586,8 @@ static void WindowRideConstructionConstruct(rct_window* w)
 static void WindowRideConstructionMouseupDemolish(rct_window* w)
 {
     int32_t direction;
+    // The direction is reset by ride_initialise_construction_window(), but we need it to remove flat rides properly.
+    Direction currentDirection = _currentTrackPieceDirection;
     TileElement* tileElement;
     CoordsXYE inputElement, outputElement;
     track_begin_end trackBeginEnd;
@@ -1674,8 +1676,7 @@ static void WindowRideConstructionMouseupDemolish(rct_window* w)
     }
 
     auto trackRemoveAction = TrackRemoveAction(
-        _currentTrackPieceType, 0,
-        { _currentTrackBegin.x, _currentTrackBegin.y, _currentTrackBegin.z, _currentTrackPieceDirection });
+        _currentTrackPieceType, 0, { _currentTrackBegin.x, _currentTrackBegin.y, _currentTrackBegin.z, currentDirection });
 
     const auto rideId = w->rideId;
     trackRemoveAction.SetCallback([=](const GameAction* ga, const GameActions::Result* result) {


### PR DESCRIPTION
Fixes #15947
Fixes #15960 
This change fixes a problem where when trying to remove a rotated ride,
_currentTrackPieceDirection would be reset back to 0 by calling
ride_initialise_construction_window, causing TrackRemoveAction to not
being able to find and remove the ride.
Using a local variable with the current direction, saved before resetting
the global variable, fixes this issue.