### PR TITLE
Remove custom window widget limit

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1207,7 +1207,7 @@ void InputStateWidgetPressed(
                 || widgetIndex != cursor_widgetIndex)
                 break;
 
-            if (w->disabled_widgets & (1ULL << widgetIndex))
+            if (WidgetIsDisabled(w, widgetIndex))
                 break;
 
             if (_clickRepeatTicks != 0)
@@ -1217,7 +1217,7 @@ void InputStateWidgetPressed(
                 // Handle click repeat
                 if (_clickRepeatTicks >= 16 && (_clickRepeatTicks & 3) == 0)
                 {
-                    if (w->hold_down_widgets & (1ULL << widgetIndex))
+                    if (WidgetIsHoldable(w, widgetIndex))
                     {
                         window_event_mouse_down_call(w, widgetIndex);
                     }
@@ -1334,7 +1334,7 @@ void InputStateWidgetPressed(
             if (cursor_w_class != w->classification || cursor_w_number != w->number || widgetIndex != cursor_widgetIndex)
                 break;
 
-            if (w->disabled_widgets & (1ULL << widgetIndex))
+            if (WidgetIsDisabled(w, widgetIndex))
                 break;
 
             widget_invalidate_by_number(cursor_w_class, cursor_w_number, widgetIndex);

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -841,11 +841,15 @@ static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetind
 
 bool WidgetIsDisabled(rct_window* w, rct_widgetindex widgetIndex)
 {
+    if (w->classification == WC_CUSTOM)
+        return w->widgets[widgetIndex].flags & WIDGET_FLAGS::IS_DISABLED;
     return (w->disabled_widgets & (1LL << widgetIndex)) != 0;
 }
 
 bool WidgetIsHoldable(rct_window* w, rct_widgetindex widgetIndex)
 {
+    if (w->classification == WC_CUSTOM)
+        return w->widgets[widgetIndex].flags & WIDGET_FLAGS::IS_HOLDABLE;
     return (w->hold_down_widgets & (1LL << widgetIndex)) != 0;
 }
 
@@ -856,10 +860,21 @@ bool WidgetIsVisible(rct_window* w, rct_widgetindex widgetIndex)
 
 bool WidgetIsPressed(rct_window* w, rct_widgetindex widgetIndex)
 {
-    if (w->pressed_widgets & (1LL << widgetIndex))
+    if (w->classification == WC_CUSTOM)
     {
-        return true;
+        if (w->widgets[widgetIndex].flags & WIDGET_FLAGS::IS_PRESSED)
+        {
+            return true;
+        }
     }
+    else
+    {
+        if (w->pressed_widgets & (1LL << widgetIndex))
+        {
+            return true;
+        }
+    }
+
     if (input_get_state() == InputState::WidgetPressed || input_get_state() == InputState::DropdownActive)
     {
         if (!(input_test_flag(INPUT_FLAG_WIDGET_PRESSED)))

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -719,28 +719,22 @@ void Window::InvalidateWidget(rct_widgetindex widgetIndex)
 
 bool Window::IsWidgetDisabled(rct_widgetindex widgetIndex) const
 {
-    return (disabled_widgets & (1LL << widgetIndex)) != 0;
+    return WidgetIsDisabled(this, widgetIndex);
 }
 
 bool Window::IsWidgetPressed(rct_widgetindex widgetIndex) const
 {
-    return (pressed_widgets & (1LL << widgetIndex)) != 0;
+    return WidgetIsPressed(this, widgetIndex);
 }
 
 void Window::SetWidgetDisabled(rct_widgetindex widgetIndex, bool value)
 {
-    if (value)
-        disabled_widgets |= (1ULL << widgetIndex);
-    else
-        disabled_widgets &= ~(1ULL << widgetIndex);
+    WidgetSetDisabled(this, widgetIndex, value);
 }
 
 void Window::SetWidgetPressed(rct_widgetindex widgetIndex, bool value)
 {
-    if (value)
-        pressed_widgets |= (1ULL << widgetIndex);
-    else
-        pressed_widgets &= ~(1ULL << widgetIndex);
+    WidgetSetPressed(this, widgetIndex, value);
 }
 
 void Window::SetCheckboxValue(rct_widgetindex widgetIndex, bool value)
@@ -763,4 +757,21 @@ void Window::TextInputOpen(
     rct_string_id existingText, uintptr_t existingArgs, int32_t maxLength)
 {
     WindowTextInputOpen(this, callWidget, title, description, descriptionArgs, existingText, existingArgs, maxLength);
+}
+
+void window_align_tabs(rct_window* w, rct_widgetindex start_tab_id, rct_widgetindex end_tab_id)
+{
+    int32_t i, x = w->widgets[start_tab_id].left;
+    int32_t tab_width = w->widgets[start_tab_id].width();
+
+    for (i = start_tab_id; i <= end_tab_id; i++)
+    {
+        if (!WidgetIsDisabled(w, i))
+        {
+            auto& widget = w->widgets[i];
+            widget.left = x;
+            widget.right = x + tab_width;
+            x += tab_width + 1;
+        }
+    }
 }

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -34,3 +34,4 @@ struct Window : rct_window
 
 void WindowAllWheelInput();
 void ApplyScreenSaverLockSetting();
+void window_align_tabs(rct_window* w, rct_widgetindex start_tab_id, rct_widgetindex end_tab_id);

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -913,7 +913,6 @@ namespace OpenRCT2::Ui::Windows
             }
 
             // Add custom widgets
-            auto firstCustomWidgetIndex = widgetList.size();
             auto totalWidgets = info.Desc.Widgets.size();
             auto tabWidgetsOffset = totalWidgets;
             if (info.Desc.Tabs.size() != 0)
@@ -946,24 +945,6 @@ namespace OpenRCT2::Ui::Windows
                     listView.OnHighlight = widgetDesc.OnHighlight;
                     listView.CanSelect = widgetDesc.CanSelect;
                     info.ListViews.push_back(std::move(listView));
-                }
-            }
-
-            for (size_t i = firstCustomWidgetIndex; i < widgetList.size(); i++)
-            {
-                auto mask = 1ULL << i;
-                auto widgetFlags = widgetList[i].flags;
-                if (widgetFlags & WIDGET_FLAGS::IS_PRESSED)
-                {
-                    pressed_widgets |= mask;
-                }
-                if (widgetFlags & WIDGET_FLAGS::IS_DISABLED)
-                {
-                    disabled_widgets |= mask;
-                }
-                if (widgetFlags & WIDGET_FLAGS::IS_HOLDABLE)
-                {
-                    hold_down_widgets |= mask;
                 }
             }
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -308,7 +308,7 @@ public:
 
         for (rct_widgetindex i = WIDX_FILTER_RIDE_TAB_TRANSPORT; i <= WIDX_FILTER_RIDE_TAB_STALL; i++)
         {
-            if (!(pressed_widgets & (1ULL << i)))
+            if (!IsWidgetPressed(i))
                 continue;
 
             frame_no++;
@@ -959,7 +959,7 @@ public:
 
                 int32_t spriteIndex = ride_tabs[i];
                 int32_t frame = 0;
-                if (i != 0 && pressed_widgets & (1ULL << (WIDX_FILTER_RIDE_TAB_ALL + i)))
+                if (i != 0 && IsWidgetPressed(WIDX_FILTER_RIDE_TAB_ALL + i))
                 {
                     frame = frame_no / window_editor_object_selection_animation_divisor[i - 1];
                 }

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -249,7 +249,7 @@ static void WindowEditorObjectiveOptionsDrawTabImages(rct_window* w, rct_drawpix
     gfx_draw_sprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget->left, widget->top });
 
     // Tab 2
-    if (!(w->disabled_widgets & (1ULL << WIDX_TAB_2)))
+    if (!WidgetIsDisabled(w, WIDX_TAB_2))
     {
         widget = &w->widgets[WIDX_TAB_2];
         spriteIndex = SPR_TAB_RIDE_0;

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -1313,7 +1313,7 @@ static void WindowFinancesDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, in
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + page;
 
-    if (!(w->disabled_widgets & (1LL << widgetIndex)))
+    if (!WidgetIsDisabled(w, widgetIndex))
     {
         if (w->page == page)
         {

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -640,7 +640,7 @@ static void WindowFootpathPaint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
     WindowFootpathDrawDropdownButtons(w, dpi);
 
-    if (!(w->disabled_widgets & (1ULL << WIDX_CONSTRUCT)))
+    if (!WidgetIsDisabled(w, WIDX_CONSTRUCT))
     {
         // Get construction image
         uint8_t direction = (_footpathConstructDirection + get_current_rotation()) % 4;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -366,7 +366,7 @@ static void WindowGuestCommonResize(rct_window* w)
     // Ensure min size is large enough for all tabs to fit
     for (int32_t i = WIDX_TAB_1; i <= WIDX_TAB_7; i++)
     {
-        if (!(w->disabled_widgets & (1ULL << i)))
+        if (!WidgetIsDisabled(w, i))
         {
             minWidth = std::max(minWidth, w->widgets[i].right + 3);
         }
@@ -421,13 +421,13 @@ void WindowGuestDisableWidgets(rct_window* w)
 
     if (peep->CanBePickedUp())
     {
-        if (w->disabled_widgets & (1ULL << WIDX_PICKUP))
+        if (WidgetIsDisabled(w, WIDX_PICKUP))
             w->Invalidate();
     }
     else
     {
         disabled_widgets = (1ULL << WIDX_PICKUP);
-        if (!(w->disabled_widgets & (1ULL << WIDX_PICKUP)))
+        if (!WidgetIsDisabled(w, WIDX_PICKUP))
             w->Invalidate();
     }
     if (gParkFlags & PARK_FLAGS_NO_MONEY)
@@ -694,7 +694,7 @@ void WindowGuestViewportInit(rct_window* w)
  */
 static void WindowGuestOverviewTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    if (w->disabled_widgets & (1ULL << WIDX_TAB_1))
+    if (WidgetIsDisabled(w, WIDX_TAB_1))
         return;
 
     const auto& widget = w->widgets[WIDX_TAB_1];
@@ -766,7 +766,7 @@ static void WindowGuestOverviewTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void WindowGuestStatsTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    if (w->disabled_widgets & (1ULL << WIDX_TAB_2))
+    if (WidgetIsDisabled(w, WIDX_TAB_2))
         return;
 
     const auto& widget = w->widgets[WIDX_TAB_2];
@@ -804,7 +804,7 @@ static void WindowGuestStatsTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void WindowGuestRidesTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    if (w->disabled_widgets & (1ULL << WIDX_TAB_3))
+    if (WidgetIsDisabled(w, WIDX_TAB_3))
         return;
 
     const auto& widget = w->widgets[WIDX_TAB_3];
@@ -826,7 +826,7 @@ static void WindowGuestRidesTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void WindowGuestFinanceTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    if (w->disabled_widgets & (1ULL << WIDX_TAB_4))
+    if (WidgetIsDisabled(w, WIDX_TAB_4))
         return;
 
     const auto& widget = w->widgets[WIDX_TAB_4];
@@ -848,7 +848,7 @@ static void WindowGuestFinanceTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void WindowGuestThoughtsTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    if (w->disabled_widgets & (1ULL << WIDX_TAB_5))
+    if (WidgetIsDisabled(w, WIDX_TAB_5))
         return;
 
     const auto& widget = w->widgets[WIDX_TAB_5];
@@ -870,7 +870,7 @@ static void WindowGuestThoughtsTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 static void WindowGuestInventoryTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    if (w->disabled_widgets & (1ULL << WIDX_TAB_6))
+    if (WidgetIsDisabled(w, WIDX_TAB_6))
         return;
 
     const auto& widget = w->widgets[WIDX_TAB_6];
@@ -881,7 +881,7 @@ static void WindowGuestInventoryTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 
 static void WindowGuestDebugTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    if (w->disabled_widgets & (1ULL << WIDX_TAB_7))
+    if (WidgetIsDisabled(w, WIDX_TAB_7))
         return;
 
     const auto& widget = w->widgets[WIDX_TAB_7];

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -1279,7 +1279,7 @@ static void WindowMapgenDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int3
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + page;
 
-    if (!(w->disabled_widgets & (1LL << widgetIndex)))
+    if (!WidgetIsDisabled(w, widgetIndex))
     {
         if (w->page == page)
         {

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -611,7 +611,7 @@ static void WindowNewRideDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + page;
 
-    if (w->widgets[widgetIndex].type != WindowWidgetType::Empty && !(w->disabled_widgets & (1LL << widgetIndex)))
+    if (w->widgets[widgetIndex].type != WindowWidgetType::Empty && !WidgetIsDisabled(w, widgetIndex))
     {
         int32_t frame = 0;
         if (_windowNewRideCurrentTab == page)

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -229,7 +229,7 @@ private:
     {
         rct_widgetindex widgetIndex = WIDX_FIRST_TAB + p;
 
-        if (!(disabled_widgets & (1LL << widgetIndex)))
+        if (!WidgetIsDisabled(this, widgetIndex))
         {
             if (page == p)
             {

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2103,7 +2103,7 @@ private:
 
         auto screenCoords = windowPos + ScreenCoordsXY{ widget->left, widget->top };
 
-        if (!(disabled_widgets & (1LL << widgetIndex)))
+        if (!WidgetIsDisabled(this, widgetIndex))
         {
             if (page == p)
             {

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1608,13 +1608,15 @@ static void WindowParkDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
     int32_t sprite_idx;
 
     // Entrance tab
-    if (!(w->disabled_widgets & (1ULL << WIDX_TAB_1)))
+    if (!WidgetIsDisabled(w, WIDX_TAB_1))
+    {
         gfx_draw_sprite(
             dpi, ImageId(SPR_TAB_PARK_ENTRANCE),
             w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_TAB_1].left, w->widgets[WIDX_TAB_1].top });
+    }
 
     // Rating tab
-    if (!(w->disabled_widgets & (1ULL << WIDX_TAB_2)))
+    if (!WidgetIsDisabled(w, WIDX_TAB_2))
     {
         sprite_idx = SPR_TAB_GRAPH_0;
         if (w->page == WINDOW_PARK_PAGE_RATING)
@@ -1630,7 +1632,7 @@ static void WindowParkDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
     }
 
     // Guests tab
-    if (!(w->disabled_widgets & (1ULL << WIDX_TAB_3)))
+    if (!WidgetIsDisabled(w, WIDX_TAB_3))
     {
         sprite_idx = SPR_TAB_GRAPH_0;
         if (w->page == WINDOW_PARK_PAGE_GUESTS)
@@ -1649,7 +1651,7 @@ static void WindowParkDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
     }
 
     // Price tab
-    if (!(w->disabled_widgets & (1ULL << WIDX_TAB_4)))
+    if (!WidgetIsDisabled(w, WIDX_TAB_4))
     {
         sprite_idx = SPR_TAB_ADMISSION_0;
         if (w->page == WINDOW_PARK_PAGE_PRICE)
@@ -1659,7 +1661,7 @@ static void WindowParkDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
     }
 
     // Statistics tab
-    if (!(w->disabled_widgets & (1ULL << WIDX_TAB_5)))
+    if (!WidgetIsDisabled(w, WIDX_TAB_5))
     {
         sprite_idx = SPR_TAB_STATS_0;
         if (w->page == WINDOW_PARK_PAGE_STATS)
@@ -1669,7 +1671,7 @@ static void WindowParkDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
     }
 
     // Objective tab
-    if (!(w->disabled_widgets & (1ULL << WIDX_TAB_6)))
+    if (!WidgetIsDisabled(w, WIDX_TAB_6))
     {
         sprite_idx = SPR_TAB_OBJECTIVE_0;
         if (w->page == WINDOW_PARK_PAGE_OBJECTIVE)
@@ -1679,10 +1681,12 @@ static void WindowParkDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
     }
 
     // Awards tab
-    if (!(w->disabled_widgets & (1ULL << WIDX_TAB_7)))
+    if (!WidgetIsDisabled(w, WIDX_TAB_7))
+    {
         gfx_draw_sprite(
             dpi, ImageId(SPR_TAB_AWARDS),
             w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_TAB_7].left, w->widgets[WIDX_TAB_7].top });
+    }
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -600,7 +600,7 @@ static void WindowResearchDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, in
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + page;
 
-    if (!(w->disabled_widgets & (1LL << widgetIndex)))
+    if (!WidgetIsDisabled(w, widgetIndex))
     {
         if (w->page == page)
         {

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -831,7 +831,7 @@ static void WindowRideDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int32_
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + page;
 
-    if (!(w->disabled_widgets & (1LL << widgetIndex)))
+    if (!WidgetIsDisabled(w, widgetIndex))
     {
         if (w->page == page)
         {
@@ -851,7 +851,7 @@ static void WindowRideDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int32_
 static void WindowRideDrawTabMain(rct_drawpixelinfo* dpi, rct_window* w)
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + WINDOW_RIDE_PAGE_MAIN;
-    if (!(w->disabled_widgets & (1LL << widgetIndex)))
+    if (!WidgetIsDisabled(w, widgetIndex))
     {
         auto ride = get_ride(w->rideId);
         if (ride != nullptr)
@@ -891,7 +891,7 @@ static void WindowRideDrawTabVehicle(rct_drawpixelinfo* dpi, rct_window* w)
     rct_widgetindex widgetIndex = WIDX_TAB_1 + WINDOW_RIDE_PAGE_VEHICLE;
     const auto& widget = w->widgets[widgetIndex];
 
-    if (!(w->disabled_widgets & (1LL << widgetIndex)))
+    if (!WidgetIsDisabled(w, widgetIndex))
     {
         auto screenCoords = ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
         int32_t width = widget.right - screenCoords.x;
@@ -961,7 +961,7 @@ static void WindowRideDrawTabCustomer(rct_drawpixelinfo* dpi, rct_window* w)
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + WINDOW_RIDE_PAGE_CUSTOMER;
 
-    if (!(w->disabled_widgets & (1LL << widgetIndex)))
+    if (!WidgetIsDisabled(w, widgetIndex))
     {
         const auto& widget = w->widgets[widgetIndex];
         int32_t spriteIndex = 0;

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -290,13 +290,13 @@ void WindowStaffDisableWidgets(rct_window* w)
     {
         if (peep->CanBePickedUp())
         {
-            if (w->disabled_widgets & (1ULL << WIDX_PICKUP))
+            if (WidgetIsDisabled(w, WIDX_PICKUP))
                 w->Invalidate();
         }
         else
         {
             disabled_widgets |= (1ULL << WIDX_PICKUP);
-            if (!(w->disabled_widgets & (1ULL << WIDX_PICKUP)))
+            if (!WidgetIsDisabled(w, WIDX_PICKUP))
                 w->Invalidate();
         }
     }
@@ -950,7 +950,7 @@ void WindowStaffOverviewPaint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 void WindowStaffOptionsTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    if (w->disabled_widgets & (1ULL << WIDX_TAB_2))
+    if (WidgetIsDisabled(w, WIDX_TAB_2))
         return;
 
     int32_t image_id = SPR_TAB_STAFF_OPTIONS_0;
@@ -970,7 +970,7 @@ void WindowStaffOptionsTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 void WindowStaffStatsTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    if (w->disabled_widgets & (1ULL << WIDX_TAB_3))
+    if (WidgetIsDisabled(w, WIDX_TAB_3))
         return;
 
     int32_t image_id = SPR_TAB_STATS_0;
@@ -989,7 +989,7 @@ void WindowStaffStatsTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
  */
 void WindowStaffOverviewTabPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    if (w->disabled_widgets & (1ULL << WIDX_TAB_1))
+    if (WidgetIsDisabled(w, WIDX_TAB_1))
         return;
 
     const auto& widget = w->widgets[WIDX_TAB_1];

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -126,12 +126,12 @@ constexpr rct_widget MakeSpinnerIncreaseWidget(
 void WidgetScrollUpdateThumbs(rct_window* w, rct_widgetindex widget_index);
 void WidgetDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
 
-bool WidgetIsDisabled(rct_window* w, rct_widgetindex widgetIndex);
-bool WidgetIsHoldable(rct_window* w, rct_widgetindex widgetIndex);
-bool WidgetIsVisible(rct_window* w, rct_widgetindex widgetIndex);
-bool WidgetIsPressed(rct_window* w, rct_widgetindex widgetIndex);
-bool WidgetIsHighlighted(rct_window* w, rct_widgetindex widgetIndex);
-bool WidgetIsActiveTool(rct_window* w, rct_widgetindex widgetIndex);
+bool WidgetIsDisabled(const rct_window* w, rct_widgetindex widgetIndex);
+bool WidgetIsHoldable(const rct_window* w, rct_widgetindex widgetIndex);
+bool WidgetIsVisible(const rct_window* w, rct_widgetindex widgetIndex);
+bool WidgetIsPressed(const rct_window* w, rct_widgetindex widgetIndex);
+bool WidgetIsHighlighted(const rct_window* w, rct_widgetindex widgetIndex);
+bool WidgetIsActiveTool(const rct_window* w, rct_widgetindex widgetIndex);
 void WidgetScrollGetPart(
     rct_window* w, const rct_widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
     int32_t* output_scroll_area, int32_t* scroll_id);
@@ -140,4 +140,5 @@ void WidgetSetEnabled(rct_window* w, rct_widgetindex widgetIndex, bool enabled);
 void WidgetSetDisabled(rct_window* w, rct_widgetindex widgetIndex, bool value);
 void WidgetSetHoldable(rct_window* w, rct_widgetindex widgetIndex, bool value);
 void WidgetSetVisible(rct_window* w, rct_widgetindex widgetIndex, bool value);
-void WidgetSetCheckboxValue(rct_window* w, rct_widgetindex widgetIndex, int32_t value);
+void WidgetSetPressed(rct_window* w, rct_widgetindex widgetIndex, bool value);
+void WidgetSetCheckboxValue(rct_window* w, rct_widgetindex widgetIndex, bool value);

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1748,24 +1748,6 @@ void window_resize_gui_scenario_editor(int32_t width, int32_t height)
     }
 }
 
-/* Based on rct2: 0x6987ED and another version from window_park */
-void window_align_tabs(rct_window* w, rct_widgetindex start_tab_id, rct_widgetindex end_tab_id)
-{
-    int32_t i, x = w->widgets[start_tab_id].left;
-    int32_t tab_width = w->widgets[start_tab_id].width();
-
-    for (i = start_tab_id; i <= end_tab_id; i++)
-    {
-        if (!(w->disabled_widgets & (1LL << i)))
-        {
-            auto& widget = w->widgets[i];
-            widget.left = x;
-            widget.right = x + tab_width;
-            x += tab_width + 1;
-        }
-    }
-}
-
 /**
  *
  *  rct2: 0x006CBCC3

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -777,8 +777,6 @@ void ride_construction_toolupdate_entrance_exit(const ScreenCoordsXY& screenCoor
 void ride_construction_toolupdate_construct(const ScreenCoordsXY& screenCoords);
 void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords);
 
-void window_align_tabs(rct_window* w, rct_widgetindex start_tab_id, rct_widgetindex end_tab_id);
-
 void window_staff_list_init_vars();
 
 void window_event_close_call(rct_window* w);


### PR DESCRIPTION
`enabled_widgets` was used to enable input for widgets. However I do not recall anywhere this being used to specifically disable a widget which doesn't use the dedicated `disabled_widgets` flag. I don't think there is any purpose in keeping this, so I have removed all uses of it.

As for the other widget flags: `disabled_widgets`, `holdable_widgets`, and `pressed_widgets`, for custom windows these are not used and instead the flags field on `rct_widget` is used. Hopefully all built in windows will move to doing it this way in due course.

I havent' yet removed all the occurances of `enabled_widgets` as that will be a very large diff, but I can do it if desired in this PR.