### PR TITLE
Fix #16715. The first time we save a park, default to the park's name…

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -390,7 +390,7 @@ static u8string Browse(bool isSave)
         // The file browser requires a file path instead of just a directory
         if (!_defaultPath.empty())
         {
-            Path::Combine(path, _defaultPath);
+            path = Path::Combine(path, _defaultPath);
         }
         else
         {
@@ -401,7 +401,7 @@ static u8string Browse(bool isSave)
                 // Use localised "Unnamed Park" if park name was empty.
                 buffer = format_string(STR_UNNAMED_PARK, nullptr);
             }
-            Path::Combine(path, buffer);
+            path = Path::Combine(path, buffer);
         }
     }
 

--- a/src/openrct2/core/Path.hpp
+++ b/src/openrct2/core/Path.hpp
@@ -16,7 +16,7 @@
 
 namespace Path
 {
-    u8string Combine(u8string_view a, u8string_view b);
+    [[nodiscard]] u8string Combine(u8string_view a, u8string_view b);
 
     template<typename... Args> static u8string Combine(u8string_view a, u8string_view b, Args... args)
     {


### PR DESCRIPTION
… as the file name

Previously it looks we forgot to save the output of Combine. Combine returns the newly combined string without modifying the given values.

Tested it locally. Issue appears to be fixed (defaulted to park's name instead of empty string). 