### PR TITLE
Force convert all rle compression to bmp

### DIFF
--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -801,6 +801,7 @@ namespace OpenRCT2
             }
             gfx_load_g2();
             gfx_load_csg();
+            GfxConvert();
             font_sprite_initialise_characters();
             return true;
         }

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -519,6 +519,7 @@ void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FilterPalet
 bool gfx_load_g1(const OpenRCT2::IPlatformEnvironment& env);
 bool gfx_load_g2();
 bool gfx_load_csg();
+void GfxConvert();
 void gfx_unload_g1();
 void gfx_unload_g2();
 void gfx_unload_csg();


### PR DESCRIPTION
This is just a test to show no reduction in performance converting all assets to BMP format. (this will allow for considerable simplification of the drawing code)

Atm this is only converting g1/g2/csg will roll it out to objects as well if needed.