### PR TITLE
Turn GeneralConfiguration::rct1_path into an u8string

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2027,14 +2027,13 @@ private:
                 if (!rct1path.empty())
                 {
                     // Check if this directory actually contains RCT1
-                    if (Csg1datPresentAtLocation(rct1path.c_str()))
+                    if (Csg1datPresentAtLocation(rct1path))
                     {
-                        if (Csg1idatPresentAtLocation(rct1path.c_str()))
+                        if (Csg1idatPresentAtLocation(rct1path))
                         {
-                            if (CsgAtLocationIsUsable(rct1path.c_str()))
+                            if (CsgAtLocationIsUsable(rct1path))
                             {
-                                SafeFree(gConfigGeneral.rct1_path);
-                                gConfigGeneral.rct1_path = String::Duplicate(rct1path.c_str());
+                                gConfigGeneral.rct1_path = std::move(rct1path);
                                 gConfigInterface.scenarioselect_last_tab = 0;
                                 config_save_default();
                                 context_show_error(STR_RESTART_REQUIRED, STR_NONE, {});
@@ -2058,9 +2057,9 @@ private:
                 break;
             }
             case WIDX_PATH_TO_RCT1_CLEAR:
-                if (!str_is_null_or_empty(gConfigGeneral.rct1_path))
+                if (!gConfigGeneral.rct1_path.empty())
                 {
-                    SafeFree(gConfigGeneral.rct1_path);
+                    gConfigGeneral.rct1_path.clear();
                     config_save_default();
                 }
                 Invalidate();
@@ -2146,9 +2145,8 @@ private:
             STR_WINDOW_OBJECTIVE_VALUE_GUEST_COUNT, ft, { colours[1] });
 
         const auto normalisedPath = Platform::StrDecompToPrecomp(gConfigGeneral.rct1_path);
-        const auto* normalisedPathC = normalisedPath.c_str();
         ft = Formatter();
-        ft.Add<const utf8*>(normalisedPathC);
+        ft.Add<const utf8*>(normalisedPath.c_str());
 
         rct_widget pathWidget = widgets[WIDX_PATH_TO_RCT1_BUTTON];
 
@@ -2165,14 +2163,14 @@ private:
     {
         if (widgetIndex == WIDX_PATH_TO_RCT1_BUTTON)
         {
-            if (str_is_null_or_empty(gConfigGeneral.rct1_path))
+            if (gConfigGeneral.rct1_path.empty())
             {
                 // No tooltip if the path is empty
                 return { STR_NONE, {} };
             }
 
             auto ft = Formatter();
-            ft.Add<utf8*>(gConfigGeneral.rct1_path);
+            ft.Add<utf8*>(gConfigGeneral.rct1_path.c_str());
             return { fallback, ft };
         }
         return { fallback, {} };

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -170,7 +170,7 @@ std::unique_ptr<IPlatformEnvironment> OpenRCT2::CreatePlatformEnvironment()
     }
     if (gCustomRCT1DataPath.empty())
     {
-        env->SetBasePath(DIRBASE::RCT1, String::ToStd(gConfigGeneral.rct1_path));
+        env->SetBasePath(DIRBASE::RCT1, gConfigGeneral.rct1_path);
     }
     if (gCustomRCT2DataPath.empty())
     {

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -153,7 +153,7 @@ namespace Config
             model->fullscreen_mode = reader->GetInt32("fullscreen_mode", 0);
             model->fullscreen_height = reader->GetInt32("fullscreen_height", -1);
             model->fullscreen_width = reader->GetInt32("fullscreen_width", -1);
-            model->rct1_path = reader->GetCString("rct1_path", nullptr);
+            model->rct1_path = reader->GetString("rct1_path", "");
             model->rct2_path = reader->GetString("game_path", "");
             model->landscape_smoothing = reader->GetBoolean("landscape_smoothing", true);
             model->language = reader->GetEnum<int32_t>("language", Platform::GetLocaleLanguage(), Enum_LanguageEnum);
@@ -782,7 +782,6 @@ bool config_save(u8string_view path)
 
 void config_release()
 {
-    SafeFree(gConfigGeneral.rct1_path);
     SafeFree(gConfigGeneral.custom_currency_symbol);
     SafeFree(gConfigGeneral.last_save_game_directory);
     SafeFree(gConfigGeneral.last_save_landscape_directory);
@@ -924,8 +923,7 @@ bool config_find_or_browse_install_directory()
     std::string rct1Path = Config::FindRCT1Path();
     if (!rct1Path.empty())
     {
-        free(gConfigGeneral.rct1_path);
-        gConfigGeneral.rct1_path = String::Duplicate(rct1Path);
+        gConfigGeneral.rct1_path = std::move(rct1Path);
     }
 
     return true;

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -26,8 +26,8 @@ enum class DrawingEngine : int32_t;
 struct GeneralConfiguration
 {
     // Paths
-    utf8* rct1_path;
-    std::string rct2_path;
+    u8string rct1_path;
+    u8string rct2_path;
 
     // Display
     int32_t default_display;

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -307,7 +307,7 @@ bool gfx_load_csg()
 {
     log_verbose("gfx_load_csg()");
 
-    if (str_is_null_or_empty(gConfigGeneral.rct1_path))
+    if (gConfigGeneral.rct1_path.empty())
     {
         log_verbose("  unable to load CSG, RCT1 path not set");
         return false;


### PR DESCRIPTION
Fixes a crash when opening Advanced Options on the first launch.

While this is a refactor fixing the issue, it's technically a regression introduced by #16599 - a null `rct1_path` would crash the refactored function.

Fixes #16609
Fixes #16618
Fixes #16622