### PR TITLE
Change #16493: Boat Hide and Submarine Ride have wrong support costs

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Improved: [#16408] Improve --version cli option to report more compatibility information.
 - Change: [#16077] When importing SV6 files, the RCT1 land types are only added when they were actually used.
 - Change: [#16424] Following an entity in the title sequence no longer toggles underground view when it's underground.
+- Change: [#16493] Boat Hire and Submarine Ride support costs do not match their visual appearance (original bug).
 - Fix: [#13336] Can no longer place Bumble Bee track design (reverts #12707).
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#15830] Objects with RCT1 images are very glitchy if OpenRCT2 is not linked to an RCT1 install.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,7 +21,7 @@
 - Improved: [#16408] Improve --version cli option to report more compatibility information.
 - Change: [#16077] When importing SV6 files, the RCT1 land types are only added when they were actually used.
 - Change: [#16424] Following an entity in the title sequence no longer toggles underground view when it's underground.
-- Change: [#16493] Boat Hire and Submarine Ride support costs do not match their visual appearance (original bug).
+- Change: [#16493] Boat Hire and Submarine Ride support costs now match their visual appearance.
 - Fix: [#13336] Can no longer place Bumble Bee track design (reverts #12707).
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#15830] Objects with RCT1 images are very glitchy if OpenRCT2 is not linked to an RCT1 install.

--- a/src/openrct2/ride/water/meta/BoatHire.h
+++ b/src/openrct2/ride/water/meta/BoatHire.h
@@ -40,7 +40,7 @@ constexpr const RideTypeDescriptor BoatHireRTD =
     SET_FIELD(RatingsCalculationFunction, ride_ratings_calculate_boat_hire),
     SET_FIELD(RatingsMultipliers, { 70, 6, 0 }),
     SET_FIELD(UpkeepCosts, { 50, 1, 0, 4, 0, 0 }),
-    SET_FIELD(BuildCosts, { 55, 5, 5, }),
+    SET_FIELD(BuildCosts, { 55, 0, 5, }),
     SET_FIELD(DefaultPrices, { 10, 0 }),
     SET_FIELD(DefaultMusic, MUSIC_OBJECT_WATER),
     SET_FIELD(PhotoItem, ShopItem::Photo),

--- a/src/openrct2/ride/water/meta/SubmarineRide.h
+++ b/src/openrct2/ride/water/meta/SubmarineRide.h
@@ -42,7 +42,7 @@ constexpr const RideTypeDescriptor SubmarineRideRTD =
     SET_FIELD(RatingsCalculationFunction, ride_ratings_calculate_submarine_ride),
     SET_FIELD(RatingsMultipliers, { 70, 6, 0 }),
     SET_FIELD(UpkeepCosts, { 50, 1, 0, 4, 0, 0 }),
-    SET_FIELD(BuildCosts, { 70, 0, 5, }),
+    SET_FIELD(BuildCosts, { 70, 5, 5, }),
     SET_FIELD(DefaultPrices, { 10, 0 }),
     SET_FIELD(DefaultMusic, MUSIC_OBJECT_WATER),
     SET_FIELD(PhotoItem, ShopItem::Photo),


### PR DESCRIPTION
Boat Hire now has no support costs, while Submarine Ride costs $2.50 per level. This reflects their visual appearance.

![image](https://user-images.githubusercontent.com/7947461/150697415-6a5dfbfb-87a4-447b-859c-b994cf995948.png)
![image](https://user-images.githubusercontent.com/7947461/150697417-2f31470e-4fb1-40cd-9fef-23bf00d6cc00.png)

Closes #16493