### PR TITLE
Clean up palette import

### DIFF
--- a/src/openrct2/CmdlineSprite.h
+++ b/src/openrct2/CmdlineSprite.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "common.h"
+#include "drawing/ImageImporter.h"
 
 int32_t cmdline_for_sprite(const char** argv, int32_t argc);
-extern int32_t gSpriteMode;
+extern OpenRCT2::Drawing::ImageImporter::IMPORT_MODE gSpriteMode;

--- a/src/openrct2/cmdline/SpriteCommands.cpp
+++ b/src/openrct2/cmdline/SpriteCommands.cpp
@@ -16,7 +16,9 @@
 #define SZ_CLOSEST "closest"
 #define SZ_DITHERING "dithering"
 
-int32_t gSpriteMode = 0;
+using IMPORT_MODE = OpenRCT2::Drawing::ImageImporter::IMPORT_MODE;
+
+IMPORT_MODE gSpriteMode = IMPORT_MODE::DEFAULT;
 
 static const char* _mode;
 
@@ -47,9 +49,9 @@ const CommandLineCommand CommandLine::SpriteCommands[]
 static exitcode_t HandleSprite(CommandLineArgEnumerator* argEnumerator)
 {
     if (String::Equals(_mode, SZ_CLOSEST, true))
-        gSpriteMode = 1;
+        gSpriteMode = IMPORT_MODE::CLOSEST;
     else if (String::Equals(_mode, SZ_DITHERING, true))
-        gSpriteMode = 2;
+        gSpriteMode = IMPORT_MODE::DITHERING;
     Memory::Free(_mode);
 
     const char** argv = const_cast<const char**>(argEnumerator->GetArguments()) + argEnumerator->GetIndex() - 1;

--- a/src/openrct2/drawing/ImageImporter.h
+++ b/src/openrct2/drawing/ImageImporter.h
@@ -41,16 +41,22 @@ namespace OpenRCT2::Drawing
         enum IMPORT_FLAGS
         {
             NONE = 0,
-            KEEP_PALETTE = 1 << 0,
             RLE = 1 << 1,
+        };
+
+        enum class PALETTE : uint8_t
+        {
+            OPENRCT2,
+            KEEP_INDICES,
         };
 
         ImportResult Import(
             const Image& image, int32_t srcX, int32_t srcY, int32_t width, int32_t height, int32_t offsetX, int32_t offsetY,
-            IMPORT_FLAGS flags = IMPORT_FLAGS::NONE, IMPORT_MODE mode = IMPORT_MODE::DEFAULT) const;
-        ImportResult Import(
-            const Image& image, int32_t offsetX = 0, int32_t offsetY = 0, IMPORT_FLAGS flags = IMPORT_FLAGS::NONE,
+            PALETTE palette = PALETTE::OPENRCT2, IMPORT_FLAGS flags = IMPORT_FLAGS::NONE,
             IMPORT_MODE mode = IMPORT_MODE::DEFAULT) const;
+        ImportResult Import(
+            const Image& image, int32_t offsetX = 0, int32_t offsetY = 0, PALETTE palette = PALETTE::OPENRCT2,
+            IMPORT_FLAGS flags = IMPORT_FLAGS::NONE, IMPORT_MODE mode = IMPORT_MODE::DEFAULT) const;
 
     private:
         enum class PaletteIndexType : uint8_t
@@ -64,7 +70,7 @@ namespace OpenRCT2::Drawing
 
         static std::vector<int32_t> GetPixels(
             const uint8_t* pixels, uint32_t pitch, uint32_t srcX, uint32_t srcY, uint32_t width, uint32_t height,
-            IMPORT_FLAGS flags, IMPORT_MODE mode);
+            PALETTE palette, IMPORT_FLAGS flags, IMPORT_MODE mode);
         static std::vector<uint8_t> EncodeRaw(const int32_t* pixels, uint32_t width, uint32_t height);
         static std::vector<uint8_t> EncodeRLE(const int32_t* pixels, uint32_t width, uint32_t height);
 

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -145,7 +145,8 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
             auto image = Imaging::ReadFromBuffer(imageData);
 
             ImageImporter importer;
-            auto importResult = importer.Import(image, 0, 0, ImageImporter::IMPORT_FLAGS::RLE);
+            auto importResult = importer.Import(
+                image, 0, 0, ImageImporter::PALETTE::OPENRCT2, ImageImporter::IMPORT_FLAGS::RLE);
 
             result.push_back(std::make_unique<RequiredImage>(importResult.Element));
         }
@@ -179,13 +180,14 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
     try
     {
         auto flags = ImageImporter::IMPORT_FLAGS::NONE;
+        auto palette = ImageImporter::PALETTE::OPENRCT2;
         if (!raw)
         {
             flags = static_cast<ImageImporter::IMPORT_FLAGS>(flags | ImageImporter::IMPORT_FLAGS::RLE);
         }
         if (keepPalette)
         {
-            flags = static_cast<ImageImporter::IMPORT_FLAGS>(flags | ImageImporter::IMPORT_FLAGS::KEEP_PALETTE);
+            palette = ImageImporter::PALETTE::KEEP_INDICES;
         }
 
         auto itSource = std::find_if(
@@ -204,7 +206,7 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
             srcHeight = image.Height;
 
         ImageImporter importer;
-        auto importResult = importer.Import(image, srcX, srcY, srcWidth, srcHeight, x, y, flags);
+        auto importResult = importer.Import(image, srcX, srcY, srcWidth, srcHeight, x, y, palette, flags);
         auto g1element = importResult.Element;
         g1element.zoomed_offset = zoomOffset;
         result.push_back(std::make_unique<RequiredImage>(g1element));

--- a/test/tests/ImageImporterTests.cpp
+++ b/test/tests/ImageImporterTests.cpp
@@ -41,7 +41,7 @@ TEST_F(ImageImporterTests, Import_Logo)
 
     ImageImporter importer;
     auto image = Imaging::ReadFromFile(logoPath, IMAGE_FORMAT::PNG_32);
-    auto result = importer.Import(image, 3, 5, ImageImporter::IMPORT_FLAGS::RLE);
+    auto result = importer.Import(image, 3, 5, ImageImporter::PALETTE::OPENRCT2, ImageImporter::IMPORT_FLAGS::RLE);
 
     ASSERT_EQ(result.Buffer.data(), result.Element.offset);
     ASSERT_EQ(128, result.Element.width);


### PR DESCRIPTION
This cleans up palette handling in sprite import and makes it much easier to add more (especially the green one that every other tool uses).