### PR TITLE
[Plugin] Fix ride object from overflowing with more than 256 ride types

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -53,6 +53,7 @@
 - Fix: [#16542] “Same price throughout park” status not correctly imported for RCT1 saves.
 - Fix: [#16572] Crash when trying to place track designs.
 - Fix: [#16591] [Plugin] setInterval and setTimeout is not disposed when map unloads.
+- Fix: [#16711] [Plugin] Car.rideObject overflowing with more than 256 ride types.
 - Fix: [objects#165] Glitch when Bengal Tiger Cars go through a corner.
 
 0.3.5.1 (2021-11-21)

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -90,12 +90,12 @@ namespace OpenRCT2::Scripting
         return ::GetEntity<Vehicle>(_id);
     }
 
-    uint8_t ScVehicle::rideObject_get() const
+    ObjectEntryIndex ScVehicle::rideObject_get() const
     {
         auto vehicle = GetVehicle();
         return vehicle != nullptr ? vehicle->ride_subtype : 0;
     }
-    void ScVehicle::rideObject_set(uint8_t value)
+    void ScVehicle::rideObject_set(ObjectEntryIndex value)
     {
         ThrowIfGameStateNotMutable();
         auto vehicle = GetVehicle();

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
@@ -28,8 +28,8 @@ namespace OpenRCT2::Scripting
     private:
         Vehicle* GetVehicle() const;
 
-        uint8_t rideObject_get() const;
-        void rideObject_set(uint8_t value);
+        ObjectEntryIndex rideObject_get() const;
+        void rideObject_set(ObjectEntryIndex value);
 
         uint8_t vehicleObject_get() const;
         void vehicleObject_set(uint8_t value);


### PR DESCRIPTION
Hey,

If a park has more than 256 rides selected, the [`rideObject` property on the `Car` entity](https://github.com/OpenRCT2/OpenRCT2/blob/f2117508c4979dfc107117b9cb6f04651af0b726/distribution/openrct2.d.ts#L1141) starts returning and applying incorrect indices. This is probably because the relevant index uses the `ObjectEntryIndex` (= `uint16_t`), while the script bindings used a plain `uint8_t`, so when NSF increased the limit of this field, the new difference in bits in the bindings went unchanged and unnoticed. This PR fixes that.

If you wish to reproduce the error:
1. Download the [RideVehicleEditor](https://github.com/Basssiiie/OpenRCT2-RideVehicleEditor/releases).
2. Get a park with more than 256 ride objects selected, for example this one: [SixFlagsMM-all-rides.zip](https://github.com/OpenRCT2/OpenRCT2/files/8127589/SixFlagsMM-all-rides.zip)
3. Select a vehicle.
4. Change its type to a vehicle type at the end of the list, for example the Wooden Coaster Car 6-seater, both reversed and not reversed, or the Virginia Reels cars. (It's alphabetically sorted internally as well, the highest indices are at the end.)
5. Select another vehicle or train and then select the edited vehicle again.
6. The plugin now thinks it's a different vehicle type (which it reads straight from `rideObject`).
7. Download one of the artifacts in this PR and repeat these steps to see the correct vehicle type stays selected.

Thank you for your time!
