### PR TITLE
Parkobj loads rct_gx

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,7 @@
 - Feature: [#16132, #16389] The Corkscrew, Twister and Vertical Drop Roller Coasters can now draw inline twists.
 - Feature: [#16144] [Plugin] Add ImageManager to API.
 - Feature: [#16731] [Plugin] New API for fetching and manipulating a staff member's patrol area.
+- Feature: [#16806] Parkobj can load sprites from RCT image archives.
 - Improved: [#3517] Cheats are now saved with the park.
 - Improved: [#10150] Ride stations are now properly checked if they’re sheltered.
 - Improved: [#10664, #16072] Visibility status can be modified directly in the Tile Inspector's list.

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -70,7 +70,7 @@ static inline uint32_t rctc_to_rct2_index(uint32_t image)
 }
 // clang-format on
 
-void read_and_convert_gxdat(IStream* stream, size_t count, bool is_rctc, rct_g1_element* elements)
+static void read_and_convert_gxdat(IStream* stream, size_t count, bool is_rctc, rct_g1_element* elements)
 {
     auto g1Elements32 = std::make_unique<rct_g1_element_32bit[]>(count);
     stream->Read(g1Elements32.get(), count * sizeof(rct_g1_element_32bit));

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -378,7 +378,7 @@ std::optional<rct_gx> GxfLoadGx(const std::vector<uint8_t>& buffer)
         // Read element data
         gx.data = istream.ReadArray<uint8_t>(gx.header.total_size);
 
-        return gx;
+        return std::make_optional(std::move(gx));
     }
     catch (const std::exception&)
     {

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -362,7 +362,7 @@ bool gfx_load_csg()
     }
 }
 
-std::optional<rct_gx> GxfLoadGx(const std::vector<uint8_t>& buffer)
+std::optional<rct_gx> GfxLoadGx(const std::vector<uint8_t>& buffer)
 {
     try
     {

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -378,11 +378,6 @@ std::optional<rct_gx> GxfLoadGx(const std::vector<uint8_t>& buffer)
         // Read element data
         gx.data = istream.ReadArray<uint8_t>(gx.header.total_size);
 
-        // Fix entry data offsets
-        for (uint32_t i = 0; i < gx.header.num_entries; i++)
-        {
-            gx.elements[i].offset += reinterpret_cast<uintptr_t>(gx.data.get());
-        }
         return gx;
     }
     catch (const std::exception&)

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -362,7 +362,7 @@ bool gfx_load_csg()
     }
 }
 
-std::optional<rct_gx> gfx_load_gx(std::vector<uint8_t> buffer)
+std::optional<rct_gx> GxfLoadGx(const std::vector<uint8_t>& buffer)
 {
     try
     {

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -364,11 +364,11 @@ bool gfx_load_csg()
 
 std::optional<rct_gx> gfx_load_gx(std::vector<uint8_t> buffer)
 {
-    OpenRCT2::MemoryStream istream(&buffer, buffer.size());
-    rct_gx gx;
-
     try
     {
+        OpenRCT2::MemoryStream istream(buffer.data(), buffer.size());
+        rct_gx gx;
+
         gx.header = istream.ReadValue<rct_g1_header>();
 
         // Read element headers

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -526,7 +526,7 @@ void gfx_unload_csg();
 const rct_g1_element* gfx_get_g1_element(ImageId imageId);
 const rct_g1_element* gfx_get_g1_element(ImageIndex image_id);
 void gfx_set_g1_element(ImageIndex imageId, const rct_g1_element* g1);
-std::optional<rct_gx> gfx_load_gx(std::vector<uint8_t> buffer);
+std::optional<rct_gx> GxfLoadGx(const std::vector<uint8_t>& buffer);
 bool is_csg_loaded();
 void FASTCALL gfx_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL gfx_bmp_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -526,7 +526,7 @@ void gfx_unload_csg();
 const rct_g1_element* gfx_get_g1_element(ImageId imageId);
 const rct_g1_element* gfx_get_g1_element(ImageIndex image_id);
 void gfx_set_g1_element(ImageIndex imageId, const rct_g1_element* g1);
-std::optional<rct_gx> GxfLoadGx(const std::vector<uint8_t>& buffer);
+std::optional<rct_gx> GfxLoadGx(const std::vector<uint8_t>& buffer);
 bool is_csg_loaded();
 void FASTCALL gfx_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL gfx_bmp_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -28,7 +28,8 @@ struct ScreenRect;
 namespace OpenRCT2
 {
     struct IPlatformEnvironment;
-}
+    struct IStream;
+} // namespace OpenRCT2
 
 namespace OpenRCT2::Drawing
 {
@@ -516,6 +517,7 @@ void gfx_fill_rect_inset(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t
 void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FilterPaletteID palette);
 
 // sprite
+void read_and_convert_gxdat(OpenRCT2::IStream* stream, size_t count, bool is_rctc, rct_g1_element* elements);
 bool gfx_load_g1(const OpenRCT2::IPlatformEnvironment& env);
 bool gfx_load_g2();
 bool gfx_load_csg();
@@ -525,6 +527,7 @@ void gfx_unload_csg();
 const rct_g1_element* gfx_get_g1_element(ImageId imageId);
 const rct_g1_element* gfx_get_g1_element(ImageIndex image_id);
 void gfx_set_g1_element(ImageIndex imageId, const rct_g1_element* g1);
+std::optional<rct_gx> gfx_load_gx(std::vector<uint8_t> buffer);
 bool is_csg_loaded();
 void FASTCALL gfx_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL gfx_bmp_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -517,7 +517,6 @@ void gfx_fill_rect_inset(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t
 void gfx_filter_rect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FilterPaletteID palette);
 
 // sprite
-void read_and_convert_gxdat(OpenRCT2::IStream* stream, size_t count, bool is_rctc, rct_g1_element* elements);
 bool gfx_load_g1(const OpenRCT2::IPlatformEnvironment& env);
 bool gfx_load_g2();
 bool gfx_load_csg();

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -236,7 +236,7 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::LoadImageArc
 {
     std::vector<std::unique_ptr<RequiredImage>> result;
     auto gxRaw = context->GetData(path);
-    std::optional<rct_gx> gxData = GxfLoadGx(gxRaw);
+    std::optional<rct_gx> gxData = GfxLoadGx(gxRaw);
     if (gxData.has_value())
     {
         // Fix entry data offsets

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -236,7 +236,7 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::LoadImageArc
 {
     std::vector<std::unique_ptr<RequiredImage>> result;
     auto gxRaw = context->GetData(path);
-    std::optional<rct_gx> gxData = gfx_load_gx(gxRaw);
+    std::optional<rct_gx> gxData = GxfLoadGx(gxRaw);
     if (gxData.has_value())
     {
         size_t placeHoldersAdded = 0;

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -141,6 +141,7 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
     {
         auto name = s.substr(5);
         auto rangeStart = name.find('[');
+        if (rangeStart != std::string::npos)
         {
             auto rangeString = name.substr(rangeStart);
             auto range = ParseRange(name.substr(rangeStart));

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -137,7 +137,7 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
             result = LoadObjectImages(context, name, range);
         }
     }
-    else if (String::StartsWith(s, "$LIA:"))
+    else if (String::StartsWith(s, "$LGX:"))
     {
         auto name = s.substr(5);
         auto rangeStart = name.find('[');

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -239,6 +239,12 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::LoadImageArc
     std::optional<rct_gx> gxData = GxfLoadGx(gxRaw);
     if (gxData.has_value())
     {
+        // Fix entry data offsets
+        for (uint32_t i = 0; i < gxData->header.num_entries; i++)
+        {
+            gxData->elements[i].offset += reinterpret_cast<uintptr_t>(gxData->data.get());
+        }
+
         size_t placeHoldersAdded = 0;
         for (auto i : range)
         {

--- a/src/openrct2/object/ImageTable.h
+++ b/src/openrct2/object/ImageTable.h
@@ -45,6 +45,8 @@ private:
         IReadObjectContext* context, const std::string& name, const std::vector<int32_t>& range);
     [[nodiscard]] static std::vector<int32_t> ParseRange(std::string s);
     [[nodiscard]] static std::string FindLegacyObject(const std::string& name);
+    [[nodiscard]] static std::vector<std::unique_ptr<ImageTable::RequiredImage>> LoadImageArchiveImages(
+        IReadObjectContext* context, const std::string& path, const std::vector<int32_t>& range);
 
 public:
     ImageTable() = default;

--- a/src/openrct2/object/ImageTable.h
+++ b/src/openrct2/object/ImageTable.h
@@ -46,7 +46,7 @@ private:
     [[nodiscard]] static std::vector<int32_t> ParseRange(std::string s);
     [[nodiscard]] static std::string FindLegacyObject(const std::string& name);
     [[nodiscard]] static std::vector<std::unique_ptr<ImageTable::RequiredImage>> LoadImageArchiveImages(
-        IReadObjectContext* context, const std::string& path, const std::vector<int32_t>& range);
+        IReadObjectContext* context, const std::string& path, const std::vector<int32_t>& range = {});
 
 public:
     ImageTable() = default;


### PR DESCRIPTION
Loading of sprite atlases is not as fast as desired. rct_gx archives seem to load much faster.

Test objects: https://github.com/OpenRCT2/OpenRCT2/discussions/16746#discussioncomment-2298523

Will address https://github.com/OpenRCT2/OpenRCT2/issues/15547