### PR TITLE
Refactor last_*_directory and last_run_version to use u8string

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -962,10 +962,9 @@ static void WindowLoadsaveInvokeCallback(int32_t result, const utf8* path)
     }
 }
 
-static void SavePath(utf8** config_str, const char* path)
+static void SetAndSaveConfigPath(u8string& config_str, u8string_view path)
 {
-    free(*config_str);
-    *config_str = path_get_directory(path);
+    config_str = Path::GetDirectory(path);
     config_save_default();
 }
 
@@ -996,14 +995,14 @@ static void WindowLoadsaveSelect(rct_window* w, const char* path)
     switch (_type & 0x0F)
     {
         case (LOADSAVETYPE_LOAD | LOADSAVETYPE_GAME):
-            SavePath(&gConfigGeneral.last_save_game_directory, pathBuffer);
+            SetAndSaveConfigPath(gConfigGeneral.last_save_game_directory, pathBuffer);
             WindowLoadsaveInvokeCallback(MODAL_RESULT_OK, pathBuffer);
             window_close_by_class(WC_LOADSAVE);
             gfx_invalidate_screen();
             break;
 
         case (LOADSAVETYPE_SAVE | LOADSAVETYPE_GAME):
-            SavePath(&gConfigGeneral.last_save_game_directory, pathBuffer);
+            SetAndSaveConfigPath(gConfigGeneral.last_save_game_directory, pathBuffer);
             if (scenario_save(pathBuffer, gConfigGeneral.save_plugin_data ? 1 : 0))
             {
                 gScenarioSavePath = pathBuffer;
@@ -1023,7 +1022,7 @@ static void WindowLoadsaveSelect(rct_window* w, const char* path)
             break;
 
         case (LOADSAVETYPE_LOAD | LOADSAVETYPE_LANDSCAPE):
-            SavePath(&gConfigGeneral.last_save_landscape_directory, pathBuffer);
+            SetAndSaveConfigPath(gConfigGeneral.last_save_landscape_directory, pathBuffer);
             if (Editor::LoadLandscape(pathBuffer))
             {
                 gCurrentLoadedPath = pathBuffer;
@@ -1039,7 +1038,7 @@ static void WindowLoadsaveSelect(rct_window* w, const char* path)
             break;
 
         case (LOADSAVETYPE_SAVE | LOADSAVETYPE_LANDSCAPE):
-            SavePath(&gConfigGeneral.last_save_landscape_directory, pathBuffer);
+            SetAndSaveConfigPath(gConfigGeneral.last_save_landscape_directory, pathBuffer);
             gScenarioFileName = std::string(String::ToStringView(pathBuffer, std::size(pathBuffer)));
             if (scenario_save(pathBuffer, gConfigGeneral.save_plugin_data ? 3 : 2))
             {
@@ -1057,7 +1056,7 @@ static void WindowLoadsaveSelect(rct_window* w, const char* path)
 
         case (LOADSAVETYPE_SAVE | LOADSAVETYPE_SCENARIO):
         {
-            SavePath(&gConfigGeneral.last_save_scenario_directory, pathBuffer);
+            SetAndSaveConfigPath(gConfigGeneral.last_save_scenario_directory, pathBuffer);
             int32_t parkFlagsBackup = gParkFlags;
             gParkFlags &= ~PARK_FLAGS_SPRITES_INITIALISED;
             gEditorStep = EditorStep::Invalid;
@@ -1082,7 +1081,7 @@ static void WindowLoadsaveSelect(rct_window* w, const char* path)
 
         case (LOADSAVETYPE_LOAD | LOADSAVETYPE_TRACK):
         {
-            SavePath(&gConfigGeneral.last_save_track_directory, pathBuffer);
+            SetAndSaveConfigPath(gConfigGeneral.last_save_track_directory, pathBuffer);
             auto intent = Intent(WC_INSTALL_TRACK);
             intent.putExtra(INTENT_EXTRA_PATH, std::string{ pathBuffer });
             context_open_intent(&intent);
@@ -1093,7 +1092,7 @@ static void WindowLoadsaveSelect(rct_window* w, const char* path)
 
         case (LOADSAVETYPE_SAVE | LOADSAVETYPE_TRACK):
         {
-            SavePath(&gConfigGeneral.last_save_track_directory, pathBuffer);
+            SetAndSaveConfigPath(gConfigGeneral.last_save_track_directory, pathBuffer);
 
             path_set_extension(pathBuffer, "td6", sizeof(pathBuffer));
 

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -370,14 +370,14 @@ namespace OpenRCT2
 
             crash_init();
 
-            if (gConfigGeneral.last_run_version != nullptr && String::Equals(gConfigGeneral.last_run_version, OPENRCT2_VERSION))
+            if (String::Equals(gConfigGeneral.last_run_version, OPENRCT2_VERSION))
             {
                 gOpenRCT2ShowChangelog = false;
             }
             else
             {
                 gOpenRCT2ShowChangelog = true;
-                gConfigGeneral.last_run_version = String::Duplicate(OPENRCT2_VERSION);
+                gConfigGeneral.last_run_version = OPENRCT2_VERSION;
                 config_save_default();
             }
 

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -179,7 +179,7 @@ namespace Config
             model->auto_staff_placement = reader->GetBoolean("auto_staff", true);
             model->handymen_mow_default = reader->GetBoolean("handymen_mow_default", false);
             model->default_inspection_interval = reader->GetInt32("default_inspection_interval", 2);
-            model->last_run_version = reader->GetCString("last_run_version", nullptr);
+            model->last_run_version = reader->GetString("last_run_version", "");
             model->invert_viewport_drag = reader->GetBoolean("invert_viewport_drag", false);
             model->load_save_sort = reader->GetEnum<Sort>("load_save_sort", Sort::NameAscending, Enum_Sort);
             model->minimize_fullscreen_focus_loss = reader->GetBoolean("minimize_fullscreen_focus_loss", true);
@@ -202,10 +202,10 @@ namespace Config
             model->scenario_select_mode = reader->GetInt32("scenario_select_mode", SCENARIO_SELECT_MODE_ORIGIN);
             model->scenario_unlocking_enabled = reader->GetBoolean("scenario_unlocking_enabled", true);
             model->scenario_hide_mega_park = reader->GetBoolean("scenario_hide_mega_park", true);
-            model->last_save_game_directory = reader->GetCString("last_game_directory", nullptr);
-            model->last_save_landscape_directory = reader->GetCString("last_landscape_directory", nullptr);
-            model->last_save_scenario_directory = reader->GetCString("last_scenario_directory", nullptr);
-            model->last_save_track_directory = reader->GetCString("last_track_directory", nullptr);
+            model->last_save_game_directory = reader->GetString("last_game_directory", "");
+            model->last_save_landscape_directory = reader->GetString("last_landscape_directory", "");
+            model->last_save_scenario_directory = reader->GetString("last_scenario_directory", "");
+            model->last_save_track_directory = reader->GetString("last_track_directory", "");
             model->use_native_browse_dialog = reader->GetBoolean("use_native_browse_dialog", false);
             model->window_limit = reader->GetInt32("window_limit", WINDOW_LIMIT_MAX);
             model->zoom_to_cursor = reader->GetBoolean("zoom_to_cursor", true);
@@ -783,11 +783,6 @@ bool config_save(u8string_view path)
 void config_release()
 {
     SafeFree(gConfigGeneral.custom_currency_symbol);
-    SafeFree(gConfigGeneral.last_save_game_directory);
-    SafeFree(gConfigGeneral.last_save_landscape_directory);
-    SafeFree(gConfigGeneral.last_save_scenario_directory);
-    SafeFree(gConfigGeneral.last_save_track_directory);
-    SafeFree(gConfigGeneral.last_run_version);
     SafeFree(gConfigInterface.current_theme_preset);
     SafeFree(gConfigInterface.current_title_sequence_preset);
     SafeFree(gConfigSound.device);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -101,11 +101,11 @@ struct GeneralConfiguration
     // Loading and saving
     bool confirmation_prompt;
     Sort load_save_sort;
-    utf8* last_save_game_directory;
-    utf8* last_save_landscape_directory;
-    utf8* last_save_scenario_directory;
-    utf8* last_save_track_directory;
-    utf8* last_run_version;
+    u8string last_save_game_directory;
+    u8string last_save_landscape_directory;
+    u8string last_save_scenario_directory;
+    u8string last_save_track_directory;
+    u8string last_run_version;
     bool use_native_browse_dialog;
     int64_t last_version_check_time;
 };


### PR DESCRIPTION
Fixes a regression from #16631 causing a crash when constructing `u8string` from a `nullptr`.

This calls for a bigger refactor replacing `path_get_*` functions with modern `Path::` equivalents, but I keep them out of this PR as this is kind of a hotfix.

Fixes #16644
Fixes #16646
Fixes #16649