### PR TITLE
Fix #16140: Disable 'follow this' when view is 'overall' or 'station'

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -45,6 +45,7 @@
 - Fix: [#16063] Object Selection preview for objects with glass is broken.
 - Fix: [#16075] Exporting track designs saves scenery in incorrect locations.
 - Fix: [#16087] The Looping Roller Coaster booster is now always drawn correctly.
+- Fix: [#16140] The 'Follow this' option is now disabled when the ride view is set to 'overall' or a station.
 - Fix: [#16162] Go Karts speeds are not correctly randomised, they only go very fast or very slow.
 - Fix: [#16188] Medium-size banked turns on the Twister and Vertical Roller Coaster have incorrect support placement (partly original bug).
 - Fix: [#16264, #16572] Placing saved track design crashes game.

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1927,9 +1927,10 @@ static void WindowRideShowLocateDropdown(rct_window* w, rct_widget* widget)
     WindowDropdownShowText(
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1], 0, 2);
     gDropdownDefaultIndex = 0;
-    if (!ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_TRACK))
+    if (!ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_TRACK) || w->ride.view == 0
+        || w->ride.view > ride->num_vehicles)
     {
-        // Disable if we're a flat ride
+        // Disable if we're a flat ride, 'overall view' is selected or a station is selected
         Dropdown::SetDisabled(1, true);
     }
 }


### PR DESCRIPTION
Resolves #16140.

The 'follow this' option will now be disabled when the view is set to 'overall' or a station, since there isn't anything to follow in these options.