### PR TITLE
Fix #16426: Empty changelog when installed to non-standard prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,6 +415,7 @@ endif ()
 if (NOT MACOS_BUNDLE OR (MACOS_BUNDLE AND WITH_TESTS))
     # Install
     # Don't recurse, grab all *.txt and *.md files
+    add_definitions(-DDOCDIR="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}")
     file(GLOB DOC_FILES "${ROOT_DIR}/distribution/*.txt")
     list(APPEND DOC_FILES "${ROOT_DIR}/contributors.md"
                         "${ROOT_DIR}/licence.txt"

--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -64,6 +64,7 @@ namespace Platform
         static const utf8* searchLocations[] = {
             "./doc",
             "/usr/share/doc/openrct2",
+            DOCDIR,
         };
         for (auto searchLocation : searchLocations)
         {


### PR DESCRIPTION
Since erikjanp sadly didn’t react to our request to make PRs of his own, I decided to do it myself.

Do not squash merge!