### PR TITLE
Create Dropdown::Item and use it for gDropdownItems

### DIFF
--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1253,7 +1253,7 @@ void InputStateWidgetPressed(
                         dropdown_index = DropdownIndexFromPoint(screenCoords, w);
                         dropdownCleanup = dropdown_index == -1
                             || (dropdown_index < Dropdown::ItemsMaxSize && Dropdown::IsDisabled(dropdown_index))
-                            || gDropdownItemsFormat[dropdown_index] == Dropdown::SeparatorString;
+                            || gDropdownItems[dropdown_index].IsSeparator();
                         w = nullptr; // To be closed right next
                     }
                     else
@@ -1419,7 +1419,7 @@ void InputStateWidgetPressed(
             return;
         }
 
-        if (gDropdownItemsFormat[dropdown_index] == Dropdown::SeparatorString)
+        if (gDropdownItems[dropdown_index].IsSeparator())
         {
             return;
         }

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -59,14 +59,31 @@ uint32_t DropdownGetAppropriateImageDropdownItemsPerRow(uint32_t numItems);
 
 namespace Dropdown
 {
+    enum class ItemFlag : uint8_t
+    {
+        IsDisabled = (1 << 0),
+        IsChecked = (1 << 1),
+    };
+
     struct Item
     {
         rct_string_id Format;
         int64_t Args;
+        uint8_t Flags;
 
         constexpr bool IsSeparator() const
         {
             return Format == SeparatorString;
+        }
+
+        constexpr bool IsDisabled() const
+        {
+            return (Flags & EnumValue(ItemFlag::IsDisabled));
+        }
+
+        constexpr bool IsChecked() const
+        {
+            return (Flags & EnumValue(ItemFlag::IsChecked));
         }
     };
 

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -16,6 +16,8 @@
 
 namespace Dropdown
 {
+    struct Item;
+
     constexpr const rct_string_id SeparatorString = 0;
     constexpr const rct_string_id FormatColourPicker = 0xFFFE;
     constexpr const rct_string_id FormatLandPicker = 0xFFFF;
@@ -35,8 +37,7 @@ namespace Dropdown
 } // namespace Dropdown
 
 extern int32_t gDropdownNumItems;
-extern rct_string_id gDropdownItemsFormat[Dropdown::ItemsMaxSize];
-extern int64_t gDropdownItemsArgs[Dropdown::ItemsMaxSize];
+extern Dropdown::Item gDropdownItems[Dropdown::ItemsMaxSize];
 extern bool gDropdownIsColour;
 extern int32_t gDropdownLastColourHover;
 extern int32_t gDropdownHighlightedIndex;
@@ -58,6 +59,17 @@ uint32_t DropdownGetAppropriateImageDropdownItemsPerRow(uint32_t numItems);
 
 namespace Dropdown
 {
+    struct Item
+    {
+        rct_string_id Format;
+        int64_t Args;
+
+        constexpr bool IsSeparator() const
+        {
+            return Format == SeparatorString;
+        }
+    };
+
     struct ItemExt
     {
         constexpr ItemExt(int32_t _expectedItemIndex, uint32_t _itemFormat, rct_string_id _stringId)
@@ -87,8 +99,8 @@ namespace Dropdown
         for (int i = 0; i < N; ++i)
         {
             const ItemExt& item = items[i];
-            gDropdownItemsFormat[i] = item.itemFormat;
-            gDropdownItemsArgs[i] = item.stringId;
+            gDropdownItems[i].Format = item.itemFormat;
+            gDropdownItems[i].Args = item.stringId;
         }
     }
 

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -58,9 +58,9 @@ uint32_t DropdownGetAppropriateImageDropdownItemsPerRow(uint32_t numItems);
 
 namespace Dropdown
 {
-    struct Item
+    struct ItemExt
     {
-        constexpr Item(int32_t _expectedItemIndex, uint32_t _itemFormat, rct_string_id _stringId)
+        constexpr ItemExt(int32_t _expectedItemIndex, uint32_t _itemFormat, rct_string_id _stringId)
             : expectedItemIndex(_expectedItemIndex)
             , itemFormat(_itemFormat)
             , stringId(_stringId)
@@ -72,31 +72,31 @@ namespace Dropdown
         rct_string_id stringId;
     };
 
-    constexpr Item ToggleOption(int32_t _expectedItemIndex, rct_string_id _stringId)
+    constexpr ItemExt ToggleOption(int32_t _expectedItemIndex, rct_string_id _stringId)
     {
-        return Item(_expectedItemIndex, STR_TOGGLE_OPTION, _stringId);
+        return ItemExt(_expectedItemIndex, STR_TOGGLE_OPTION, _stringId);
     }
 
-    constexpr Item Separator()
+    constexpr ItemExt Separator()
     {
-        return Item(-1, Dropdown::SeparatorString, STR_EMPTY);
+        return ItemExt(-1, Dropdown::SeparatorString, STR_EMPTY);
     }
 
-    template<int N> void SetItems(const Dropdown::Item (&items)[N])
+    template<int N> void SetItems(const Dropdown::ItemExt (&items)[N])
     {
         for (int i = 0; i < N; ++i)
         {
-            const Item& item = items[i];
+            const ItemExt& item = items[i];
             gDropdownItemsFormat[i] = item.itemFormat;
             gDropdownItemsArgs[i] = item.stringId;
         }
     }
 
-    template<int N> constexpr bool ItemIDsMatchIndices(const Dropdown::Item (&items)[N])
+    template<int N> constexpr bool ItemIDsMatchIndices(const Dropdown::ItemExt (&items)[N])
     {
         for (int i = 0; i < N; ++i)
         {
-            const Dropdown::Item& item = items[i];
+            const Dropdown::ItemExt& item = items[i];
             if (item.expectedItemIndex >= 0 && item.expectedItemIndex != i)
                 return false;
         }

--- a/src/openrct2-ui/interface/LandTool.cpp
+++ b/src/openrct2-ui/interface/LandTool.cpp
@@ -71,7 +71,7 @@ void LandTool::ShowSurfaceStyleDropdown(rct_window* w, rct_widget* widget, Objec
             if (surfaceObj->Colour != 255)
                 imageId = imageId.WithPrimary(surfaceObj->Colour);
 
-            gDropdownItemsFormat[itemIndex] = Dropdown::FormatLandPicker;
+            gDropdownItems[itemIndex].Format = Dropdown::FormatLandPicker;
             Dropdown::SetImage(itemIndex, imageId);
             if (i == currentSurfaceType)
             {
@@ -101,7 +101,7 @@ void LandTool::ShowEdgeStyleDropdown(rct_window* w, rct_widget* widget, ObjectEn
         // If fallback images are loaded, the RCT1 styles will just look like copies of already existing styles, so hide them.
         if (edgeObj != nullptr && !edgeObj->UsesFallbackImages())
         {
-            gDropdownItemsFormat[itemIndex] = Dropdown::FormatLandPicker;
+            gDropdownItems[itemIndex].Format = Dropdown::FormatLandPicker;
             Dropdown::SetImage(itemIndex, ImageId(edgeObj->IconImageId));
             if (i == currentEdgeType)
             {

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -643,10 +643,10 @@ namespace OpenRCT2::Ui::Windows
                     const auto numItems = std::min<size_t>(items.size(), Dropdown::ItemsMaxSize);
                     for (size_t i = 0; i < numItems; i++)
                     {
-                        gDropdownItemsFormat[i] = selectedIndex == static_cast<int32_t>(i) ? STR_OPTIONS_DROPDOWN_ITEM_SELECTED
-                                                                                           : STR_OPTIONS_DROPDOWN_ITEM;
+                        gDropdownItems[i].Format = selectedIndex == static_cast<int32_t>(i) ? STR_OPTIONS_DROPDOWN_ITEM_SELECTED
+                                                                                            : STR_OPTIONS_DROPDOWN_ITEM;
                         auto sz = items[i].c_str();
-                        std::memcpy(&gDropdownItemsArgs[i], &sz, sizeof(const char*));
+                        std::memcpy(&gDropdownItems[i].Args, &sz, sizeof(const char*));
                     }
                     WindowDropdownShowTextCustomWidth(
                         { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1,

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -163,8 +163,8 @@ public:
 
                 for (int32_t i = 0; i < 13; ++i)
                 {
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = BannerColouredTextFormats[i + 1];
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Args = BannerColouredTextFormats[i + 1];
                 }
 
                 // Switch to the dropdown box widget.

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -908,8 +908,8 @@ private:
 
                 for (size_t i = 0; i < std::size(WeatherTypes); i++)
                 {
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = WeatherTypes[i];
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Args = WeatherTypes[i];
                 }
                 WindowDropdownShowTextCustomWidth(
                     { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
@@ -927,8 +927,8 @@ private:
 
                 for (size_t i = 0; i < std::size(_staffSpeedNames); i++)
                 {
-                    gDropdownItemsArgs[i] = _staffSpeedNames[i];
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Args = _staffSpeedNames[i];
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
                 }
 
                 WindowDropdownShowTextCustomWidth(

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -86,11 +86,11 @@ public:
                 }
                 break;
             case WIDX_AFFIX_DROPDOWN_BUTTON:
-                gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[0] = STR_PREFIX;
+                gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[0].Args = STR_PREFIX;
 
-                gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[1] = STR_SUFFIX;
+                gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[1].Args = STR_SUFFIX;
 
                 WindowDropdownShowTextCustomWidth(
                     { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -50,8 +50,6 @@ static bool _dropdown_list_vertically;
 int32_t gDropdownNumItems;
 Dropdown::Item gDropdownItems[Dropdown::ItemsMaxSize];
 static ImageId _dropdownItemsImages[Dropdown::ItemsMaxSize];
-static BitSet<Dropdown::ItemsMaxSize> _dropdownItemsChecked = {};
-static BitSet<Dropdown::ItemsMaxSize> _dropdownItemsDisabled = {};
 bool gDropdownIsColour;
 int32_t gDropdownLastColourHover;
 int32_t gDropdownHighlightedIndex;
@@ -59,40 +57,54 @@ int32_t gDropdownDefaultIndex;
 static bool _dropdownPrepareUseImages;
 static bool _dropdownUseImages;
 
+static void ResetDropdownFlags()
+{
+    for (size_t i = 0; i < std::size(gDropdownItems); i++)
+    {
+        gDropdownItems[i].Flags = 0;
+    }
+}
+
 bool Dropdown::IsChecked(int32_t index)
 {
-    if (index < 0 || index >= static_cast<int32_t>(std::size(_dropdownItemsDisabled)))
+    if (index < 0 || index >= static_cast<int32_t>(std::size(gDropdownItems)))
     {
         return false;
     }
-    return _dropdownItemsChecked[index];
+    return gDropdownItems[index].IsChecked();
 }
 
 bool Dropdown::IsDisabled(int32_t index)
 {
-    if (index < 0 || index >= static_cast<int32_t>(std::size(_dropdownItemsDisabled)))
+    if (index < 0 || index >= static_cast<int32_t>(std::size(gDropdownItems)))
     {
         return true;
     }
-    return _dropdownItemsDisabled[index];
+    return gDropdownItems[index].IsDisabled();
 }
 
 void Dropdown::SetChecked(int32_t index, bool value)
 {
-    if (index < 0 || index >= static_cast<int32_t>(std::size(_dropdownItemsDisabled)))
+    if (index < 0 || index >= static_cast<int32_t>(std::size(gDropdownItems)))
     {
         return;
     }
-    _dropdownItemsChecked[index] = value;
+    if (value)
+        gDropdownItems[index].Flags |= EnumValue(Dropdown::ItemFlag::IsChecked);
+    else
+        gDropdownItems[index].Flags &= ~EnumValue(Dropdown::ItemFlag::IsChecked);
 }
 
 void Dropdown::SetDisabled(int32_t index, bool value)
 {
-    if (index < 0 || index >= static_cast<int32_t>(std::size(_dropdownItemsDisabled)))
+    if (index < 0 || index >= static_cast<int32_t>(std::size(gDropdownItems)))
     {
         return;
     }
-    _dropdownItemsDisabled[index] = value;
+    if (value)
+        gDropdownItems[index].Flags |= EnumValue(Dropdown::ItemFlag::IsDisabled);
+    else
+        gDropdownItems[index].Flags &= ~EnumValue(Dropdown::ItemFlag::IsDisabled);
 }
 
 void Dropdown::SetImage(int32_t index, ImageId image)
@@ -209,8 +221,7 @@ void WindowDropdownShowTextCustomWidth(
 
     // Input state
     gDropdownHighlightedIndex = -1;
-    _dropdownItemsDisabled.reset();
-    _dropdownItemsChecked.reset();
+    ResetDropdownFlags();
     gDropdownIsColour = false;
     gDropdownDefaultIndex = -1;
     input_set_state(InputState::DropdownActive);
@@ -299,8 +310,7 @@ void WindowDropdownShowImage(
 
     // Input state
     gDropdownHighlightedIndex = -1;
-    _dropdownItemsDisabled.reset();
-    _dropdownItemsChecked.reset();
+    ResetDropdownFlags();
     gDropdownIsColour = false;
     gDropdownDefaultIndex = -1;
     input_set_state(InputState::DropdownActive);

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -48,8 +48,7 @@ static int32_t _dropdown_item_height;
 static bool _dropdown_list_vertically;
 
 int32_t gDropdownNumItems;
-rct_string_id gDropdownItemsFormat[Dropdown::ItemsMaxSize];
-int64_t gDropdownItemsArgs[Dropdown::ItemsMaxSize];
+Dropdown::Item gDropdownItems[Dropdown::ItemsMaxSize];
 static ImageId _dropdownItemsImages[Dropdown::ItemsMaxSize];
 static BitSet<Dropdown::ItemsMaxSize> _dropdownItemsChecked = {};
 static BitSet<Dropdown::ItemsMaxSize> _dropdownItemsDisabled = {};
@@ -135,7 +134,7 @@ void WindowDropdownShowText(const ScreenCoordsXY& screenPos, int32_t extray, uin
     max_string_width = 0;
     for (size_t i = 0; i < num_items; i++)
     {
-        format_string(buffer, 256, gDropdownItemsFormat[i], static_cast<void*>(&gDropdownItemsArgs[i]));
+        format_string(buffer, 256, gDropdownItems[i].Format, static_cast<void*>(&gDropdownItems[i].Args));
         string_width = gfx_get_string_width(buffer, FontSpriteBase::MEDIUM);
         max_string_width = std::max(string_width, max_string_width);
     }
@@ -328,7 +327,7 @@ static void WindowDropdownPaint(rct_window* w, rct_drawpixelinfo* dpi)
         ScreenCoordsXY screenCoords = w->windowPos
             + ScreenCoordsXY{ 2 + (cellCoords.x * _dropdown_item_width), 2 + (cellCoords.y * _dropdown_item_height) };
 
-        if (gDropdownItemsFormat[i] == Dropdown::SeparatorString)
+        if (gDropdownItems[i].IsSeparator())
         {
             const ScreenCoordsXY leftTop = screenCoords + ScreenCoordsXY{ 0, (_dropdown_item_height / 2) };
             const ScreenCoordsXY rightBottom = leftTop + ScreenCoordsXY{ _dropdown_item_width - 1, 0 };
@@ -356,12 +355,12 @@ static void WindowDropdownPaint(rct_window* w, rct_drawpixelinfo* dpi)
                 gfx_filter_rect(dpi, { screenCoords, rightBottom }, FilterPaletteID::PaletteDarken3);
             }
 
-            rct_string_id item = gDropdownItemsFormat[i];
+            rct_string_id item = gDropdownItems[i].Format;
             if (item == Dropdown::FormatLandPicker || item == Dropdown::FormatColourPicker)
             {
                 // Image item
                 auto image = _dropdownUseImages ? _dropdownItemsImages[i]
-                                                : ImageId::FromUInt32(static_cast<uint32_t>(gDropdownItemsArgs[i]));
+                                                : ImageId::FromUInt32(static_cast<uint32_t>(gDropdownItems[i].Args));
                 if (item == Dropdown::FormatColourPicker && highlightedIndex == i)
                     image = image.WithIndexOffset(1);
                 gfx_draw_sprite(dpi, image, screenCoords);
@@ -380,7 +379,7 @@ static void WindowDropdownPaint(rct_window* w, rct_drawpixelinfo* dpi)
                     colour = NOT_TRANSLUCENT(w->colours[0]) | COLOUR_FLAG_INSET;
 
                 // Draw item string
-                Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItemsArgs[i]));
+                Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItems[i].Args));
                 DrawTextEllipsised(dpi, screenCoords, w->width - 5, item, ft, { colour });
             }
         }
@@ -436,8 +435,8 @@ void WindowDropdownShowColour(rct_window* w, rct_widget* widget, uint8_t dropdow
         if (selectedColour == i)
             defaultIndex = i;
 
-        gDropdownItemsFormat[i] = Dropdown::FormatColourPicker;
-        gDropdownItemsArgs[i] = (i << 32) | (SPRITE_ID_PALETTE_COLOUR_1(i) | SPR_PALETTE_BTN);
+        gDropdownItems[i].Format = Dropdown::FormatColourPicker;
+        gDropdownItems[i].Args = (i << 32) | (SPRITE_ID_PALETTE_COLOUR_1(i) | SPR_PALETTE_BTN);
     }
 
     // Show dropdown

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -455,34 +455,34 @@ public:
         {
             case WIDX_FILTER_DROPDOWN:
 
-                gDropdownItemsFormat[DDIX_FILTER_RCT1] = STR_TOGGLE_OPTION;
-                gDropdownItemsFormat[DDIX_FILTER_AA] = STR_TOGGLE_OPTION;
-                gDropdownItemsFormat[DDIX_FILTER_LL] = STR_TOGGLE_OPTION;
-                gDropdownItemsFormat[DDIX_FILTER_RCT2] = STR_TOGGLE_OPTION;
-                gDropdownItemsFormat[DDIX_FILTER_WW] = STR_TOGGLE_OPTION;
-                gDropdownItemsFormat[DDIX_FILTER_TT] = STR_TOGGLE_OPTION;
-                gDropdownItemsFormat[DDIX_FILTER_OO] = STR_TOGGLE_OPTION;
-                gDropdownItemsFormat[DDIX_FILTER_CUSTOM] = STR_TOGGLE_OPTION;
+                gDropdownItems[DDIX_FILTER_RCT1].Format = STR_TOGGLE_OPTION;
+                gDropdownItems[DDIX_FILTER_AA].Format = STR_TOGGLE_OPTION;
+                gDropdownItems[DDIX_FILTER_LL].Format = STR_TOGGLE_OPTION;
+                gDropdownItems[DDIX_FILTER_RCT2].Format = STR_TOGGLE_OPTION;
+                gDropdownItems[DDIX_FILTER_WW].Format = STR_TOGGLE_OPTION;
+                gDropdownItems[DDIX_FILTER_TT].Format = STR_TOGGLE_OPTION;
+                gDropdownItems[DDIX_FILTER_OO].Format = STR_TOGGLE_OPTION;
+                gDropdownItems[DDIX_FILTER_CUSTOM].Format = STR_TOGGLE_OPTION;
 
-                gDropdownItemsArgs[DDIX_FILTER_RCT1] = STR_SCENARIO_CATEGORY_RCT1;
-                gDropdownItemsArgs[DDIX_FILTER_AA] = STR_SCENARIO_CATEGORY_RCT1_AA;
-                gDropdownItemsArgs[DDIX_FILTER_LL] = STR_SCENARIO_CATEGORY_RCT1_LL;
-                gDropdownItemsArgs[DDIX_FILTER_RCT2] = STR_ROLLERCOASTER_TYCOON_2_DROPDOWN;
-                gDropdownItemsArgs[DDIX_FILTER_WW] = STR_OBJECT_FILTER_WW;
-                gDropdownItemsArgs[DDIX_FILTER_TT] = STR_OBJECT_FILTER_TT;
-                gDropdownItemsArgs[DDIX_FILTER_OO] = STR_OBJECT_FILTER_OPENRCT2_OFFICIAL;
-                gDropdownItemsArgs[DDIX_FILTER_CUSTOM] = STR_OBJECT_FILTER_CUSTOM;
+                gDropdownItems[DDIX_FILTER_RCT1].Args = STR_SCENARIO_CATEGORY_RCT1;
+                gDropdownItems[DDIX_FILTER_AA].Args = STR_SCENARIO_CATEGORY_RCT1_AA;
+                gDropdownItems[DDIX_FILTER_LL].Args = STR_SCENARIO_CATEGORY_RCT1_LL;
+                gDropdownItems[DDIX_FILTER_RCT2].Args = STR_ROLLERCOASTER_TYCOON_2_DROPDOWN;
+                gDropdownItems[DDIX_FILTER_WW].Args = STR_OBJECT_FILTER_WW;
+                gDropdownItems[DDIX_FILTER_TT].Args = STR_OBJECT_FILTER_TT;
+                gDropdownItems[DDIX_FILTER_OO].Args = STR_OBJECT_FILTER_OPENRCT2_OFFICIAL;
+                gDropdownItems[DDIX_FILTER_CUSTOM].Args = STR_OBJECT_FILTER_CUSTOM;
 
                 // Track manager cannot select multiple, so only show selection filters if not in track manager
                 if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER))
                 {
                     numSelectionItems = 3;
-                    gDropdownItemsFormat[DDIX_FILTER_SEPARATOR] = 0;
-                    gDropdownItemsFormat[DDIX_FILTER_SELECTED] = STR_TOGGLE_OPTION;
-                    gDropdownItemsFormat[DDIX_FILTER_NONSELECTED] = STR_TOGGLE_OPTION;
-                    gDropdownItemsArgs[DDIX_FILTER_SEPARATOR] = STR_NONE;
-                    gDropdownItemsArgs[DDIX_FILTER_SELECTED] = STR_SELECTED_ONLY;
-                    gDropdownItemsArgs[DDIX_FILTER_NONSELECTED] = STR_NON_SELECTED_ONLY;
+                    gDropdownItems[DDIX_FILTER_SEPARATOR].Format = 0;
+                    gDropdownItems[DDIX_FILTER_SELECTED].Format = STR_TOGGLE_OPTION;
+                    gDropdownItems[DDIX_FILTER_NONSELECTED].Format = STR_TOGGLE_OPTION;
+                    gDropdownItems[DDIX_FILTER_SEPARATOR].Args = STR_NONE;
+                    gDropdownItems[DDIX_FILTER_SELECTED].Args = STR_SELECTED_ONLY;
+                    gDropdownItems[DDIX_FILTER_NONSELECTED].Args = STR_NON_SELECTED_ONLY;
                 }
 
                 WindowDropdownShowText(

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -414,8 +414,8 @@ static void WindowEditorObjectiveOptionsShowObjectiveDropdown(rct_window* w)
         const bool objectiveAllowedByPaymentSettings = (i != OBJECTIVE_MONTHLY_RIDE_INCOME) || park_ride_prices_unlocked();
         if (objectiveAllowedByMoneyUsage && objectiveAllowedByPaymentSettings)
         {
-            gDropdownItemsFormat[numItems] = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItemsArgs[numItems] = ObjectiveDropdownOptionNames[i];
+            gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItems[numItems].Args = ObjectiveDropdownOptionNames[i];
             numItems++;
         }
     }
@@ -427,7 +427,7 @@ static void WindowEditorObjectiveOptionsShowObjectiveDropdown(rct_window* w)
     objectiveType = gScenarioObjective.Type;
     for (int32_t j = 0; j < numItems; j++)
     {
-        if (gDropdownItemsArgs[j] - STR_OBJECTIVE_DROPDOWN_NONE == objectiveType)
+        if (gDropdownItems[j].Args - STR_OBJECTIVE_DROPDOWN_NONE == objectiveType)
         {
             Dropdown::SetChecked(j, true);
             break;
@@ -444,8 +444,8 @@ static void WindowEditorObjectiveOptionsShowCategoryDropdown(rct_window* w)
 
     for (i = SCENARIO_CATEGORY_BEGINNER; i <= SCENARIO_CATEGORY_OTHER; i++)
     {
-        gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[i] = ScenarioCategoryStringIds[i];
+        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[i].Args = ScenarioCategoryStringIds[i];
     }
     WindowDropdownShowTextCustomWidth(
         { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
@@ -651,7 +651,7 @@ static void WindowEditorObjectiveOptionsMainDropdown(rct_window* w, rct_widgetin
     {
         case WIDX_OBJECTIVE_DROPDOWN:
             // TODO: Don't rely on string ID order
-            newObjectiveType = static_cast<uint8_t>(gDropdownItemsArgs[dropdownIndex] - STR_OBJECTIVE_DROPDOWN_NONE);
+            newObjectiveType = static_cast<uint8_t>(gDropdownItems[dropdownIndex].Args - STR_OBJECTIVE_DROPDOWN_NONE);
             if (gScenarioObjective.Type != newObjectiveType)
                 WindowEditorObjectiveOptionsSetObjective(w, newObjectiveType);
             break;

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -480,8 +480,8 @@ static void WindowEditorScenarioOptionsShowClimateDropdown(rct_window* w)
 
     for (i = 0; i < static_cast<uint8_t>(ClimateType::Count); i++)
     {
-        gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[i] = ClimateNames[i];
+        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[i].Args = ClimateNames[i];
     }
     WindowDropdownShowTextCustomWidth(
         { w->windowPos.x + dropdownWidget.left, w->windowPos.y + dropdownWidget.top }, dropdownWidget.height() + 1,
@@ -1179,12 +1179,12 @@ static void WindowEditorScenarioOptionsParkMousedown(rct_window* w, rct_widgetin
         case WIDX_PAY_FOR_PARK_OR_RIDES_DROPDOWN:
             dropdownWidget = widget - 1;
 
-            gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItemsArgs[0] = STR_FREE_PARK_ENTER;
-            gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItemsArgs[1] = STR_PAY_PARK_ENTER;
-            gDropdownItemsFormat[2] = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItemsArgs[2] = STR_PAID_ENTRY_PAID_RIDES;
+            gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItems[0].Args = STR_FREE_PARK_ENTER;
+            gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItems[1].Args = STR_PAY_PARK_ENTER;
+            gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItems[2].Args = STR_PAID_ENTRY_PAID_RIDES;
 
             WindowDropdownShowTextCustomWidth(
                 { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() - 1,

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -1197,8 +1197,8 @@ static void WindowFinancesResearchMousedown(rct_window* w, rct_widgetindex widge
 
     for (i = 0; i < 4; i++)
     {
-        gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[i] = ResearchFundingLevelNames[i];
+        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[i].Args = ResearchFundingLevelNames[i];
     }
     WindowDropdownShowTextCustomWidth(
         { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -751,7 +751,7 @@ static void WindowFootpathShowFootpathTypesDialog(rct_window* w, rct_widget* wid
             defaultIndex = numPathTypes;
         }
 
-        gDropdownItemsFormat[numPathTypes] = STR_NONE;
+        gDropdownItems[numPathTypes].Format = STR_NONE;
         Dropdown::SetImage(numPathTypes, ImageId(pathType->PreviewImageId));
         _dropdownEntries.push_back({ ObjectType::FootpathSurface, i });
         numPathTypes++;
@@ -776,7 +776,7 @@ static void WindowFootpathShowFootpathTypesDialog(rct_window* w, rct_widget* wid
             defaultIndex = numPathTypes;
         }
 
-        gDropdownItemsFormat[numPathTypes] = STR_NONE;
+        gDropdownItems[numPathTypes].Format = STR_NONE;
         Dropdown::SetImage(
             numPathTypes, ImageId(showQueues ? pathEntry->GetQueuePreviewImage() : pathEntry->GetPreviewImage()));
         _dropdownEntries.push_back({ ObjectType::Paths, i });
@@ -810,7 +810,7 @@ static void WindowFootpathShowRailingsTypesDialog(rct_window* w, rct_widget* wid
             defaultIndex = numRailingsTypes;
         }
 
-        gDropdownItemsFormat[numRailingsTypes] = STR_NONE;
+        gDropdownItems[numRailingsTypes].Format = STR_NONE;
         Dropdown::SetImage(numRailingsTypes, ImageId(railingsEntry->PreviewImageId));
         _dropdownEntries.push_back({ ObjectType::FootpathRailings, i });
         numRailingsTypes++;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -651,8 +651,8 @@ static void WindowGuestOverviewDropdown(rct_window* w, rct_widgetindex widgetInd
 
 static void WindowGuestShowLocateDropdown(rct_window* w, rct_widget* widget)
 {
-    gDropdownItemsFormat[0] = STR_LOCATE_SUBJECT_TIP;
-    gDropdownItemsFormat[1] = STR_FOLLOW_SUBJECT_TIP;
+    gDropdownItems[0].Format = STR_LOCATE_SUBJECT_TIP;
+    gDropdownItems[1].Format = STR_FOLLOW_SUBJECT_TIP;
 
     WindowDropdownShowText(
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1], 0, 2);

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -354,8 +354,8 @@ public:
 
                 for (size_t i = 0; i < _numPages; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    uint16_t* args = reinterpret_cast<uint16_t*>(&gDropdownItemsArgs[i]);
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                    uint16_t* args = reinterpret_cast<uint16_t*>(&gDropdownItems[i].Args);
                     args[0] = STR_PAGE_X;
                     args[1] = static_cast<uint16_t>(i + 1);
                 }
@@ -364,10 +364,10 @@ public:
             }
             case WIDX_INFO_TYPE_DROPDOWN_BUTTON:
             {
-                gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[0] = GetViewName(GuestViewType::Actions);
-                gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[1] = GetViewName(GuestViewType::Thoughts);
+                gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[0].Args = GetViewName(GuestViewType::Actions);
+                gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[1].Args = GetViewName(GuestViewType::Thoughts);
 
                 auto* widget = &widgets[widgetIndex - 1];
                 WindowDropdownShowTextCustomWidth(

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -305,8 +305,8 @@ static void WindowMultiplayerGroupsShowGroupDropdown(rct_window* w, rct_widget* 
 
     for (i = 0; i < network_get_num_groups(); i++)
     {
-        gDropdownItemsFormat[i] = STR_OPTIONS_DROPDOWN_ITEM;
-        gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(network_get_group_name(i));
+        gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
+        gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(network_get_group_name(i));
     }
     if (widget == &window_multiplayer_groups_widgets[WIDX_DEFAULT_GROUP_DROPDOWN])
     {

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -196,8 +196,8 @@ public:
                         int32_t maxSize = std::min(Dropdown::ItemsMaxSize, static_cast<int32_t>(ShopItems.size()));
                         for (int32_t i = 0; i < maxSize; i++)
                         {
-                            gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                            gDropdownItemsArgs[i] = GetShopItemDescriptor(ShopItems[i]).Naming.Plural;
+                            gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                            gDropdownItems[i].Args = GetShopItemDescriptor(ShopItems[i]).Naming.Plural;
                             numItems++;
                         }
 
@@ -216,15 +216,15 @@ public:
                         if (curRide != nullptr)
                         {
                             // HACK until dropdown items have longer argument buffers
-                            gDropdownItemsFormat[numItems] = STR_DROPDOWN_MENU_LABEL;
-                            Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItemsArgs[numItems]));
+                            gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
+                            Formatter ft(reinterpret_cast<uint8_t*>(&gDropdownItems[numItems].Args));
                             if (curRide->custom_name.empty())
                             {
                                 curRide->FormatNameTo(ft);
                             }
                             else
                             {
-                                gDropdownItemsFormat[numItems] = STR_OPTIONS_DROPDOWN_ITEM;
+                                gDropdownItems[numItems].Format = STR_OPTIONS_DROPDOWN_ITEM;
                                 ft.Add<const char*>(curRide->custom_name.c_str());
                             }
                             numItems++;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -834,9 +834,9 @@ private:
                 {
                     const Resolution& resolution = resolutions[i];
 
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
 
-                    uint16_t* args = reinterpret_cast<uint16_t*>(&gDropdownItemsArgs[i]);
+                    uint16_t* args = reinterpret_cast<uint16_t*>(&gDropdownItems[i].Args);
                     args[0] = STR_RESOLUTION_X_BY_Y;
                     args[1] = resolution.Width;
                     args[2] = resolution.Height;
@@ -858,12 +858,12 @@ private:
 
             break;
             case WIDX_FULLSCREEN_DROPDOWN:
-                gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsFormat[2] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[0] = STR_OPTIONS_DISPLAY_WINDOWED;
-                gDropdownItemsArgs[1] = STR_OPTIONS_DISPLAY_FULLSCREEN;
-                gDropdownItemsArgs[2] = STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS;
+                gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[0].Args = STR_OPTIONS_DISPLAY_WINDOWED;
+                gDropdownItems[1].Args = STR_OPTIONS_DISPLAY_FULLSCREEN;
+                gDropdownItems[2].Args = STR_OPTIONS_DISPLAY_FULLSCREEN_BORDERLESS;
 
                 ShowDropdown(widget, 3);
 
@@ -878,8 +878,8 @@ private:
 
                 for (int32_t i = 0; i < numItems; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = DrawingEngineStringIds[i];
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Args = DrawingEngineStringIds[i];
                 }
                 ShowDropdown(widget, numItems);
                 Dropdown::SetChecked(EnumValue(gConfigGeneral.drawing_engine), true);
@@ -1108,12 +1108,12 @@ private:
         switch (widgetIndex)
         {
             case WIDX_VIRTUAL_FLOOR_DROPDOWN:
-                gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsFormat[2] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[0] = STR_VIRTUAL_FLOOR_STYLE_DISABLED;
-                gDropdownItemsArgs[1] = STR_VIRTUAL_FLOOR_STYLE_TRANSPARENT;
-                gDropdownItemsArgs[2] = STR_VIRTUAL_FLOOR_STYLE_GLASSY;
+                gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[0].Args = STR_VIRTUAL_FLOOR_STYLE_DISABLED;
+                gDropdownItems[1].Args = STR_VIRTUAL_FLOOR_STYLE_TRANSPARENT;
+                gDropdownItems[2].Args = STR_VIRTUAL_FLOOR_STYLE_GLASSY;
 
                 rct_widget* widget = &widgets[widgetIndex - 1];
                 ShowDropdown(widget, 3);
@@ -1205,10 +1205,10 @@ private:
         switch (widgetIndex)
         {
             case WIDX_HEIGHT_LABELS_DROPDOWN:
-                gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[0] = STR_HEIGHT_IN_UNITS;
-                gDropdownItemsArgs[1] = STR_REAL_VALUES;
+                gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[0].Args = STR_HEIGHT_IN_UNITS;
+                gDropdownItems[1].Args = STR_REAL_VALUES;
 
                 ShowDropdown(widget, 2);
 
@@ -1224,14 +1224,14 @@ private:
 
                 for (size_t i = 0; i < numOrdinaryCurrencies; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = CurrencyDescriptors[i].stringId;
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Args = CurrencyDescriptors[i].stringId;
                 }
 
-                gDropdownItemsFormat[numOrdinaryCurrencies] = Dropdown::SeparatorString;
+                gDropdownItems[numOrdinaryCurrencies].Format = Dropdown::SeparatorString;
 
-                gDropdownItemsFormat[numOrdinaryCurrencies + 1] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[numOrdinaryCurrencies + 1] = CurrencyDescriptors[EnumValue(CurrencyType::Custom)].stringId;
+                gDropdownItems[numOrdinaryCurrencies + 1].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[numOrdinaryCurrencies + 1].Args = CurrencyDescriptors[EnumValue(CurrencyType::Custom)].stringId;
 
                 ShowDropdown(widget, numItems);
 
@@ -1246,22 +1246,22 @@ private:
                 break;
             }
             case WIDX_DISTANCE_DROPDOWN:
-                gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsFormat[2] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[0] = STR_IMPERIAL;
-                gDropdownItemsArgs[1] = STR_METRIC;
-                gDropdownItemsArgs[2] = STR_SI;
+                gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[0].Args = STR_IMPERIAL;
+                gDropdownItems[1].Args = STR_METRIC;
+                gDropdownItems[2].Args = STR_SI;
 
                 ShowDropdown(widget, 3);
 
                 Dropdown::SetChecked(static_cast<int32_t>(gConfigGeneral.measurement_format), true);
                 break;
             case WIDX_TEMPERATURE_DROPDOWN:
-                gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[0] = STR_CELSIUS;
-                gDropdownItemsArgs[1] = STR_FAHRENHEIT;
+                gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[0].Args = STR_CELSIUS;
+                gDropdownItems[1].Args = STR_FAHRENHEIT;
 
                 ShowDropdown(widget, 2);
 
@@ -1270,8 +1270,8 @@ private:
             case WIDX_LANGUAGE_DROPDOWN:
                 for (size_t i = 1; i < LANGUAGE_COUNT; i++)
                 {
-                    gDropdownItemsFormat[i - 1] = STR_OPTIONS_DROPDOWN_ITEM;
-                    gDropdownItemsArgs[i - 1] = reinterpret_cast<uintptr_t>(LanguagesDescriptors[i].native_name);
+                    gDropdownItems[i - 1].Format = STR_OPTIONS_DROPDOWN_ITEM;
+                    gDropdownItems[i - 1].Args = reinterpret_cast<uintptr_t>(LanguagesDescriptors[i].native_name);
                 }
                 ShowDropdown(widget, LANGUAGE_COUNT - 1);
                 Dropdown::SetChecked(LocalisationService_GetCurrentLanguage() - 1, true);
@@ -1279,8 +1279,8 @@ private:
             case WIDX_DATE_FORMAT_DROPDOWN:
                 for (size_t i = 0; i < 4; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = DateFormatStringIds[i];
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Args = DateFormatStringIds[i];
                 }
                 ShowDropdown(widget, 4);
                 Dropdown::SetChecked(gConfigGeneral.date_format, true);
@@ -1473,8 +1473,8 @@ private:
                 // populate the list with the sound devices
                 for (int32_t i = 0; i < OpenRCT2::Audio::GetDeviceCount(); i++)
                 {
-                    gDropdownItemsFormat[i] = STR_OPTIONS_DROPDOWN_ITEM;
-                    gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(OpenRCT2::Audio::GetDeviceName(i).c_str());
+                    gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
+                    gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(OpenRCT2::Audio::GetDeviceName(i).c_str());
                 }
 
                 ShowDropdown(widget, OpenRCT2::Audio::GetDeviceCount());
@@ -1486,8 +1486,8 @@ private:
 
                 for (size_t i = 0; i < numItems; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = TitleMusicNames[i];
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Args = TitleMusicNames[i];
                 }
 
                 ShowDropdown(widget, numItems);
@@ -1721,8 +1721,8 @@ private:
 
                 for (size_t i = 0; i < numItems; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_OPTIONS_DROPDOWN_ITEM;
-                    gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(ThemeManagerGetAvailableThemeName(i));
+                    gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
+                    gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(ThemeManagerGetAvailableThemeName(i));
                 }
 
                 WindowDropdownShowTextCustomWidth(
@@ -1842,8 +1842,8 @@ private:
                 uint32_t numItems = static_cast<int32_t>(title_sequence_manager_get_count());
                 for (size_t i = 0; i < numItems; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_OPTIONS_DROPDOWN_ITEM;
-                    gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(title_sequence_manager_get_name(i));
+                    gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
+                    gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(title_sequence_manager_get_name(i));
                 }
 
                 WindowDropdownShowText(
@@ -1857,10 +1857,10 @@ private:
             {
                 uint32_t numItems = 2;
 
-                gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[0] = STR_OPTIONS_SCENARIO_DIFFICULTY;
-                gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[1] = STR_OPTIONS_SCENARIO_ORIGIN;
+                gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[0].Args = STR_OPTIONS_SCENARIO_DIFFICULTY;
+                gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[1].Args = STR_OPTIONS_SCENARIO_ORIGIN;
 
                 WindowDropdownShowTextCustomWidth(
                     { windowPos.x + widget->left, windowPos.y + widget->top }, widget->height() + 1, colours[1], 0,
@@ -1872,8 +1872,8 @@ private:
             case WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN:
                 for (size_t i = 0; i < 7; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = RideInspectionIntervalNames[i];
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Args = RideInspectionIntervalNames[i];
                 }
 
                 ShowDropdown(widget, 7);
@@ -2076,8 +2076,8 @@ private:
             case WIDX_AUTOSAVE_DROPDOWN:
                 for (size_t i = AUTOSAVE_EVERY_MINUTE; i <= AUTOSAVE_NEVER; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = AutosaveNames[i];
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Args = AutosaveNames[i];
                 }
 
                 ShowDropdown(widget, AUTOSAVE_NEVER + 1);

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -545,10 +545,10 @@ static void WindowParkEntranceMousedown(rct_window* w, rct_widgetindex widgetInd
 {
     if (widgetIndex == WIDX_OPEN_OR_CLOSE)
     {
-        gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[0] = STR_CLOSE_PARK;
-        gDropdownItemsArgs[1] = STR_OPEN_PARK;
+        gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[0].Args = STR_CLOSE_PARK;
+        gDropdownItems[1].Args = STR_OPEN_PARK;
         WindowDropdownShowText(
             { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1], 0, 2);
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -204,8 +204,8 @@ static void WindowPlayerOverviewShowGroupDropdown(rct_window* w, rct_widget* wid
 
     for (i = 0; i < network_get_num_groups(); i++)
     {
-        gDropdownItemsFormat[i] = STR_OPTIONS_DROPDOWN_ITEM;
-        gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(network_get_group_name(i));
+        gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
+        gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(network_get_group_name(i));
     }
 
     Dropdown::SetChecked(network_get_group_index(network_get_player_group(player)), true);

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -460,8 +460,8 @@ static void WindowResearchFundingMousedown(rct_window* w, rct_widgetindex widget
 
     for (i = 0; i < 4; i++)
     {
-        gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[i] = ResearchFundingLevelNames[i];
+        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[i].Args = ResearchFundingLevelNames[i];
     }
     WindowDropdownShowTextCustomWidth(
         { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1833,8 +1833,8 @@ static void WindowRideShowViewDropdown(rct_window* w, rct_widget* widget)
         w->colours[1], 0, 0, numItems, widget->right - dropdownWidget->left);
 
     // First item
-    gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-    gDropdownItemsArgs[0] = STR_OVERALL_VIEW;
+    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+    gDropdownItems[0].Args = STR_OVERALL_VIEW;
     int32_t currentItem = 1;
 
     const auto& rtd = ride->GetRideTypeDescriptor();
@@ -1843,8 +1843,8 @@ static void WindowRideShowViewDropdown(rct_window* w, rct_widget* widget)
     int32_t name = GetRideComponentName(rtd.NameConvention.vehicle).number;
     for (int32_t i = 1; i <= ride->num_vehicles; i++)
     {
-        gDropdownItemsFormat[currentItem] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[currentItem] = name | (currentItem << 16);
+        gDropdownItems[currentItem].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[currentItem].Args = name | (currentItem << 16);
         currentItem++;
     }
 
@@ -1852,8 +1852,8 @@ static void WindowRideShowViewDropdown(rct_window* w, rct_widget* widget)
     name = GetRideComponentName(rtd.NameConvention.station).number;
     for (int32_t i = 1; i <= ride->num_stations; i++)
     {
-        gDropdownItemsFormat[currentItem] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[currentItem] = name | (i << 16);
+        gDropdownItems[currentItem].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[currentItem].Args = name | (i << 16);
         currentItem++;
     }
 
@@ -1913,8 +1913,8 @@ static void WindowRideSetDropdown(RideStatusDropdownInfo& info, RideStatus statu
     if (info.Ride->SupportsStatus(status))
     {
         auto index = info.NumItems;
-        gDropdownItemsFormat[index] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[index] = text;
+        gDropdownItems[index].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[index].Args = text;
         if (info.CurrentStatus == status)
         {
             info.CheckedIndex = index;
@@ -2006,8 +2006,8 @@ static void WindowRideShowRideTypeDropdown(rct_window* w, rct_widget* widget)
 
     for (size_t i = 0; i < RideDropdownData.size(); i++)
     {
-        gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[i] = RideDropdownData[i].label_id;
+        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[i].Args = RideDropdownData[i].label_id;
     }
 
     rct_widget* dropdownWidget = widget - 1;
@@ -2037,8 +2037,8 @@ static void WindowRideShowLocateDropdown(rct_window* w, rct_widget* widget)
     if (ride == nullptr)
         return;
 
-    gDropdownItemsFormat[0] = STR_LOCATE_SUBJECT_TIP;
-    gDropdownItemsFormat[1] = STR_FOLLOW_SUBJECT_TIP;
+    gDropdownItems[0].Format = STR_LOCATE_SUBJECT_TIP;
+    gDropdownItems[1].Format = STR_FOLLOW_SUBJECT_TIP;
 
     WindowDropdownShowText(
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1], 0, 2);
@@ -2149,8 +2149,8 @@ static void WindowRideShowVehicleTypeDropdown(rct_window* w, rct_widget* widget)
 
     for (size_t i = 0; i < numItems; i++)
     {
-        gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[i] = VehicleDropdownData[i].label_id;
+        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[i].Args = VehicleDropdownData[i].label_id;
     }
 
     rct_widget* dropdownWidget = widget - 1;
@@ -2238,9 +2238,9 @@ static void WindowRideMainDropdown(rct_window* w, rct_widgetindex widgetIndex, i
                 {
                     dropdownIndex = gDropdownHighlightedIndex;
                 }
-                if (dropdownIndex < static_cast<int32_t>(std::size(gDropdownItemsArgs)))
+                if (dropdownIndex < static_cast<int32_t>(std::size(gDropdownItems)))
                 {
-                    switch (gDropdownItemsArgs[dropdownIndex])
+                    switch (gDropdownItems[dropdownIndex].Args)
                     {
                         case STR_CLOSE_RIDE:
                             status = RideStatus::Closed;
@@ -3181,8 +3181,8 @@ static void WindowRideModeDropdown(rct_window* w, rct_widget* widget)
     {
         if (availableModes & (1ULL << i))
         {
-            gDropdownItemsFormat[numAvailableModes] = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItemsArgs[numAvailableModes] = RideModeNames[i];
+            gDropdownItems[numAvailableModes].Format = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItems[numAvailableModes].Args = RideModeNames[i];
 
             if (ride->mode == static_cast<RideMode>(i))
                 checkedIndex = numAvailableModes;
@@ -3214,8 +3214,8 @@ static void WindowRideLoadDropdown(rct_window* w, rct_widget* widget)
     auto dropdownWidget = widget - 1;
     for (auto i = 0; i < 5; i++)
     {
-        gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[i] = VehicleLoadNames[i];
+        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[i].Args = VehicleLoadNames[i];
     }
     WindowDropdownShowTextCustomWidth(
         { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
@@ -3824,8 +3824,8 @@ static void WindowRideMaintenanceMousedown(rct_window* w, rct_widgetindex widget
             dropdownWidget--;
             for (int32_t i = 0; i < 7; i++)
             {
-                gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[i] = RideInspectionIntervalNames[i];
+                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].Args = RideInspectionIntervalNames[i];
             }
             WindowDropdownShowTextCustomWidth(
                 { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
@@ -3841,8 +3841,8 @@ static void WindowRideMaintenanceMousedown(rct_window* w, rct_widgetindex widget
                 if (rideEntry->ride_type[j] != RIDE_TYPE_NULL)
                     break;
             }
-            gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItemsArgs[0] = STR_DEBUG_FIX_RIDE;
+            gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItems[0].Args = STR_DEBUG_FIX_RIDE;
             for (int32_t i = 0; i < 8; i++)
             {
                 assert(j < static_cast<int32_t>(std::size(rideEntry->ride_type)));
@@ -3853,8 +3853,8 @@ static void WindowRideMaintenanceMousedown(rct_window* w, rct_widgetindex widget
                         if (ride->num_vehicles != 1)
                             continue;
                     }
-                    gDropdownItemsFormat[num_items] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[num_items] = RideBreakdownReasonNames[i];
+                    gDropdownItems[num_items].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[num_items].Args = RideBreakdownReasonNames[i];
                     num_items++;
                 }
             }
@@ -3886,8 +3886,8 @@ static void WindowRideMaintenanceMousedown(rct_window* w, rct_widgetindex widget
                                 Dropdown::SetChecked(num_items, true);
                                 break;
                             }
-                            gDropdownItemsFormat[num_items] = STR_DROPDOWN_MENU_LABEL;
-                            gDropdownItemsArgs[num_items] = RideBreakdownReasonNames[i];
+                            gDropdownItems[num_items].Format = STR_DROPDOWN_MENU_LABEL;
+                            gDropdownItems[num_items].Args = RideBreakdownReasonNames[i];
                             num_items++;
                         }
                     }
@@ -4331,8 +4331,8 @@ static void WindowRideColourMousedown(rct_window* w, rct_widgetindex widgetIndex
         case WIDX_TRACK_COLOUR_SCHEME_DROPDOWN:
             for (i = 0; i < OpenRCT2::Limits::NumColourSchemes; i++)
             {
-                gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[i] = ColourSchemeNames[i];
+                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].Args = ColourSchemeNames[i];
             }
 
             WindowDropdownShowTextCustomWidth(
@@ -4353,8 +4353,8 @@ static void WindowRideColourMousedown(rct_window* w, rct_widgetindex widgetIndex
         case WIDX_MAZE_STYLE_DROPDOWN:
             for (i = 0; i < 4; i++)
             {
-                gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[i] = MazeOptions[i].text;
+                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].Args = MazeOptions[i].text;
             }
 
             WindowDropdownShowTextCustomWidth(
@@ -4372,11 +4372,11 @@ static void WindowRideColourMousedown(rct_window* w, rct_widgetindex widgetIndex
                 auto stationObj = static_cast<StationObject*>(objManager.GetLoadedObject(ObjectType::Station, i));
                 if (stationObj != nullptr)
                 {
-                    gDropdownItemsFormat[ddIndex] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[ddIndex] = stationObj->NameStringId;
+                    gDropdownItems[ddIndex].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[ddIndex].Args = stationObj->NameStringId;
                     if (ride->entrance_style == i)
                     {
-                        gDropdownItemsFormat[ddIndex] = STR_DROPDOWN_MENU_LABEL_SELECTED;
+                        gDropdownItems[ddIndex].Format = STR_DROPDOWN_MENU_LABEL_SELECTED;
                     }
                     ddIndex++;
                 }
@@ -4390,9 +4390,9 @@ static void WindowRideColourMousedown(rct_window* w, rct_widgetindex widgetIndex
         case WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN:
             for (i = 0; i < 3; i++)
             {
-                gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[i] = (GetRideComponentName(ride->GetRideTypeDescriptor().NameConvention.vehicle).singular
-                                         << 16)
+                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].Args = (GetRideComponentName(ride->GetRideTypeDescriptor().NameConvention.vehicle).singular
+                                          << 16)
                     | VehicleColourSchemeNames[i];
             }
 
@@ -4412,8 +4412,8 @@ static void WindowRideColourMousedown(rct_window* w, rct_widgetindex widgetIndex
                                                                                          : STR_RIDE_COLOUR_VEHICLE_OPTION;
             for (i = 0; i < std::min(numItems, Dropdown::ItemsMaxSize); i++)
             {
-                gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[i] = (static_cast<int64_t>(i + 1) << 32)
+                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].Args = (static_cast<int64_t>(i + 1) << 32)
                     | ((GetRideComponentName(ride->GetRideTypeDescriptor().NameConvention.vehicle).capitalised) << 16)
                     | stringId;
             }
@@ -5107,8 +5107,8 @@ static void WindowRideMusicMousedown(rct_window* w, rct_widgetindex widgetIndex,
     for (size_t i = 0; i < numItems; i++)
     {
         auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, musicOrder[i]));
-        gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItemsArgs[i] = musicObj->NameStringId;
+        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[i].Args = musicObj->NameStringId;
     }
 
     WindowDropdownShowTextCustomWidth(
@@ -5415,8 +5415,8 @@ static void WindowRideMeasurementsMousedown(rct_window* w, rct_widgetindex widge
     if (ride == nullptr)
         return;
 
-    gDropdownItemsFormat[0] = STR_SAVE_TRACK_DESIGN_ITEM;
-    gDropdownItemsFormat[1] = STR_SAVE_TRACK_DESIGN_WITH_SCENERY_ITEM;
+    gDropdownItems[0].Format = STR_SAVE_TRACK_DESIGN_ITEM;
+    gDropdownItems[1].Format = STR_SAVE_TRACK_DESIGN_WITH_SCENERY_ITEM;
 
     WindowDropdownShowText(
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1],

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3079,7 +3079,7 @@ static void WindowRideConstructionShowSpecialTrackDropdown(rct_window* w, rct_wi
             if (ride != nullptr && (ride->type == RIDE_TYPE_MONSTER_TRUCKS || ride->type == RIDE_TYPE_CAR_RIDE))
                 trackPieceStringId = STR_LOG_BUMPS;
         }
-        gDropdownItemsFormat[i] = trackPieceStringId;
+        gDropdownItems[i].Format = trackPieceStringId;
         if ((trackPiece | RideConstructionSpecialPieceSelected) == _currentTrackCurve)
         {
             defaultIndex = i;

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -264,8 +264,8 @@ public:
         if (widgetIndex == WIDX_OPEN_CLOSE_ALL)
         {
             const auto& widget = widgets[widgetIndex];
-            gDropdownItemsFormat[0] = STR_CLOSE_ALL;
-            gDropdownItemsFormat[1] = STR_OPEN_ALL;
+            gDropdownItems[0].Format = STR_CLOSE_ALL;
+            gDropdownItems[1].Format = STR_OPEN_ALL;
             WindowDropdownShowText({ windowPos.x + widget.left, windowPos.y + widget.top }, widget.height(), colours[1], 0, 2);
         }
         else if (widgetIndex == WIDX_INFORMATION_TYPE_DROPDOWN)
@@ -295,8 +295,8 @@ public:
                     selectedIndex = numItems;
                 }
 
-                gDropdownItemsFormat[numItems] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[numItems] = ride_info_type_string_mapping[type];
+                gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[numItems].Args = ride_info_type_string_mapping[type];
                 numItems++;
             }
 
@@ -335,7 +335,7 @@ public:
                 return;
 
             int32_t informationType = INFORMATION_TYPE_STATUS;
-            uint32_t arg = static_cast<uint32_t>(gDropdownItemsArgs[dropdownIndex]);
+            uint32_t arg = static_cast<uint32_t>(gDropdownItems[dropdownIndex].Args);
             for (size_t i = 0; i < std::size(ride_info_type_string_mapping); i++)
             {
                 if (arg == ride_info_type_string_mapping[i])

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -263,14 +263,14 @@ static void WindowServerListScrollMousedown(rct_window* w, int32_t scrollIndex, 
 
         const auto& listWidget = w->widgets[WIDX_LIST];
 
-        gDropdownItemsFormat[0] = STR_JOIN_GAME;
+        gDropdownItems[0].Format = STR_JOIN_GAME;
         if (server.Favourite)
         {
-            gDropdownItemsFormat[1] = STR_REMOVE_FROM_FAVOURITES;
+            gDropdownItems[1].Format = STR_REMOVE_FROM_FAVOURITES;
         }
         else
         {
-            gDropdownItemsFormat[1] = STR_ADD_TO_FAVOURITES;
+            gDropdownItems[1].Format = STR_ADD_TO_FAVOURITES;
         }
         auto dropdownPos = ScreenCoordsXY{ w->windowPos.x + listWidget.left + screenCoords.x + 2 - w->scrolls[0].h_left,
                                            w->windowPos.y + listWidget.top + screenCoords.y + 2 - w->scrolls[0].v_top };

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -517,8 +517,8 @@ void WindowStaffOverviewMousedown(rct_window* w, rct_widgetindex widgetIndex, rc
         case WIDX_PATROL:
         {
             // Dropdown names
-            gDropdownItemsFormat[0] = STR_SET_PATROL_AREA;
-            gDropdownItemsFormat[1] = STR_CLEAR_PATROL_AREA;
+            gDropdownItems[0].Format = STR_SET_PATROL_AREA;
+            gDropdownItems[1].Format = STR_CLEAR_PATROL_AREA;
 
             auto dropdownPos = ScreenCoordsXY{ widget->left + w->windowPos.x, widget->top + w->windowPos.y };
             int32_t extray = widget->height() + 1;
@@ -591,8 +591,8 @@ void WindowStaffOverviewDropdown(rct_window* w, rct_widgetindex widgetIndex, int
 
 static void WindowStaffShowLocateDropdown(rct_window* w, rct_widget* widget)
 {
-    gDropdownItemsFormat[0] = STR_LOCATE_SUBJECT_TIP;
-    gDropdownItemsFormat[1] = STR_FOLLOW_SUBJECT_TIP;
+    gDropdownItems[0].Format = STR_LOCATE_SUBJECT_TIP;
+    gDropdownItems[1].Format = STR_FOLLOW_SUBJECT_TIP;
 
     WindowDropdownShowText(
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1], 0, 2);
@@ -1426,8 +1426,8 @@ void WindowStaffOptionsMousedown(rct_window* w, rct_widgetindex widgetIndex, rct
         {
             checkedIndex = i;
         }
-        gDropdownItemsArgs[i] = StaffCostumeNames[static_cast<uint8_t>(costume)];
-        gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
+        gDropdownItems[i].Args = StaffCostumeNames[static_cast<uint8_t>(costume)];
+        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
     }
 
     // Get the dropdown box widget instead of button.

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -511,8 +511,8 @@ static void WindowThemesMousedown(rct_window* w, rct_widgetindex widgetIndex, rc
             widget--;
             for (int32_t i = 0; i < num_items; i++)
             {
-                gDropdownItemsFormat[i] = STR_OPTIONS_DROPDOWN_ITEM;
-                gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(ThemeManagerGetAvailableThemeName(i));
+                gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
+                gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(ThemeManagerGetAvailableThemeName(i));
             }
 
             WindowDropdownShowTextCustomWidth(

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1117,12 +1117,12 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
                     widget--;
 
                     // Fill dropdown list
-                    gDropdownItemsFormat[0] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsFormat[1] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsFormat[2] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[0] = STR_TILE_INSPECTOR_WALL_FLAT;
-                    gDropdownItemsArgs[1] = STR_TILE_INSPECTOR_WALL_SLOPED_LEFT;
-                    gDropdownItemsArgs[2] = STR_TILE_INSPECTOR_WALL_SLOPED_RIGHT;
+                    gDropdownItems[0].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[1].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[2].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[0].Args = STR_TILE_INSPECTOR_WALL_FLAT;
+                    gDropdownItems[1].Args = STR_TILE_INSPECTOR_WALL_SLOPED_LEFT;
+                    gDropdownItems[2].Args = STR_TILE_INSPECTOR_WALL_SLOPED_RIGHT;
                     WindowDropdownShowTextCustomWidth(
                         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1], 0,
                         Dropdown::Flag::StayOpen, 3, widget->width() - 3);

--- a/src/openrct2-ui/windows/TitleCommandEditor.cpp
+++ b/src/openrct2-ui/windows/TitleCommandEditor.cpp
@@ -376,8 +376,8 @@ static void WindowTitleCommandEditorMousedown(rct_window* w, rct_widgetindex wid
             size_t numItems = NUM_COMMANDS;
             for (size_t i = 0; i < numItems; i++)
             {
-                gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                gDropdownItemsArgs[i] = _window_title_command_editor_orders[i].nameStringId;
+                gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[i].Args = _window_title_command_editor_orders[i].nameStringId;
             }
 
             WindowDropdownShowTextCustomWidth(
@@ -393,8 +393,8 @@ static void WindowTitleCommandEditorMousedown(rct_window* w, rct_widgetindex wid
                 int32_t numItems = 4;
                 for (int32_t i = 0; i < numItems; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_DROPDOWN_MENU_LABEL;
-                    gDropdownItemsArgs[i] = SpeedNames[i];
+                    gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+                    gDropdownItems[i].Args = SpeedNames[i];
                 }
 
                 WindowDropdownShowTextCustomWidth(
@@ -408,8 +408,8 @@ static void WindowTitleCommandEditorMousedown(rct_window* w, rct_widgetindex wid
                 int32_t numItems = static_cast<int32_t>(_sequence->Saves.size());
                 for (int32_t i = 0; i < numItems; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_OPTIONS_DROPDOWN_ITEM;
-                    gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(_sequence->Saves[i].c_str());
+                    gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
+                    gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(_sequence->Saves[i].c_str());
                 }
 
                 WindowDropdownShowTextCustomWidth(

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -533,8 +533,8 @@ static void WindowTitleEditorMousedown(rct_window* w, rct_widgetindex widgetInde
                 int32_t numItems = static_cast<int32_t>(title_sequence_manager_get_count());
                 for (int32_t i = 0; i < numItems; i++)
                 {
-                    gDropdownItemsFormat[i] = STR_OPTIONS_DROPDOWN_ITEM;
-                    gDropdownItemsArgs[i] = reinterpret_cast<uintptr_t>(title_sequence_manager_get_name(i));
+                    gDropdownItems[i].Format = STR_OPTIONS_DROPDOWN_ITEM;
+                    gDropdownItems[i].Args = reinterpret_cast<uintptr_t>(title_sequence_manager_get_name(i));
                 }
 
                 widget--;

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -172,11 +172,11 @@ static void WindowTitleMenuMousedown(rct_window* w, rct_widgetindex widgetIndex,
 {
     if (widgetIndex == WIDX_GAME_TOOLS)
     {
-        gDropdownItemsFormat[0] = STR_SCENARIO_EDITOR;
-        gDropdownItemsFormat[1] = STR_CONVERT_SAVED_GAME_TO_SCENARIO;
-        gDropdownItemsFormat[2] = STR_ROLLER_COASTER_DESIGNER;
-        gDropdownItemsFormat[3] = STR_TRACK_DESIGNS_MANAGER;
-        gDropdownItemsFormat[4] = STR_OPEN_USER_CONTENT_FOLDER;
+        gDropdownItems[0].Format = STR_SCENARIO_EDITOR;
+        gDropdownItems[1].Format = STR_CONVERT_SAVED_GAME_TO_SCENARIO;
+        gDropdownItems[2].Format = STR_ROLLER_COASTER_DESIGNER;
+        gDropdownItems[3].Format = STR_TRACK_DESIGNS_MANAGER;
+        gDropdownItems[4].Format = STR_OPEN_USER_CONTENT_FOLDER;
         WindowDropdownShowText(
             { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, TRANSLUCENT(w->colours[0]),
             Dropdown::Flag::StayOpen, 5);

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -439,64 +439,64 @@ static void WindowTopToolbarMousedown(rct_window* w, rct_widgetindex widgetIndex
         case WIDX_FILE_MENU:
             if (gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER))
             {
-                gDropdownItemsFormat[numItems++] = STR_ABOUT;
-                gDropdownItemsFormat[numItems++] = STR_OPTIONS;
-                gDropdownItemsFormat[numItems++] = STR_SCREENSHOT;
-                gDropdownItemsFormat[numItems++] = STR_GIANT_SCREENSHOT;
-                gDropdownItemsFormat[numItems++] = STR_EMPTY;
-                gDropdownItemsFormat[numItems++] = STR_FILE_BUG_ON_GITHUB;
+                gDropdownItems[numItems++].Format = STR_ABOUT;
+                gDropdownItems[numItems++].Format = STR_OPTIONS;
+                gDropdownItems[numItems++].Format = STR_SCREENSHOT;
+                gDropdownItems[numItems++].Format = STR_GIANT_SCREENSHOT;
+                gDropdownItems[numItems++].Format = STR_EMPTY;
+                gDropdownItems[numItems++].Format = STR_FILE_BUG_ON_GITHUB;
 
                 if (OpenRCT2::GetContext()->HasNewVersionInfo())
-                    gDropdownItemsFormat[numItems++] = STR_UPDATE_AVAILABLE;
+                    gDropdownItems[numItems++].Format = STR_UPDATE_AVAILABLE;
 
-                gDropdownItemsFormat[numItems++] = STR_EMPTY;
+                gDropdownItems[numItems++].Format = STR_EMPTY;
 
                 if (gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER)
-                    gDropdownItemsFormat[numItems++] = STR_QUIT_ROLLERCOASTER_DESIGNER;
+                    gDropdownItems[numItems++].Format = STR_QUIT_ROLLERCOASTER_DESIGNER;
                 else
-                    gDropdownItemsFormat[numItems++] = STR_QUIT_TRACK_DESIGNS_MANAGER;
+                    gDropdownItems[numItems++].Format = STR_QUIT_TRACK_DESIGNS_MANAGER;
 
-                gDropdownItemsFormat[numItems++] = STR_EXIT_OPENRCT2;
+                gDropdownItems[numItems++].Format = STR_EXIT_OPENRCT2;
             }
             else if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
             {
-                gDropdownItemsFormat[numItems++] = STR_LOAD_LANDSCAPE;
-                gDropdownItemsFormat[numItems++] = STR_SAVE_LANDSCAPE;
-                gDropdownItemsFormat[numItems++] = STR_EMPTY;
-                gDropdownItemsFormat[numItems++] = STR_ABOUT;
-                gDropdownItemsFormat[numItems++] = STR_OPTIONS;
-                gDropdownItemsFormat[numItems++] = STR_SCREENSHOT;
-                gDropdownItemsFormat[numItems++] = STR_GIANT_SCREENSHOT;
-                gDropdownItemsFormat[numItems++] = STR_EMPTY;
-                gDropdownItemsFormat[numItems++] = STR_FILE_BUG_ON_GITHUB;
+                gDropdownItems[numItems++].Format = STR_LOAD_LANDSCAPE;
+                gDropdownItems[numItems++].Format = STR_SAVE_LANDSCAPE;
+                gDropdownItems[numItems++].Format = STR_EMPTY;
+                gDropdownItems[numItems++].Format = STR_ABOUT;
+                gDropdownItems[numItems++].Format = STR_OPTIONS;
+                gDropdownItems[numItems++].Format = STR_SCREENSHOT;
+                gDropdownItems[numItems++].Format = STR_GIANT_SCREENSHOT;
+                gDropdownItems[numItems++].Format = STR_EMPTY;
+                gDropdownItems[numItems++].Format = STR_FILE_BUG_ON_GITHUB;
 
                 if (OpenRCT2::GetContext()->HasNewVersionInfo())
-                    gDropdownItemsFormat[numItems++] = STR_UPDATE_AVAILABLE;
+                    gDropdownItems[numItems++].Format = STR_UPDATE_AVAILABLE;
 
-                gDropdownItemsFormat[numItems++] = STR_EMPTY;
-                gDropdownItemsFormat[numItems++] = STR_QUIT_SCENARIO_EDITOR;
-                gDropdownItemsFormat[numItems++] = STR_EXIT_OPENRCT2;
+                gDropdownItems[numItems++].Format = STR_EMPTY;
+                gDropdownItems[numItems++].Format = STR_QUIT_SCENARIO_EDITOR;
+                gDropdownItems[numItems++].Format = STR_EXIT_OPENRCT2;
             }
             else
             {
-                gDropdownItemsFormat[numItems++] = STR_NEW_GAME;
-                gDropdownItemsFormat[numItems++] = STR_LOAD_GAME;
-                gDropdownItemsFormat[numItems++] = STR_SAVE_GAME;
-                gDropdownItemsFormat[numItems++] = STR_SAVE_GAME_AS;
-                gDropdownItemsFormat[numItems++] = STR_EMPTY;
-                gDropdownItemsFormat[numItems++] = STR_ABOUT;
-                gDropdownItemsFormat[numItems++] = STR_OPTIONS;
-                gDropdownItemsFormat[numItems++] = STR_SCREENSHOT;
-                gDropdownItemsFormat[numItems++] = STR_GIANT_SCREENSHOT;
-                gDropdownItemsFormat[numItems++] = STR_EMPTY;
-                gDropdownItemsFormat[numItems++] = STR_FILE_BUG_ON_GITHUB;
+                gDropdownItems[numItems++].Format = STR_NEW_GAME;
+                gDropdownItems[numItems++].Format = STR_LOAD_GAME;
+                gDropdownItems[numItems++].Format = STR_SAVE_GAME;
+                gDropdownItems[numItems++].Format = STR_SAVE_GAME_AS;
+                gDropdownItems[numItems++].Format = STR_EMPTY;
+                gDropdownItems[numItems++].Format = STR_ABOUT;
+                gDropdownItems[numItems++].Format = STR_OPTIONS;
+                gDropdownItems[numItems++].Format = STR_SCREENSHOT;
+                gDropdownItems[numItems++].Format = STR_GIANT_SCREENSHOT;
+                gDropdownItems[numItems++].Format = STR_EMPTY;
+                gDropdownItems[numItems++].Format = STR_FILE_BUG_ON_GITHUB;
 
                 if (OpenRCT2::GetContext()->HasNewVersionInfo())
-                    gDropdownItemsFormat[numItems++] = STR_UPDATE_AVAILABLE;
+                    gDropdownItems[numItems++].Format = STR_UPDATE_AVAILABLE;
 
-                gDropdownItemsFormat[numItems++] = STR_EMPTY;
-                gDropdownItemsFormat[numItems++] = STR_QUIT_TO_MENU;
-                gDropdownItemsFormat[numItems++] = STR_EXIT_OPENRCT2;
+                gDropdownItems[numItems++].Format = STR_EMPTY;
+                gDropdownItems[numItems++].Format = STR_QUIT_TO_MENU;
+                gDropdownItems[numItems++].Format = STR_EXIT_OPENRCT2;
             }
 
             WindowDropdownShowText(
@@ -3305,23 +3305,23 @@ static void WindowTopToolbarToolAbort(rct_window* w, rct_widgetindex widgetIndex
 static void TopToolbarInitMapMenu(rct_window* w, rct_widget* widget)
 {
     auto i = 0;
-    gDropdownItemsFormat[i++] = STR_SHORTCUT_SHOW_MAP;
-    gDropdownItemsFormat[i++] = STR_EXTRA_VIEWPORT;
+    gDropdownItems[i++].Format = STR_SHORTCUT_SHOW_MAP;
+    gDropdownItems[i++].Format = STR_EXTRA_VIEWPORT;
     if ((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && gEditorStep == EditorStep::LandscapeEditor)
     {
-        gDropdownItemsFormat[i++] = STR_MAPGEN_WINDOW_TITLE;
+        gDropdownItems[i++].Format = STR_MAPGEN_WINDOW_TITLE;
     }
 
 #ifdef ENABLE_SCRIPTING
     const auto& customMenuItems = OpenRCT2::Scripting::CustomMenuItems;
     if (!customMenuItems.empty())
     {
-        gDropdownItemsFormat[i++] = STR_EMPTY;
+        gDropdownItems[i++].Format = STR_EMPTY;
         for (const auto& item : customMenuItems)
         {
-            gDropdownItemsFormat[i] = STR_STRING;
+            gDropdownItems[i].Format = STR_STRING;
             auto sz = item.Text.c_str();
-            std::memcpy(&gDropdownItemsArgs[i], &sz, sizeof(const char*));
+            std::memcpy(&gDropdownItems[i].Args, &sz, sizeof(const char*));
             i++;
         }
     }
@@ -3371,22 +3371,22 @@ static void TopToolbarMapMenuDropdown(int16_t dropdownIndex)
 static void TopToolbarInitFastforwardMenu(rct_window* w, rct_widget* widget)
 {
     int32_t num_items = 4;
-    gDropdownItemsFormat[0] = STR_TOGGLE_OPTION;
-    gDropdownItemsFormat[1] = STR_TOGGLE_OPTION;
-    gDropdownItemsFormat[2] = STR_TOGGLE_OPTION;
-    gDropdownItemsFormat[3] = STR_TOGGLE_OPTION;
+    gDropdownItems[0].Format = STR_TOGGLE_OPTION;
+    gDropdownItems[1].Format = STR_TOGGLE_OPTION;
+    gDropdownItems[2].Format = STR_TOGGLE_OPTION;
+    gDropdownItems[3].Format = STR_TOGGLE_OPTION;
     if (gConfigGeneral.debugging_tools)
     {
-        gDropdownItemsFormat[4] = STR_EMPTY;
-        gDropdownItemsFormat[5] = STR_TOGGLE_OPTION;
-        gDropdownItemsArgs[5] = STR_SPEED_HYPER;
+        gDropdownItems[4].Format = STR_EMPTY;
+        gDropdownItems[5].Format = STR_TOGGLE_OPTION;
+        gDropdownItems[5].Args = STR_SPEED_HYPER;
         num_items = 6;
     }
 
-    gDropdownItemsArgs[0] = STR_SPEED_NORMAL;
-    gDropdownItemsArgs[1] = STR_SPEED_QUICK;
-    gDropdownItemsArgs[2] = STR_SPEED_FAST;
-    gDropdownItemsArgs[3] = STR_SPEED_TURBO;
+    gDropdownItems[0].Args = STR_SPEED_NORMAL;
+    gDropdownItems[1].Args = STR_SPEED_QUICK;
+    gDropdownItems[2].Args = STR_SPEED_FAST;
+    gDropdownItems[3].Args = STR_SPEED_TURBO;
 
     WindowDropdownShowText(
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[0] | 0x80, 0,
@@ -3433,8 +3433,8 @@ static void TopToolbarFastforwardMenuDropdown(int16_t dropdownIndex)
 
 static void TopToolbarInitRotateMenu(rct_window* w, rct_widget* widget)
 {
-    gDropdownItemsFormat[0] = STR_ROTATE_CLOCKWISE;
-    gDropdownItemsFormat[1] = STR_ROTATE_ANTI_CLOCKWISE;
+    gDropdownItems[0].Format = STR_ROTATE_CLOCKWISE;
+    gDropdownItems[1].Format = STR_ROTATE_ANTI_CLOCKWISE;
 
     WindowDropdownShowText(
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1] | 0x80, 0, 2);
@@ -3554,10 +3554,10 @@ static void TopToolbarCheatsMenuDropdown(int16_t dropdownIndex)
 
 static void TopToolbarInitDebugMenu(rct_window* w, rct_widget* widget)
 {
-    gDropdownItemsFormat[DDIDX_CONSOLE] = STR_TOGGLE_OPTION;
-    gDropdownItemsArgs[DDIDX_CONSOLE] = STR_DEBUG_DROPDOWN_CONSOLE;
-    gDropdownItemsFormat[DDIDX_DEBUG_PAINT] = STR_TOGGLE_OPTION;
-    gDropdownItemsArgs[DDIDX_DEBUG_PAINT] = STR_DEBUG_DROPDOWN_DEBUG_PAINT;
+    gDropdownItems[DDIDX_CONSOLE].Format = STR_TOGGLE_OPTION;
+    gDropdownItems[DDIDX_CONSOLE].Args = STR_DEBUG_DROPDOWN_CONSOLE;
+    gDropdownItems[DDIDX_DEBUG_PAINT].Format = STR_TOGGLE_OPTION;
+    gDropdownItems[DDIDX_DEBUG_PAINT].Args = STR_DEBUG_DROPDOWN_DEBUG_PAINT;
 
     WindowDropdownShowText(
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[0] | 0x80,
@@ -3568,8 +3568,8 @@ static void TopToolbarInitDebugMenu(rct_window* w, rct_widget* widget)
 
 static void TopToolbarInitNetworkMenu(rct_window* w, rct_widget* widget)
 {
-    gDropdownItemsFormat[DDIDX_MULTIPLAYER] = STR_MULTIPLAYER;
-    gDropdownItemsFormat[DDIDX_MULTIPLAYER_RECONNECT] = STR_MULTIPLAYER_RECONNECT;
+    gDropdownItems[DDIDX_MULTIPLAYER].Format = STR_MULTIPLAYER;
+    gDropdownItems[DDIDX_MULTIPLAYER_RECONNECT].Format = STR_MULTIPLAYER_RECONNECT;
 
     WindowDropdownShowText(
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[0] | 0x80, 0,

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -3464,7 +3464,7 @@ static void TopToolbarInitCheatsMenu(rct_window* w, rct_widget* widget)
 {
     using namespace Dropdown;
 
-    constexpr Item items[] = {
+    constexpr ItemExt items[] = {
         ToggleOption(DDIDX_CHEATS, STR_CHEAT_TITLE),
         ToggleOption(DDIDX_TILE_INSPECTOR, STR_DEBUG_DROPDOWN_TILE_INSPECTOR),
         ToggleOption(DDIDX_OBJECT_SELECTION, STR_DEBUG_DROPDOWN_OBJECT_SELECTION),
@@ -3631,7 +3631,7 @@ static void TopToolbarNetworkMenuDropdown(int16_t dropdownIndex)
 static void TopToolbarInitViewMenu(rct_window* w, rct_widget* widget)
 {
     using namespace Dropdown;
-    constexpr Item items[] = {
+    constexpr ItemExt items[] = {
         ToggleOption(DDIDX_UNDERGROUND_INSIDE, STR_UNDERGROUND_VIEW),
         ToggleOption(DDIDX_TRANSPARENT_WATER, STR_VIEWPORT_TRANSPARENT_WATER),
         ToggleOption(DDIDX_HIDE_BASE, STR_REMOVE_BASE_LAND),


### PR DESCRIPTION
This constitutes some work towards getting dropdowns to use less global state.

The next step is to create a class for the dropdown itself and have the items as an std::vector.