### PR TITLE
Fix RCT2 Fruity Ices Stall colour

### DIFF
--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -887,7 +887,7 @@ namespace RCT2
             if (dst->type == RIDE_TYPE_FOOD_STALL)
             {
                 auto object = object_entry_get_object(ObjectType::Ride, dst->subtype);
-                if (object != nullptr && object->GetIdentifier() == "rct2.icecr1")
+                if (object != nullptr && object->GetIdentifier() == "rct2.ride.icecr1")
                 {
                     dst->track_colour[0].main = COLOUR_LIGHT_BLUE;
                 }


### PR DESCRIPTION
Error was introduced during the mass rename of objects in the late stages of the NSF.