### PR TITLE
Fix Recent Messages only shows at most 6 or 7 notifications once opened

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -182,6 +182,7 @@ The following people are not part of the development team, but have been contrib
 * Christian Haase (chrhaase)
 * Cory Sanin (CorySanin)
 * Vinícius Hashimoto (vkhashimoto)
+* Gal B. (GalBr)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Change: [#16493] Boat Hire and Submarine Ride support costs now match their visual appearance.
 - Fix: [#13336] Can no longer place Bumble Bee track design (reverts #12707).
 - Fix: [#14155] Map Generator sometimes places non-tree objects as trees.
+- Fix: [#14674] Recent Messages only shows first few notifications.
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#15830] Objects with RCT1 images are very glitchy if OpenRCT2 is not linked to an RCT1 install.
 - Fix: [#15947, #15960] Removing a flat ride results in an error message and duplicate structures.

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -42,6 +42,8 @@ static rct_widget window_news_widgets[] = {
     WIDGETS_END,
 };
 
+// clang-format on
+
 class NewsWindow final : public Window
 {
 private:
@@ -190,7 +192,8 @@ public:
 
             // Background
             gfx_fill_rect_inset(
-                &dpi, { -1, y, 383, y + itemHeight - 1 }, colours[1], (INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_GREY));
+                &dpi, { -1, y, 383, y + itemHeight - 1 }, colours[1],
+                (INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_GREY));
 
             // Date text
             {
@@ -218,7 +221,6 @@ public:
                     {
                         press = INSET_RECT_FLAG_BORDER_INSET;
                     }
-
                 }
                 gfx_fill_rect_inset(&dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
 

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -120,8 +120,8 @@ public:
 
     ScreenSize OnScrollGetSize(int32_t scrollIndex) override
     {
-        static int32_t _scrollHeight = static_cast<int32_t>(gNewsItems.GetArchived().size()) * CalculateItemHeight();
-        return {WW, _scrollHeight};
+        int32_t scrollHeight = static_cast<int32_t>(gNewsItems.GetArchived().size()) * CalculateItemHeight();
+        return { WW, scrollHeight };
     }
 
     void OnScrollMouseDown(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override


### PR DESCRIPTION
Fixes #14674
_scrollHeight was a static variable,  causing it to always have the value 0. Honestly I'm not sure why that happened.
This commit fixes this issue by changing this variable to not be static.