### PR TITLE
Add ability for plugins to access ride's chain lift speed

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Feature: [#16132, #16389] The Corkscrew, Twister and Vertical Drop Roller Coasters can now draw inline twists.
 - Feature: [#16144] [Plugin] Add ImageManager to API.
 - Feature: [#16731] [Plugin] New API for fetching and manipulating a staff member's patrol area.
+- Feature: [#16800] [Plugin] Add lift hill speed properties to API.
 - Feature: [#16806] Parkobj can load sprites from RCT image archives.
 - Improved: [#3517] Cheats are now saved with the park.
 - Improved: [#10150] Ride stations are now properly checked if they’re sheltered.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1069,6 +1069,21 @@ declare global {
          * The percentage of downtime for this ride from 0 to 100.
          */
         readonly downtime: number;
+
+        /**
+         * The currently set chain lift speed.
+         */
+        liftHillSpeed: number;
+
+        /**
+         * The max chain lift speed for this ride.
+         */
+        readonly maxLiftHillSpeed: number;
+
+        /**
+         * The min chain lift speed for this ride.
+         */
+        readonly minLiftHillSpeed: number;
     }
 
     type RideClassification = "ride" | "stall" | "facility";

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1071,17 +1071,17 @@ declare global {
         readonly downtime: number;
 
         /**
-         * The currently set chain lift speed.
+         * The currently set chain lift speed in miles per hour.
          */
         liftHillSpeed: number;
 
         /**
-         * The max chain lift speed for this ride.
+         * The max chain lift speed for this ride in miles per hour.
          */
         readonly maxLiftHillSpeed: number;
 
         /**
-         * The min chain lift speed for this ride.
+         * The min chain lift speed for this ride in miles per hour.
          */
         readonly minLiftHillSpeed: number;
     }

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 49;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 50;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/ride/ScRide.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.cpp
@@ -14,6 +14,7 @@
 #    include "../../../Context.h"
 #    include "../../../common.h"
 #    include "../../../ride/Ride.h"
+#    include "../../../ride/RideData.h"
 #    include "../../Duktape.hpp"
 #    include "../../ScriptEngine.h"
 #    include "../object/ScObject.hpp"
@@ -494,6 +495,35 @@ namespace OpenRCT2::Scripting
         return ride != nullptr ? ride->downtime : 0;
     }
 
+    uint8_t ScRide::liftHillSpeed_get() const
+    {
+        auto ride = GetRide();
+        return ride != nullptr ? ride->lift_hill_speed : 0;
+    }
+
+    void ScRide::lifthillSpeed_set(uint8_t value)
+    {
+        ThrowIfGameStateNotMutable();
+
+        auto ride = GetRide();
+        if (ride)
+        {
+            ride->lift_hill_speed = value;
+        }
+    }
+
+    uint8_t ScRide::maxLiftHillSpeed_get() const
+    {
+        auto ride = GetRide();
+        return ride != nullptr ? ride->GetRideTypeDescriptor().LiftData.maximum_speed : 0;
+    }
+
+    uint8_t ScRide::minLiftHillSpeed_get() const
+    {
+        auto ride = GetRide();
+        return ride != nullptr ? ride->GetRideTypeDescriptor().LiftData.minimum_speed : 0;
+    }
+
     void ScRide::Register(duk_context* ctx)
     {
         dukglue_register_property(ctx, &ScRide::id_get, nullptr, "id");
@@ -525,6 +555,9 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScRide::inspectionInterval_get, &ScRide::inspectionInterval_set, "inspectionInterval");
         dukglue_register_property(ctx, &ScRide::value_get, &ScRide::value_set, "value");
         dukglue_register_property(ctx, &ScRide::downtime_get, nullptr, "downtime");
+        dukglue_register_property(ctx, &ScRide::liftHillSpeed_get, &ScRide::lifthillSpeed_set, "liftHillSpeed");
+        dukglue_register_property(ctx, &ScRide::maxLiftHillSpeed_get, nullptr, "maxLiftHillSpeed");
+        dukglue_register_property(ctx, &ScRide::minLiftHillSpeed_get, nullptr, "minLiftHillSpeed");
     }
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/ride/ScRide.hpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.hpp
@@ -155,6 +155,12 @@ namespace OpenRCT2::Scripting
 
         uint8_t downtime_get() const;
 
+        uint8_t liftHillSpeed_get() const;
+        void lifthillSpeed_set(uint8_t value);
+
+        uint8_t maxLiftHillSpeed_get() const;
+        uint8_t minLiftHillSpeed_get() const;
+
         Ride* GetRide() const;
 
     public:


### PR DESCRIPTION
I wanted to use this info in a plugin, but couldn't find it... so added it.