### PR TITLE
Fix #15909: Prevent text overflow in 'Select ride design' windows

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -36,7 +36,7 @@
 - Fix: [#15413] Modifying park rating with plugins desyncs park rating history from actual park rating.
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#15830] Objects with RCT1 images are very glitchy if OpenRCT2 is not linked to an RCT1 install.
-- Fix: [#15909] Text can overflow in 'Select ride design' windows.
+- Fix: [#15909] Text can overflow in ‘Select ride design’ windows.
 - Fix: [#15947, #15960] Removing a flat ride results in an error message and duplicate structures.
 - Fix: [#15998] Cannot set map size to the actual maximum.
 - Fix: [#16007] Scenario Editor “Entry Price” appears to the right of the value field.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -36,6 +36,7 @@
 - Fix: [#15413] Modifying park rating with plugins desyncs park rating history from actual park rating.
 - Fix: [#15571] Non-ASCII characters in scenario description get distorted while saving.
 - Fix: [#15830] Objects with RCT1 images are very glitchy if OpenRCT2 is not linked to an RCT1 install.
+- Fix: [#15909] Text can overflow in 'Select ride design' windows.
 - Fix: [#15947, #15960] Removing a flat ride results in an error message and duplicate structures.
 - Fix: [#15998] Cannot set map size to the actual maximum.
 - Fix: [#16007] Scenario Editor “Entry Price” appears to the right of the value field.

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -28,7 +28,7 @@
 #include <vector>
 
 static constexpr const rct_string_id WINDOW_TITLE = STR_SELECT_DESIGN;
-static constexpr const int32_t WH = 431;
+static constexpr const int32_t WH = 441;
 static constexpr const int32_t WW = 600;
 static constexpr const int32_t DEBUG_PATH_HEIGHT = 12;
 static constexpr const int32_t ROTATE_AND_SCENERY_BUTTON_SIZE = 24;


### PR DESCRIPTION
Resolves #15909. 

For designs with a long description, a line of text in the 'Select ride design' window could overflow onto the next window element.
The window height was just one newline too small. Therefore, increased the window size with a single line.