### PR TITLE
Fix crash where peeps enter through extra ride entrances

### DIFF
--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -3645,7 +3645,12 @@ void Guest::UpdateRideAdvanceThroughEntrance()
         return;
     }
 
-    Guard::Assert(RideSubState == PeepRideSubState::LeaveEntrance, "Peep ridesubstate should be LeaveEntrance");
+    if (RideSubState == PeepRideSubState::InEntrance)
+    {
+        RideSubState = PeepRideSubState::FreeVehicleCheck;
+        return;
+    }
+
     if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_NO_VEHICLES))
     {
         const auto& station = ride->GetStation(CurrentRideStation);

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "20"
+#define NETWORK_STREAM_VERSION "21"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
This should fix #16170 and close #16177. 

WIth this change the peep gets on the ride... and exits after over as expected. No crash. :) 
