### PR TITLE
Clean-up OptionsWindow

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -63,13 +63,14 @@ enum WindowOptionsWidgetIdx {
     WIDX_TITLE,
     WIDX_CLOSE,
     WIDX_PAGE_BACKGROUND,
-    WIDX_TAB_1,
-    WIDX_TAB_2,
-    WIDX_TAB_3,
-    WIDX_TAB_4,
-    WIDX_TAB_5,
-    WIDX_TAB_6,
-    WIDX_TAB_7,
+    WIDX_FIRST_TAB,
+    WIDX_TAB_DISPLAY = WIDX_FIRST_TAB,
+    WIDX_TAB_RENDERING,
+    WIDX_TAB_CULTURE,
+    WIDX_TAB_AUDIO,
+    WIDX_TAB_CONTROLS_AND_INTERFACE,
+    WIDX_TAB_MISC,
+    WIDX_TAB_ADVANCED,
 
     WIDX_PAGE_START,
 
@@ -419,13 +420,13 @@ const int32_t window_options_tab_animation_frames[] =
 
 #define MAIN_OPTIONS_ENABLED_WIDGETS \
     (1ULL << WIDX_CLOSE) | \
-    (1ULL << WIDX_TAB_1) | \
-    (1ULL << WIDX_TAB_2) | \
-    (1ULL << WIDX_TAB_3) | \
-    (1ULL << WIDX_TAB_4) | \
-    (1ULL << WIDX_TAB_5) | \
-    (1ULL << WIDX_TAB_6) | \
-    (1ULL << WIDX_TAB_7)
+    (1ULL << WIDX_TAB_DISPLAY) | \
+    (1ULL << WIDX_TAB_RENDERING) | \
+    (1ULL << WIDX_TAB_CULTURE) | \
+    (1ULL << WIDX_TAB_AUDIO) | \
+    (1ULL << WIDX_TAB_CONTROLS_AND_INTERFACE) | \
+    (1ULL << WIDX_TAB_MISC) | \
+    (1ULL << WIDX_TAB_ADVANCED)
 
 static uint64_t window_options_page_enabled_widgets[] = {
     MAIN_OPTIONS_ENABLED_WIDGETS |
@@ -744,14 +745,14 @@ private:
             case WIDX_CLOSE:
                 window_close(this);
                 break;
-            case WIDX_TAB_1:
-            case WIDX_TAB_2:
-            case WIDX_TAB_3:
-            case WIDX_TAB_4:
-            case WIDX_TAB_5:
-            case WIDX_TAB_6:
-            case WIDX_TAB_7:
-                SetPage(widgetIndex - WIDX_TAB_1);
+            case WIDX_TAB_DISPLAY:
+            case WIDX_TAB_RENDERING:
+            case WIDX_TAB_CULTURE:
+            case WIDX_TAB_AUDIO:
+            case WIDX_TAB_CONTROLS_AND_INTERFACE:
+            case WIDX_TAB_MISC:
+            case WIDX_TAB_ADVANCED:
+                SetPage(widgetIndex - WIDX_FIRST_TAB);
                 break;
         }
     }
@@ -792,7 +793,7 @@ private:
     {
         // Tab animation
         this->frame_no++;
-        widget_invalidate(this, WIDX_TAB_1 + this->page);
+        widget_invalidate(this, WIDX_FIRST_TAB + this->page);
     }
 #pragma endregion
 
@@ -2300,8 +2301,8 @@ private:
     void SetPressedTab()
     {
         for (int32_t i = 0; i < WINDOW_OPTIONS_PAGE_COUNT; i++)
-            this->pressed_widgets &= ~(1 << (WIDX_TAB_1 + i));
-        this->pressed_widgets |= 1LL << (WIDX_TAB_1 + this->page);
+            this->pressed_widgets &= ~(1 << (WIDX_FIRST_TAB + i));
+        this->pressed_widgets |= 1LL << (WIDX_FIRST_TAB + this->page);
     }
 
     void ShowDropdown(rct_widget* widget, int32_t num_items)
@@ -2325,7 +2326,7 @@ private:
 
     void DrawTabImage(rct_drawpixelinfo* dpi, int32_t p, int32_t spriteIndex)
     {
-        rct_widgetindex widgetIndex = WIDX_TAB_1 + p;
+        rct_widgetindex widgetIndex = WIDX_FIRST_TAB + p;
         rct_widget* widget = &this->widgets[widgetIndex];
 
         auto screenCoords = this->windowPos + ScreenCoordsXY{ widget->left, widget->top };

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -500,7 +500,7 @@ public:
         enabled_widgets = window_options_page_enabled_widgets[WINDOW_OPTIONS_PAGE_DISPLAY];
         page = WINDOW_OPTIONS_PAGE_DISPLAY;
         frame_no = 0;
-        WindowInitScrollWidgets(this);
+        InitScrollWidgets();
     }
 
     void OnMouseUp(rct_widgetindex widgetIndex) override
@@ -737,7 +737,7 @@ private:
         if (window_options_page_widgets[page] != widgets)
         {
             widgets = window_options_page_widgets[page];
-            WindowInitScrollWidgets(this);
+            InitScrollWidgets();
         }
         SetPressedTab();
 
@@ -2189,7 +2189,7 @@ private:
         Invalidate();
         window_event_resize_call(this);
         window_event_invalidate_call(this);
-        WindowInitScrollWidgets(this);
+        InitScrollWidgets();
         Invalidate();
     }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -746,6 +746,14 @@ public:
         }
     }
 
+    OpenRCT2String OnTooltip(rct_widgetindex widgetIndex, rct_string_id fallback) override
+    {
+        if (page == WINDOW_OPTIONS_PAGE_ADVANCED)
+            return AdvancedTooltip(widgetIndex, fallback);
+
+        return rct_window::OnTooltip(widgetIndex, fallback);
+    }
+
 private:
 #pragma region Common events
     void CommonMouseUp(rct_widgetindex widgetIndex)

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -539,10 +539,10 @@ class OptionsWindow final : public Window
 public:
     void OnOpen() override
     {
-        this->widgets = window_options_display_widgets;
-        this->enabled_widgets = window_options_page_enabled_widgets[WINDOW_OPTIONS_PAGE_DISPLAY];
-        this->page = WINDOW_OPTIONS_PAGE_DISPLAY;
-        this->frame_no = 0;
+        widgets = window_options_display_widgets;
+        enabled_widgets = window_options_page_enabled_widgets[WINDOW_OPTIONS_PAGE_DISPLAY];
+        page = WINDOW_OPTIONS_PAGE_DISPLAY;
+        frame_no = 0;
         WindowInitScrollWidgets(this);
     }
 
@@ -721,7 +721,7 @@ public:
 
     ScreenSize OnScrollGetSize(int32_t scrollIndex) override
     {
-        switch (this->page)
+        switch (page)
         {
             case WINDOW_OPTIONS_PAGE_AUDIO:
                 return AudioScrollGetSize(scrollIndex);
@@ -759,20 +759,20 @@ private:
 
     void CommonPrepareDrawBefore()
     {
-        if (window_options_page_widgets[this->page] != this->widgets)
+        if (window_options_page_widgets[page] != widgets)
         {
-            this->widgets = window_options_page_widgets[this->page];
+            widgets = window_options_page_widgets[page];
             WindowInitScrollWidgets(this);
         }
         SetPressedTab();
 
-        this->disabled_widgets = 0;
+        disabled_widgets = 0;
         auto hasFilePicker = OpenRCT2::GetContext()->GetUiContext()->HasFilePicker();
         if (!hasFilePicker)
         {
-            this->enabled_widgets &= ~(1ULL << WIDX_ALWAYS_NATIVE_LOADSAVE);
-            this->disabled_widgets |= (1ULL << WIDX_ALWAYS_NATIVE_LOADSAVE);
-            this->widgets[WIDX_ALWAYS_NATIVE_LOADSAVE].type = WindowWidgetType::Empty;
+            enabled_widgets &= ~(1ULL << WIDX_ALWAYS_NATIVE_LOADSAVE);
+            disabled_widgets |= (1ULL << WIDX_ALWAYS_NATIVE_LOADSAVE);
+            widgets[WIDX_ALWAYS_NATIVE_LOADSAVE].type = WindowWidgetType::Empty;
         }
     }
 
@@ -780,20 +780,20 @@ private:
     {
         // Automatically adjust window height to fit widgets
         int32_t y = 0;
-        for (auto widget = &this->widgets[WIDX_PAGE_START]; widget->type != WindowWidgetType::Last; widget++)
+        for (auto widget = &widgets[WIDX_PAGE_START]; widget->type != WindowWidgetType::Last; widget++)
         {
             y = std::max<int32_t>(y, widget->bottom);
         }
-        this->height = y + 6;
-        this->widgets[WIDX_BACKGROUND].bottom = this->height - 1;
-        this->widgets[WIDX_PAGE_BACKGROUND].bottom = this->height - 1;
+        height = y + 6;
+        widgets[WIDX_BACKGROUND].bottom = height - 1;
+        widgets[WIDX_PAGE_BACKGROUND].bottom = height - 1;
     }
 
     void CommonUpdate()
     {
         // Tab animation
-        this->frame_no++;
-        widget_invalidate(this, WIDX_FIRST_TAB + this->page);
+        frame_no++;
+        widget_invalidate(this, WIDX_FIRST_TAB + page);
     }
 #pragma endregion
 
@@ -806,47 +806,47 @@ private:
                 gConfigGeneral.uncap_fps ^= 1;
                 drawing_engine_set_vsync(gConfigGeneral.use_vsync);
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_USE_VSYNC_CHECKBOX:
                 gConfigGeneral.use_vsync ^= 1;
                 drawing_engine_set_vsync(gConfigGeneral.use_vsync);
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_SHOW_FPS_CHECKBOX:
                 gConfigGeneral.show_fps ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_MULTITHREADING_CHECKBOX:
                 gConfigGeneral.multithreading ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_MINIMIZE_FOCUS_LOSS:
                 gConfigGeneral.minimize_fullscreen_focus_loss ^= 1;
                 platform_refresh_video(false);
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_STEAM_OVERLAY_PAUSE:
                 gConfigGeneral.steam_overlay_pause ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_DISABLE_SCREENSAVER_LOCK:
                 gConfigGeneral.disable_screensaver ^= 1;
                 ApplyScreenSaverLockSetting();
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
         }
     }
 
     void DisplayMouseDown(rct_widgetindex widgetIndex)
     {
-        rct_widget* widget = &this->widgets[widgetIndex - 1];
+        rct_widget* widget = &widgets[widgetIndex - 1];
 
         switch (widgetIndex)
         {
@@ -873,7 +873,7 @@ private:
                     }
                 }
 
-                this->ShowDropdown(widget, static_cast<int32_t>(resolutions.size()));
+                ShowDropdown(widget, static_cast<int32_t>(resolutions.size()));
 
                 if (selectedResolution != -1 && selectedResolution < 32)
                 {
@@ -890,7 +890,7 @@ private:
                 gDropdownItemsArgs[1] = STR_OPTIONS_DISPLAY_FULLSCREEN;
                 gDropdownItemsArgs[2] = STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS;
 
-                this->ShowDropdown(widget, 3);
+                ShowDropdown(widget, 3);
 
                 Dropdown::SetChecked(gConfigGeneral.fullscreen_mode, true);
                 break;
@@ -906,7 +906,7 @@ private:
                     gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
                     gDropdownItemsArgs[i] = DrawingEngineStringIds[i];
                 }
-                this->ShowDropdown(widget, numItems);
+                ShowDropdown(widget, numItems);
                 Dropdown::SetChecked(EnumValue(gConfigGeneral.drawing_engine), true);
                 break;
             }
@@ -974,7 +974,7 @@ private:
                     bool recreate_window = drawing_engine_requires_new_window(srcEngine, dstEngine);
                     platform_refresh_video(recreate_window);
                     config_save_default();
-                    this->Invalidate();
+                    Invalidate();
                 }
                 break;
         }
@@ -993,33 +993,33 @@ private:
         // Disable resolution dropdown on "Windowed" and "Fullscreen (desktop)"
         if (gConfigGeneral.fullscreen_mode != static_cast<int32_t>(OpenRCT2::Ui::FULLSCREEN_MODE::FULLSCREEN))
         {
-            this->disabled_widgets |= (1ULL << WIDX_RESOLUTION_DROPDOWN);
-            this->disabled_widgets |= (1ULL << WIDX_RESOLUTION);
+            disabled_widgets |= (1ULL << WIDX_RESOLUTION_DROPDOWN);
+            disabled_widgets |= (1ULL << WIDX_RESOLUTION);
         }
         else
         {
-            this->disabled_widgets &= ~(1ULL << WIDX_RESOLUTION_DROPDOWN);
-            this->disabled_widgets &= ~(1ULL << WIDX_RESOLUTION);
+            disabled_widgets &= ~(1ULL << WIDX_RESOLUTION_DROPDOWN);
+            disabled_widgets &= ~(1ULL << WIDX_RESOLUTION);
         }
 
         // Disable Steam Overlay checkbox when using software rendering.
         if (gConfigGeneral.drawing_engine == DrawingEngine::Software)
         {
-            this->disabled_widgets |= (1ULL << WIDX_STEAM_OVERLAY_PAUSE);
+            disabled_widgets |= (1ULL << WIDX_STEAM_OVERLAY_PAUSE);
         }
         else
         {
-            this->disabled_widgets &= ~(1ULL << WIDX_STEAM_OVERLAY_PAUSE);
+            disabled_widgets &= ~(1ULL << WIDX_STEAM_OVERLAY_PAUSE);
         }
 
         // Disable changing VSync for Software engine, as we can't control its use of VSync
         if (gConfigGeneral.drawing_engine == DrawingEngine::Software)
         {
-            this->disabled_widgets |= (1ULL << WIDX_USE_VSYNC_CHECKBOX);
+            disabled_widgets |= (1ULL << WIDX_USE_VSYNC_CHECKBOX);
         }
         else
         {
-            this->disabled_widgets &= ~(1ULL << WIDX_USE_VSYNC_CHECKBOX);
+            disabled_widgets &= ~(1ULL << WIDX_USE_VSYNC_CHECKBOX);
         }
 
         WidgetSetCheckboxValue(this, WIDX_UNCAP_FPS_CHECKBOX, gConfigGeneral.uncap_fps);
@@ -1031,8 +1031,8 @@ private:
         WidgetSetCheckboxValue(this, WIDX_DISABLE_SCREENSAVER_LOCK, gConfigGeneral.disable_screensaver);
 
         // Dropdown captions for straightforward strings.
-        this->widgets[WIDX_FULLSCREEN].text = window_options_fullscreen_mode_names[gConfigGeneral.fullscreen_mode];
-        this->widgets[WIDX_DRAWING_ENGINE].text = DrawingEngineStringIds[EnumValue(gConfigGeneral.drawing_engine)];
+        widgets[WIDX_FULLSCREEN].text = window_options_fullscreen_mode_names[gConfigGeneral.fullscreen_mode];
+        widgets[WIDX_DRAWING_ENGINE].text = DrawingEngineStringIds[EnumValue(gConfigGeneral.drawing_engine)];
 
         CommonPrepareDrawAfter();
     }
@@ -1040,33 +1040,31 @@ private:
     void DisplayDraw(rct_drawpixelinfo* dpi)
     {
         WindowDrawWidgets(this, dpi);
-        this->DrawTabImages(dpi);
+        DrawTabImages(dpi);
 
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_FULLSCREEN].top + 1 }, STR_FULLSCREEN_MODE, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_FULLSCREEN].top + 1 }, STR_FULLSCREEN_MODE, {}, { colours[1] });
 
         // Disable resolution dropdown on "Windowed" and "Fullscreen (desktop)"
-        colour_t colour = this->colours[1];
+        colour_t colour = colours[1];
         if (gConfigGeneral.fullscreen_mode != static_cast<int32_t>(OpenRCT2::Ui::FULLSCREEN_MODE::FULLSCREEN))
         {
             colour |= COLOUR_FLAG_INSET;
         }
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10 + 15, this->widgets[WIDX_RESOLUTION].top + 1 }, STR_DISPLAY_RESOLUTION,
-            {}, { colour });
+            dpi, windowPos + ScreenCoordsXY{ 10 + 15, widgets[WIDX_RESOLUTION].top + 1 }, STR_DISPLAY_RESOLUTION, {},
+            { colour });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_SCALE].top + 1 }, STR_UI_SCALING_DESC, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_SCALE].top + 1 }, STR_UI_SCALING_DESC, {}, { colours[1] });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_DRAWING_ENGINE].top + 1 }, STR_DRAWING_ENGINE, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_DRAWING_ENGINE].top + 1 }, STR_DRAWING_ENGINE, {},
+            { colours[1] });
 
         auto ft = Formatter();
         ft.Add<int32_t>(static_cast<int32_t>(gConfigGeneral.window_scale * 100));
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ this->widgets[WIDX_SCALE].left + 1, this->widgets[WIDX_SCALE].top + 1 },
-            STR_WINDOW_OBJECTIVE_VALUE_RATING, ft, { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_SCALE].left + 1, widgets[WIDX_SCALE].top + 1 },
+            STR_WINDOW_OBJECTIVE_VALUE_RATING, ft, { colours[1] });
     }
 #pragma endregion
 
@@ -1098,44 +1096,44 @@ private:
             case WIDX_DAY_NIGHT_CHECKBOX:
                 gConfigGeneral.day_night_cycle ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_ENABLE_LIGHT_FX_CHECKBOX:
                 gConfigGeneral.enable_light_fx ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX:
                 gConfigGeneral.enable_light_fx_for_vehicles ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_UPPER_CASE_BANNERS_CHECKBOX:
                 gConfigGeneral.upper_case_banners ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX:
                 gConfigGeneral.disable_lightning_effect ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX:
                 gConfigGeneral.render_weather_effects ^= 1;
                 gConfigGeneral.render_weather_gloom = gConfigGeneral.render_weather_effects;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 gfx_invalidate_screen();
                 break;
             case WIDX_SHOW_GUEST_PURCHASES_CHECKBOX:
                 gConfigGeneral.show_guest_purchases ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_TRANSPARENT_SCREENSHOTS_CHECKBOX:
                 gConfigGeneral.transparent_screenshot ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
         }
     }
@@ -1152,8 +1150,8 @@ private:
                 gDropdownItemsArgs[1] = STR_VIRTUAL_FLOOR_STYLE_TRANSPARENT;
                 gDropdownItemsArgs[2] = STR_VIRTUAL_FLOOR_STYLE_GLASSY;
 
-                rct_widget* widget = &this->widgets[widgetIndex - 1];
-                this->ShowDropdown(widget, 3);
+                rct_widget* widget = &widgets[widgetIndex - 1];
+                ShowDropdown(widget, 3);
 
                 Dropdown::SetChecked(static_cast<int32_t>(gConfigGeneral.virtual_floor_style), true);
                 break;
@@ -1191,17 +1189,16 @@ private:
             STR_VIRTUAL_FLOOR_STYLE_GLASSY,
         };
 
-        this->widgets[WIDX_VIRTUAL_FLOOR].text = VirtualFloorStyleStrings[static_cast<int32_t>(
-            gConfigGeneral.virtual_floor_style)];
+        widgets[WIDX_VIRTUAL_FLOOR].text = VirtualFloorStyleStrings[static_cast<int32_t>(gConfigGeneral.virtual_floor_style)];
 
         WidgetSetCheckboxValue(this, WIDX_ENABLE_LIGHT_FX_CHECKBOX, gConfigGeneral.enable_light_fx);
         if (gConfigGeneral.day_night_cycle && gConfigGeneral.drawing_engine == DrawingEngine::SoftwareWithHardwareDisplay)
         {
-            this->disabled_widgets &= ~(1ULL << WIDX_ENABLE_LIGHT_FX_CHECKBOX);
+            disabled_widgets &= ~(1ULL << WIDX_ENABLE_LIGHT_FX_CHECKBOX);
         }
         else
         {
-            this->disabled_widgets |= (1ULL << WIDX_ENABLE_LIGHT_FX_CHECKBOX);
+            disabled_widgets |= (1ULL << WIDX_ENABLE_LIGHT_FX_CHECKBOX);
             gConfigGeneral.enable_light_fx = false;
         }
 
@@ -1209,11 +1206,11 @@ private:
         if (gConfigGeneral.day_night_cycle && gConfigGeneral.drawing_engine == DrawingEngine::SoftwareWithHardwareDisplay
             && gConfigGeneral.enable_light_fx)
         {
-            this->disabled_widgets &= ~(1ULL << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);
+            disabled_widgets &= ~(1ULL << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);
         }
         else
         {
-            this->disabled_widgets |= (1ULL << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);
+            disabled_widgets |= (1ULL << WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX);
             gConfigGeneral.enable_light_fx_for_vehicles = false;
         }
 
@@ -1224,13 +1221,13 @@ private:
         if (!gConfigGeneral.render_weather_effects && !gConfigGeneral.render_weather_gloom)
         {
             WidgetSetCheckboxValue(this, WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX, true);
-            this->enabled_widgets &= ~(1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
-            this->disabled_widgets |= (1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
+            enabled_widgets &= ~(1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
+            disabled_widgets |= (1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
         }
         else
         {
-            this->enabled_widgets |= (1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
-            this->disabled_widgets &= ~(1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
+            enabled_widgets |= (1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
+            disabled_widgets &= ~(1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
         }
 
         CommonPrepareDrawAfter();
@@ -1247,7 +1244,7 @@ private:
 #pragma region Culture tab events
     void CultureMouseDown(rct_widgetindex widgetIndex)
     {
-        rct_widget* widget = &this->widgets[widgetIndex - 1];
+        rct_widget* widget = &widgets[widgetIndex - 1];
 
         switch (widgetIndex)
         {
@@ -1257,7 +1254,7 @@ private:
                 gDropdownItemsArgs[0] = STR_HEIGHT_IN_UNITS;
                 gDropdownItemsArgs[1] = STR_REAL_VALUES;
 
-                this->ShowDropdown(widget, 2);
+                ShowDropdown(widget, 2);
 
                 Dropdown::SetChecked(gConfigGeneral.show_height_as_units ? 0 : 1, true);
                 break;
@@ -1280,7 +1277,7 @@ private:
                 gDropdownItemsFormat[numOrdinaryCurrencies + 1] = STR_DROPDOWN_MENU_LABEL;
                 gDropdownItemsArgs[numOrdinaryCurrencies + 1] = CurrencyDescriptors[EnumValue(CurrencyType::Custom)].stringId;
 
-                this->ShowDropdown(widget, numItems);
+                ShowDropdown(widget, numItems);
 
                 if (gConfigGeneral.currency_format == CurrencyType::Custom)
                 {
@@ -1300,7 +1297,7 @@ private:
                 gDropdownItemsArgs[1] = STR_METRIC;
                 gDropdownItemsArgs[2] = STR_SI;
 
-                this->ShowDropdown(widget, 3);
+                ShowDropdown(widget, 3);
 
                 Dropdown::SetChecked(static_cast<int32_t>(gConfigGeneral.measurement_format), true);
                 break;
@@ -1310,7 +1307,7 @@ private:
                 gDropdownItemsArgs[0] = STR_CELSIUS;
                 gDropdownItemsArgs[1] = STR_FAHRENHEIT;
 
-                this->ShowDropdown(widget, 2);
+                ShowDropdown(widget, 2);
 
                 Dropdown::SetChecked(static_cast<int32_t>(gConfigGeneral.temperature_format), true);
                 break;
@@ -1320,7 +1317,7 @@ private:
                     gDropdownItemsFormat[i - 1] = STR_OPTIONS_DROPDOWN_ITEM;
                     gDropdownItemsArgs[i - 1] = reinterpret_cast<uintptr_t>(LanguagesDescriptors[i].native_name);
                 }
-                this->ShowDropdown(widget, LANGUAGE_COUNT - 1);
+                ShowDropdown(widget, LANGUAGE_COUNT - 1);
                 Dropdown::SetChecked(LocalisationService_GetCurrentLanguage() - 1, true);
                 break;
             case WIDX_DATE_FORMAT_DROPDOWN:
@@ -1329,7 +1326,7 @@ private:
                     gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
                     gDropdownItemsArgs[i] = DateFormatStringIds[i];
                 }
-                this->ShowDropdown(widget, 4);
+                ShowDropdown(widget, 4);
                 Dropdown::SetChecked(gConfigGeneral.date_format, true);
                 break;
         }
@@ -1351,7 +1348,7 @@ private:
                     gConfigGeneral.show_height_as_units = 1;
                 }
                 config_save_default();
-                this->UpdateHeightMarkers();
+                UpdateHeightMarkers();
                 break;
             case WIDX_CURRENCY_DROPDOWN:
                 if (dropdownIndex == EnumValue(CurrencyType::Custom) + 1)
@@ -1369,7 +1366,7 @@ private:
             case WIDX_DISTANCE_DROPDOWN:
                 gConfigGeneral.measurement_format = static_cast<MeasurementFormat>(dropdownIndex);
                 config_save_default();
-                this->UpdateHeightMarkers();
+                UpdateHeightMarkers();
                 break;
             case WIDX_TEMPERATURE_DROPDOWN:
                 if (dropdownIndex != static_cast<int32_t>(gConfigGeneral.temperature_format))
@@ -1418,14 +1415,14 @@ private:
 
     void CulturePrepareDraw()
     {
-        this->CommonPrepareDrawBefore();
+        CommonPrepareDrawBefore();
 
         // Language
         auto ft = Formatter::Common();
         ft.Add<char*>(LanguagesDescriptors[LocalisationService_GetCurrentLanguage()].native_name);
 
         // Currency: pounds, dollars, etc. (10 total)
-        this->widgets[WIDX_CURRENCY].text = CurrencyDescriptors[EnumValue(gConfigGeneral.currency_format)].stringId;
+        widgets[WIDX_CURRENCY].text = CurrencyDescriptors[EnumValue(gConfigGeneral.currency_format)].stringId;
 
         // Distance: metric / imperial / si
         {
@@ -1442,45 +1439,38 @@ private:
                     stringId = STR_SI;
                     break;
             }
-            this->widgets[WIDX_DISTANCE].text = stringId;
+            widgets[WIDX_DISTANCE].text = stringId;
         }
 
         // Date format
-        this->widgets[WIDX_DATE_FORMAT].text = DateFormatStringIds[gConfigGeneral.date_format];
+        widgets[WIDX_DATE_FORMAT].text = DateFormatStringIds[gConfigGeneral.date_format];
 
         // Temperature: celsius/fahrenheit
-        this->widgets[WIDX_TEMPERATURE].text = gConfigGeneral.temperature_format == TemperatureUnit::Fahrenheit ? STR_FAHRENHEIT
-                                                                                                                : STR_CELSIUS;
+        widgets[WIDX_TEMPERATURE].text = gConfigGeneral.temperature_format == TemperatureUnit::Fahrenheit ? STR_FAHRENHEIT
+                                                                                                          : STR_CELSIUS;
 
         // Height: units/real values
-        this->widgets[WIDX_HEIGHT_LABELS].text = gConfigGeneral.show_height_as_units ? STR_HEIGHT_IN_UNITS : STR_REAL_VALUES;
+        widgets[WIDX_HEIGHT_LABELS].text = gConfigGeneral.show_height_as_units ? STR_HEIGHT_IN_UNITS : STR_REAL_VALUES;
 
-        this->CommonPrepareDrawAfter();
+        CommonPrepareDrawAfter();
     }
 
     void CultureDraw(rct_drawpixelinfo* dpi)
     {
         WindowDrawWidgets(this, dpi);
-        this->DrawTabImages(dpi);
+        DrawTabImages(dpi);
 
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_LANGUAGE].top + 1 }, STR_OPTIONS_LANGUAGE, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_LANGUAGE].top + 1 }, STR_OPTIONS_LANGUAGE, {}, { colours[1] });
+        DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_CURRENCY].top + 1 }, STR_CURRENCY, {}, { colours[1] });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_CURRENCY].top + 1 }, STR_CURRENCY, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_DISTANCE].top + 1 }, STR_DISTANCE_AND_SPEED, {}, { colours[1] });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_DISTANCE].top + 1 }, STR_DISTANCE_AND_SPEED, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TEMPERATURE].top + 1 }, STR_TEMPERATURE, {}, { colours[1] });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_TEMPERATURE].top + 1 }, STR_TEMPERATURE, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_HEIGHT_LABELS].top + 1 }, STR_HEIGHT_LABELS, {}, { colours[1] });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_HEIGHT_LABELS].top + 1 }, STR_HEIGHT_LABELS, {},
-            { this->colours[1] });
-        DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_DATE_FORMAT].top + 1 }, STR_DATE_FORMAT, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_DATE_FORMAT].top + 1 }, STR_DATE_FORMAT, {}, { colours[1] });
     }
 
 #pragma endregion
@@ -1493,7 +1483,7 @@ private:
             case WIDX_SOUND_CHECKBOX:
                 gConfigSound.sound_enabled = !gConfigSound.sound_enabled;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
 
             case WIDX_MASTER_SOUND_CHECKBOX:
@@ -1504,7 +1494,7 @@ private:
                     OpenRCT2::Audio::Resume();
                 window_invalidate_by_class(WC_TOP_TOOLBAR);
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
 
             case WIDX_MUSIC_CHECKBOX:
@@ -1514,20 +1504,20 @@ private:
                     OpenRCT2::RideAudio::StopAllChannels();
                 }
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
 
             case WIDX_AUDIO_FOCUS_CHECKBOX:
                 gConfigSound.audio_focus = !gConfigSound.audio_focus;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
         }
     }
 
     void AudioMouseDown(rct_widgetindex widgetIndex)
     {
-        rct_widget* widget = &this->widgets[widgetIndex - 1];
+        rct_widget* widget = &widgets[widgetIndex - 1];
 
         switch (widgetIndex)
         {
@@ -1541,7 +1531,7 @@ private:
                     gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(OpenRCT2::Audio::GetDeviceName(i).c_str());
                 }
 
-                this->ShowDropdown(widget, OpenRCT2::Audio::GetDeviceCount());
+                ShowDropdown(widget, OpenRCT2::Audio::GetDeviceCount());
 
                 Dropdown::SetChecked(OpenRCT2::Audio::GetCurrentDeviceIndex(), true);
                 break;
@@ -1554,7 +1544,7 @@ private:
                     gDropdownItemsArgs[i] = window_options_title_music_names[i];
                 }
 
-                this->ShowDropdown(widget, numItems);
+                ShowDropdown(widget, numItems);
 
                 Dropdown::SetChecked(gConfigSound.title_music, true);
                 break;
@@ -1587,7 +1577,7 @@ private:
                     config_save_default();
                     OpenRCT2::Audio::PlayTitleMusic();
                 }
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_TITLE_MUSIC_DROPDOWN:
                 if ((dropdownIndex == 1 || dropdownIndex == 3) && !File::Exists(context_get_path_legacy(PATH_ID_CSS50)))
@@ -1598,7 +1588,7 @@ private:
                 {
                     gConfigSound.title_music = static_cast<int8_t>(dropdownIndex);
                     config_save_default();
-                    this->Invalidate();
+                    Invalidate();
                 }
 
                 OpenRCT2::Audio::StopTitleMusic();
@@ -1610,9 +1600,9 @@ private:
 
     void AudioUpdate()
     {
-        const auto& masterVolumeWidget = this->widgets[WIDX_MASTER_VOLUME];
-        const auto& masterVolumeScroll = this->scrolls[0];
-        uint8_t masterVolume = this->GetScrollPercentage(masterVolumeWidget, masterVolumeScroll);
+        const auto& masterVolumeWidget = widgets[WIDX_MASTER_VOLUME];
+        const auto& masterVolumeScroll = scrolls[0];
+        uint8_t masterVolume = GetScrollPercentage(masterVolumeWidget, masterVolumeScroll);
         if (masterVolume != gConfigSound.master_volume)
         {
             gConfigSound.master_volume = masterVolume;
@@ -1620,9 +1610,9 @@ private:
             widget_invalidate(this, WIDX_MASTER_VOLUME);
         }
 
-        const auto& soundVolumeWidget = this->widgets[WIDX_MASTER_VOLUME];
-        const auto& soundVolumeScroll = this->scrolls[1];
-        uint8_t soundVolume = this->GetScrollPercentage(soundVolumeWidget, soundVolumeScroll);
+        const auto& soundVolumeWidget = widgets[WIDX_MASTER_VOLUME];
+        const auto& soundVolumeScroll = scrolls[1];
+        uint8_t soundVolume = GetScrollPercentage(soundVolumeWidget, soundVolumeScroll);
         if (soundVolume != gConfigSound.sound_volume)
         {
             gConfigSound.sound_volume = soundVolume;
@@ -1630,9 +1620,9 @@ private:
             widget_invalidate(this, WIDX_SOUND_VOLUME);
         }
 
-        const auto& musicVolumeWidget = this->widgets[WIDX_MASTER_VOLUME];
-        const auto& musicVolumeScroll = this->scrolls[2];
-        uint8_t rideMusicVolume = this->GetScrollPercentage(musicVolumeWidget, musicVolumeScroll);
+        const auto& musicVolumeWidget = widgets[WIDX_MASTER_VOLUME];
+        const auto& musicVolumeScroll = scrolls[2];
+        uint8_t rideMusicVolume = GetScrollPercentage(musicVolumeWidget, musicVolumeScroll);
         if (rideMusicVolume != gConfigSound.ride_music_volume)
         {
             gConfigSound.ride_music_volume = rideMusicVolume;
@@ -1648,7 +1638,7 @@ private:
 
     void AudioPrepareDraw()
     {
-        this->CommonPrepareDrawBefore();
+        CommonPrepareDrawBefore();
 
         // Sound device
         rct_string_id audioDeviceStringId = STR_OPTIONS_SOUND_VALUE_DEFAULT;
@@ -1673,11 +1663,11 @@ private:
             }
         }
 
-        this->widgets[WIDX_SOUND].text = audioDeviceStringId;
+        widgets[WIDX_SOUND].text = audioDeviceStringId;
         auto ft = Formatter::Common();
         ft.Add<char*>(audioDeviceName);
 
-        this->widgets[WIDX_TITLE_MUSIC].text = window_options_title_music_names[gConfigSound.title_music];
+        widgets[WIDX_TITLE_MUSIC].text = window_options_title_music_names[gConfigSound.title_music];
 
         WidgetSetCheckboxValue(this, WIDX_SOUND_CHECKBOX, gConfigSound.sound_enabled);
         WidgetSetCheckboxValue(this, WIDX_MASTER_SOUND_CHECKBOX, gConfigSound.master_sound_enabled);
@@ -1687,20 +1677,20 @@ private:
         WidgetSetEnabled(this, WIDX_MUSIC_CHECKBOX, gConfigSound.master_sound_enabled);
 
         // Initialize only on first frame, otherwise the scrollbars won't be able to be modified
-        if (this->frame_no == 0)
+        if (frame_no == 0)
         {
-            this->InitializeScrollPosition(WIDX_MASTER_VOLUME, 0, gConfigSound.master_volume);
-            this->InitializeScrollPosition(WIDX_SOUND_VOLUME, 1, gConfigSound.sound_volume);
-            this->InitializeScrollPosition(WIDX_MUSIC_VOLUME, 2, gConfigSound.ride_music_volume);
+            InitializeScrollPosition(WIDX_MASTER_VOLUME, 0, gConfigSound.master_volume);
+            InitializeScrollPosition(WIDX_SOUND_VOLUME, 1, gConfigSound.sound_volume);
+            InitializeScrollPosition(WIDX_MUSIC_VOLUME, 2, gConfigSound.ride_music_volume);
         }
 
-        this->CommonPrepareDrawAfter();
+        CommonPrepareDrawAfter();
     }
 
     void AudioDraw(rct_drawpixelinfo* dpi)
     {
         WindowDrawWidgets(this, dpi);
-        this->DrawTabImages(dpi);
+        DrawTabImages(dpi);
     }
 
 #pragma endregion
@@ -1716,76 +1706,76 @@ private:
             case WIDX_SCREEN_EDGE_SCROLLING:
                 gConfigGeneral.edge_scrolling ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_TRAP_CURSOR:
                 gConfigGeneral.trap_cursor ^= 1;
                 config_save_default();
                 context_set_cursor_trap(gConfigGeneral.trap_cursor);
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_ZOOM_TO_CURSOR:
                 gConfigGeneral.zoom_to_cursor ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_TOOLBAR_SHOW_FINANCES:
                 gConfigInterface.toolbar_show_finances ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 window_invalidate_by_class(WC_TOP_TOOLBAR);
                 break;
             case WIDX_TOOLBAR_SHOW_RESEARCH:
                 gConfigInterface.toolbar_show_research ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 window_invalidate_by_class(WC_TOP_TOOLBAR);
                 break;
             case WIDX_TOOLBAR_SHOW_CHEATS:
                 gConfigInterface.toolbar_show_cheats ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 window_invalidate_by_class(WC_TOP_TOOLBAR);
                 break;
             case WIDX_TOOLBAR_SHOW_NEWS:
                 gConfigInterface.toolbar_show_news ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 window_invalidate_by_class(WC_TOP_TOOLBAR);
                 break;
             case WIDX_TOOLBAR_SHOW_MUTE:
                 gConfigInterface.toolbar_show_mute ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 window_invalidate_by_class(WC_TOP_TOOLBAR);
                 break;
             case WIDX_TOOLBAR_SHOW_CHAT:
                 gConfigInterface.toolbar_show_chat ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 window_invalidate_by_class(WC_TOP_TOOLBAR);
                 break;
             case WIDX_TOOLBAR_SHOW_ZOOM:
                 gConfigInterface.toolbar_show_zoom ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 window_invalidate_by_class(WC_TOP_TOOLBAR);
                 break;
             case WIDX_INVERT_DRAG:
                 gConfigGeneral.invert_viewport_drag ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_THEMES_BUTTON:
                 context_open_window(WC_THEMES);
-                this->Invalidate();
+                Invalidate();
                 break;
         }
     }
 
     void ControlsMouseDown(rct_widgetindex widgetIndex)
     {
-        rct_widget* widget = &this->widgets[widgetIndex - 1];
+        rct_widget* widget = &widgets[widgetIndex - 1];
 
         switch (widgetIndex)
         {
@@ -1799,8 +1789,8 @@ private:
                 }
 
                 WindowDropdownShowTextCustomWidth(
-                    { this->windowPos.x + widget->left, this->windowPos.y + widget->top }, widget->height() + 1,
-                    this->colours[1], 0, Dropdown::Flag::StayOpen, numItems, widget->width() - 3);
+                    { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
+                    Dropdown::Flag::StayOpen, numItems, widget->width() - 3);
 
                 Dropdown::SetChecked(static_cast<int32_t>(ThemeManagerGetAvailableThemeIndex()), true);
                 widget_invalidate(this, WIDX_THEMES_DROPDOWN);
@@ -1827,7 +1817,7 @@ private:
 
     void ControlsPrepareDraw()
     {
-        this->CommonPrepareDrawBefore();
+        CommonPrepareDrawBefore();
 
         WidgetSetCheckboxValue(this, WIDX_SCREEN_EDGE_SCROLLING, gConfigGeneral.edge_scrolling);
         WidgetSetCheckboxValue(this, WIDX_TRAP_CURSOR, gConfigGeneral.trap_cursor);
@@ -1846,20 +1836,20 @@ private:
         auto ft = Formatter::Common();
         ft.Add<utf8*>(activeThemeName);
 
-        this->CommonPrepareDrawAfter();
+        CommonPrepareDrawAfter();
     }
 
     void ControlsDraw(rct_drawpixelinfo* dpi)
     {
         WindowDrawWidgets(this, dpi);
-        this->DrawTabImages(dpi);
+        DrawTabImages(dpi);
 
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_TOOLBAR_BUTTONS_GROUP].top + 15 },
-            STR_SHOW_TOOLBAR_BUTTONS_FOR, {}, { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TOOLBAR_BUTTONS_GROUP].top + 15 }, STR_SHOW_TOOLBAR_BUTTONS_FOR,
+            {}, { colours[1] });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_THEMES].top + 1 }, STR_THEMES_LABEL_CURRENT_THEME, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_THEMES].top + 1 }, STR_THEMES_LABEL_CURRENT_THEME, {},
+            { colours[1] });
     }
 
 #pragma endregion
@@ -1872,13 +1862,13 @@ private:
             case WIDX_REAL_NAME_CHECKBOX:
                 gConfigGeneral.show_real_names_of_guests ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 peep_update_names(gConfigGeneral.show_real_names_of_guests);
                 break;
             case WIDX_AUTO_STAFF_PLACEMENT:
                 gConfigGeneral.auto_staff_placement ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_TITLE_SEQUENCE_BUTTON:
                 WindowTitleEditorOpen(0);
@@ -1891,12 +1881,12 @@ private:
             case WIDX_TITLE_SEQUENCE_RANDOM:
                 gConfigInterface.random_title_sequence ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_AUTO_OPEN_SHOPS:
                 gConfigGeneral.auto_open_shops = !gConfigGeneral.auto_open_shops;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_ALLOW_EARLY_COMPLETION:
                 gConfigGeneral.allow_early_completion ^= 1;
@@ -1909,14 +1899,14 @@ private:
                     GameActions::Execute(&setAllowEarlyCompletionAction);
                 }
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
         }
     }
 
     void MiscMouseDown(rct_widgetindex widgetIndex)
     {
-        rct_widget* widget = &this->widgets[widgetIndex - 1];
+        rct_widget* widget = &widgets[widgetIndex - 1];
 
         switch (widgetIndex)
         {
@@ -1930,8 +1920,8 @@ private:
                 }
 
                 WindowDropdownShowText(
-                    { this->windowPos.x + widget->left, this->windowPos.y + widget->top }, widget->height() + 1,
-                    this->colours[1], Dropdown::Flag::StayOpen, numItems);
+                    { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1],
+                    Dropdown::Flag::StayOpen, numItems);
 
                 Dropdown::SetChecked(static_cast<int32_t>(title_get_current_sequence()), true);
                 break;
@@ -1946,8 +1936,8 @@ private:
                 gDropdownItemsArgs[1] = STR_OPTIONS_SCENARIO_ORIGIN;
 
                 WindowDropdownShowTextCustomWidth(
-                    { this->windowPos.x + widget->left, this->windowPos.y + widget->top }, widget->height() + 1,
-                    this->colours[1], 0, Dropdown::Flag::StayOpen, numItems, widget->width() - 3);
+                    { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
+                    Dropdown::Flag::StayOpen, numItems, widget->width() - 3);
 
                 Dropdown::SetChecked(gConfigGeneral.scenario_select_mode, true);
                 break;
@@ -1959,7 +1949,7 @@ private:
                     gDropdownItemsArgs[i] = RideInspectionIntervalNames[i];
                 }
 
-                this->ShowDropdown(widget, 7);
+                ShowDropdown(widget, 7);
                 Dropdown::SetChecked(gConfigGeneral.default_inspection_interval, true);
                 break;
         }
@@ -1977,7 +1967,7 @@ private:
                 {
                     title_sequence_change_preset(static_cast<size_t>(dropdownIndex));
                     config_save_default();
-                    this->Invalidate();
+                    Invalidate();
                 }
                 break;
             case WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN:
@@ -1985,7 +1975,7 @@ private:
                 {
                     gConfigGeneral.default_inspection_interval = static_cast<uint8_t>(dropdownIndex);
                     config_save_default();
-                    this->Invalidate();
+                    Invalidate();
                 }
                 break;
             case WIDX_SCENARIO_GROUPING_DROPDOWN:
@@ -1994,7 +1984,7 @@ private:
                     gConfigGeneral.scenario_select_mode = dropdownIndex;
                     gConfigInterface.scenarioselect_last_tab = 0;
                     config_save_default();
-                    this->Invalidate();
+                    Invalidate();
                     window_close_by_class(WC_SCENARIO_SELECT);
                 }
                 break;
@@ -2003,7 +1993,7 @@ private:
 
     void MiscPrepareDraw()
     {
-        this->CommonPrepareDrawBefore();
+        CommonPrepareDrawBefore();
 
         const utf8* name = title_sequence_manager_get_name(title_get_config_sequence());
         auto ft = Formatter::Common();
@@ -2013,15 +2003,15 @@ private:
         // and the server cannot change the setting during gameplay to prevent desyncs
         if (network_get_mode() != NETWORK_MODE_NONE)
         {
-            this->disabled_widgets |= (1ULL << WIDX_REAL_NAME_CHECKBOX);
-            this->widgets[WIDX_REAL_NAME_CHECKBOX].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
+            disabled_widgets |= (1ULL << WIDX_REAL_NAME_CHECKBOX);
+            widgets[WIDX_REAL_NAME_CHECKBOX].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
             // Disable the use of the allow_early_completion option during network play on clients.
             // This is to prevent confusion on clients because changing this setting during network play wouldn't change
             // the way scenarios are completed during this network-session
             if (network_get_mode() == NETWORK_MODE_CLIENT)
             {
-                this->disabled_widgets |= (1ULL << WIDX_ALLOW_EARLY_COMPLETION);
-                this->widgets[WIDX_ALLOW_EARLY_COMPLETION].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
+                disabled_widgets |= (1ULL << WIDX_ALLOW_EARLY_COMPLETION);
+                widgets[WIDX_ALLOW_EARLY_COMPLETION].tooltip = STR_OPTION_DISABLED_DURING_NETWORK_PLAY;
             }
         }
 
@@ -2034,51 +2024,51 @@ private:
         // Disable title sequence dropdown if set to random
         if (gConfigInterface.random_title_sequence)
         {
-            this->disabled_widgets |= (1ULL << WIDX_TITLE_SEQUENCE_DROPDOWN);
-            this->disabled_widgets |= (1ULL << WIDX_TITLE_SEQUENCE);
+            disabled_widgets |= (1ULL << WIDX_TITLE_SEQUENCE_DROPDOWN);
+            disabled_widgets |= (1ULL << WIDX_TITLE_SEQUENCE);
         }
         else
         {
-            this->disabled_widgets &= ~(1ULL << WIDX_TITLE_SEQUENCE_DROPDOWN);
-            this->disabled_widgets &= ~(1ULL << WIDX_TITLE_SEQUENCE);
+            disabled_widgets &= ~(1ULL << WIDX_TITLE_SEQUENCE_DROPDOWN);
+            disabled_widgets &= ~(1ULL << WIDX_TITLE_SEQUENCE);
         }
 
         if (gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_DIFFICULTY)
-            this->widgets[WIDX_SCENARIO_GROUPING].text = STR_OPTIONS_SCENARIO_DIFFICULTY;
+            widgets[WIDX_SCENARIO_GROUPING].text = STR_OPTIONS_SCENARIO_DIFFICULTY;
         else
-            this->widgets[WIDX_SCENARIO_GROUPING].text = STR_OPTIONS_SCENARIO_ORIGIN;
+            widgets[WIDX_SCENARIO_GROUPING].text = STR_OPTIONS_SCENARIO_ORIGIN;
 
         WidgetSetCheckboxValue(this, WIDX_SCENARIO_UNLOCKING, gConfigGeneral.scenario_unlocking_enabled);
 
         if (gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_ORIGIN)
         {
-            this->disabled_widgets &= ~(1ULL << WIDX_SCENARIO_UNLOCKING);
+            disabled_widgets &= ~(1ULL << WIDX_SCENARIO_UNLOCKING);
         }
         else
         {
-            this->disabled_widgets |= (1ULL << WIDX_SCENARIO_UNLOCKING);
+            disabled_widgets |= (1ULL << WIDX_SCENARIO_UNLOCKING);
         }
 
-        this->widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].text = RideInspectionIntervalNames[gConfigGeneral
-                                                                                               .default_inspection_interval];
+        widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].text = RideInspectionIntervalNames[gConfigGeneral
+                                                                                         .default_inspection_interval];
 
-        this->CommonPrepareDrawAfter();
+        CommonPrepareDrawAfter();
     }
 
     void MiscDraw(rct_drawpixelinfo* dpi)
     {
         WindowDrawWidgets(this, dpi);
-        this->DrawTabImages(dpi);
+        DrawTabImages(dpi);
 
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_TITLE_SEQUENCE].top + 1 }, STR_TITLE_SEQUENCE, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TITLE_SEQUENCE].top + 1 }, STR_TITLE_SEQUENCE, {},
+            { colours[1] });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_SCENARIO_GROUPING].top + 1 },
-            STR_OPTIONS_SCENARIO_GROUPING, {}, { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_SCENARIO_GROUPING].top + 1 }, STR_OPTIONS_SCENARIO_GROUPING, {},
+            { colours[1] });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 10, this->widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].top + 1 },
-            STR_DEFAULT_INSPECTION_INTERVAL, {}, { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].top + 1 },
+            STR_DEFAULT_INSPECTION_INTERVAL, {}, { colours[1] });
     }
 
 #pragma endregion
@@ -2096,22 +2086,22 @@ private:
             case WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM:
                 gConfigGeneral.allow_loading_with_incorrect_checksum = !gConfigGeneral.allow_loading_with_incorrect_checksum;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_SAVE_PLUGIN_DATA_CHECKBOX:
                 gConfigGeneral.save_plugin_data ^= 1;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_STAY_CONNECTED_AFTER_DESYNC:
                 gConfigNetwork.stay_connected = !gConfigNetwork.stay_connected;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_ALWAYS_NATIVE_LOADSAVE:
                 gConfigGeneral.use_native_browse_dialog = !gConfigGeneral.use_native_browse_dialog;
                 config_save_default();
-                this->Invalidate();
+                Invalidate();
                 break;
             case WIDX_PATH_TO_RCT1_BUTTON:
             {
@@ -2147,7 +2137,7 @@ private:
                         context_show_error(STR_PATH_TO_RCT1_WRONG_ERROR, STR_NONE, {});
                     }
                 }
-                this->Invalidate();
+                Invalidate();
                 break;
             }
             case WIDX_PATH_TO_RCT1_CLEAR:
@@ -2156,14 +2146,14 @@ private:
                     SafeFree(gConfigGeneral.rct1_path);
                     config_save_default();
                 }
-                this->Invalidate();
+                Invalidate();
                 break;
         }
     }
 
     void AdvancedMouseDown(rct_widgetindex widgetIndex)
     {
-        rct_widget* widget = &this->widgets[widgetIndex - 1];
+        rct_widget* widget = &widgets[widgetIndex - 1];
 
         switch (widgetIndex)
         {
@@ -2174,7 +2164,7 @@ private:
                     gDropdownItemsArgs[i] = window_options_autosave_names[i];
                 }
 
-                this->ShowDropdown(widget, AUTOSAVE_NEVER + 1);
+                ShowDropdown(widget, AUTOSAVE_NEVER + 1);
                 Dropdown::SetChecked(gConfigGeneral.autosave_frequency, true);
                 break;
             case WIDX_AUTOSAVE_AMOUNT_UP:
@@ -2208,7 +2198,7 @@ private:
                 {
                     gConfigGeneral.autosave_frequency = static_cast<uint8_t>(dropdownIndex);
                     config_save_default();
-                    this->Invalidate();
+                    Invalidate();
                 }
                 break;
         }
@@ -2216,7 +2206,7 @@ private:
 
     void AdvancedPrepareDraw()
     {
-        this->CommonPrepareDrawBefore();
+        CommonPrepareDrawBefore();
 
         WidgetSetCheckboxValue(this, WIDX_DEBUGGING_TOOLS, gConfigGeneral.debugging_tools);
         WidgetSetCheckboxValue(
@@ -2225,43 +2215,41 @@ private:
         WidgetSetCheckboxValue(this, WIDX_STAY_CONNECTED_AFTER_DESYNC, gConfigNetwork.stay_connected);
         WidgetSetCheckboxValue(this, WIDX_ALWAYS_NATIVE_LOADSAVE, gConfigGeneral.use_native_browse_dialog);
 
-        this->CommonPrepareDrawAfter();
+        CommonPrepareDrawAfter();
     }
 
     void AdvancedDraw(rct_drawpixelinfo* dpi)
     {
         WindowDrawWidgets(this, dpi);
-        this->DrawTabImages(dpi);
+        DrawTabImages(dpi);
 
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 24, this->widgets[WIDX_AUTOSAVE].top + 1 },
-            STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, {}, { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 24, widgets[WIDX_AUTOSAVE].top + 1 }, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, {},
+            { colours[1] });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ this->widgets[WIDX_AUTOSAVE].left + 1, this->widgets[WIDX_AUTOSAVE].top },
-            window_options_autosave_names[gConfigGeneral.autosave_frequency], {}, { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_AUTOSAVE].left + 1, widgets[WIDX_AUTOSAVE].top },
+            window_options_autosave_names[gConfigGeneral.autosave_frequency], {}, { colours[1] });
         DrawTextBasic(
-            dpi, this->windowPos + ScreenCoordsXY{ 24, this->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 }, STR_AUTOSAVE_AMOUNT, {},
-            { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ 24, widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 }, STR_AUTOSAVE_AMOUNT, {},
+            { colours[1] });
         auto ft = Formatter();
         ft.Add<int32_t>(static_cast<int32_t>(gConfigGeneral.autosave_amount));
         DrawTextBasic(
-            dpi,
-            this->windowPos
-                + ScreenCoordsXY{ this->widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, this->widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 },
-            STR_WINDOW_OBJECTIVE_VALUE_GUEST_COUNT, ft, { this->colours[1] });
+            dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 },
+            STR_WINDOW_OBJECTIVE_VALUE_GUEST_COUNT, ft, { colours[1] });
 
         ft = Formatter();
         ft.Add<utf8*>(Platform::StrDecompToPrecomp(gConfigGeneral.rct1_path));
 
-        rct_widget pathWidget = this->widgets[WIDX_PATH_TO_RCT1_BUTTON];
+        rct_widget pathWidget = widgets[WIDX_PATH_TO_RCT1_BUTTON];
 
         // Apply vertical alignment if appropriate.
         int32_t widgetHeight = pathWidget.bottom - pathWidget.top;
         int32_t lineHeight = font_get_line_height(FontSpriteBase::MEDIUM);
         uint32_t padding = widgetHeight > lineHeight ? (widgetHeight - lineHeight) / 2 : 0;
-        ScreenCoordsXY screenCoords = { this->windowPos.x + pathWidget.left + 1,
-                                        this->windowPos.y + pathWidget.top + static_cast<int32_t>(padding) };
-        DrawTextEllipsised(dpi, screenCoords, 277, STR_STRING, ft, { this->colours[1] });
+        ScreenCoordsXY screenCoords = { windowPos.x + pathWidget.left + 1,
+                                        windowPos.y + pathWidget.top + static_cast<int32_t>(padding) };
+        DrawTextEllipsised(dpi, screenCoords, 277, STR_STRING, ft, { colours[1] });
     }
 
     OpenRCT2String AdvancedTooltip(rct_widgetindex widgetIndex, rct_string_id fallback)
@@ -2285,58 +2273,58 @@ private:
 
     void SetPage(int32_t p)
     {
-        this->page = p;
-        this->frame_no = 0;
-        this->enabled_widgets = window_options_page_enabled_widgets[this->page];
-        this->pressed_widgets = 0;
-        this->widgets = window_options_page_widgets[this->page];
+        page = p;
+        frame_no = 0;
+        enabled_widgets = window_options_page_enabled_widgets[page];
+        pressed_widgets = 0;
+        widgets = window_options_page_widgets[page];
 
-        this->Invalidate();
+        Invalidate();
         window_event_resize_call(this);
         window_event_invalidate_call(this);
         WindowInitScrollWidgets(this);
-        this->Invalidate();
+        Invalidate();
     }
 
     void SetPressedTab()
     {
         for (int32_t i = 0; i < WINDOW_OPTIONS_PAGE_COUNT; i++)
-            this->pressed_widgets &= ~(1 << (WIDX_FIRST_TAB + i));
-        this->pressed_widgets |= 1LL << (WIDX_FIRST_TAB + this->page);
+            pressed_widgets &= ~(1 << (WIDX_FIRST_TAB + i));
+        pressed_widgets |= 1LL << (WIDX_FIRST_TAB + page);
     }
 
     void ShowDropdown(rct_widget* widget, int32_t num_items)
     {
         // helper function, all dropdown boxes have similar properties
         WindowDropdownShowTextCustomWidth(
-            { this->windowPos.x + widget->left, this->windowPos.y + widget->top }, widget->height() + 1, this->colours[1], 0,
+            { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
             Dropdown::Flag::StayOpen, num_items, widget->width() - 3);
     }
 
     void DrawTabImages(rct_drawpixelinfo* dpi)
     {
-        this->DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_DISPLAY, SPR_TAB_PAINT_0);
-        this->DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_RENDERING, SPR_G2_TAB_TREE);
-        this->DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_CULTURE, SPR_TAB_TIMER_0);
-        this->DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_AUDIO, SPR_TAB_MUSIC_0);
-        this->DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE, SPR_TAB_GEARS_0);
-        this->DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_MISC, SPR_TAB_RIDE_0);
-        this->DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_ADVANCED, SPR_TAB_WRENCH_0);
+        DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_DISPLAY, SPR_TAB_PAINT_0);
+        DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_RENDERING, SPR_G2_TAB_TREE);
+        DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_CULTURE, SPR_TAB_TIMER_0);
+        DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_AUDIO, SPR_TAB_MUSIC_0);
+        DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE, SPR_TAB_GEARS_0);
+        DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_MISC, SPR_TAB_RIDE_0);
+        DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_ADVANCED, SPR_TAB_WRENCH_0);
     }
 
     void DrawTabImage(rct_drawpixelinfo* dpi, int32_t p, int32_t spriteIndex)
     {
         rct_widgetindex widgetIndex = WIDX_FIRST_TAB + p;
-        rct_widget* widget = &this->widgets[widgetIndex];
+        rct_widget* widget = &widgets[widgetIndex];
 
-        auto screenCoords = this->windowPos + ScreenCoordsXY{ widget->left, widget->top };
+        auto screenCoords = windowPos + ScreenCoordsXY{ widget->left, widget->top };
 
-        if (!(this->disabled_widgets & (1LL << widgetIndex)))
+        if (!(disabled_widgets & (1LL << widgetIndex)))
         {
-            if (this->page == p)
+            if (page == p)
             {
-                int32_t frame = this->frame_no / window_options_tab_animation_divisor[this->page];
-                spriteIndex += (frame % window_options_tab_animation_frames[this->page]);
+                int32_t frame = frame_no / window_options_tab_animation_divisor[page];
+                spriteIndex += (frame % window_options_tab_animation_frames[page]);
             }
 
             // Draw normal, enabled sprite.
@@ -2345,7 +2333,7 @@ private:
         else
         {
             // Get the window background colour
-            uint8_t window_colour = NOT_TRANSLUCENT(this->colours[widget->colour]);
+            uint8_t window_colour = NOT_TRANSLUCENT(colours[widget->colour]);
 
             // Draw greyed out (light border bottom right shadow)
             gfx_draw_sprite_solid(dpi, spriteIndex, screenCoords + ScreenCoordsXY{ 1, 1 }, ColourMapA[window_colour].lighter);
@@ -2369,8 +2357,8 @@ private:
 
     void InitializeScrollPosition(rct_widgetindex widgetIndex, int32_t scrollId, uint8_t volume)
     {
-        const auto& widget = this->widgets[widgetIndex];
-        auto& scroll = this->scrolls[scrollId];
+        const auto& widget = widgets[widgetIndex];
+        auto& scroll = scrolls[scrollId];
 
         int32_t widgetSize = scroll.h_right - (widget.width() - 1);
         scroll.h_left = ceil(volume / 100.0f * widgetSize);

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2309,17 +2309,11 @@ private:
     }
 };
 
-// clang-format on
 /**
  *
  *  rct2: 0x006BAC5B
  */
 rct_window* WindowOptionsOpen()
 {
-    auto* window = window_bring_to_front_by_class(WC_OPTIONS);
-    if (window == nullptr)
-    {
-        window = WindowCreate<OptionsWindow>(WC_OPTIONS, WW, WH, WF_CENTRE_SCREEN);
-    }
-    return window;
+    return WindowFocusOrCreate<OptionsWindow>(WC_OPTIONS, WW, WH, WF_CENTRE_SCREEN);
 }

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -418,15 +418,15 @@ const int32_t window_options_tab_animation_frames[] =
 
 #pragma region Enabled Widgets
 
-#define MAIN_OPTIONS_ENABLED_WIDGETS \
-    (1ULL << WIDX_CLOSE) | \
-    (1ULL << WIDX_TAB_DISPLAY) | \
-    (1ULL << WIDX_TAB_RENDERING) | \
-    (1ULL << WIDX_TAB_CULTURE) | \
-    (1ULL << WIDX_TAB_AUDIO) | \
-    (1ULL << WIDX_TAB_CONTROLS_AND_INTERFACE) | \
-    (1ULL << WIDX_TAB_MISC) | \
-    (1ULL << WIDX_TAB_ADVANCED)
+constexpr int MAIN_OPTIONS_ENABLED_WIDGETS =
+    (1ULL << WIDX_CLOSE) |
+    (1ULL << WIDX_TAB_DISPLAY) |
+    (1ULL << WIDX_TAB_RENDERING) |
+    (1ULL << WIDX_TAB_CULTURE) |
+    (1ULL << WIDX_TAB_AUDIO) |
+    (1ULL << WIDX_TAB_CONTROLS_AND_INTERFACE) |
+    (1ULL << WIDX_TAB_MISC) |
+    (1ULL << WIDX_TAB_ADVANCED);
 
 static uint64_t window_options_page_enabled_widgets[] = {
     MAIN_OPTIONS_ENABLED_WIDGETS |

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -611,6 +611,9 @@ public:
 
     void OnDropdown(rct_widgetindex widgetIndex, int32_t dropdownIndex) override
     {
+        if (dropdownIndex == -1)
+            return;
+
         switch (page)
         {
             case WINDOW_OPTIONS_PAGE_DISPLAY:
@@ -641,6 +644,8 @@ public:
 
     void OnPrepareDraw() override
     {
+        CommonPrepareDrawBefore();
+
         switch (page)
         {
             case WINDOW_OPTIONS_PAGE_DISPLAY:
@@ -667,10 +672,15 @@ public:
             default:
                 break;
         }
+
+        CommonPrepareDrawAfter();
     }
 
     void OnDraw(rct_drawpixelinfo& dpi) override
     {
+        DrawWidgets(dpi);
+        DrawTabImages(&dpi);
+
         switch (page)
         {
             case WINDOW_OPTIONS_PAGE_DISPLAY:
@@ -930,9 +940,6 @@ private:
 
     void DisplayDropdown(rct_widgetindex widgetIndex, int32_t dropdownIndex)
     {
-        if (dropdownIndex == -1)
-            return;
-
         switch (widgetIndex)
         {
             case WIDX_RESOLUTION_DROPDOWN:
@@ -982,8 +989,6 @@ private:
 
     void DisplayPrepareDraw()
     {
-        CommonPrepareDrawBefore();
-
         // Resolution dropdown caption.
         auto ft = Formatter::Common();
         ft.Increment(16);
@@ -1033,15 +1038,10 @@ private:
         // Dropdown captions for straightforward strings.
         widgets[WIDX_FULLSCREEN].text = window_options_fullscreen_mode_names[gConfigGeneral.fullscreen_mode];
         widgets[WIDX_DRAWING_ENGINE].text = DrawingEngineStringIds[EnumValue(gConfigGeneral.drawing_engine)];
-
-        CommonPrepareDrawAfter();
     }
 
     void DisplayDraw(rct_drawpixelinfo* dpi)
     {
-        WindowDrawWidgets(this, dpi);
-        DrawTabImages(dpi);
-
         DrawTextBasic(
             dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_FULLSCREEN].top + 1 }, STR_FULLSCREEN_MODE, {}, { colours[1] });
 
@@ -1160,9 +1160,6 @@ private:
 
     void RenderingDropdown(rct_widgetindex widgetIndex, int32_t dropdownIndex)
     {
-        if (dropdownIndex == -1)
-            return;
-
         switch (widgetIndex)
         {
             case WIDX_VIRTUAL_FLOOR_DROPDOWN:
@@ -1174,8 +1171,6 @@ private:
 
     void RenderingPrepareDraw()
     {
-        CommonPrepareDrawBefore();
-
         SetCheckboxValue(WIDX_TILE_SMOOTHING_CHECKBOX, gConfigGeneral.landscape_smoothing);
         SetCheckboxValue(WIDX_GRIDLINES_CHECKBOX, gConfigGeneral.always_show_gridlines);
         SetCheckboxValue(WIDX_DAY_NIGHT_CHECKBOX, gConfigGeneral.day_night_cycle);
@@ -1229,14 +1224,10 @@ private:
             enabled_widgets |= (1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
             disabled_widgets &= ~(1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
         }
-
-        CommonPrepareDrawAfter();
     }
 
     void RenderingDraw(rct_drawpixelinfo* dpi)
     {
-        WindowDrawWidgets(this, dpi);
-        DrawTabImages(dpi);
     }
 
 #pragma endregion
@@ -1334,9 +1325,6 @@ private:
 
     void CultureDropdown(rct_widgetindex widgetIndex, int32_t dropdownIndex)
     {
-        if (dropdownIndex == -1)
-            return;
-
         switch (widgetIndex)
         {
             case WIDX_HEIGHT_LABELS_DROPDOWN:
@@ -1415,8 +1403,6 @@ private:
 
     void CulturePrepareDraw()
     {
-        CommonPrepareDrawBefore();
-
         // Language
         auto ft = Formatter::Common();
         ft.Add<char*>(LanguagesDescriptors[LocalisationService_GetCurrentLanguage()].native_name);
@@ -1451,15 +1437,10 @@ private:
 
         // Height: units/real values
         widgets[WIDX_HEIGHT_LABELS].text = gConfigGeneral.show_height_as_units ? STR_HEIGHT_IN_UNITS : STR_REAL_VALUES;
-
-        CommonPrepareDrawAfter();
     }
 
     void CultureDraw(rct_drawpixelinfo* dpi)
     {
-        WindowDrawWidgets(this, dpi);
-        DrawTabImages(dpi);
-
         DrawTextBasic(
             dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_LANGUAGE].top + 1 }, STR_OPTIONS_LANGUAGE, {}, { colours[1] });
         DrawTextBasic(dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_CURRENCY].top + 1 }, STR_CURRENCY, {}, { colours[1] });
@@ -1553,9 +1534,6 @@ private:
 
     void AudioDropdown(rct_widgetindex widgetIndex, int32_t dropdownIndex)
     {
-        if (dropdownIndex == -1)
-            return;
-
         switch (widgetIndex)
         {
             case WIDX_SOUND_DROPDOWN:
@@ -1638,8 +1616,6 @@ private:
 
     void AudioPrepareDraw()
     {
-        CommonPrepareDrawBefore();
-
         // Sound device
         rct_string_id audioDeviceStringId = STR_OPTIONS_SOUND_VALUE_DEFAULT;
         const char* audioDeviceName = nullptr;
@@ -1683,14 +1659,10 @@ private:
             InitializeScrollPosition(WIDX_SOUND_VOLUME, 1, gConfigSound.sound_volume);
             InitializeScrollPosition(WIDX_MUSIC_VOLUME, 2, gConfigSound.ride_music_volume);
         }
-
-        CommonPrepareDrawAfter();
     }
 
     void AudioDraw(rct_drawpixelinfo* dpi)
     {
-        WindowDrawWidgets(this, dpi);
-        DrawTabImages(dpi);
     }
 
 #pragma endregion
@@ -1800,9 +1772,6 @@ private:
 
     void ControlsDropdown(rct_widgetindex widgetIndex, int32_t dropdownIndex)
     {
-        if (dropdownIndex == -1)
-            return;
-
         switch (widgetIndex)
         {
             case WIDX_THEMES_DROPDOWN:
@@ -1817,8 +1786,6 @@ private:
 
     void ControlsPrepareDraw()
     {
-        CommonPrepareDrawBefore();
-
         SetCheckboxValue(WIDX_SCREEN_EDGE_SCROLLING, gConfigGeneral.edge_scrolling);
         SetCheckboxValue(WIDX_TRAP_CURSOR, gConfigGeneral.trap_cursor);
         SetCheckboxValue(WIDX_INVERT_DRAG, gConfigGeneral.invert_viewport_drag);
@@ -1835,15 +1802,10 @@ private:
         const utf8* activeThemeName = ThemeManagerGetAvailableThemeName(activeAvailableThemeIndex);
         auto ft = Formatter::Common();
         ft.Add<utf8*>(activeThemeName);
-
-        CommonPrepareDrawAfter();
     }
 
     void ControlsDraw(rct_drawpixelinfo* dpi)
     {
-        WindowDrawWidgets(this, dpi);
-        DrawTabImages(dpi);
-
         DrawTextBasic(
             dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TOOLBAR_BUTTONS_GROUP].top + 15 }, STR_SHOW_TOOLBAR_BUTTONS_FOR,
             {}, { colours[1] });
@@ -1957,9 +1919,6 @@ private:
 
     void MiscDropdown(rct_widgetindex widgetIndex, int32_t dropdownIndex)
     {
-        if (dropdownIndex == -1)
-            return;
-
         switch (widgetIndex)
         {
             case WIDX_TITLE_SEQUENCE_DROPDOWN:
@@ -1993,8 +1952,6 @@ private:
 
     void MiscPrepareDraw()
     {
-        CommonPrepareDrawBefore();
-
         const utf8* name = title_sequence_manager_get_name(title_get_config_sequence());
         auto ft = Formatter::Common();
         ft.Add<utf8*>(name);
@@ -2051,15 +2008,10 @@ private:
 
         widgets[WIDX_DEFAULT_INSPECTION_INTERVAL].text = RideInspectionIntervalNames[gConfigGeneral
                                                                                          .default_inspection_interval];
-
-        CommonPrepareDrawAfter();
     }
 
     void MiscDraw(rct_drawpixelinfo* dpi)
     {
-        WindowDrawWidgets(this, dpi);
-        DrawTabImages(dpi);
-
         DrawTextBasic(
             dpi, windowPos + ScreenCoordsXY{ 10, widgets[WIDX_TITLE_SEQUENCE].top + 1 }, STR_TITLE_SEQUENCE, {},
             { colours[1] });
@@ -2188,9 +2140,6 @@ private:
 
     void AdvancedDropdown(rct_widgetindex widgetIndex, int32_t dropdownIndex)
     {
-        if (dropdownIndex == -1)
-            return;
-
         switch (widgetIndex)
         {
             case WIDX_AUTOSAVE_DROPDOWN:
@@ -2206,23 +2155,16 @@ private:
 
     void AdvancedPrepareDraw()
     {
-        CommonPrepareDrawBefore();
-
         SetCheckboxValue(WIDX_DEBUGGING_TOOLS, gConfigGeneral.debugging_tools);
         WidgetSetCheckboxValue(
             this, WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM, gConfigGeneral.allow_loading_with_incorrect_checksum);
         SetCheckboxValue(WIDX_SAVE_PLUGIN_DATA_CHECKBOX, gConfigGeneral.save_plugin_data);
         SetCheckboxValue(WIDX_STAY_CONNECTED_AFTER_DESYNC, gConfigNetwork.stay_connected);
         SetCheckboxValue(WIDX_ALWAYS_NATIVE_LOADSAVE, gConfigGeneral.use_native_browse_dialog);
-
-        CommonPrepareDrawAfter();
     }
 
     void AdvancedDraw(rct_drawpixelinfo* dpi)
     {
-        WindowDrawWidgets(this, dpi);
-        DrawTabImages(dpi);
-
         DrawTextBasic(
             dpi, windowPos + ScreenCoordsXY{ 24, widgets[WIDX_AUTOSAVE].top + 1 }, STR_OPTIONS_AUTOSAVE_FREQUENCY_LABEL, {},
             { colours[1] });

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -373,49 +373,6 @@ static rct_widget *window_options_page_widgets[] = {
 
 #pragma endregion
 
-static constexpr const rct_string_id window_options_autosave_names[6] = {
-    STR_SAVE_EVERY_MINUTE,
-    STR_SAVE_EVERY_5MINUTES,
-    STR_SAVE_EVERY_15MINUTES,
-    STR_SAVE_EVERY_30MINUTES,
-    STR_SAVE_EVERY_HOUR,
-    STR_SAVE_NEVER,
-};
-
-static constexpr const rct_string_id window_options_title_music_names[] = {
-    STR_OPTIONS_MUSIC_VALUE_NONE ,
-    STR_ROLLERCOASTER_TYCOON_1_DROPDOWN ,
-    STR_ROLLERCOASTER_TYCOON_2_DROPDOWN ,
-    STR_OPTIONS_MUSIC_VALUE_RANDOM,
-};
-
-static constexpr const rct_string_id window_options_fullscreen_mode_names[] = {
-    STR_OPTIONS_DISPLAY_WINDOWED,
-    STR_OPTIONS_DISPLAY_FULLSCREEN,
-    STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS,
-};
-
-const int32_t window_options_tab_animation_divisor[] =
-{
-    4, // WINDOW_OPTIONS_PAGE_DISPLAY,
-    1, // WINDOW_OPTIONS_PAGE_RENDERING,
-    8, // WINDOW_OPTIONS_PAGE_CULTURE,
-    2, // WINDOW_OPTIONS_PAGE_AUDIO,
-    2, // WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE,
-    4, // WINDOW_OPTIONS_PAGE_MISC,
-    2, // WINDOW_OPTIONS_PAGE_ADVANCED,
-};
-const int32_t window_options_tab_animation_frames[] =
-{
-     8, // WINDOW_OPTIONS_PAGE_DISPLAY,
-     1, // WINDOW_OPTIONS_PAGE_RENDERING,
-     8, // WINDOW_OPTIONS_PAGE_CULTURE,
-    16, // WINDOW_OPTIONS_PAGE_AUDIO,
-     4, // WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE,
-    16, // WINDOW_OPTIONS_PAGE_MISC,
-    16, // WINDOW_OPTIONS_PAGE_ADVANCED,
-};
-
 #pragma region Enabled Widgets
 
 constexpr int MAIN_OPTIONS_ENABLED_WIDGETS =
@@ -1044,7 +1001,7 @@ private:
         SetCheckboxValue(WIDX_DISABLE_SCREENSAVER_LOCK, gConfigGeneral.disable_screensaver);
 
         // Dropdown captions for straightforward strings.
-        widgets[WIDX_FULLSCREEN].text = window_options_fullscreen_mode_names[gConfigGeneral.fullscreen_mode];
+        widgets[WIDX_FULLSCREEN].text = FullscreenModeNames[gConfigGeneral.fullscreen_mode];
         widgets[WIDX_DRAWING_ENGINE].text = DrawingEngineStringIds[EnumValue(gConfigGeneral.drawing_engine)];
     }
 
@@ -1530,7 +1487,7 @@ private:
                 for (size_t i = 0; i < numItems; i++)
                 {
                     gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = window_options_title_music_names[i];
+                    gDropdownItemsArgs[i] = TitleMusicNames[i];
                 }
 
                 ShowDropdown(widget, numItems);
@@ -1651,7 +1608,7 @@ private:
         auto ft = Formatter::Common();
         ft.Add<char*>(audioDeviceName);
 
-        widgets[WIDX_TITLE_MUSIC].text = window_options_title_music_names[gConfigSound.title_music];
+        widgets[WIDX_TITLE_MUSIC].text = TitleMusicNames[gConfigSound.title_music];
 
         SetCheckboxValue(WIDX_SOUND_CHECKBOX, gConfigSound.sound_enabled);
         SetCheckboxValue(WIDX_MASTER_SOUND_CHECKBOX, gConfigSound.master_sound_enabled);
@@ -2121,7 +2078,7 @@ private:
                 for (size_t i = AUTOSAVE_EVERY_MINUTE; i <= AUTOSAVE_NEVER; i++)
                 {
                     gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = window_options_autosave_names[i];
+                    gDropdownItemsArgs[i] = AutosaveNames[i];
                 }
 
                 ShowDropdown(widget, AUTOSAVE_NEVER + 1);
@@ -2178,7 +2135,7 @@ private:
             { colours[1] });
         DrawTextBasic(
             dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_AUTOSAVE].left + 1, widgets[WIDX_AUTOSAVE].top },
-            window_options_autosave_names[gConfigGeneral.autosave_frequency], {}, { colours[1] });
+            AutosaveNames[gConfigGeneral.autosave_frequency], {}, { colours[1] });
         DrawTextBasic(
             dpi, windowPos + ScreenCoordsXY{ 24, widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 }, STR_AUTOSAVE_AMOUNT, {},
             { colours[1] });
@@ -2273,8 +2230,8 @@ private:
         {
             if (page == p)
             {
-                int32_t frame = frame_no / window_options_tab_animation_divisor[page];
-                spriteIndex += (frame % window_options_tab_animation_frames[page]);
+                int32_t frame = frame_no / TabAnimationDivisor[page];
+                spriteIndex += (frame % TabAnimationFrames[page]);
             }
 
             // Draw normal, enabled sprite.
@@ -2315,6 +2272,44 @@ private:
 
         WidgetScrollUpdateThumbs(this, widgetIndex);
     }
+
+    static constexpr rct_string_id AutosaveNames[] = {
+        STR_SAVE_EVERY_MINUTE,    STR_SAVE_EVERY_5MINUTES, STR_SAVE_EVERY_15MINUTES,
+        STR_SAVE_EVERY_30MINUTES, STR_SAVE_EVERY_HOUR,     STR_SAVE_NEVER,
+    };
+
+    static constexpr rct_string_id TitleMusicNames[] = {
+        STR_OPTIONS_MUSIC_VALUE_NONE,
+        STR_ROLLERCOASTER_TYCOON_1_DROPDOWN,
+        STR_ROLLERCOASTER_TYCOON_2_DROPDOWN,
+        STR_OPTIONS_MUSIC_VALUE_RANDOM,
+    };
+
+    static constexpr rct_string_id FullscreenModeNames[] = {
+        STR_OPTIONS_DISPLAY_WINDOWED,
+        STR_OPTIONS_DISPLAY_FULLSCREEN,
+        STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS,
+    };
+
+    static constexpr int32_t TabAnimationDivisor[] = {
+        4, // WINDOW_OPTIONS_PAGE_DISPLAY,
+        1, // WINDOW_OPTIONS_PAGE_RENDERING,
+        8, // WINDOW_OPTIONS_PAGE_CULTURE,
+        2, // WINDOW_OPTIONS_PAGE_AUDIO,
+        2, // WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE,
+        4, // WINDOW_OPTIONS_PAGE_MISC,
+        2, // WINDOW_OPTIONS_PAGE_ADVANCED,
+    };
+
+    static constexpr int32_t TabAnimationFrames[] = {
+        8,  // WINDOW_OPTIONS_PAGE_DISPLAY,
+        1,  // WINDOW_OPTIONS_PAGE_RENDERING,
+        8,  // WINDOW_OPTIONS_PAGE_CULTURE,
+        16, // WINDOW_OPTIONS_PAGE_AUDIO,
+        4,  // WINDOW_OPTIONS_PAGE_CONTROLS_AND_INTERFACE,
+        16, // WINDOW_OPTIONS_PAGE_MISC,
+        16, // WINDOW_OPTIONS_PAGE_ADVANCED,
+    };
 };
 
 /**

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1022,13 +1022,13 @@ private:
             disabled_widgets &= ~(1ULL << WIDX_USE_VSYNC_CHECKBOX);
         }
 
-        WidgetSetCheckboxValue(this, WIDX_UNCAP_FPS_CHECKBOX, gConfigGeneral.uncap_fps);
-        WidgetSetCheckboxValue(this, WIDX_USE_VSYNC_CHECKBOX, gConfigGeneral.use_vsync);
-        WidgetSetCheckboxValue(this, WIDX_SHOW_FPS_CHECKBOX, gConfigGeneral.show_fps);
-        WidgetSetCheckboxValue(this, WIDX_MULTITHREADING_CHECKBOX, gConfigGeneral.multithreading);
-        WidgetSetCheckboxValue(this, WIDX_MINIMIZE_FOCUS_LOSS, gConfigGeneral.minimize_fullscreen_focus_loss);
-        WidgetSetCheckboxValue(this, WIDX_STEAM_OVERLAY_PAUSE, gConfigGeneral.steam_overlay_pause);
-        WidgetSetCheckboxValue(this, WIDX_DISABLE_SCREENSAVER_LOCK, gConfigGeneral.disable_screensaver);
+        SetCheckboxValue(WIDX_UNCAP_FPS_CHECKBOX, gConfigGeneral.uncap_fps);
+        SetCheckboxValue(WIDX_USE_VSYNC_CHECKBOX, gConfigGeneral.use_vsync);
+        SetCheckboxValue(WIDX_SHOW_FPS_CHECKBOX, gConfigGeneral.show_fps);
+        SetCheckboxValue(WIDX_MULTITHREADING_CHECKBOX, gConfigGeneral.multithreading);
+        SetCheckboxValue(WIDX_MINIMIZE_FOCUS_LOSS, gConfigGeneral.minimize_fullscreen_focus_loss);
+        SetCheckboxValue(WIDX_STEAM_OVERLAY_PAUSE, gConfigGeneral.steam_overlay_pause);
+        SetCheckboxValue(WIDX_DISABLE_SCREENSAVER_LOCK, gConfigGeneral.disable_screensaver);
 
         // Dropdown captions for straightforward strings.
         widgets[WIDX_FULLSCREEN].text = window_options_fullscreen_mode_names[gConfigGeneral.fullscreen_mode];
@@ -1176,12 +1176,12 @@ private:
     {
         CommonPrepareDrawBefore();
 
-        WidgetSetCheckboxValue(this, WIDX_TILE_SMOOTHING_CHECKBOX, gConfigGeneral.landscape_smoothing);
-        WidgetSetCheckboxValue(this, WIDX_GRIDLINES_CHECKBOX, gConfigGeneral.always_show_gridlines);
-        WidgetSetCheckboxValue(this, WIDX_DAY_NIGHT_CHECKBOX, gConfigGeneral.day_night_cycle);
-        WidgetSetCheckboxValue(this, WIDX_SHOW_GUEST_PURCHASES_CHECKBOX, gConfigGeneral.show_guest_purchases);
-        WidgetSetCheckboxValue(this, WIDX_TRANSPARENT_SCREENSHOTS_CHECKBOX, gConfigGeneral.transparent_screenshot);
-        WidgetSetCheckboxValue(this, WIDX_UPPER_CASE_BANNERS_CHECKBOX, gConfigGeneral.upper_case_banners);
+        SetCheckboxValue(WIDX_TILE_SMOOTHING_CHECKBOX, gConfigGeneral.landscape_smoothing);
+        SetCheckboxValue(WIDX_GRIDLINES_CHECKBOX, gConfigGeneral.always_show_gridlines);
+        SetCheckboxValue(WIDX_DAY_NIGHT_CHECKBOX, gConfigGeneral.day_night_cycle);
+        SetCheckboxValue(WIDX_SHOW_GUEST_PURCHASES_CHECKBOX, gConfigGeneral.show_guest_purchases);
+        SetCheckboxValue(WIDX_TRANSPARENT_SCREENSHOTS_CHECKBOX, gConfigGeneral.transparent_screenshot);
+        SetCheckboxValue(WIDX_UPPER_CASE_BANNERS_CHECKBOX, gConfigGeneral.upper_case_banners);
 
         static constexpr rct_string_id VirtualFloorStyleStrings[] = {
             STR_VIRTUAL_FLOOR_STYLE_DISABLED,
@@ -1191,7 +1191,7 @@ private:
 
         widgets[WIDX_VIRTUAL_FLOOR].text = VirtualFloorStyleStrings[static_cast<int32_t>(gConfigGeneral.virtual_floor_style)];
 
-        WidgetSetCheckboxValue(this, WIDX_ENABLE_LIGHT_FX_CHECKBOX, gConfigGeneral.enable_light_fx);
+        SetCheckboxValue(WIDX_ENABLE_LIGHT_FX_CHECKBOX, gConfigGeneral.enable_light_fx);
         if (gConfigGeneral.day_night_cycle && gConfigGeneral.drawing_engine == DrawingEngine::SoftwareWithHardwareDisplay)
         {
             disabled_widgets &= ~(1ULL << WIDX_ENABLE_LIGHT_FX_CHECKBOX);
@@ -1202,7 +1202,7 @@ private:
             gConfigGeneral.enable_light_fx = false;
         }
 
-        WidgetSetCheckboxValue(this, WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX, gConfigGeneral.enable_light_fx_for_vehicles);
+        SetCheckboxValue(WIDX_ENABLE_LIGHT_FX_FOR_VEHICLES_CHECKBOX, gConfigGeneral.enable_light_fx_for_vehicles);
         if (gConfigGeneral.day_night_cycle && gConfigGeneral.drawing_engine == DrawingEngine::SoftwareWithHardwareDisplay
             && gConfigGeneral.enable_light_fx)
         {
@@ -1217,10 +1217,10 @@ private:
         WidgetSetCheckboxValue(
             this, WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX,
             gConfigGeneral.render_weather_effects || gConfigGeneral.render_weather_gloom);
-        WidgetSetCheckboxValue(this, WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX, gConfigGeneral.disable_lightning_effect);
+        SetCheckboxValue(WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX, gConfigGeneral.disable_lightning_effect);
         if (!gConfigGeneral.render_weather_effects && !gConfigGeneral.render_weather_gloom)
         {
-            WidgetSetCheckboxValue(this, WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX, true);
+            SetCheckboxValue(WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX, true);
             enabled_widgets &= ~(1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
             disabled_widgets |= (1ULL << WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX);
         }
@@ -1669,10 +1669,10 @@ private:
 
         widgets[WIDX_TITLE_MUSIC].text = window_options_title_music_names[gConfigSound.title_music];
 
-        WidgetSetCheckboxValue(this, WIDX_SOUND_CHECKBOX, gConfigSound.sound_enabled);
-        WidgetSetCheckboxValue(this, WIDX_MASTER_SOUND_CHECKBOX, gConfigSound.master_sound_enabled);
-        WidgetSetCheckboxValue(this, WIDX_MUSIC_CHECKBOX, gConfigSound.ride_music_enabled);
-        WidgetSetCheckboxValue(this, WIDX_AUDIO_FOCUS_CHECKBOX, gConfigSound.audio_focus);
+        SetCheckboxValue(WIDX_SOUND_CHECKBOX, gConfigSound.sound_enabled);
+        SetCheckboxValue(WIDX_MASTER_SOUND_CHECKBOX, gConfigSound.master_sound_enabled);
+        SetCheckboxValue(WIDX_MUSIC_CHECKBOX, gConfigSound.ride_music_enabled);
+        SetCheckboxValue(WIDX_AUDIO_FOCUS_CHECKBOX, gConfigSound.audio_focus);
         WidgetSetEnabled(this, WIDX_SOUND_CHECKBOX, gConfigSound.master_sound_enabled);
         WidgetSetEnabled(this, WIDX_MUSIC_CHECKBOX, gConfigSound.master_sound_enabled);
 
@@ -1819,17 +1819,17 @@ private:
     {
         CommonPrepareDrawBefore();
 
-        WidgetSetCheckboxValue(this, WIDX_SCREEN_EDGE_SCROLLING, gConfigGeneral.edge_scrolling);
-        WidgetSetCheckboxValue(this, WIDX_TRAP_CURSOR, gConfigGeneral.trap_cursor);
-        WidgetSetCheckboxValue(this, WIDX_INVERT_DRAG, gConfigGeneral.invert_viewport_drag);
-        WidgetSetCheckboxValue(this, WIDX_ZOOM_TO_CURSOR, gConfigGeneral.zoom_to_cursor);
-        WidgetSetCheckboxValue(this, WIDX_TOOLBAR_SHOW_FINANCES, gConfigInterface.toolbar_show_finances);
-        WidgetSetCheckboxValue(this, WIDX_TOOLBAR_SHOW_RESEARCH, gConfigInterface.toolbar_show_research);
-        WidgetSetCheckboxValue(this, WIDX_TOOLBAR_SHOW_CHEATS, gConfigInterface.toolbar_show_cheats);
-        WidgetSetCheckboxValue(this, WIDX_TOOLBAR_SHOW_NEWS, gConfigInterface.toolbar_show_news);
-        WidgetSetCheckboxValue(this, WIDX_TOOLBAR_SHOW_MUTE, gConfigInterface.toolbar_show_mute);
-        WidgetSetCheckboxValue(this, WIDX_TOOLBAR_SHOW_CHAT, gConfigInterface.toolbar_show_chat);
-        WidgetSetCheckboxValue(this, WIDX_TOOLBAR_SHOW_ZOOM, gConfigInterface.toolbar_show_zoom);
+        SetCheckboxValue(WIDX_SCREEN_EDGE_SCROLLING, gConfigGeneral.edge_scrolling);
+        SetCheckboxValue(WIDX_TRAP_CURSOR, gConfigGeneral.trap_cursor);
+        SetCheckboxValue(WIDX_INVERT_DRAG, gConfigGeneral.invert_viewport_drag);
+        SetCheckboxValue(WIDX_ZOOM_TO_CURSOR, gConfigGeneral.zoom_to_cursor);
+        SetCheckboxValue(WIDX_TOOLBAR_SHOW_FINANCES, gConfigInterface.toolbar_show_finances);
+        SetCheckboxValue(WIDX_TOOLBAR_SHOW_RESEARCH, gConfigInterface.toolbar_show_research);
+        SetCheckboxValue(WIDX_TOOLBAR_SHOW_CHEATS, gConfigInterface.toolbar_show_cheats);
+        SetCheckboxValue(WIDX_TOOLBAR_SHOW_NEWS, gConfigInterface.toolbar_show_news);
+        SetCheckboxValue(WIDX_TOOLBAR_SHOW_MUTE, gConfigInterface.toolbar_show_mute);
+        SetCheckboxValue(WIDX_TOOLBAR_SHOW_CHAT, gConfigInterface.toolbar_show_chat);
+        SetCheckboxValue(WIDX_TOOLBAR_SHOW_ZOOM, gConfigInterface.toolbar_show_zoom);
 
         size_t activeAvailableThemeIndex = ThemeManagerGetAvailableThemeIndex();
         const utf8* activeThemeName = ThemeManagerGetAvailableThemeName(activeAvailableThemeIndex);
@@ -2015,11 +2015,11 @@ private:
             }
         }
 
-        WidgetSetCheckboxValue(this, WIDX_REAL_NAME_CHECKBOX, gConfigGeneral.show_real_names_of_guests);
-        WidgetSetCheckboxValue(this, WIDX_AUTO_STAFF_PLACEMENT, gConfigGeneral.auto_staff_placement);
-        WidgetSetCheckboxValue(this, WIDX_AUTO_OPEN_SHOPS, gConfigGeneral.auto_open_shops);
-        WidgetSetCheckboxValue(this, WIDX_TITLE_SEQUENCE_RANDOM, gConfigInterface.random_title_sequence);
-        WidgetSetCheckboxValue(this, WIDX_ALLOW_EARLY_COMPLETION, gConfigGeneral.allow_early_completion);
+        SetCheckboxValue(WIDX_REAL_NAME_CHECKBOX, gConfigGeneral.show_real_names_of_guests);
+        SetCheckboxValue(WIDX_AUTO_STAFF_PLACEMENT, gConfigGeneral.auto_staff_placement);
+        SetCheckboxValue(WIDX_AUTO_OPEN_SHOPS, gConfigGeneral.auto_open_shops);
+        SetCheckboxValue(WIDX_TITLE_SEQUENCE_RANDOM, gConfigInterface.random_title_sequence);
+        SetCheckboxValue(WIDX_ALLOW_EARLY_COMPLETION, gConfigGeneral.allow_early_completion);
 
         // Disable title sequence dropdown if set to random
         if (gConfigInterface.random_title_sequence)
@@ -2038,7 +2038,7 @@ private:
         else
             widgets[WIDX_SCENARIO_GROUPING].text = STR_OPTIONS_SCENARIO_ORIGIN;
 
-        WidgetSetCheckboxValue(this, WIDX_SCENARIO_UNLOCKING, gConfigGeneral.scenario_unlocking_enabled);
+        SetCheckboxValue(WIDX_SCENARIO_UNLOCKING, gConfigGeneral.scenario_unlocking_enabled);
 
         if (gConfigGeneral.scenario_select_mode == SCENARIO_SELECT_MODE_ORIGIN)
         {
@@ -2208,12 +2208,12 @@ private:
     {
         CommonPrepareDrawBefore();
 
-        WidgetSetCheckboxValue(this, WIDX_DEBUGGING_TOOLS, gConfigGeneral.debugging_tools);
+        SetCheckboxValue(WIDX_DEBUGGING_TOOLS, gConfigGeneral.debugging_tools);
         WidgetSetCheckboxValue(
             this, WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM, gConfigGeneral.allow_loading_with_incorrect_checksum);
-        WidgetSetCheckboxValue(this, WIDX_SAVE_PLUGIN_DATA_CHECKBOX, gConfigGeneral.save_plugin_data);
-        WidgetSetCheckboxValue(this, WIDX_STAY_CONNECTED_AFTER_DESYNC, gConfigNetwork.stay_connected);
-        WidgetSetCheckboxValue(this, WIDX_ALWAYS_NATIVE_LOADSAVE, gConfigGeneral.use_native_browse_dialog);
+        SetCheckboxValue(WIDX_SAVE_PLUGIN_DATA_CHECKBOX, gConfigGeneral.save_plugin_data);
+        SetCheckboxValue(WIDX_STAY_CONNECTED_AFTER_DESYNC, gConfigNetwork.stay_connected);
+        SetCheckboxValue(WIDX_ALWAYS_NATIVE_LOADSAVE, gConfigGeneral.use_native_browse_dialog);
 
         CommonPrepareDrawAfter();
     }

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -793,7 +793,7 @@ private:
     {
         // Tab animation
         frame_no++;
-        widget_invalidate(this, WIDX_FIRST_TAB + page);
+        InvalidateWidget(WIDX_FIRST_TAB + page);
     }
 #pragma endregion
 
@@ -1607,7 +1607,7 @@ private:
         {
             gConfigSound.master_volume = masterVolume;
             config_save_default();
-            widget_invalidate(this, WIDX_MASTER_VOLUME);
+            InvalidateWidget(WIDX_MASTER_VOLUME);
         }
 
         const auto& soundVolumeWidget = widgets[WIDX_MASTER_VOLUME];
@@ -1617,7 +1617,7 @@ private:
         {
             gConfigSound.sound_volume = soundVolume;
             config_save_default();
-            widget_invalidate(this, WIDX_SOUND_VOLUME);
+            InvalidateWidget(WIDX_SOUND_VOLUME);
         }
 
         const auto& musicVolumeWidget = widgets[WIDX_MASTER_VOLUME];
@@ -1627,7 +1627,7 @@ private:
         {
             gConfigSound.ride_music_volume = rideMusicVolume;
             config_save_default();
-            widget_invalidate(this, WIDX_MUSIC_VOLUME);
+            InvalidateWidget(WIDX_MUSIC_VOLUME);
         }
     }
 
@@ -1793,7 +1793,7 @@ private:
                     Dropdown::Flag::StayOpen, numItems, widget->width() - 3);
 
                 Dropdown::SetChecked(static_cast<int32_t>(ThemeManagerGetAvailableThemeIndex()), true);
-                widget_invalidate(this, WIDX_THEMES_DROPDOWN);
+                InvalidateWidget(WIDX_THEMES_DROPDOWN);
                 break;
         }
     }
@@ -2170,18 +2170,18 @@ private:
             case WIDX_AUTOSAVE_AMOUNT_UP:
                 gConfigGeneral.autosave_amount += 1;
                 config_save_default();
-                widget_invalidate(this, WIDX_AUTOSAVE);
-                widget_invalidate(this, WIDX_AUTOSAVE_DROPDOWN);
-                widget_invalidate(this, WIDX_AUTOSAVE_AMOUNT);
+                InvalidateWidget(WIDX_AUTOSAVE);
+                InvalidateWidget(WIDX_AUTOSAVE_DROPDOWN);
+                InvalidateWidget(WIDX_AUTOSAVE_AMOUNT);
                 break;
             case WIDX_AUTOSAVE_AMOUNT_DOWN:
                 if (gConfigGeneral.autosave_amount > 1)
                 {
                     gConfigGeneral.autosave_amount -= 1;
                     config_save_default();
-                    widget_invalidate(this, WIDX_AUTOSAVE);
-                    widget_invalidate(this, WIDX_AUTOSAVE_DROPDOWN);
-                    widget_invalidate(this, WIDX_AUTOSAVE_AMOUNT);
+                    InvalidateWidget(WIDX_AUTOSAVE);
+                    InvalidateWidget(WIDX_AUTOSAVE_DROPDOWN);
+                    InvalidateWidget(WIDX_AUTOSAVE_AMOUNT);
                 }
         }
     }


### PR DESCRIPTION
When working on #16482 I used the OptionsWindow code as a guide, but then it turned out there are a few ways this does not quite fit the code style. So, I have applied the feedback I got there, to this code as well. :^)

In doing so, I noticed the AdvancedTooltip() method was never called, so the tooltip was empty. This was the reason for the crash in #16504 so now that's fixed too! Empty tooltips should not cause crashes but at least this one is fixed.