### PR TITLE
Update guest list defaults

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -183,6 +183,7 @@ The following people are not part of the development team, but have been contrib
 * Cory Sanin (CorySanin)
 * Vinícius Hashimoto (vkhashimoto)
 * Gal B. (GalBr)
+* Rik Smeets (rik-smeets)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -28,6 +28,7 @@
 - Change: [#16077] When importing SV6 files, the RCT1 land types are only added when they were actually used.
 - Change: [#16424] Following an entity in the title sequence no longer toggles underground view when it's underground.
 - Change: [#16493] Boat Hire and Submarine Ride support costs now match their visual appearance.
+- Change: [#16710] Changed default view of Guest List to 'Thoughts' and selected tab will default to 'Summarised' (when opened from the menu).
 - Fix: [#11752] Track pieces with fractional cost are too cheap to build.
 - Fix: [#12774] [Plugin] Scripts will not be re-initialised when a new scenario is loaded from within a running scenario.
 - Fix: [#13336] Can no longer place Bumble Bee track design (reverts #12707).

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -156,7 +156,8 @@ public:
         widgets = window_guest_list_widgets;
         WindowInitScrollWidgets(this);
 
-        _selectedTab = TabId::Individual;
+        _selectedTab = TabId::Summarised;
+        _selectedView = GuestViewType::Thoughts;
         _numPages = 1;
         widgets[WIDX_TRACKING].type = WindowWidgetType::FlatBtn;
         widgets[WIDX_FILTER_BY_NAME].type = WindowWidgetType::FlatBtn;
@@ -192,7 +193,7 @@ public:
                     _selectedFilter = GuestFilterType::Guests;
                     _highlightedIndex = {};
                     _selectedTab = TabId::Individual;
-                    _selectedView = GuestViewType::Actions;
+                    _selectedView = GuestViewType::Thoughts;
                 }
                 break;
             }
@@ -207,7 +208,7 @@ public:
                     _selectedFilter = GuestFilterType::Guests;
                     _highlightedIndex = {};
                     _selectedTab = TabId::Individual;
-                    _selectedView = GuestViewType::Actions;
+                    _selectedView = GuestViewType::Thoughts;
                 }
                 break;
             }


### PR DESCRIPTION
*As discussed on [Discord](https://discord.com/channels/264137540670324737/691735032531779684/945758936479461396).*

Most players use the guest list to view guest thoughts, in order to spot potential issues in the park. Therefore, change the default views of the guest list:
- When opening the guest list, set selected tab to 'Summarised' and selected view to 'Thoughts'.
- When opening the guest list via 'Guests on ride' or 'Guests in queue', also set selected view to 'Thoughts'.