### PR TITLE
Fix money overflow in scenario_entrance_fee_too_high_check and more

### DIFF
--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -231,7 +231,7 @@ static bool award_is_deserved_worst_value(int32_t activeAwardTypes)
     if (gParkFlags & PARK_FLAGS_NO_MONEY)
         return false;
 
-    money32 parkEntranceFee = park_get_entrance_fee();
+    const auto parkEntranceFee = park_get_entrance_fee();
     if (parkEntranceFee == MONEY(0, 00))
         return false;
     if (parkEntranceFee <= gTotalRideValueForMoney)

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -237,8 +237,7 @@ void scenario_success_submit_name(const char* name)
  */
 static void scenario_entrance_fee_too_high_check()
 {
-    money16 totalRideValueForMoney = gTotalRideValueForMoney;
-    money16 max_fee = totalRideValueForMoney + (totalRideValueForMoney / 2);
+    const auto max_fee = add_clamp_money16(gTotalRideValueForMoney, gTotalRideValueForMoney / 2);
 
     if ((gParkFlags & PARK_FLAGS_PARK_OPEN) && park_get_entrance_fee() > max_fee)
     {

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -723,6 +723,14 @@ int64_t add_clamp_int64_t(int64_t value, int64_t value_to_add)
     return value;
 }
 
+money16 add_clamp_money16(money16 value, money16 value_to_add)
+{
+    // This function is intended only for clarity, as money16
+    // is technically the same as int16_t
+    assert_struct_size(money16, sizeof(int16_t));
+    return add_clamp_int16_t(value, value_to_add);
+}
+
 money32 add_clamp_money32(money32 value, money32 value_to_add)
 {
     // This function is intended only for clarity, as money32
@@ -731,7 +739,7 @@ money32 add_clamp_money32(money32 value, money32 value_to_add)
     return add_clamp_int32_t(value, value_to_add);
 }
 
-money32 add_clamp_money64(money64 value, money64 value_to_add)
+money64 add_clamp_money64(money64 value, money64 value_to_add)
 {
     // This function is intended only for clarity, as money64
     // is technically the same as int64_t

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -61,8 +61,9 @@ int8_t add_clamp_int8_t(int8_t value, int8_t value_to_add);
 int16_t add_clamp_int16_t(int16_t value, int16_t value_to_add);
 int32_t add_clamp_int32_t(int32_t value, int32_t value_to_add);
 int64_t add_clamp_int64_t(int64_t value, int64_t value_to_add);
+money16 add_clamp_money16(money16 value, money16 value_to_add);
 money32 add_clamp_money32(money32 value, money32 value_to_add);
-money32 add_clamp_money64(money64 value, money64 value_to_add);
+money64 add_clamp_money64(money64 value, money64 value_to_add);
 
 uint8_t lerp(uint8_t a, uint8_t b, float t);
 float flerp(float a, float b, float t);

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -489,7 +489,7 @@ money64 Park::CalculateParkValue() const
     }
 
     // +7.00 per guest
-    result += gNumGuestsInPark * MONEY(7, 00);
+    result += static_cast<money64>(gNumGuestsInPark) * MONEY(7, 00);
 
     return result;
 }
@@ -500,7 +500,7 @@ money64 Park::CalculateRideValue(const Ride* ride) const
     if (ride != nullptr && ride->value != RIDE_VALUE_UNDEFINED)
     {
         const auto& rtd = ride->GetRideTypeDescriptor();
-        result = (ride->value * 10LL) * (static_cast<money64>(ride_customers_in_last_5_minutes(ride)) + rtd.BonusValue * 4);
+        result = (ride->value * 10LL) * (static_cast<money64>(ride_customers_in_last_5_minutes(ride)) + rtd.BonusValue * 4LL);
     }
     return result;
 }


### PR DESCRIPTION
Fixes a few issues with the money values:
1. `add_clamp_money64` operated on `money64` but returned `money32`, potentially clamping values much more than needed.
2. `Park::CalculateParkValue()` and `Park::CalculateRideValue` could technically overflow money values with too many guests and too high `rtd.BonusValue`. This also shuts up Visual Studio static analysis warnings.
3. `scenario_entrance_fee_too_high_check` can overflow when `gTotalRideValueForMoney` is too high, and apparently it is possible to hit that with big legitimate parks, resulting in a "too high entrance fee" warning showing even for **free** parks. Saving `money * 1.5` in a wider variable fixes it:
![image](https://user-images.githubusercontent.com/7947461/151659913-25e44d13-ba68-46db-b3ef-b6e871bee2a9.png)

