### PR TITLE
Fix bug where file extension can get added twice

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -419,7 +419,7 @@ static u8string Browse(bool isSave)
     {
         // When the given save type was given, Windows still interprets a filename with a dot in its name as a custom extension,
         // meaning files like "My Coaster v1.2" will not get the .td6 extension by default.
-        if (isSave && get_file_extension_type(path) != fileType)
+        if (isSave && get_file_extension_type(outPath) != fileType)
             path_append_extension(outPath, extension.c_str(), std::size(outPath));
     }
 


### PR DESCRIPTION
All of my recent save files are auto getting '.park.park' as the extension.

The reason for this is the wrong path is being checked to then add the extension.

Examples:

![image](https://user-images.githubusercontent.com/5749838/155824039-64c79f2e-880c-45e5-97ca-9f0bdf6d8bdc.png)

