### PR TITLE
[#16251] openrct2.d.ts: mark 'callback' argument of queryAction and executeAction as optional

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Improved: [#10150] Ride stations are now properly checked if they’re sheltered.
 - Improved: [#10664, #16072] Visibility status can be modified directly in the Tile Inspector's list.
 - Improved: [#16251] Plugin API handles null values better.
+- Improved: [#16251] openrct2.d.ts: mark 'callback' argument of queryAction and executeAction as optional.
 - Improved: [#16258] Increased image limit in the engine.
 - Improved: [#16408] Improve --version cli option to report more compatibility information.
 - Change: [#16077] When importing SV6 files, the RCT1 land types are only added when they were actually used.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -241,8 +241,8 @@ declare global {
          * @param args The action parameters.
          * @param callback The function to be called with the result of the action.
          */
-        queryAction(action: ActionType, args: object, callback: (result: GameActionResult) => void): void;
-        queryAction(action: string, args: object, callback: (result: GameActionResult) => void): void;
+        queryAction(action: ActionType, args: object, callback?: (result: GameActionResult) => void): void;
+        queryAction(action: string, args: object, callback?: (result: GameActionResult) => void): void;
 
         /**
          * Executes a game action. In a network game, this will send a request to the server and wait
@@ -251,8 +251,8 @@ declare global {
          * @param args The action parameters.
          * @param callback The function to be called with the result of the action.
          */
-        executeAction(action: ActionType, args: object, callback: (result: GameActionResult) => void): void;
-        executeAction(action: string, args: object, callback: (result: GameActionResult) => void): void;
+        executeAction(action: ActionType, args: object, callback?: (result: GameActionResult) => void): void;
+        executeAction(action: string, args: object, callback?: (result: GameActionResult) => void): void;
 
         /**
          * Subscribes to the given hook.


### PR DESCRIPTION
Implementation-wise, the 'callback' argument is optional, which makes sense.