### PR TITLE
Fix peeps not showing on one side of pirate ship

### DIFF
--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -81,9 +81,9 @@ static void PaintSwingingShipRiders(
             if (vehicle.num_peeps <= peep)
                 break;
 
-            auto frameNum = 1 + (row * 2) + (direction >> 1);
+            auto frameNum = 1 + (row * 2) + ((direction >> 1) ^ col);
             auto imageIndex = baseImageIndex + frameNum;
-            auto imageId = ImageId(imageIndex, vehicle.peep_tshirt_colours[row], vehicle.peep_tshirt_colours[row + 1]);
+            auto imageId = ImageId(imageIndex, vehicle.peep_tshirt_colours[peep], vehicle.peep_tshirt_colours[peep + 1]);
             PaintAddImageAsChild(session, imageId, offset, bbLength, bbOffset);
 
             peep += 2;


### PR DESCRIPTION
Fixes #16485
This commit fixes this bug by adding a missing ^ operator on frameNum.
Before a recent refactor, the framenum was changed to the mirrored one
with "^ 1", but it was omitted. Using "^ col" when col is 0 or 1, adds
this back.