### PR TITLE
Close #12793: Excitement/Intensity/Nausea ratings to Ride List view with sorting

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3650,6 +3650,13 @@ STR_6457    :Report a bug on GitHub
 STR_6458    :Follow this on Main View
 STR_6460    :D
 STR_6461    :Direction
+STR_6462    :Excitement
+STR_6463    :Excitement: {COMMA2DP32}
+STR_6464    :Intensity
+STR_6465    :Intensity: {COMMA2DP32}
+STR_6466    :Nausea
+STR_6467    :Nausea: {COMMA2DP32}
+STR_6468    :Not Yet Known
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [#4933] Allow map sizes of 999 × 999 (up from 254 × 254).
 - Feature: [#7660] Custom music objects that are distributed with the save.
 - Feature: [#8407] Ride platforms can be made invisible.
+- Feature: [#12793] Add Excitement/Intensity/Nausea ratings to Ride List view with sorting.
 - Feature: [#13858] Flatride bases can be made invisible.
 - Feature: [#14676] [Plugin] Allow plugins to store data in .park files.
 - Feature: [#15367] Individual track elements can now be drawn as another ride type.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5501,8 +5501,7 @@ static void WindowRideMeasurementsPaint(rct_window* w, rct_drawpixelinfo* dpi)
             auto ft = Formatter();
             ft.Add<uint32_t>(ride->excitement);
             ft.Add<rct_string_id>(ratingName);
-            rct_string_id stringId = ride->excitement == RIDE_RATING_UNDEFINED ? STR_EXCITEMENT_RATING_NOT_YET_AVAILABLE
-                                                                               : STR_EXCITEMENT_RATING;
+            rct_string_id stringId = !ride_has_ratings(ride) ? STR_EXCITEMENT_RATING_NOT_YET_AVAILABLE : STR_EXCITEMENT_RATING;
             DrawTextBasic(dpi, screenCoords, stringId, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
 
@@ -5513,7 +5512,7 @@ static void WindowRideMeasurementsPaint(rct_window* w, rct_drawpixelinfo* dpi)
             ft.Add<rct_string_id>(ratingName);
 
             stringId = STR_INTENSITY_RATING;
-            if (ride->excitement == RIDE_RATING_UNDEFINED)
+            if (!ride_has_ratings(ride))
                 stringId = STR_INTENSITY_RATING_NOT_YET_AVAILABLE;
             else if (ride->intensity >= RIDE_RATING(10, 00))
                 stringId = STR_INTENSITY_RATING_RED;
@@ -5526,7 +5525,7 @@ static void WindowRideMeasurementsPaint(rct_window* w, rct_drawpixelinfo* dpi)
             ft = Formatter();
             ft.Add<uint32_t>(ride->nausea);
             ft.Add<rct_string_id>(ratingName);
-            stringId = ride->excitement == RIDE_RATING_UNDEFINED ? STR_NAUSEA_RATING_NOT_YET_AVAILABLE : STR_NAUSEA_RATING;
+            stringId = !ride_has_ratings(ride) ? STR_NAUSEA_RATING_NOT_YET_AVAILABLE : STR_NAUSEA_RATING;
             DrawTextBasic(dpi, screenCoords, stringId, ft);
             screenCoords.y += 2 * LIST_ROW_HEIGHT;
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -93,6 +93,9 @@ enum
     INFORMATION_TYPE_RELIABILITY,
     INFORMATION_TYPE_DOWN_TIME,
     INFORMATION_TYPE_GUESTS_FAVOURITE,
+    INFORMATION_TYPE_EXCITEMENT,
+    INFORMATION_TYPE_INTENSITY,
+    INFORMATION_TYPE_NAUSEA,
     DROPDOWN_LIST_COUNT,
 };
 
@@ -112,6 +115,9 @@ static constexpr const rct_string_id ride_info_type_string_mapping[DROPDOWN_LIST
     STR_RELIABILITY,
     STR_DOWN_TIME,
     STR_GUESTS_FAVOURITE,
+    STR_RIDE_LIST_EXCITEMENT,
+    STR_RIDE_LIST_INTENSITY,
+    STR_RIDE_LIST_NAUSEA,
 };
 
 static constexpr const rct_string_id ride_list_statusbar_count_strings[PAGE_COUNT] = {
@@ -136,6 +142,9 @@ static constexpr const bool ride_info_type_money_mapping[DROPDOWN_LIST_COUNT] = 
     false, // Reliability
     false, // Down time
     false, // Guests favourite
+    false, // Excitement
+    false, // Intensity
+    false, // Nausea
 };
 
 static constexpr const rct_string_id page_names[] = {
@@ -267,7 +276,7 @@ public:
 
             int32_t lastType;
             if (page == PAGE_RIDES)
-                lastType = INFORMATION_TYPE_GUESTS_FAVOURITE;
+                lastType = INFORMATION_TYPE_NAUSEA;
             else
                 lastType = INFORMATION_TYPE_RUNNING_COST;
 
@@ -689,6 +698,30 @@ public:
                                                                          : STR_GUESTS_FAVOURITE_PLURAL_LABEL;
                     }
                     break;
+                case INFORMATION_TYPE_EXCITEMENT:
+                    formatSecondary = STR_RATING_UKNOWN_LABEL;
+                    if (ride_has_ratings(ridePtr))
+                    {
+                        formatSecondary = STR_EXCITEMENT_LABEL;
+                        ft.Add<uint16_t>(ridePtr->excitement);
+                    }
+                    break;
+                case INFORMATION_TYPE_INTENSITY:
+                    formatSecondary = STR_RATING_UKNOWN_LABEL;
+                    if (ride_has_ratings(ridePtr))
+                    {
+                        formatSecondary = STR_INTENSITY_LABEL;
+                        ft.Add<uint16_t>(ridePtr->intensity);
+                    }
+                    break;
+                case INFORMATION_TYPE_NAUSEA:
+                    formatSecondary = STR_RATING_UKNOWN_LABEL;
+                    if (ride_has_ratings(ridePtr))
+                    {
+                        formatSecondary = STR_NAUSEA_LABEL;
+                        ft.Add<uint16_t>(ridePtr->nausea);
+                    }
+                    break;
             }
 
             if (formatSecondaryEnabled)
@@ -867,6 +900,24 @@ private:
                     currentListPosition = SortList(
                         currentListPosition, rideRef, [](const Ride& thisRide, const Ride& otherRide) -> bool {
                             return thisRide.guests_favourite <= otherRide.guests_favourite;
+                        });
+                    break;
+                case INFORMATION_TYPE_EXCITEMENT:
+                    currentListPosition = SortList(
+                        currentListPosition, rideRef, [](const Ride& thisRide, const Ride& otherRide) -> bool {
+                            return thisRide.excitement <= otherRide.excitement;
+                        });
+                    break;
+                case INFORMATION_TYPE_INTENSITY:
+                    currentListPosition = SortList(
+                        currentListPosition, rideRef, [](const Ride& thisRide, const Ride& otherRide) -> bool {
+                            return thisRide.intensity <= otherRide.intensity;
+                        });
+                    break;
+                case INFORMATION_TYPE_NAUSEA:
+                    currentListPosition = SortList(
+                        currentListPosition, rideRef, [](const Ride& thisRide, const Ride& otherRide) -> bool {
+                            return thisRide.nausea <= otherRide.nausea;
                         });
                     break;
             }

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3917,6 +3917,14 @@ enum : uint16_t
     STR_TILE_INSPECTOR_DIRECTION_SHORT = 6460,
     STR_TILE_INSPECTOR_DIRECTION = 6461,
 
+    STR_RIDE_LIST_EXCITEMENT = 6462,
+    STR_EXCITEMENT_LABEL = 6463,
+    STR_RIDE_LIST_INTENSITY = 6464,
+    STR_INTENSITY_LABEL = 6465,
+    STR_RIDE_LIST_NAUSEA = 6466,
+    STR_NAUSEA_LABEL = 6467,
+    STR_RATING_UKNOWN_LABEL = 6468,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
This PR references issue #12793. Adding a simple overview for Excitement/Intensity/Nausea in the Ride List.

Excitement:
![excitement](https://user-images.githubusercontent.com/10876411/153965820-8c9be165-7225-4309-b98b-afc598e6bf0c.gif)

Intensity:
![Intensity](https://user-images.githubusercontent.com/10876411/153966752-6897fb3d-10f9-4f41-8b0d-948605c3c5f8.gif)

Nausea:
![Nausea](https://user-images.githubusercontent.com/10876411/153966757-19c505be-9df1-432f-9099-f7064942da52.gif)

