### PR TITLE
Fix #16591: Plugins: setInterval and setTimeout is not disposed when map unloads

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -44,6 +44,7 @@
 - Fix: [#16535] Entering construction mode unblocks all paths.
 - Fix: [#16542] “Same price throughout park” status not correctly imported for RCT1 saves.
 - Fix: [#16572] Crash when trying to place track designs.
+- Fix: [#16591] [Plugin] setInterval and setTimeout is not disposed when map unloads.
 - Fix: [objects#165] Glitch when Bengal Tiger Cars go through a corner.
 
 0.3.5.1 (2021-11-21)

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -9,16 +9,17 @@
 
 #ifdef ENABLE_SCRIPTING
 
+#    include "../UiContext.h"
 #    include "../interface/Dropdown.h"
+#    include "../interface/Widget.h"
 #    include "../scripting/ScGraphicsContext.hpp"
 #    include "../scripting/ScWidget.hpp"
+#    include "../windows/Window.h"
 #    include "CustomListView.h"
 #    include "ScUi.hpp"
 #    include "ScWindow.hpp"
 
 #    include <limits>
-#    include <openrct2-ui/interface/Widget.h>
-#    include <openrct2-ui/windows/Window.h>
 #    include <openrct2/drawing/Drawing.h>
 #    include <openrct2/interface/Window.h>
 #    include <openrct2/localisation/Formatter.h>
@@ -1430,6 +1431,29 @@ namespace OpenRCT2::Ui::Windows
             {
                 customWidgetInfo->MaxLength = value;
             }
+        }
+    }
+
+    void CloseWindowsOwnedByPlugin(std::shared_ptr<Plugin> plugin)
+    {
+        // Get all the windows that need closing
+        std::vector<std::shared_ptr<rct_window>> customWindows;
+        for (const auto& window : g_window_list)
+        {
+            if (window->classification == WC_CUSTOM)
+            {
+                auto customWindow = reinterpret_cast<CustomWindow*>(window.get());
+                auto customInfo = reinterpret_cast<CustomWindowInfo*>(customWindow->custom_info);
+                if (customInfo != nullptr && customInfo->Owner == plugin)
+                {
+                    customWindows.push_back(window);
+                }
+            }
+        }
+
+        for (auto& window : customWindows)
+        {
+            window_close(window.get());
         }
     }
 

--- a/src/openrct2-ui/scripting/CustomWindow.h
+++ b/src/openrct2-ui/scripting/CustomWindow.h
@@ -36,6 +36,7 @@ namespace OpenRCT2::Ui::Windows
     CustomListView* GetCustomListView(rct_window* w, rct_widgetindex widgetIndex);
     int32_t GetWidgetMaxLength(rct_window* w, rct_widgetindex widgetIndex);
     void SetWidgetMaxLength(rct_window* w, rct_widgetindex widgetIndex, int32_t value);
+    void CloseWindowsOwnedByPlugin(std::shared_ptr<Plugin> plugin);
 } // namespace OpenRCT2::Ui::Windows
 
 #endif

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -162,6 +162,8 @@ namespace OpenRCT2::Scripting
             auto& execInfo = _scriptEngine.GetExecInfo();
             auto owner = execInfo.GetCurrentPlugin();
 
+            owner->ThrowIfStopping();
+
             std::shared_ptr<ScWindow> scWindow = nullptr;
             auto w = window_custom_open(owner, desc);
             if (w != nullptr)

--- a/src/openrct2-ui/scripting/UiExtensions.cpp
+++ b/src/openrct2-ui/scripting/UiExtensions.cpp
@@ -56,6 +56,8 @@ void UiScriptExtensions::Extend(ScriptEngine& scriptEngine)
     ScWindow::Register(ctx);
 
     InitialiseCustomMenuItems(scriptEngine);
+    scriptEngine.SubscribeToPluginStoppedEvent(
+        [](std::shared_ptr<Plugin> plugin) -> void { CloseWindowsOwnedByPlugin(plugin); });
 }
 
 std::shared_ptr<ScWindow> ScWidget::window_get() const

--- a/src/openrct2/scripting/Plugin.cpp
+++ b/src/openrct2/scripting/Plugin.cpp
@@ -96,9 +96,23 @@ void Plugin::Start()
     _hasStarted = true;
 }
 
-void Plugin::Stop()
+void Plugin::StopBegin()
 {
+    _isStopping = true;
+}
+
+void Plugin::StopEnd()
+{
+    _isStopping = false;
     _hasStarted = false;
+}
+
+void Plugin::ThrowIfStopping() const
+{
+    if (IsStopping())
+    {
+        duk_error(_context, DUK_ERR_ERROR, "Plugin is stopping.");
+    }
 }
 
 void Plugin::LoadCodeFromFile()

--- a/src/openrct2/scripting/Plugin.h
+++ b/src/openrct2/scripting/Plugin.h
@@ -54,6 +54,7 @@ namespace OpenRCT2::Scripting
         PluginMetadata _metadata{};
         std::string _code;
         bool _hasStarted{};
+        bool _isStopping{};
 
     public:
         std::string GetPath() const
@@ -81,6 +82,11 @@ namespace OpenRCT2::Scripting
             return _hasStarted;
         }
 
+        bool IsStopping() const
+        {
+            return _isStopping;
+        }
+
         int32_t GetTargetAPIVersion() const;
 
         Plugin() = default;
@@ -91,7 +97,10 @@ namespace OpenRCT2::Scripting
         void SetCode(std::string_view code);
         void Load();
         void Start();
-        void Stop();
+        void StopBegin();
+        void StopEnd();
+
+        void ThrowIfStopping() const;
 
     private:
         void LoadCodeFromFile();

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -509,24 +509,18 @@ void ScriptEngine::StopPlugin(std::shared_ptr<Plugin> plugin)
 {
     if (plugin->HasStarted())
     {
-        RemoveCustomGameActions(plugin);
-        RemoveIntervals(plugin);
-        RemoveSockets(plugin);
-        _hookEngine.UnsubscribeAll(plugin);
+        plugin->StopBegin();
+
         for (const auto& callback : _pluginStoppedSubscriptions)
         {
             callback(plugin);
         }
+        RemoveCustomGameActions(plugin);
+        RemoveIntervals(plugin);
+        RemoveSockets(plugin);
+        _hookEngine.UnsubscribeAll(plugin);
 
-        ScriptExecutionInfo::PluginScope scope(_execInfo, plugin, false);
-        try
-        {
-            plugin->Stop();
-        }
-        catch (const std::exception& e)
-        {
-            _console.WriteLineError(e.what());
-        }
+        plugin->StopEnd();
     }
 }
 

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -725,7 +725,7 @@ DukValue ScriptEngine::ExecutePluginCall(
     bool isGameStateMutable)
 {
     DukStackFrame frame(_context);
-    if (func.is_function())
+    if (func.is_function() && plugin->HasStarted())
     {
         ScriptExecutionInfo::PluginScope scope(_execInfo, plugin, isGameStateMutable);
         func.push();


### PR DESCRIPTION
* Do not run any plugin callbacks if the plugin is stopped.
* When a plugin is stopped, close all windows created by that plugin.
* When the plugin is being stopped, do not allow opening of new windows by that plugin. This is mainly to prevent the close event of a window, opening a new window, if the plugin is being stopped.