### PR TITLE
Close #5141: Removes headless servers from player count and player list (2nd attempt)

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1003,7 +1003,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
 
         // Draw number of players.
         auto ft = Formatter();
-        ft.Add<int32_t>(network_get_num_players());
+        ft.Add<int32_t>(network_get_num_visible_players());
         DrawTextBasic(
             dpi, screenPos + ScreenCoordsXY{ 23, 1 }, STR_COMMA16, ft,
             { COLOUR_WHITE | COLOUR_FLAG_OUTLINE, TextAlignment::RIGHT });

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "13"
+#define NETWORK_STREAM_VERSION "14"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;
@@ -1607,6 +1607,7 @@ void NetworkBase::Server_Send_GAMEINFO(NetworkConnection& connection)
 
     packet.WriteString(jsonObj.dump());
     packet << _serverState.gamestateSnapshotsEnabled;
+    packet << IsServerPlayerInvisible;
 
 #    endif
     connection.QueuePacket(std::move(packet));
@@ -3121,6 +3122,7 @@ void NetworkBase::Client_Handle_GAMEINFO([[maybe_unused]] NetworkConnection& con
 {
     auto jsonString = packet.ReadString();
     packet >> _serverState.gamestateSnapshotsEnabled;
+    packet >> IsServerPlayerInvisible;
 
     json_t jsonData = Json::FromString(jsonString);
 
@@ -3759,6 +3761,11 @@ int32_t network_get_pickup_peep_old_x(uint8_t playerid)
         return player->PickupPeepOldX;
     }
     return -1;
+}
+
+bool network_is_server_player_invisible()
+{
+    return OpenRCT2::GetContext()->GetNetwork().IsServerPlayerInvisible;
 }
 
 int32_t network_get_current_player_group_index()

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -4001,6 +4001,10 @@ int32_t network_get_num_players()
 {
     return 1;
 }
+int32_t network_get_num_visible_players()
+{
+    return 1;
+}
 const char* network_get_player_name(uint32_t index)
 {
     return "local (OpenRCT2 compiled without MP)";
@@ -4151,6 +4155,10 @@ uint8_t network_get_current_player_id()
 int32_t network_get_current_player_group_index()
 {
     return 0;
+}
+bool network_is_server_player_invisible()
+{
+    return false;
 }
 void network_append_chat_log(std::string_view)
 {

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -377,8 +377,7 @@ bool NetworkBase::BeginServer(uint16_t port, const std::string& address)
     ServerProviderEmail = gConfigNetwork.provider_email;
     ServerProviderWebsite = gConfigNetwork.provider_website;
 
-    if (gOpenRCT2Headless)
-        IsServerPlayerInvisible = true;
+    IsServerPlayerInvisible = gOpenRCT2Headless;
 
     CheatsReset();
     LoadGroups();

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -111,7 +111,6 @@ static u8string network_get_public_key_path(u8string_view playerName, u8string_v
 NetworkBase::NetworkBase(OpenRCT2::IContext& context)
     : OpenRCT2::System(context)
 {
-    wsa_initialized = false;
     mode = NETWORK_MODE_NONE;
     status = NETWORK_STATUS_NONE;
     last_ping_sent_time = 0;

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -42,6 +42,8 @@ public: // Common
     auto GetGroupIteratorByID(uint8_t id) const;
     NetworkPlayer* GetPlayerByID(uint8_t id) const;
     NetworkGroup* GetGroupByID(uint8_t id) const;
+    int32_t GetTotalNumPlayers() const noexcept;
+    int32_t GetNumVisiblePlayers() const noexcept;
     void SetPassword(u8string_view password);
     uint8_t GetDefaultGroup() const noexcept;
     std::string BeginLog(const std::string& directory, const std::string& midName, const std::string& filenameFormat);
@@ -177,6 +179,7 @@ public: // Public common
     std::string ServerProviderWebsite;
     std::vector<std::unique_ptr<NetworkPlayer>> player_list;
     std::vector<std::unique_ptr<NetworkGroup>> group_list;
+    bool IsServerPlayerInvisible = false;
 
 private: // Common Data
     using CommandHandler = void (NetworkBase::*)(NetworkConnection& connection, NetworkPacket& packet);

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -189,7 +189,6 @@ private: // Common Data
     uint8_t default_group = 0;
     bool _closeLock = false;
     bool _requireClose = false;
-    bool wsa_initialized = false;
 
 private: // Server Data
     std::unordered_map<NetworkCommand, CommandHandler> server_command_handlers;

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -290,7 +290,7 @@ private:
 
     json_t GetHeartbeatJson()
     {
-        uint32_t numPlayers = network_get_num_players();
+        uint32_t numPlayers = network_get_num_visible_players();
 
         json_t root = {
             { "token", _token },

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -93,6 +93,7 @@ void network_set_pickup_peep(uint8_t playerid, Peep* peep);
 [[nodiscard]] Peep* network_get_pickup_peep(uint8_t playerid);
 void network_set_pickup_peep_old_x(uint8_t playerid, int32_t x);
 [[nodiscard]] int32_t network_get_pickup_peep_old_x(uint8_t playerid);
+[[nodiscard]] bool network_is_server_player_invisible();
 
 void network_send_chat(const char* text, const std::vector<uint8_t>& playerIds = {});
 void network_send_game_action(const GameAction* action);

--- a/src/openrct2/network/network.h
+++ b/src/openrct2/network/network.h
@@ -56,6 +56,7 @@ void network_flush();
 [[nodiscard]] uint32_t network_get_server_tick();
 [[nodiscard]] uint8_t network_get_current_player_id();
 [[nodiscard]] int32_t network_get_num_players();
+[[nodiscard]] int32_t network_get_num_visible_players();
 [[nodiscard]] const char* network_get_player_name(uint32_t index);
 [[nodiscard]] uint32_t network_get_player_flags(uint32_t index);
 [[nodiscard]] int32_t network_get_player_ping(uint32_t index);


### PR DESCRIPTION
I previously worked on the same issue in pull request #16624, but my previous solution ended up a bit more complicated than it needed to be. This pull request adds the variable `IsServerPlayerInvisible` to NetworkBase, which determines whether or not the server itself counts towards the player count on the server list, as well as whether or not the server's player is shown in the client-side player list (note that the server player does still exist, it's simply hidden from the list).

Notable:
 - When the server is invisible, it does not count towards the maximum number of connected players.
 - The server player can always be seen in the player list when `gConfigGeneral.debugging_tools` is true.
 - I bumped `NETWORK_STREAM_VERSION` because `IsServerPlayerInvisible` needed to be synchronized.
 - As a bit of miscellaneous cleanup, I also noticed that the variable `wsa_initialized` in NetworkBase was never being read, so I removed it.