### PR TITLE
Fix #16582: Translate in-game console help text

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3650,6 +3650,7 @@ STR_6457    :Report a bug on GitHub
 STR_6458    :Follow this on Main View
 STR_6460    :D
 STR_6461    :Direction
+STR_6462    :Type ‘help’ for a list of available commands. Type ‘hide’ to hide the console.
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/interface/Window.h>
 #include <openrct2/localisation/Language.h>
 #include <openrct2/localisation/LocalisationService.h>
+#include <openrct2/localisation/StringIds.h>
 
 using namespace OpenRCT2::Ui;
 

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -39,7 +39,7 @@ static int32_t InGameConsoleGetLineHeight()
 InGameConsole::InGameConsole()
 {
     InteractiveConsole::WriteLine(OPENRCT2_NAME " " OPENRCT2_VERSION);
-    InteractiveConsole::WriteLine("Type 'help' for a list of available commands. Type 'hide' to hide the console.");
+    InteractiveConsole::WriteLine(language_get_string(STR_CONSOLE_HELP_TEXT));
     InteractiveConsole::WriteLine("");
     WritePrompt();
 }

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3917,6 +3917,8 @@ enum : uint16_t
     STR_TILE_INSPECTOR_DIRECTION_SHORT = 6460,
     STR_TILE_INSPECTOR_DIRECTION = 6461,
 
+    STR_CONSOLE_HELP_TEXT = 6462,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
For #16582.

Unfortunately couldn't test it in game. Left it as draft.