### PR TITLE
Win32: Fix a Y2038 bug in TimeToSystemTime

### DIFF
--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -185,11 +185,12 @@ namespace Platform
 
     static SYSTEMTIME TimeToSystemTime(std::time_t timestamp)
     {
-        LONGLONG ll = Int32x32To64(timestamp, 10000000) + 116444736000000000;
+        ULARGE_INTEGER time_value;
+        time_value.QuadPart = (timestamp * 10000000LL) + 116444736000000000LL;
 
         FILETIME ft;
-        ft.dwLowDateTime = static_cast<DWORD>(ll);
-        ft.dwHighDateTime = ll >> 32;
+        ft.dwLowDateTime = time_value.LowPart;
+        ft.dwHighDateTime = time_value.HighPart;
 
         SYSTEMTIME st;
         FileTimeToSystemTime(&ft, &st);


### PR DESCRIPTION
This PR is a part of a mini-project of mine to fix Y2038 bugs caused by [a code snippet from this MSDN article](https://docs.microsoft.com/en-us/windows/win32/sysinfo/converting-a-time-t-value-to-a-file-time).

`Int32x32To64`, as the name suggests, performs a multiplication of two 32-bit values **with truncation**.
Using it with a 64-bit `time_t` truncated the value, effectively introducing a Year 2038 bug all over again.

In the PR, I update the function to mirror an updated code snippet I submitted to MSDN recently.