### PR TITLE
Refactor path_end_with_separator and filename_valid_characters

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -579,7 +579,7 @@ static void WindowLoadsaveTextinput(rct_window* w, rct_widgetindex widgetIndex, 
     {
         case WIDX_NEW_FOLDER:
         {
-            if (!filename_valid_characters(text))
+            if (!Platform::IsFilenameValid(text))
             {
                 context_show_error(STR_ERROR_INVALID_CHARACTERS, STR_NONE, {});
                 return;
@@ -971,7 +971,7 @@ static bool IsValidPath(const char* path)
     //      which handles multiple patterns
     auto filename = Path::GetFileNameWithoutExtension(path);
 
-    return filename_valid_characters(filename.c_str());
+    return Platform::IsFilenameValid(filename);
 }
 
 static void WindowLoadsaveSelect(rct_window* w, const char* path)

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -19,8 +19,8 @@
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
+#include <openrct2/platform/Platform.h>
 #include <openrct2/sprites.h>
-#include <openrct2/util/Util.h>
 
 enum
 {
@@ -698,7 +698,7 @@ static void WindowThemesTextinput(rct_window* w, rct_widgetindex widgetIndex, ch
     {
         case WIDX_THEMES_DUPLICATE_BUTTON:
         case WIDX_THEMES_RENAME_BUTTON:
-            if (filename_valid_characters(text))
+            if (Platform::IsFilenameValid(text))
             {
                 if (ThemeGetIndexForName(text) == SIZE_MAX)
                 {

--- a/src/openrct2-ui/windows/TitleEditor.cpp
+++ b/src/openrct2-ui/windows/TitleEditor.cpp
@@ -24,6 +24,7 @@
 #include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/object/ObjectManager.h>
+#include <openrct2/platform/Platform.h>
 #include <openrct2/scenario/Scenario.h>
 #include <openrct2/scenario/ScenarioRepository.h>
 #include <openrct2/scenario/ScenarioSources.h>
@@ -32,7 +33,6 @@
 #include <openrct2/title/TitleSequence.h>
 #include <openrct2/title/TitleSequenceManager.h>
 #include <openrct2/title/TitleSequencePlayer.h>
-#include <openrct2/util/Util.h>
 #include <openrct2/windows/Intent.h>
 
 using namespace OpenRCT2;
@@ -635,7 +635,7 @@ static void WindowTitleEditorTextinput(rct_window* w, rct_widgetindex widgetInde
         case WIDX_TITLE_EDITOR_NEW_BUTTON:
         case WIDX_TITLE_EDITOR_DUPLICATE_BUTTON:
         case WIDX_TITLE_EDITOR_RENAME_BUTTON:
-            if (filename_valid_characters(text))
+            if (Platform::IsFilenameValid(text))
             {
                 if (title_sequence_manager_get_index_for_name(text) == SIZE_MAX)
                 {
@@ -1137,7 +1137,7 @@ static void WindowTitleEditorAddParkCallback(int32_t result, const utf8* path)
 
 static void WindowTitleEditorRenamePark(size_t index, const utf8* name)
 {
-    if (!filename_valid_characters(name))
+    if (!Platform::IsFilenameValid(name))
     {
         context_show_error(STR_ERROR_INVALID_CHARACTERS, STR_NONE, {});
         return;

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -14,8 +14,8 @@
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
+#include <openrct2/platform/Platform.h>
 #include <openrct2/ride/TrackDesignRepository.h>
-#include <openrct2/util/Util.h>
 
 static constexpr const rct_string_id WINDOW_TITLE = STR_STRING;
 static constexpr const int32_t WH = 44;
@@ -164,7 +164,7 @@ static void WindowTrackManageTextinput(rct_window* w, rct_widgetindex widgetInde
         return;
     }
 
-    if (!filename_valid_characters(text))
+    if (!Platform::IsFilenameValid(text))
     {
         context_show_error(STR_CANT_RENAME_TRACK_DESIGN, STR_NEW_NAME_CONTAINS_INVALID_CHARACTERS, {});
         return;

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -71,6 +71,7 @@ namespace Platform
     uint64_t GetFileSize(std::string_view path);
     std::string ResolveCasing(std::string_view path, bool fileExists);
     std::string SanitiseFilename(std::string_view originalName);
+    bool IsFilenameValid(u8string_view fileName);
 
     uint16_t GetLocaleLanguage();
     CurrencyType GetLocaleCurrency();

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -26,6 +26,12 @@
 #include <cstring>
 #include <time.h>
 
+#ifdef _WIN32
+static constexpr std::array _prohibitedCharacters = { '<', '>', '*', '\\', ':', '|', '?', '"', '/' };
+#else
+static constexpr std::array _prohibitedCharacters = { '/' };
+#endif
+
 namespace Platform
 {
     void CoreInit()
@@ -96,20 +102,20 @@ namespace Platform
 
     std::string SanitiseFilename(std::string_view originalName)
     {
-#ifdef _WIN32
-        static constexpr std::array prohibited = { '<', '>', '*', '\\', ':', '|', '?', '"', '/' };
-#else
-        static constexpr std::array prohibited = { '/' };
-#endif
         auto sanitised = std::string(originalName);
         std::replace_if(
             sanitised.begin(), sanitised.end(),
             [](const std::string::value_type& ch) -> bool {
-                return std::find(prohibited.begin(), prohibited.end(), ch) != prohibited.end();
+                return std::find(_prohibitedCharacters.begin(), _prohibitedCharacters.end(), ch) != _prohibitedCharacters.end();
             },
             '_');
         sanitised = String::Trim(sanitised);
         return sanitised;
+    }
+
+    bool IsFilenameValid(u8string_view fileName)
+    {
+        return fileName.find_first_of(_prohibitedCharacters.data(), 0, _prohibitedCharacters.size()) == fileName.npos;
     }
 
 #ifndef __ANDROID__

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -51,17 +51,6 @@ int32_t mph_to_dmps(int32_t mph)
     return (mph * 73243) >> 14;
 }
 
-bool filename_valid_characters(const utf8* filename)
-{
-    for (int32_t i = 0; filename[i] != '\0'; i++)
-    {
-        if (filename[i] == '\\' || filename[i] == '/' || filename[i] == ':' || filename[i] == '?' || filename[i] == '*'
-            || filename[i] == '<' || filename[i] == '>' || filename[i] == '|')
-            return false;
-    }
-    return true;
-}
-
 int32_t bitscanforward(int32_t source)
 {
 #if defined(_MSC_VER) && (_MSC_VER >= 1400) // Visual Studio 2005

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -62,18 +62,6 @@ bool filename_valid_characters(const utf8* filename)
     return true;
 }
 
-void path_end_with_separator(utf8* path, size_t size)
-{
-    size_t length = strnlen(path, size);
-    if (length >= size - 1)
-        return;
-
-    if ((length == 0) || ((path[length - 1] != *PATH_SEPARATOR) && path[length - 1] != '/'))
-    {
-        safe_strcat(path, PATH_SEPARATOR, size);
-    }
-}
-
 int32_t bitscanforward(int32_t source)
 {
 #if defined(_MSC_VER) && (_MSC_VER >= 1400) // Visual Studio 2005

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -25,8 +25,6 @@ int32_t mph_to_dmps(int32_t mph);
 
 bool filename_valid_characters(const utf8* filename);
 
-void path_end_with_separator(utf8* path, size_t size);
-
 bool sse41_available();
 bool avx2_available();
 

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -23,8 +23,6 @@ int32_t metres_to_feet(int32_t metres);
 int32_t mph_to_kmph(int32_t mph);
 int32_t mph_to_dmps(int32_t mph);
 
-bool filename_valid_characters(const utf8* filename);
-
 bool sse41_available();
 bool avx2_available();
 


### PR DESCRIPTION
This PR refactors two remaining path functions from `Util.cpp`:
1. `path_end_with_separator` is now completely deprecated. To enable this, `CmdlineSprite.cpp` received a comprehensive refactor.
2. `filename_valid_characters` is replaced with `Platform::IsFilenameValid` that mirrors an already existing `Platform::SanitiseFilename`. For consistency between the two functions, I made them use the same list of prohibited characters **which differs from the original list in `filename_valid_characters`!!!**

Resolves #16654. With this PR, #16724 and #16771, I consider this refactor complete.