### PR TITLE
Fix #15413: Modifying park rating with plugins desyncs history

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -31,6 +31,7 @@
 - Fix: [#13336] Can no longer place Bumble Bee track design (reverts #12707).
 - Fix: [#14155] Map Generator sometimes places non-tree objects as trees.
 - Fix: [#14674] Recent Messages only shows first few notifications.
+- Fix: [#15413] Modifying park rating with plugins desyncs park rating history from actual park rating.
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#15830] Objects with RCT1 images are very glitchy if OpenRCT2 is not linked to an RCT1 install.
 - Fix: [#15947, #15960] Removing a flat ride results in an error message and duplicate structures.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "18"
+#define NETWORK_STREAM_VERSION "19"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -310,6 +310,12 @@ void Park::Update(const Date& date)
 {
     PROFILED_FUNCTION();
 
+    // Every new week
+    if (date.IsWeekStart())
+    {
+        UpdateHistories();
+    }
+
     // Every ~13 seconds
     if (gCurrentTicks % 512 == 0)
     {
@@ -324,17 +330,14 @@ void Park::Update(const Date& date)
         auto intent = Intent(INTENT_ACTION_UPDATE_PARK_RATING);
         context_broadcast_intent(&intent);
     }
+
     // Every ~102 seconds
     if (gCurrentTicks % 4096 == 0)
     {
         gParkSize = CalculateParkSize();
         window_invalidate_by_class(WC_PARK_INFORMATION);
     }
-    // Every new week
-    if (date.IsWeekStart())
-    {
-        UpdateHistories();
-    }
+
     GenerateGuests();
 }
 
@@ -755,7 +758,7 @@ void Park::UpdateHistories()
     gNumGuestsInParkLastWeek = gNumGuestsInPark;
 
     // Update park rating, guests in park and current cash history
-    HistoryPushRecord<uint8_t, 32>(gParkRatingHistory, CalculateParkRating() / 4);
+    HistoryPushRecord<uint8_t, 32>(gParkRatingHistory, gParkRating / 4);
     HistoryPushRecord<uint32_t, 32>(gGuestsInParkHistory, gNumGuestsInPark);
     HistoryPushRecord<money64, std::size(gCashHistory)>(gCashHistory, finance_get_current_cash() - gBankLoan);
 


### PR DESCRIPTION
Update park rating history before park rating.