### PR TITLE
Refactor path_append_extension and safe_strcat_path

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1530,3 +1530,16 @@ bool ContextOpenCommonFileDialog(utf8* outFilename, OpenRCT2::Ui::FileDialogDesc
         return false;
     }
 }
+
+u8string ContextOpenCommonFileDialog(OpenRCT2::Ui::FileDialogDesc& desc)
+{
+    try
+    {
+        return GetContext()->GetUiContext()->ShowFileDialog(desc);
+    }
+    catch (const std::exception& ex)
+    {
+        log_error(ex.what());
+        return u8string{};
+    }
+}

--- a/src/openrct2/Context.h
+++ b/src/openrct2/Context.h
@@ -287,3 +287,4 @@ const utf8* context_get_path_legacy(int32_t pathId);
 bool context_load_park_from_file(const utf8* path);
 bool context_load_park_from_stream(void* stream);
 bool ContextOpenCommonFileDialog(utf8* outFilename, OpenRCT2::Ui::FileDialogDesc& desc, size_t outSize);
+u8string ContextOpenCommonFileDialog(OpenRCT2::Ui::FileDialogDesc& desc);

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -396,16 +396,6 @@ char* safe_strcat(char* destination, const char* source, size_t size)
     return result;
 }
 
-char* safe_strcat_path(char* destination, const char* source, size_t size)
-{
-    path_end_with_separator(destination, size);
-    if (source[0] == *PATH_SEPARATOR)
-    {
-        source = source + 1;
-    }
-    return safe_strcat(destination, source, size);
-}
-
 #if defined(_WIN32)
 char* strcasestr(const char* haystack, const char* needle)
 {

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -62,20 +62,6 @@ bool filename_valid_characters(const utf8* filename)
     return true;
 }
 
-void path_append_extension(utf8* path, const utf8* newExtension, size_t size)
-{
-    // Skip to the dot if the extension starts with a pattern (starts with "*.")
-    if (newExtension[0] == '*')
-        newExtension++;
-
-    // Append a dot to the filename if the new extension doesn't start with it
-    if (newExtension[0] != '.')
-        safe_strcat(path, ".", size);
-
-    // Append the extension to the path
-    safe_strcat(path, newExtension, size);
-}
-
 void path_end_with_separator(utf8* path, size_t size)
 {
     size_t length = strnlen(path, size);

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -39,7 +39,6 @@ int32_t strlogicalcmp(char const* a, char const* b);
 utf8* safe_strtrunc(utf8* text, size_t size);
 char* safe_strcpy(char* destination, const char* source, size_t num);
 char* safe_strcat(char* destination, const char* source, size_t size);
-char* safe_strcat_path(char* destination, const char* source, size_t size);
 #if defined(_WIN32)
 char* strcasestr(const char* haystack, const char* needle);
 #endif

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -25,7 +25,6 @@ int32_t mph_to_dmps(int32_t mph);
 
 bool filename_valid_characters(const utf8* filename);
 
-void path_append_extension(utf8* path, const utf8* newExtension, size_t size);
 void path_end_with_separator(utf8* path, size_t size);
 
 bool sse41_available();


### PR DESCRIPTION
This PR is a part of #16654 and removes `path_append_extension` and `safe_strcat_path` in favour of modern `Path::` equivalents.

This doesn't "complete" the refactor task fully - in order to do that I also want to remove `path_end_with_separator` but I currently don't understand its remaining uses in `CmdlineSprite.cpp` so I left it be for now.