### PR TITLE
Closes #5141: Removes headless servers from player count and player list

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -52,6 +52,7 @@
 #include <openrct2/interface/InteractiveConsole.h>
 #include <openrct2/interface/Screenshot.h>
 #include <openrct2/localisation/Formatter.h>
+#include <openrct2/network/NetworkBase.h>
 #include <openrct2/network/network.h>
 #include <openrct2/paint/VirtualFloor.h>
 #include <openrct2/scenario/Scenario.h>
@@ -1000,8 +1001,10 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
         gfx_draw_sprite(dpi, ImageId(imgId), screenPos + ScreenCoordsXY{ 3, 11 });
 
         // Draw number of players.
+        auto playerCount = GetContext()->GetNetwork().CountVisiblePlayers();
+
         auto ft = Formatter();
-        ft.Add<int32_t>(network_get_num_players());
+        ft.Add<int32_t>(playerCount);
         DrawTextBasic(
             dpi, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft,
             { COLOUR_WHITE | COLOUR_FLAG_OUTLINE, TextAlignment::RIGHT });

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -25,6 +25,7 @@
 #include "localisation/Date.h"
 #include "localisation/Localisation.h"
 #include "management/NewsItem.h"
+#include "network/NetworkBase.h"
 #include "network/network.h"
 #include "platform/Platform2.h"
 #include "profiling/Profiling.h"
@@ -137,9 +138,9 @@ void GameState::Tick()
     if (network_get_mode() == NETWORK_MODE_SERVER && gConfigNetwork.pause_server_if_no_clients)
     {
         // If we are headless we always have 1 player (host), pause if no one else is around.
-        if (gOpenRCT2Headless && network_get_num_players() == 1)
+        if (gOpenRCT2Headless && GetContext()->GetNetwork().GetTotalPlayerCount() == 1)
         {
-            isPaused |= true;
+            isPaused = true;
         }
     }
 

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -41,6 +41,8 @@ public: // Common
     auto GetGroupIteratorByID(uint8_t id) const;
     NetworkPlayer* GetPlayerByID(uint8_t id) const;
     NetworkGroup* GetGroupByID(uint8_t id) const;
+    int32_t GetTotalPlayerCount() const;
+    int32_t CountVisiblePlayers() const;
     void SetPassword(u8string_view password);
     uint8_t GetDefaultGroup() const noexcept;
     std::string BeginLog(const std::string& directory, const std::string& midName, const std::string& filenameFormat);

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -11,6 +11,7 @@
 
 #    include "NetworkServerAdvertiser.h"
 
+#    include "../Context.h"
 #    include "../config/Config.h"
 #    include "../core/Console.hpp"
 #    include "../core/Guard.hpp"
@@ -25,6 +26,7 @@
 #    include "../util/Util.h"
 #    include "../world/Map.h"
 #    include "../world/Park.h"
+#    include "NetworkBase.h"
 #    include "Socket.h"
 #    include "network.h"
 
@@ -291,7 +293,7 @@ private:
 
     json_t GetHeartbeatJson()
     {
-        uint32_t numPlayers = network_get_num_players();
+        uint32_t numPlayers = OpenRCT2::GetContext()->GetNetwork().CountVisiblePlayers();
 
         json_t root = {
             { "token", _token },

--- a/src/openrct2/network/NetworkTypes.h
+++ b/src/openrct2/network/NetworkTypes.h
@@ -35,6 +35,9 @@ enum
 enum
 {
     NETWORK_PLAYER_FLAG_ISSERVER = 1 << 0,
+    NETWORK_PLAYER_FLAG_ISHIDDEN = 1 << 1,
+    // Hidden players are not shown on the player list (except in developer mode)
+    // and don't count towards the player limit.
 };
 
 enum


### PR DESCRIPTION
This pull request adds the flag `NETWORK_PLAYER_FLAG_ISHIDDEN` to remove headless servers from the player count in the server list. Hidden players are (normally) not visible in the player list and do not add to the player count (nor do they count towards the maximum amount of players). Although the code supports having any player as a hidden player, there is currently no way for any player other than a headless server to become hidden.

Hidden players can, however, be seen in the player list if the "debugging tools" option is enabled.

The main effect of this commit is that empty headless servers will have a player count of 0 instead of 1.