### PR TITLE
Close #16566: Favour WinNT preprocessor version checks over MinGW

### DIFF
--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -9,12 +9,6 @@
 
 #ifdef _WIN32
 
-#    if defined(__MINGW32__) && !defined(WINVER) && !defined(_WIN32_WINNT)
-// 0x0600 == vista
-#        define WINVER 0x0600
-#        define _WIN32_WINNT 0x0600
-#    endif // __MINGW32__
-
 // Windows.h needs to be included first
 // clang-format off
 #    include <windows.h>
@@ -41,7 +35,7 @@
 
 static std::wstring SHGetPathFromIDListLongPath(LPCITEMIDLIST pidl)
 {
-#    if defined(__MINGW32__)
+#    if _WIN32_WINNT < 0x0600
     std::wstring pszPath(MAX_PATH, 0);
     auto result = SHGetPathFromIDListW(pidl, pszPath.data());
 #    else

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -15,6 +15,7 @@
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/PlatformEnvironment.h>
 #include <openrct2/Version.h>
+#include <openrct2/core/FileSystem.hpp>
 #include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Localisation.h>
@@ -65,12 +66,7 @@ public:
     const std::string GetChangelogText()
     {
         auto path = GetChangelogPath();
-#if defined(_WIN32) && !defined(__MINGW32__)
-        auto pathW = String::ToWideChar(path);
-        auto fs = std::ifstream(pathW, std::ios::in);
-#else
-        auto fs = std::ifstream(path, std::ios::in);
-#endif
+        auto fs = std::ifstream(u8path(path), std::ios::in);
         if (!fs.is_open())
         {
             throw std::runtime_error("Unable to open " + path);

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -96,7 +96,7 @@ static exitcode_t HandleCommandJoin(CommandLineArgEnumerator * enumerator);
 static exitcode_t HandleCommandSetRCT2(CommandLineArgEnumerator * enumerator);
 static exitcode_t HandleCommandScanObjects(CommandLineArgEnumerator * enumerator);
 
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32) && _WIN32_WINNT >= 0x0600
 
 static bool _removeShell = false;
 
@@ -133,7 +133,7 @@ const CommandLineCommand CommandLine::RootCommands[]
     DefineCommand("scan-objects", "<path>",             StandardOptions, HandleCommandScanObjects),
     DefineCommand("handle-uri", "openrct2://.../",      StandardOptions, CommandLine::HandleCommandUri),
 
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32) && _WIN32_WINNT >= 0x0600
     DefineCommand("register-shell", "", RegisterShellOptions, HandleCommandRegisterShell),
 #endif
 
@@ -400,7 +400,7 @@ static exitcode_t HandleCommandScanObjects([[maybe_unused]] CommandLineArgEnumer
     return EXITCODE_OK;
 }
 
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32) && _WIN32_WINNT >= 0x0600
 static exitcode_t HandleCommandRegisterShell([[maybe_unused]] CommandLineArgEnumerator* enumerator)
 {
     exitcode_t result = CommandLine::HandleCommandDefault();
@@ -419,7 +419,7 @@ static exitcode_t HandleCommandRegisterShell([[maybe_unused]] CommandLineArgEnum
     }
     return EXITCODE_OK;
 }
-#endif // defined(_WIN32) && !defined(__MINGW32__)
+#endif // defined(_WIN32) && _WIN32_WINNT >= 0x0600
 
 static void PrintAbout()
 {

--- a/src/openrct2/core/FileWatcher.cpp
+++ b/src/openrct2/core/FileWatcher.cpp
@@ -111,7 +111,7 @@ FileWatcher::FileWatcher(const std::string& directoryPath)
 FileWatcher::~FileWatcher()
 {
 #ifdef _WIN32
-#    ifdef __MINGW32__
+#    if _WIN32_WINNT < 0x0600
     // TODO CancelIo is documented as not working across a different thread but
     //      CancelIoEx is not available.
     CancelIo(_directoryHandle);

--- a/src/openrct2/core/Imaging.cpp
+++ b/src/openrct2/core/Imaging.cpp
@@ -13,6 +13,7 @@
 
 #include "../Version.h"
 #include "../drawing/Drawing.h"
+#include "FileSystem.hpp"
 #include "Guard.hpp"
 #include "IStream.hpp"
 #include "Memory.hpp"
@@ -311,12 +312,7 @@ namespace Imaging
                 return ReadFromFile(path, GetImageFormatFromPath(path));
             default:
             {
-#if defined(_WIN32) && !defined(__MINGW32__)
-                auto pathW = String::ToWideChar(path);
-                std::ifstream fs(pathW, std::ios::binary);
-#else
-                std::ifstream fs(std::string(path), std::ios::binary);
-#endif
+                std::ifstream fs(u8path(path), std::ios::binary);
                 return ReadFromStream(fs, format);
             }
         }
@@ -337,12 +333,7 @@ namespace Imaging
                 break;
             case IMAGE_FORMAT::PNG:
             {
-#if defined(_WIN32) && !defined(__MINGW32__)
-                auto pathW = String::ToWideChar(path);
-                std::ofstream fs(pathW, std::ios::binary);
-#else
-                std::ofstream fs(std::string(path), std::ios::binary);
-#endif
+                std::ofstream fs(u8path(path), std::ios::binary);
                 WritePng(fs, image);
                 break;
             }

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -7,12 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#if defined(__MINGW32__) && !defined(WINVER) && !defined(_WIN32_WINNT)
-// 0x0600 == vista
-#    define WINVER 0x0600
-#    define _WIN32_WINNT 0x0600
-#endif // __MINGW32__
-
 #include <algorithm>
 #include <cctype>
 #include <cwctype>

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -1085,13 +1085,7 @@ void NetworkBase::BeginChatLog()
     auto env = GetContext().GetPlatformEnvironment();
     auto directory = env->GetDirectoryPath(DIRBASE::USER, DIRID::LOG_CHAT);
     _chatLogPath = BeginLog(directory, "", _chatLogFilenameFormat);
-
-#    if defined(_WIN32) && !defined(__MINGW32__)
-    auto pathW = String::ToWideChar(_chatLogPath);
-    _chat_log_fs.open(pathW.c_str(), std::ios::out | std::ios::app);
-#    else
-    _chat_log_fs.open(_chatLogPath, std::ios::out | std::ios::app);
-#    endif
+    _chat_log_fs.open(u8path(_chatLogPath), std::ios::out | std::ios::app);
 }
 
 void NetworkBase::AppendChatLog(std::string_view s)
@@ -1112,13 +1106,7 @@ void NetworkBase::BeginServerLog()
     auto env = GetContext().GetPlatformEnvironment();
     auto directory = env->GetDirectoryPath(DIRBASE::USER, DIRID::LOG_SERVER);
     _serverLogPath = BeginLog(directory, ServerName, _serverLogFilenameFormat);
-
-#    if defined(_WIN32) && !defined(__MINGW32__)
-    auto pathW = String::ToWideChar(_serverLogPath);
-    _server_log_fs.open(pathW.c_str(), std::ios::out | std::ios::app | std::ios::binary);
-#    else
-    _server_log_fs.open(_serverLogPath, std::ios::out | std::ios::app | std::ios::binary);
-#    endif
+    _server_log_fs.open(u8path(_serverLogPath), std::ios::out | std::ios::app | std::ios::binary);
 
     // Log server start event
     utf8 logMessage[256];

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -643,7 +643,7 @@ private:
     std::string GetIpAddressFromSocket(const sockaddr_in* addr) const
     {
         std::string result;
-#    if defined(__MINGW32__)
+#    if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600
         if (addr->sin_family == AF_INET)
         {
             result = inet_ntoa(addr->sin_addr);


### PR DESCRIPTION
**WARNING: UNTESTED!**

A full pass through the code removing all references to `__MINGW32__`, replacing it with proper WinNT version checks.
In most cases it's self explanatory, just one thing to note: snippets like
```cpp
#if defined(_WIN32) && !defined(__MINGW32__)
                auto pathW = String::ToWideChar(path);
                std::ifstream fs(pathW, std::ios::binary);
#else
                std::ifstream fs(std::string(path), std::ios::binary);
#endif
```
have been replaced with just `std::ifstream fs(u8path(path), std::ios::binary);`, since `fstream` has a constructor accepting a `fs::path`.

Resolves #16566