### PR TITLE
Reducing allocations in image table

### DIFF
--- a/src/openrct2/object/ImageTable.h
+++ b/src/openrct2/object/ImageTable.h
@@ -26,44 +26,53 @@ namespace OpenRCT2
 class ImageTable
 {
 private:
-    std::unique_ptr<uint8_t[]> _data;
+    std::vector<uint8_t> _data;
     std::vector<rct_g1_element> _entries;
 
-    /**
-     * Container for a G1 image, additional information and RAII. Used by ReadJson
-     */
-    struct RequiredImage;
+    struct SubImageTable;
     [[nodiscard]] std::vector<std::pair<std::string, Image>> GetImageSources(IReadObjectContext* context, json_t& jsonImages);
-    [[nodiscard]] static std::vector<std::unique_ptr<ImageTable::RequiredImage>> ParseImages(
-        IReadObjectContext* context, std::string s);
+    [[nodiscard]] static ImageTable::SubImageTable ParseImages(IReadObjectContext* context, std::string s);
     /**
      * @note root is deliberately left non-const: json_t behaviour changes when const
      */
-    [[nodiscard]] static std::vector<std::unique_ptr<ImageTable::RequiredImage>> ParseImages(
+    [[nodiscard]] static ImageTable::SubImageTable ParseImages(
         IReadObjectContext* context, std::vector<std::pair<std::string, Image>>& imageSources, json_t& el);
-    [[nodiscard]] static std::vector<std::unique_ptr<ImageTable::RequiredImage>> LoadObjectImages(
+    [[nodiscard]] static ImageTable::SubImageTable LoadObjectImages(
         IReadObjectContext* context, const std::string& name, const std::vector<int32_t>& range);
     [[nodiscard]] static std::vector<int32_t> ParseRange(std::string s);
     [[nodiscard]] static std::string FindLegacyObject(const std::string& name);
+    size_t MergeImageData(const std::vector<uint8_t>& data);
+    void MergeEntries(const std::vector<rct_g1_element>& handles, size_t dataOffset);
+    void AddDataOffsetToEntries(size_t begin, size_t count, uint8_t* dataOffset);
 
 public:
     ImageTable() = default;
     ImageTable(const ImageTable&) = delete;
     ImageTable& operator=(const ImageTable&) = delete;
-    ~ImageTable();
 
     void Read(IReadObjectContext* context, OpenRCT2::IStream* stream);
     /**
      * @note root is deliberately left non-const: json_t behaviour changes when const
      */
     bool ReadJson(IReadObjectContext* context, json_t& root);
+    // Legacy. Replace all users with GetEntries
     const rct_g1_element* GetImages() const
     {
         return _entries.data();
     }
+    const std::vector<rct_g1_element>& GetEntries() const
+    {
+        return _entries;
+    }
+    const std::vector<uint8_t>& GetImageData() const
+    {
+        return _data;
+    }
+    // Legacy. Replace all users with GetEntries
     uint32_t GetCount() const
     {
         return static_cast<uint32_t>(_entries.size());
     }
-    void AddImage(const rct_g1_element* g1);
+    // Overrides the image table allocation singular image instance
+    void SetImage(std::vector<rct_g1_element>&& entries, std::vector<uint8_t>&& imageData);
 };

--- a/src/openrct2/object/WaterObject.h
+++ b/src/openrct2/object/WaterObject.h
@@ -33,6 +33,6 @@ public:
     void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
 
 private:
-    void ReadJsonPalette(json_t& jPalette);
+    void ReadJsonPalette(json_t& jPalette, std::vector<rct_g1_element>& entries, std::vector<uint8_t>& data);
     uint32_t ParseColour(const std::string& s) const;
 };


### PR DESCRIPTION
Aim of this PR is to change the ImageTable so that it works as follows:

1. An ImageTable will either own image data or reference data allocated to g1/g2/csg.
2. All owned image data will be allocated in one contiguous block.

A follow on PR will rework the spritesheet so that it is read as one image instead of multiple images forcing one palette across the whole image.

As it currently stands an ImageTable always owns its data but this is duplicating data if it references g1/g2/csg. In addition all data owned is in separate allocations leading to fragmentation and multiple users of `new` / `delete`.
