### PR TITLE
Fix #11752: Track pieces with fractional cost are too cheap to build

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,6 +26,7 @@
 - Change: [#16077] When importing SV6 files, the RCT1 land types are only added when they were actually used.
 - Change: [#16424] Following an entity in the title sequence no longer toggles underground view when it's underground.
 - Change: [#16493] Boat Hire and Submarine Ride support costs now match their visual appearance.
+- Fix: [#11752] Track pieces with fractional cost are too cheap to build.
 - Fix: [#13336] Can no longer place Bumble Bee track design (reverts #12707).
 - Fix: [#14155] Map Generator sometimes places non-tree objects as trees.
 - Fix: [#14674] Recent Messages only shows first few notifications.

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -119,7 +119,7 @@ GameActions::Result MazePlaceTrackAction::Query() const
 
     const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
     money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Price) >> 16));
-    res.Cost = canBuild.Cost + price / 2 * 10;
+    res.Cost = ((canBuild.Cost + price) / 2) * 10;
 
     return res;
 }
@@ -161,7 +161,7 @@ GameActions::Result MazePlaceTrackAction::Execute() const
 
     const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
     money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Price) >> 16));
-    res.Cost = canBuild.Cost + price / 2 * 10;
+    res.Cost = ((canBuild.Cost + price) / 2) * 10;
 
     auto startLoc = _loc.ToTileStart();
 

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -393,14 +393,14 @@ GameActions::Result TrackPlaceAction::Query() const
             supportHeight = (10 * COORDS_Z_STEP);
         }
 
-        cost += ((supportHeight / (2 * COORDS_Z_STEP)) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice) * 5;
+        cost += ((supportHeight / (2 * COORDS_Z_STEP)) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice);
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
     price *= ted.Price;
 
     price >>= 16;
-    res.Cost = cost + ((price / 2) * 10);
+    res.Cost = ((cost + price) / 2) * 10;
     res.SetData(std::move(resultData));
 
     return res;
@@ -522,7 +522,7 @@ GameActions::Result TrackPlaceAction::Execute() const
             supportHeight = (10 * COORDS_Z_STEP);
         }
 
-        cost += ((supportHeight / (2 * COORDS_Z_STEP)) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice) * 5;
+        cost += (supportHeight / (2 * COORDS_Z_STEP)) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice;
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
@@ -697,7 +697,7 @@ GameActions::Result TrackPlaceAction::Execute() const
     price *= ted.Price;
 
     price >>= 16;
-    res.Cost = cost + ((price / 2) * 10);
+    res.Cost = ((cost + price) / 2) * 10;
     res.SetData(std::move(resultData));
 
     return res;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "17"
+#define NETWORK_STREAM_VERSION "18"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Fixes an inconsistency with RCT2 where track prices with a fractional part did not have their price rounded up when building, but did when refunding.

This created an exploit where refunding such a track piece granted the player 0.50€ more than they spent on the piece.

Mazes are also affected looking at `MazePlaceTrackAction`, so I corrected it. However, I don't know how does it compare to RCT2.

References:
1. With a hacked currency format display, we can clearly see building pieces of Chairlift at specific levels costs less than what is refunded.
![image](https://user-images.githubusercontent.com/7947461/150417460-04db035c-f657-475f-bdec-a98a5698a061.png)
2. The bug has already been researched here, but never fixed: https://github.com/OpenRCT2/OpenRCT2/issues/11752#issuecomment-629992728
2. Marcel Vos mentioned this disparity between RCT2 and OpenRCT2 in one of his videos (timestamped): https://youtu.be/EFE37bU9R2A?t=247
However, it's incorrectly assumed to be a fix.

Fixes #11752