### PR TITLE
Update Android build environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,7 +373,7 @@ jobs:
             ./gradlew app:assemble
           popd
           mkdir -p artifacts
-          mv src/openrct2-android/app/build/outputs/apk/arm/pr/app-arm-pr.apk artifacts/openrct2-arm.apk
+          mv src/openrct2-android/app/build/outputs/apk/release/app-release.apk artifacts/openrct2-arm.apk
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:0.3.1-android
+    container: openrct2/openrct2-build:4-android
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
         run: |
           . scripts/setenv
           pushd src/openrct2-android
-            ./gradlew app:assemblePR
+            ./gradlew app:assemble
           popd
           mkdir -p artifacts
           mv src/openrct2-android/app/build/outputs/apk/arm/pr/app-arm-pr.apk artifacts/openrct2-arm.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,7 +370,7 @@ jobs:
         run: |
           . scripts/setenv
           pushd src/openrct2-android
-            ./gradlew app:assemble
+            ./gradlew app:assembleRelease
           popd
           mkdir -p artifacts
           mv src/openrct2-android/app/build/outputs/apk/release/app-release.apk artifacts/openrct2-arm.apk

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -15,7 +15,7 @@ android {
                 arguments '-DANDROID_STL=c++_shared'
                 targets 'openrct2', 'openrct2-ui', 'openrct2-cli'
                 // abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
-                abiFilters 'arm64-v8a'
+                abiFilters 'armeabi-v7a', 'arm64-v8a'
             }
         }
     }

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -1,110 +1,48 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion '29.0.2'
-
+    compileSdkVersion 31
+    ndkVersion "23.1.7779620" // Latest r23b (LTS), to be synced with CI container image
     defaultConfig {
         applicationId 'io.openrct2'
         minSdkVersion 19
-        targetSdkVersion 28
+        targetSdkVersion 31
 
         versionCode 2
         versionName '0.3.5.1'
-
         externalNativeBuild {
             cmake {
                 arguments '-DANDROID_STL=c++_shared'
                 targets 'openrct2', 'openrct2-ui', 'openrct2-cli'
+                // abiFilters 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                abiFilters 'arm64-v8a'
             }
         }
     }
-
-    sourceSets {
-        main.assets.srcDirs += 'src/main/assets/'
-    }
-
-    signingConfigs {
-        debug {
-            storeFile file('external/debug.keystore')
-        }
-    }
-
     buildTypes {
-        debug {
-            applicationIdSuffix '.debug'
-            versionNameSuffix '-DEBUG'
-        }
-        pr {
-            applicationIdSuffix '.debug'
-            signingConfig signingConfigs.debug
-        }
-        develop {
-            applicationIdSuffix '.develop'
-            versionNameSuffix '-DEVELOP'
-            signingConfig signingConfigs.debug
-        }
         release {
             signingConfig signingConfigs.debug
         }
     }
 
-    flavorDimensions "version"
-    /*
-    productFlavors {
-        full {
-            dimension "version"
-        }
+    sourceSets.main {
+        jniLibs.srcDir 'libs'
     }
-    */
-
     externalNativeBuild {
         cmake {
             path 'src/main/CMakeLists.txt'
+            version "3.18.1"
         }
     }
 
-    productFlavors {
-        /*
-        arm7 {
-            ndk {
-                abiFilters 'armeabi-v7a'
-            }
-        }
-        */
-        arm {
-            ndk {
-                abiFilters 'armeabi-v7a', 'arm64-v8a'
-            }
-        }
-        /*
-        x86 {
-            ndk {
-                abiFilters 'x86', 'x86_64'
-            }
-        }
-        */
+    lintOptions {
+        abortOnError false
     }
-}
-
-delete {
-    delete 'src/main/assets/openrct2'
-}
-
-copy {
-    from '../../../bin/data'
-    into 'src/main/assets/openrct2'
 }
 
 dependencies {
     implementation 'commons-io:commons-io:2.6'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.4.0'
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
 }
 
-allprojects {
-    gradle.projectsEvaluated {
-        tasks.withType(JavaCompile) {
-            options.compilerArgs << "-Xlint:deprecation"
-        }
-    }
-}

--- a/src/openrct2-android/app/build.gradle
+++ b/src/openrct2-android/app/build.gradle
@@ -6,7 +6,7 @@ android {
     defaultConfig {
         applicationId 'io.openrct2'
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 28
 
         versionCode 2
         versionName '0.3.5.1'

--- a/src/openrct2-android/app/src/main/AndroidManifest.xml
+++ b/src/openrct2-android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:largeHeap="true"
-        android:theme="@style/AppTheme.Splash">
+        android:theme="@style/AppTheme.Splash"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name=".MainActivity"
             android:theme="@style/AppTheme.Splash"

--- a/src/openrct2-android/app/src/main/AndroidManifest.xml
+++ b/src/openrct2-android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:theme="@style/AppTheme.Splash">
         <activity
             android:name=".MainActivity"
-            android:theme="@style/AppTheme.Splash">
+            android:theme="@style/AppTheme.Splash"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/src/openrct2-android/app/src/main/CMakeLists.txt
+++ b/src/openrct2-android/app/src/main/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.8.0)
 
 project(openrct2-android CXX)
 
@@ -131,8 +131,6 @@ include_directories(SYSTEM "${CMAKE_BINARY_DIR}/libs/include/freetype2")
 include_directories(SYSTEM "${CMAKE_BINARY_DIR}/libs/include/SDL2")
 
 # now build app's shared lib
-include_directories(./ndk_helper
-                    ${ANDROID_NDK}/sources/android/cpufeatures)
 add_definitions(-DDISABLE_HTTP -DDISABLE_DISCORD_RPC -DDISABLE_HTTP -DDISABLE_NETWORK -DDISABLE_OPENGL -DGL_GLEXT_PROTOTYPES -D__STDC_LIMIT_MACROS -DNO_TTF -DSDL_MAIN_HANDLED)
 
 # Fix SpeexDSP compilation
@@ -182,7 +180,7 @@ file(GLOB_RECURSE OPENRCT2_CLI_SOURCES
     "${ORCT2_ROOT}/src/openrct2-cli/*.hpp")
 
 add_library(openrct2 SHARED ${LIBOPENRCT2_SOURCES})
-target_link_libraries(openrct2 android stdc++ log dl z SDL2 png icu icuuc icudata ssl crypto)
+target_link_libraries(openrct2 android stdc++ log dl z SDL2 png icu icuuc icudata)# ssl crypto)
 
 add_library(openrct2-ui SHARED ${OPENRCT2_GUI_SOURCES})
 target_link_libraries(openrct2-ui openrct2 android stdc++ GLESv1_CM GLESv2 SDL2main speexdsp)

--- a/src/openrct2-android/build.gradle
+++ b/src/openrct2-android/build.gradle
@@ -2,14 +2,12 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
-        maven {
-            url "https://oss.sonatype.org/content/repositories/snapshots/"
-        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:7.0.3'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -17,7 +15,11 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenCentral()
         google()
-        jcenter()
     }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
 }

--- a/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/openrct2-android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-all.zip


### PR DESCRIPTION
Contains more backported stuff from #16107. Should also make it possible to enable std::filesystem for Android (see https://github.com/OpenRCT2/OpenRCT2/pull/16415).

Do not squash merge.