### PR TITLE
Fix more crashes related to paths

### DIFF
--- a/src/openrct2-ui/input/ShortcutManager.cpp
+++ b/src/openrct2-ui/input/ShortcutManager.cpp
@@ -283,7 +283,7 @@ void ShortcutManager::LoadLegacyBindings(const fs::path& path)
 
 void ShortcutManager::LoadUserBindings(const fs::path& path)
 {
-    auto root = Json::ReadFromFile(path);
+    auto root = Json::ReadFromFile(path.u8string());
     if (root.is_object())
     {
         for (auto it = root.begin(); it != root.end(); ++it)
@@ -329,7 +329,7 @@ void ShortcutManager::SaveUserBindings(const fs::path& path)
     json_t root;
     if (fs::exists(path))
     {
-        root = Json::ReadFromFile(path);
+        root = Json::ReadFromFile(path.u8string());
     }
 
     for (const auto& shortcut : Shortcuts)
@@ -349,7 +349,7 @@ void ShortcutManager::SaveUserBindings(const fs::path& path)
         }
     }
 
-    Json::WriteToFile(path, root);
+    Json::WriteToFile(path.u8string(), root);
 }
 
 std::string_view ShortcutManager::GetLegacyShortcutId(size_t index)

--- a/src/openrct2/core/Json.cpp
+++ b/src/openrct2/core/Json.cpp
@@ -15,7 +15,7 @@
 
 namespace Json
 {
-    json_t ReadFromFile(const utf8* path, size_t maxSize)
+    json_t ReadFromFile(u8string_view path, size_t maxSize)
     {
         auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_OPEN);
 
@@ -36,19 +36,14 @@ namespace Json
         }
         catch (const json_t::exception& e)
         {
-            throw JsonException(String::Format("Unable to parse JSON file (%s)\n\t%s", path, e.what()));
+            throw JsonException(String::StdFormat(
+                "Unable to parse JSON file (%.*s)\n\t%s", static_cast<int>(path.length()), path.data(), e.what()));
         }
 
         return json;
     }
 
-    json_t ReadFromFile(const fs::path& path, size_t maxSize)
-    {
-        auto path8 = path.u8string();
-        return ReadFromFile(path8.c_str(), maxSize);
-    }
-
-    void WriteToFile(const utf8* path, const json_t& jsonData, int indentSize)
+    void WriteToFile(u8string_view path, const json_t& jsonData, int indentSize)
     {
         // Serialise JSON
         std::string jsonOutput = jsonData.dump(indentSize);
@@ -56,12 +51,6 @@ namespace Json
         // Write to file
         auto fs = OpenRCT2::FileStream(path, OpenRCT2::FILE_MODE_WRITE);
         fs.Write(jsonOutput.data(), jsonOutput.size());
-    }
-
-    void WriteToFile(const fs::path& path, const json_t& jsonData, int indentSize)
-    {
-        auto path8 = path.u8string();
-        WriteToFile(path8.c_str(), jsonData, indentSize);
     }
 
     json_t FromString(std::string_view raw)
@@ -74,7 +63,7 @@ namespace Json
         }
         catch (const json_t::exception& e)
         {
-            log_error("Unable to parse JSON string (%s)\n\t%s", raw, e.what());
+            log_error("Unable to parse JSON string (%.*s)\n\t%s", static_cast<int>(raw.length()), raw.data(), e.what());
         }
 
         return json;
@@ -90,7 +79,7 @@ namespace Json
         }
         catch (const json_t::exception& e)
         {
-            log_error("Unable to parse JSON vector (%s)\n\t%s", vec.data(), e.what());
+            log_error("Unable to parse JSON vector (%.*s)\n\t%s", static_cast<int>(vec.size()), vec.data(), e.what());
         }
 
         return json;

--- a/src/openrct2/core/Json.hpp
+++ b/src/openrct2/core/Json.hpp
@@ -11,7 +11,6 @@
 
 #include "../common.h"
 #include "../core/String.hpp"
-#include "FileSystem.hpp"
 
 #include <nlohmann/json.hpp>
 #include <string>
@@ -35,8 +34,7 @@ namespace Json
      * @return A JSON representation of the file
      * @note This function will throw an exception if the JSON file cannot be parsed
      */
-    json_t ReadFromFile(const utf8* path, size_t maxSize = MAX_JSON_SIZE);
-    json_t ReadFromFile(const fs::path& path, size_t maxSize = MAX_JSON_SIZE);
+    json_t ReadFromFile(u8string_view path, size_t maxSize = MAX_JSON_SIZE);
 
     /**
      * Read JSON file and parse the contents
@@ -44,8 +42,7 @@ namespace Json
      * @param jsonData A JSON object
      * @param indentSize The number of spaces in an indent, or removes whitespace on -1
      */
-    void WriteToFile(const utf8* path, const json_t& jsonData, int indentSize = 4);
-    void WriteToFile(const fs::path& path, const json_t& jsonData, int indentSize = 4);
+    void WriteToFile(u8string_view path, const json_t& jsonData, int indentSize = 4);
 
     /**
      * Parse JSON from a string


### PR DESCRIPTION
1. Fixes a crash in WindowLoadsaveOpen when last_game_directory is empty. A bug in `WindowLoadsaveGetDir` left an output variable uninitialized if `last_game_directory` was empty. In Release this usually worked "fine" (by sheer luck), but in Debug it resulted in a 100% crash on converting a poisoned path variable from UTF-8 to wide chars.

Fixes #16569
Fixes #16574
Fixes #16583
Fixes #16604
Fixes #16607
Fixes #16610
Fixes #16629

2. Fixes crashes in `NetworkUserManager` functions caused by an incorrect implicit typecast of `u8string` (which is a `std::string` in disguise until C++20) to wide char. I took this opportunity to refactor the offending `Json` functions to accept `u8string` arguments instead of `fs::path`, avoiding an implicit typecast.

Fixes #15575
Fixes #16615
Fixes #16584
Fixes #16585