### PR TITLE
Improve network module in more C++ way

### DIFF
--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -82,7 +82,7 @@ void DiscordService::Tick()
     _updateTimer.Restart();
 }
 
-void DiscordService::RefreshPresence()
+void DiscordService::RefreshPresence() const
 {
     DiscordRichPresence discordPresence = {};
     discordPresence.largeImageKey = "logo";

--- a/src/openrct2/network/DiscordService.h
+++ b/src/openrct2/network/DiscordService.h
@@ -28,7 +28,7 @@ public:
     void Tick();
 
 private:
-    void RefreshPresence();
+    void RefreshPresence() const;
 };
 
 #endif

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -407,12 +407,12 @@ bool NetworkBase::BeginServer(uint16_t port, const std::string& address)
     return true;
 }
 
-int32_t NetworkBase::GetMode()
+int32_t NetworkBase::GetMode() const noexcept
 {
     return mode;
 }
 
-int32_t NetworkBase::GetStatus()
+int32_t NetworkBase::GetStatus() const noexcept
 {
     return status;
 }
@@ -430,17 +430,17 @@ NetworkAuth NetworkBase::GetAuthStatus()
     return NetworkAuth::None;
 }
 
-uint32_t NetworkBase::GetServerTick()
+uint32_t NetworkBase::GetServerTick() const noexcept
 {
     return _serverState.tick;
 }
 
-uint8_t NetworkBase::GetPlayerID()
+uint8_t NetworkBase::GetPlayerID() const noexcept
 {
     return player_id;
 }
 
-NetworkConnection* NetworkBase::GetPlayerConnection(uint8_t id)
+NetworkConnection* NetworkBase::GetPlayerConnection(uint8_t id) const
 {
     auto player = GetPlayerByID(id);
     if (player != nullptr)
@@ -653,19 +653,14 @@ void NetworkBase::UpdateClient()
     }
 }
 
-std::vector<std::unique_ptr<NetworkPlayer>>::iterator NetworkBase::GetPlayerIteratorByID(uint8_t id)
+auto NetworkBase::GetPlayerIteratorByID(uint8_t id) const
 {
-    auto it = std::find_if(player_list.begin(), player_list.end(), [&id](std::unique_ptr<NetworkPlayer> const& player) {
+    return std::find_if(player_list.begin(), player_list.end(), [id](std::unique_ptr<NetworkPlayer> const& player) {
         return player->Id == id;
     });
-    if (it != player_list.end())
-    {
-        return it;
-    }
-    return player_list.end();
 }
 
-NetworkPlayer* NetworkBase::GetPlayerByID(uint8_t id)
+NetworkPlayer* NetworkBase::GetPlayerByID(uint8_t id) const
 {
     auto it = GetPlayerIteratorByID(id);
     if (it != player_list.end())
@@ -675,18 +670,13 @@ NetworkPlayer* NetworkBase::GetPlayerByID(uint8_t id)
     return nullptr;
 }
 
-std::vector<std::unique_ptr<NetworkGroup>>::iterator NetworkBase::GetGroupIteratorByID(uint8_t id)
+auto NetworkBase::GetGroupIteratorByID(uint8_t id) const
 {
-    auto it = std::find_if(
-        group_list.begin(), group_list.end(), [&id](std::unique_ptr<NetworkGroup> const& group) { return group->Id == id; });
-    if (it != group_list.end())
-    {
-        return it;
-    }
-    return group_list.end();
+    return std::find_if(
+        group_list.begin(), group_list.end(), [id](std::unique_ptr<NetworkGroup> const& group) { return group->Id == id; });
 }
 
-NetworkGroup* NetworkBase::GetGroupByID(uint8_t id)
+NetworkGroup* NetworkBase::GetGroupByID(uint8_t id) const
 {
     auto it = GetGroupIteratorByID(id);
     if (it != group_list.end())
@@ -712,7 +702,7 @@ const char* NetworkBase::FormatChat(NetworkPlayer* fromplayer, const char* text)
     return formatted.c_str();
 }
 
-void NetworkBase::SendPacketToClients(const NetworkPacket& packet, bool front, bool gameCmd)
+void NetworkBase::SendPacketToClients(const NetworkPacket& packet, bool front, bool gameCmd) const
 {
     for (auto& client_connection : client_connection_list)
     {
@@ -727,8 +717,7 @@ void NetworkBase::SendPacketToClients(const NetworkPacket& packet, bool front, b
                 continue;
             }
         }
-        auto packetCopy = packet;
-        client_connection->QueuePacket(std::move(packetCopy), front);
+        client_connection->QueuePacket(packet, front);
     }
 }
 
@@ -765,7 +754,7 @@ bool NetworkBase::CheckSRAND(uint32_t tick, uint32_t srand0)
     return true;
 }
 
-bool NetworkBase::IsDesynchronised()
+bool NetworkBase::IsDesynchronised() const noexcept
 {
     return _serverState.state == NetworkServerState::Desynced;
 }
@@ -804,7 +793,7 @@ void NetworkBase::RequestStateSnapshot()
     Client_Send_RequestGameState(_serverState.desyncTick);
 }
 
-NetworkServerState_t NetworkBase::GetServerState() const
+NetworkServerState_t NetworkBase::GetServerState() const noexcept
 {
     return _serverState;
 }
@@ -930,7 +919,7 @@ uint8_t NetworkBase::GetGroupIDByHash(const std::string& keyhash)
     return groupId;
 }
 
-uint8_t NetworkBase::GetDefaultGroup()
+uint8_t NetworkBase::GetDefaultGroup() const noexcept
 {
     return default_group;
 }
@@ -1098,7 +1087,7 @@ void NetworkBase::BeginChatLog()
     _chatLogPath = BeginLog(directory, "", _chatLogFilenameFormat);
 
 #    if defined(_WIN32) && !defined(__MINGW32__)
-    auto pathW = String::ToWideChar(_chatLogPath.c_str());
+    auto pathW = String::ToWideChar(_chatLogPath);
     _chat_log_fs.open(pathW.c_str(), std::ios::out | std::ios::app);
 #    else
     _chat_log_fs.open(_chatLogPath, std::ios::out | std::ios::app);
@@ -1125,7 +1114,7 @@ void NetworkBase::BeginServerLog()
     _serverLogPath = BeginLog(directory, ServerName, _serverLogFilenameFormat);
 
 #    if defined(_WIN32) && !defined(__MINGW32__)
-    auto pathW = String::ToWideChar(_serverLogPath.c_str());
+    auto pathW = String::ToWideChar(_serverLogPath);
     _server_log_fs.open(pathW.c_str(), std::ios::out | std::ios::app | std::ios::binary);
 #    else
     _server_log_fs.open(_serverLogPath, std::ios::out | std::ios::app | std::ios::binary);
@@ -1205,10 +1194,10 @@ void NetworkBase::Client_Send_AUTH(
     const std::string& name, const std::string& password, const std::string& pubkey, const std::vector<uint8_t>& signature)
 {
     NetworkPacket packet(NetworkCommand::Auth);
-    packet.WriteString(network_get_version().c_str());
-    packet.WriteString(name.c_str());
-    packet.WriteString(password.c_str());
-    packet.WriteString(pubkey.c_str());
+    packet.WriteString(network_get_version());
+    packet.WriteString(name);
+    packet.WriteString(password);
+    packet.WriteString(pubkey);
     assert(signature.size() <= static_cast<size_t>(UINT32_MAX));
     packet << static_cast<uint32_t>(signature.size());
     packet.Write(signature.data(), signature.size());
@@ -1364,7 +1353,7 @@ void NetworkBase::Server_Send_AUTH(NetworkConnection& connection)
     packet << static_cast<uint32_t>(connection.AuthStatus) << new_playerid;
     if (connection.AuthStatus == NetworkAuth::BadVersion)
     {
-        packet.WriteString(network_get_version().c_str());
+        packet.WriteString(network_get_version());
     }
     connection.QueuePacket(std::move(packet));
     if (connection.AuthStatus != NetworkAuth::Ok && connection.AuthStatus != NetworkAuth::RequirePassword)
@@ -1517,7 +1506,7 @@ void NetworkBase::Server_Send_TICK()
     if (flags & NETWORK_TICK_FLAG_CHECKSUMS)
     {
         EntitiesChecksum checksum = GetAllEntitiesChecksum();
-        packet.WriteString(checksum.ToString().c_str());
+        packet.WriteString(checksum.ToString());
     }
 
     SendPacketToClients(packet);
@@ -1608,7 +1597,7 @@ void NetworkBase::Server_Send_GAMEINFO(NetworkConnection& connection)
 
     jsonObj["provider"] = jsonProvider;
 
-    packet.WriteString(jsonObj.dump().c_str());
+    packet.WriteString(jsonObj.dump());
     packet << _serverState.gamestateSnapshotsEnabled;
 
 #    endif
@@ -2163,7 +2152,7 @@ void NetworkBase::Client_Handle_TOKEN(NetworkConnection& connection, NetworkPack
     // when process dump gets collected at some point in future.
     _key.Unload();
 
-    Client_Send_AUTH(gConfigNetwork.player_name.c_str(), gCustomPassword.c_str(), pubkey.c_str(), signature);
+    Client_Send_AUTH(gConfigNetwork.player_name, gCustomPassword, pubkey, signature);
 }
 
 void NetworkBase::Server_Handle_REQUEST_GAMESTATE(NetworkConnection& connection, NetworkPacket& packet)
@@ -3109,7 +3098,7 @@ void NetworkBase::Client_Handle_EVENT([[maybe_unused]] NetworkConnection& connec
         {
             auto playerName = packet.ReadString();
             auto message = FormatStringId(STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, playerName);
-            chat_history_add(message.c_str());
+            chat_history_add(message);
             break;
         }
         case SERVER_EVENT_PLAYER_DISCONNECTED:
@@ -3125,7 +3114,7 @@ void NetworkBase::Client_Handle_EVENT([[maybe_unused]] NetworkConnection& connec
             {
                 message = FormatStringId(STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_WITH_REASON, playerName, reason);
             }
-            chat_history_add(message.c_str());
+            chat_history_add(message);
             break;
         }
     }
@@ -3449,7 +3438,7 @@ void network_chat_show_server_greeting()
         thread_local std::string greeting_formatted;
         greeting_formatted.assign("{OUTLINE}{GREEN}");
         greeting_formatted += greeting;
-        chat_history_add(greeting_formatted.c_str());
+        chat_history_add(greeting_formatted);
     }
 }
 
@@ -3856,7 +3845,7 @@ void network_send_password(const std::string& password)
     // Don't keep private key in memory. There's no need and it may get leaked
     // when process dump gets collected at some point in future.
     network._key.Unload();
-    network.Client_Send_AUTH(gConfigNetwork.player_name.c_str(), password, pubkey.c_str(), signature);
+    network.Client_Send_AUTH(gConfigNetwork.player_name, password, pubkey, signature);
 }
 
 void network_set_password(const char* password)

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -31,18 +31,18 @@ public: // Uncategorized
 public: // Common
     bool Init();
     void Close();
-    uint32_t GetServerTick();
+    uint32_t GetServerTick() const noexcept;
     // FIXME: This is currently the wrong function to override in System, will be refactored later.
     void Update() override final;
     void Flush();
     void ProcessPending();
     void ProcessPlayerList();
-    std::vector<std::unique_ptr<NetworkPlayer>>::iterator GetPlayerIteratorByID(uint8_t id);
-    std::vector<std::unique_ptr<NetworkGroup>>::iterator GetGroupIteratorByID(uint8_t id);
-    NetworkPlayer* GetPlayerByID(uint8_t id);
-    NetworkGroup* GetGroupByID(uint8_t id);
+    auto GetPlayerIteratorByID(uint8_t id) const;
+    auto GetGroupIteratorByID(uint8_t id) const;
+    NetworkPlayer* GetPlayerByID(uint8_t id) const;
+    NetworkGroup* GetGroupByID(uint8_t id) const;
     void SetPassword(u8string_view password);
-    uint8_t GetDefaultGroup();
+    uint8_t GetDefaultGroup() const noexcept;
     std::string BeginLog(const std::string& directory, const std::string& midName, const std::string& filenameFormat);
     void AppendLog(std::ostream& fs, std::string_view s);
     void BeginChatLog();
@@ -56,7 +56,7 @@ public: // Common
     void ProcessPacket(NetworkConnection& connection, NetworkPacket& packet);
 
 public: // Server
-    NetworkConnection* GetPlayerConnection(uint8_t id);
+    NetworkConnection* GetPlayerConnection(uint8_t id) const;
     void KickPlayer(int32_t playerId);
     NetworkGroup* AddGroup();
     void LoadGroups();
@@ -113,19 +113,19 @@ public: // Server
 
 public: // Client
     void Reconnect();
-    int32_t GetMode();
+    int32_t GetMode() const noexcept;
     NetworkAuth GetAuthStatus();
-    int32_t GetStatus();
-    uint8_t GetPlayerID();
+    int32_t GetStatus() const noexcept;
+    uint8_t GetPlayerID() const noexcept;
     void ProcessPlayerInfo();
     void ProcessDisconnectedClients();
     static const char* FormatChat(NetworkPlayer* fromplayer, const char* text);
-    void SendPacketToClients(const NetworkPacket& packet, bool front = false, bool gameCmd = false);
+    void SendPacketToClients(const NetworkPacket& packet, bool front = false, bool gameCmd = false) const;
     bool CheckSRAND(uint32_t tick, uint32_t srand0);
     bool CheckDesynchronizaton();
     void RequestStateSnapshot();
-    bool IsDesynchronised();
-    NetworkServerState_t GetServerState() const;
+    bool IsDesynchronised() const noexcept;
+    NetworkServerState_t GetServerState() const noexcept;
     void ServerClientDisconnected();
     bool LoadMap(OpenRCT2::IStream* stream);
     void UpdateClient();

--- a/src/openrct2/network/NetworkConnection.cpp
+++ b/src/openrct2/network/NetworkConnection.cpp
@@ -20,13 +20,9 @@
 constexpr size_t NETWORK_DISCONNECT_REASON_BUFFER_SIZE = 256;
 constexpr size_t NetworkBufferSize = 1024 * 64; // 64 KiB, maximum packet size.
 
-NetworkConnection::NetworkConnection()
+NetworkConnection::NetworkConnection() noexcept
 {
     ResetLastPacketTime();
-}
-
-NetworkConnection::~NetworkConnection()
-{
 }
 
 NetworkReadPacket NetworkConnection::ReadPacket()
@@ -155,7 +151,7 @@ void NetworkConnection::QueuePacket(NetworkPacket&& packet, bool front)
     }
 }
 
-void NetworkConnection::Disconnect()
+void NetworkConnection::Disconnect() noexcept
 {
     ShouldDisconnect = true;
 }
@@ -173,12 +169,12 @@ void NetworkConnection::SendQueuedPackets()
     }
 }
 
-void NetworkConnection::ResetLastPacketTime()
+void NetworkConnection::ResetLastPacketTime() noexcept
 {
     _lastPacketTime = platform_get_ticks();
 }
 
-bool NetworkConnection::ReceivedPacketRecently()
+bool NetworkConnection::ReceivedPacketRecently() const noexcept
 {
 #    ifndef DEBUG
     if (platform_get_ticks() > _lastPacketTime + 7000)
@@ -189,7 +185,7 @@ bool NetworkConnection::ReceivedPacketRecently()
     return true;
 }
 
-const utf8* NetworkConnection::GetLastDisconnectReason() const
+const utf8* NetworkConnection::GetLastDisconnectReason() const noexcept
 {
     return this->_lastDisconnectReason.c_str();
 }

--- a/src/openrct2/network/NetworkConnection.h
+++ b/src/openrct2/network/NetworkConnection.h
@@ -38,8 +38,7 @@ public:
     std::vector<const ObjectRepositoryItem*> RequestedObjects;
     bool ShouldDisconnect = false;
 
-    NetworkConnection();
-    ~NetworkConnection();
+    NetworkConnection() noexcept;
 
     NetworkReadPacket ReadPacket();
     void QueuePacket(NetworkPacket&& packet, bool front = false);
@@ -51,14 +50,14 @@ public:
 
     // This will not immediately disconnect the client. The disconnect
     // will happen post-tick.
-    void Disconnect();
+    void Disconnect() noexcept;
 
     bool IsValid() const;
     void SendQueuedPackets();
-    void ResetLastPacketTime();
-    bool ReceivedPacketRecently();
+    void ResetLastPacketTime() noexcept;
+    bool ReceivedPacketRecently() const noexcept;
 
-    const utf8* GetLastDisconnectReason() const;
+    const utf8* GetLastDisconnectReason() const noexcept;
     void SetLastDisconnectReason(std::string_view src);
     void SetLastDisconnectReason(const rct_string_id string_id, void* args = nullptr);
 

--- a/src/openrct2/network/NetworkGroup.cpp
+++ b/src/openrct2/network/NetworkGroup.cpp
@@ -15,7 +15,7 @@
 #    include "NetworkAction.h"
 #    include "NetworkTypes.h"
 
-NetworkGroup NetworkGroup::FromJson(json_t& jsonData)
+NetworkGroup NetworkGroup::FromJson(const json_t& jsonData)
 {
     Guard::Assert(jsonData.is_object(), "NetworkGroup::FromJson expects parameter jsonData to be object");
 
@@ -64,7 +64,7 @@ json_t NetworkGroup::ToJson() const
     return jsonGroup;
 }
 
-const std::string& NetworkGroup::GetName() const
+const std::string& NetworkGroup::GetName() const noexcept
 {
     return _name;
 }
@@ -84,7 +84,7 @@ void NetworkGroup::Read(NetworkPacket& packet)
     }
 }
 
-void NetworkGroup::Write(NetworkPacket& packet)
+void NetworkGroup::Write(NetworkPacket& packet) const
 {
     packet << Id;
     packet.WriteString(GetName().c_str());
@@ -106,7 +106,7 @@ void NetworkGroup::ToggleActionPermission(NetworkPermission index)
     ActionsAllowed[byte] ^= (1 << bit);
 }
 
-bool NetworkGroup::CanPerformAction(NetworkPermission index) const
+bool NetworkGroup::CanPerformAction(NetworkPermission index) const noexcept
 {
     size_t index_st = static_cast<size_t>(index);
     size_t byte = index_st / 8;

--- a/src/openrct2/network/NetworkGroup.h
+++ b/src/openrct2/network/NetworkGroup.h
@@ -32,15 +32,15 @@ public:
      * @return A NetworkGroup object
      * @note json is deliberately left non-const: json_t behaviour changes when const
      */
-    static NetworkGroup FromJson(json_t& json);
+    static NetworkGroup FromJson(const json_t& json);
 
-    const std::string& GetName() const;
+    const std::string& GetName() const noexcept;
     void SetName(std::string_view name);
 
     void Read(NetworkPacket& packet);
-    void Write(NetworkPacket& packet);
+    void Write(NetworkPacket& packet) const;
     void ToggleActionPermission(NetworkPermission index);
-    bool CanPerformAction(NetworkPermission index) const;
+    bool CanPerformAction(NetworkPermission index) const noexcept;
     bool CanPerformCommand(GameCommand command) const;
 
     /**

--- a/src/openrct2/network/NetworkKey.cpp
+++ b/src/openrct2/network/NetworkKey.cpp
@@ -194,7 +194,7 @@ std::string NetworkKey::PublicKeyHash()
     return nullptr;
 }
 
-bool NetworkKey::Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature)
+bool NetworkKey::Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature) const
 {
     try
     {
@@ -209,7 +209,7 @@ bool NetworkKey::Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>&
     }
 }
 
-bool NetworkKey::Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature)
+bool NetworkKey::Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature) const
 {
     try
     {

--- a/src/openrct2/network/NetworkKey.h
+++ b/src/openrct2/network/NetworkKey.h
@@ -40,8 +40,8 @@ public:
     std::string PublicKeyString();
     std::string PublicKeyHash();
     void Unload();
-    bool Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature);
-    bool Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature);
+    bool Sign(const uint8_t* md, const size_t len, std::vector<uint8_t>& signature) const;
+    bool Verify(const uint8_t* md, const size_t len, const std::vector<uint8_t>& signature) const;
 
 private:
     NetworkKey(const NetworkKey&) = delete;

--- a/src/openrct2/network/NetworkPacket.cpp
+++ b/src/openrct2/network/NetworkPacket.cpp
@@ -15,34 +15,34 @@
 
 #    include <memory>
 
-NetworkPacket::NetworkPacket(NetworkCommand id)
+NetworkPacket::NetworkPacket(NetworkCommand id) noexcept
     : Header{ 0, id }
 {
 }
 
-uint8_t* NetworkPacket::GetData()
+uint8_t* NetworkPacket::GetData() noexcept
 {
     return Data.data();
 }
 
-const uint8_t* NetworkPacket::GetData() const
+const uint8_t* NetworkPacket::GetData() const noexcept
 {
     return Data.data();
 }
 
-NetworkCommand NetworkPacket::GetCommand() const
+NetworkCommand NetworkPacket::GetCommand() const noexcept
 {
     return Header.Id;
 }
 
-void NetworkPacket::Clear()
+void NetworkPacket::Clear() noexcept
 {
     BytesTransferred = 0;
     BytesRead = 0;
     Data.clear();
 }
 
-bool NetworkPacket::CommandRequiresAuth()
+bool NetworkPacket::CommandRequiresAuth() const noexcept
 {
     switch (GetCommand())
     {

--- a/src/openrct2/network/NetworkPacket.h
+++ b/src/openrct2/network/NetworkPacket.h
@@ -27,16 +27,16 @@ static_assert(sizeof(PacketHeader) == 6);
 
 struct NetworkPacket final
 {
-    NetworkPacket() = default;
-    NetworkPacket(NetworkCommand id);
+    NetworkPacket() noexcept = default;
+    NetworkPacket(NetworkCommand id) noexcept;
 
-    uint8_t* GetData();
-    const uint8_t* GetData() const;
+    uint8_t* GetData() noexcept;
+    const uint8_t* GetData() const noexcept;
 
-    NetworkCommand GetCommand() const;
+    NetworkCommand GetCommand() const noexcept;
 
-    void Clear();
-    bool CommandRequiresAuth();
+    void Clear() noexcept;
+    bool CommandRequiresAuth() const noexcept;
 
     const uint8_t* Read(size_t size);
     std::string_view ReadString();

--- a/src/openrct2/network/NetworkPlayer.cpp
+++ b/src/openrct2/network/NetworkPlayer.cpp
@@ -31,7 +31,7 @@ void NetworkPlayer::Read(NetworkPacket& packet)
 
 void NetworkPlayer::Write(NetworkPacket& packet)
 {
-    packet.WriteString(static_cast<const char*>(Name.c_str()));
+    packet.WriteString(Name);
     packet << Id << Flags << Group << LastAction << LastActionCoord.x << LastActionCoord.y << LastActionCoord.z << MoneySpent
            << CommandsRan;
 }

--- a/src/openrct2/network/NetworkPlayer.h
+++ b/src/openrct2/network/NetworkPlayer.h
@@ -39,7 +39,7 @@ public:
     uint32_t LastDemolishRideTime = 0;
     uint32_t LastPlaceSceneryTime = 0;
     std::unordered_map<GameCommand, int32_t> CooldownTime;
-    NetworkPlayer() = default;
+    NetworkPlayer() noexcept = default;
 
     void SetName(std::string_view name);
 

--- a/src/openrct2/network/NetworkUser.cpp
+++ b/src/openrct2/network/NetworkUser.cpp
@@ -23,7 +23,7 @@
 
 constexpr const utf8* USER_STORE_FILENAME = "users.json";
 
-NetworkUser* NetworkUser::FromJson(json_t& jsonData)
+std::unique_ptr<NetworkUser> NetworkUser::FromJson(const json_t& jsonData)
 {
     Guard::Assert(jsonData.is_object(), "NetworkUser::FromJson expects parameter jsonData to be object");
 
@@ -31,10 +31,10 @@ NetworkUser* NetworkUser::FromJson(json_t& jsonData)
     const std::string name = Json::GetString(jsonData["name"]);
     json_t jsonGroupId = jsonData["groupId"];
 
-    NetworkUser* user = nullptr;
+    std::unique_ptr<NetworkUser> user = nullptr;
     if (!hash.empty() && !name.empty())
     {
-        user = new NetworkUser();
+        user = std::make_unique<NetworkUser>();
         user->Hash = hash;
         user->Name = name;
         if (jsonGroupId.is_number_integer())
@@ -62,39 +62,25 @@ json_t NetworkUser::ToJson() const
     return jsonData;
 }
 
-NetworkUserManager::~NetworkUserManager()
-{
-    DisposeUsers();
-}
-
-void NetworkUserManager::DisposeUsers()
-{
-    for (const auto& kvp : _usersByHash)
-    {
-        delete kvp.second;
-    }
-    _usersByHash.clear();
-}
-
 void NetworkUserManager::Load()
 {
     const auto path = GetStorePath();
 
     if (File::Exists(path))
     {
-        DisposeUsers();
+        _usersByHash.clear();
 
         try
         {
             json_t jsonUsers = Json::ReadFromFile(path);
-            for (auto& jsonUser : jsonUsers)
+            for (const auto& jsonUser : jsonUsers)
             {
                 if (jsonUser.is_object())
                 {
                     auto networkUser = NetworkUser::FromJson(jsonUser);
                     if (networkUser != nullptr)
                     {
-                        _usersByHash[networkUser->Hash] = networkUser;
+                        _usersByHash[networkUser->Hash] = std::move(networkUser);
                     }
                 }
             }
@@ -154,7 +140,7 @@ void NetworkUserManager::Save()
     // Add new users
     for (const auto& kvp : _usersByHash)
     {
-        const NetworkUser* networkUser = kvp.second;
+        const auto& networkUser = kvp.second;
         if (!networkUser->Remove && savedHashes.find(networkUser->Hash) == savedHashes.end())
         {
             jsonUsers.push_back(networkUser->ToJson());
@@ -168,7 +154,7 @@ void NetworkUserManager::UnsetUsersOfGroup(uint8_t groupId)
 {
     for (const auto& kvp : _usersByHash)
     {
-        NetworkUser* networkUser = kvp.second;
+        auto& networkUser = kvp.second;
         if (networkUser->GroupId.has_value() && *networkUser->GroupId == groupId)
         {
             networkUser->GroupId = std::nullopt;
@@ -178,21 +164,11 @@ void NetworkUserManager::UnsetUsersOfGroup(uint8_t groupId)
 
 void NetworkUserManager::RemoveUser(const std::string& hash)
 {
-    NetworkUser* networkUser = GetUserByHash(hash);
+    NetworkUser* networkUser = const_cast<NetworkUser*>(GetUserByHash(hash));
     if (networkUser != nullptr)
     {
         networkUser->Remove = true;
     }
-}
-
-NetworkUser* NetworkUserManager::GetUserByHash(const std::string& hash)
-{
-    auto it = _usersByHash.find(hash);
-    if (it != _usersByHash.end())
-    {
-        return it->second;
-    }
-    return nullptr;
 }
 
 const NetworkUser* NetworkUserManager::GetUserByHash(const std::string& hash) const
@@ -200,7 +176,7 @@ const NetworkUser* NetworkUserManager::GetUserByHash(const std::string& hash) co
     auto it = _usersByHash.find(hash);
     if (it != _usersByHash.end())
     {
-        return it->second;
+        return it->second.get();
     }
     return nullptr;
 }
@@ -209,10 +185,10 @@ const NetworkUser* NetworkUserManager::GetUserByName(const std::string& name) co
 {
     for (const auto& kvp : _usersByHash)
     {
-        const NetworkUser* networkUser = kvp.second;
+        const auto& networkUser = kvp.second;
         if (String::Equals(name.c_str(), networkUser->Name.c_str(), true))
         {
-            return networkUser;
+            return networkUser.get();
         }
     }
     return nullptr;
@@ -220,12 +196,13 @@ const NetworkUser* NetworkUserManager::GetUserByName(const std::string& name) co
 
 NetworkUser* NetworkUserManager::GetOrAddUser(const std::string& hash)
 {
-    NetworkUser* networkUser = GetUserByHash(hash);
+    NetworkUser* networkUser = const_cast<NetworkUser*>(GetUserByHash(hash));
     if (networkUser == nullptr)
     {
-        networkUser = new NetworkUser();
-        networkUser->Hash = hash;
-        _usersByHash[hash] = networkUser;
+        auto newNetworkUser = std::make_unique<NetworkUser>();
+        newNetworkUser->Hash = hash;
+        networkUser = newNetworkUser.get();
+        _usersByHash[hash] = std::move(newNetworkUser);
     }
     return networkUser;
 }

--- a/src/openrct2/network/NetworkUser.h
+++ b/src/openrct2/network/NetworkUser.h
@@ -13,9 +13,10 @@
 #include "../core/JsonFwd.hpp"
 #include "../core/String.hpp"
 
-#include <map>
+#include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 
 class NetworkUser final
 {
@@ -31,7 +32,7 @@ public:
      * @return Pointer to a new NetworkUser object
      * @note jsonData is deliberately left non-const: json_t behaviour changes when const
      */
-    static NetworkUser* FromJson(json_t& jsonData);
+    static std::unique_ptr<NetworkUser> FromJson(const json_t& jsonData);
 
     /**
      * Serialise a NetworkUser object into a JSON object
@@ -44,8 +45,6 @@ public:
 class NetworkUserManager final
 {
 public:
-    ~NetworkUserManager();
-
     void Load();
 
     /**
@@ -59,14 +58,12 @@ public:
     void UnsetUsersOfGroup(uint8_t groupId);
     void RemoveUser(const std::string& hash);
 
-    NetworkUser* GetUserByHash(const std::string& hash);
     const NetworkUser* GetUserByHash(const std::string& hash) const;
     const NetworkUser* GetUserByName(const std::string& name) const;
     NetworkUser* GetOrAddUser(const std::string& hash);
 
 private:
-    std::map<std::string, NetworkUser*> _usersByHash;
+    std::unordered_map<std::string, std::unique_ptr<NetworkUser>> _usersByHash;
 
-    void DisposeUsers();
     static u8string GetStorePath();
 };

--- a/src/openrct2/network/ServerList.cpp
+++ b/src/openrct2/network/ServerList.cpp
@@ -67,7 +67,7 @@ int32_t ServerListEntry::CompareTo(const ServerListEntry& other) const
     return String::Compare(a.Name, b.Name, true);
 }
 
-bool ServerListEntry::IsVersionValid() const
+bool ServerListEntry::IsVersionValid() const noexcept
 {
     return Version.empty() || Version == network_get_version();
 }
@@ -150,7 +150,7 @@ void ServerList::AddRange(const std::vector<ServerListEntry>& entries)
     Sort();
 }
 
-void ServerList::Clear()
+void ServerList::Clear() noexcept
 {
     _serverEntries.clear();
 }

--- a/src/openrct2/network/ServerList.h
+++ b/src/openrct2/network/ServerList.h
@@ -33,7 +33,7 @@ struct ServerListEntry
     bool Local{};
 
     int32_t CompareTo(const ServerListEntry& other) const;
-    bool IsVersionValid() const;
+    bool IsVersionValid() const noexcept;
 
     /**
      * Creates a ServerListEntry object from a JSON object
@@ -60,7 +60,7 @@ public:
     size_t GetCount() const;
     void Add(const ServerListEntry& entry);
     void AddRange(const std::vector<ServerListEntry>& entries);
-    void Clear();
+    void Clear() noexcept;
 
     void ReadAndAddFavourites();
     void WriteFavourites() const;

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -78,7 +78,7 @@ private:
     bool _isInitialised{};
 
 public:
-    bool IsInitialised() const
+    bool IsInitialised() const noexcept
     {
         return _isInitialised;
     }
@@ -99,7 +99,7 @@ public:
         return true;
     }
 
-    ~WSA()
+    ~WSA() noexcept
     {
         if (_isInitialised)
         {
@@ -138,9 +138,7 @@ private:
     socklen_t _addressLen{};
 
 public:
-    NetworkEndpoint()
-    {
-    }
+    NetworkEndpoint() noexcept = default;
 
     NetworkEndpoint(const sockaddr* address, socklen_t addressLen)
     {
@@ -148,12 +146,12 @@ public:
         _addressLen = addressLen;
     }
 
-    const sockaddr& GetAddress() const
+    constexpr const sockaddr& GetAddress() const noexcept
     {
         return _address;
     }
 
-    socklen_t GetAddressLen() const
+    constexpr socklen_t GetAddressLen() const noexcept
     {
         return _addressLen;
     }
@@ -257,7 +255,7 @@ private:
     std::string _error;
 
 public:
-    TcpSocket() = default;
+    TcpSocket() noexcept = default;
 
     ~TcpSocket() override
     {
@@ -624,11 +622,11 @@ public:
     }
 
 private:
-    explicit TcpSocket(SOCKET socket, const std::string& hostName, const std::string& ipAddress)
+    explicit TcpSocket(SOCKET socket, std::string hostName, std::string ipAddress) noexcept
         : _status(SocketStatus::Connected)
         , _socket(socket)
-        , _ipAddress(ipAddress)
-        , _hostName(hostName)
+        , _ipAddress(std::move(ipAddress))
+        , _hostName(std::move(hostName))
     {
     }
 
@@ -642,7 +640,7 @@ private:
         _status = SocketStatus::Closed;
     }
 
-    std::string GetIpAddressFromSocket(const sockaddr_in* addr)
+    std::string GetIpAddressFromSocket(const sockaddr_in* addr) const
     {
         std::string result;
 #    if defined(__MINGW32__)
@@ -681,7 +679,7 @@ private:
     std::string _error;
 
 public:
-    UdpSocket() = default;
+    UdpSocket() noexcept = default;
 
     ~UdpSocket() override
     {
@@ -824,14 +822,7 @@ public:
     }
 
 private:
-    explicit UdpSocket(SOCKET socket, const std::string& hostName)
-        : _status(SocketStatus::Connected)
-        , _socket(socket)
-        , _hostName(hostName)
-    {
-    }
-
-    SOCKET CreateSocket()
+    SOCKET CreateSocket() const
     {
         auto sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
         if (sock == INVALID_SOCKET)


### PR DESCRIPTION
This PR makes network related codes more C++-ish: mostly adding `const` and `noexcept` modifiers where appropriate.

I also improved `NetworkUser` to use `std::unique_ptr` instead of raw pointers and replaced `std::map` with `std::unordered_map` for user container.