### PR TITLE
Fix Signs not displaying non-English characters

### DIFF
--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -124,7 +124,8 @@ static void PaintLargeScenery3DTextLine(
     for (auto codepoint : CodepointView(line))
     {
         auto glyph = text.GetGlyph(codepoint, ' ');
-        auto glyphOffset = glyph.image_offset;
+        // Upcasting from uint8_t to uint32_t to avoid an overflow.
+        uint32_t glyphOffset = glyph.image_offset;
         auto glyphType = direction & 1;
         if (text.flags & LARGE_SCENERY_TEXT_FLAG_VERTICAL)
         {


### PR DESCRIPTION
Fixes #16479 
This variable used to be uint32_t before a refactor, but was changed to
auto, which means it's uint8_t. The offset calculation in this function
can cause an overflow with uint8_t, which causes the wrong character to
be printed on the sign.
Let me know if this is a good fix or we should take a different approach.