### PR TITLE
Fix #16365: Broken link referenced in manpages and help output

### DIFF
--- a/distribution/man/openrct2.6
+++ b/distribution/man/openrct2.6
@@ -255,14 +255,14 @@ work - forever. The only thing changed is that you can no longer save to .SV6, i
 saved as .park.
 .sp
 .Sh EXAMPLES
-.Bl -tag -width "openrct2 https://openrct2.io/files/SnowyPark.sv6 "
+.Bl -tag -width "openrct2 https://example.org/files/ExamplePark.sv6 "
 .It openrct2 ./my_park.sv6
 Open a saved park.
 .It openrct2 ./SnowyPark.sc6
 Install and open a scenario.
 .It openrct2 ./ShuttleLoop.td6
 Install a track.
-.It openrct2 https://openrct2.io/files/SnowyPark.sv6
+.It openrct2 https://example.org/files/ExamplePark.sv6
 Download and open a saved park.
 .It openrct2 host ./my_park.sv6 --port 11753 --headless
 Run a headless server for a saved park.

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -153,7 +153,7 @@ const CommandLineExample CommandLine::RootExamples[]
     { "./SnowyPark.sc6",                              "install and open a scenario"            },
     { "./ShuttleLoop.td6",                            "install a track"                        },
 #ifndef DISABLE_HTTP
-    { "https://openrct2.io/files/SnowyPark.sv6", "download and open a saved park"         },
+    { "https://example.org/files/ExamplePark.sv6", "download and open a saved park"         },
 #endif
 #ifndef DISABLE_NETWORK
     { "host ./my_park.sv6 --port 11753 --headless",   "run a headless server for a saved park" },


### PR DESCRIPTION
Link to file never existed, changed to a link that's clearly a placeholder so users can avoid broken links. Would also be happy to upload a file to the old link(https://openrct2.io/files/SnowyPark.sv6) instead as suggested by @IntelOrca, but don't know how to go about it.