### PR TITLE
Add parameters to accept for StaffFireAction

### DIFF
--- a/src/openrct2/actions/StaffFireAction.cpp
+++ b/src/openrct2/actions/StaffFireAction.cpp
@@ -20,7 +20,7 @@ StaffFireAction::StaffFireAction(EntityId spriteId)
 
 void StaffFireAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
-    visitor.Visit("spriteId", _spriteId);
+    visitor.Visit("id", _spriteId);
 }
 
 uint16_t StaffFireAction::GetActionFlags() const

--- a/src/openrct2/actions/StaffFireAction.cpp
+++ b/src/openrct2/actions/StaffFireAction.cpp
@@ -18,6 +18,11 @@ StaffFireAction::StaffFireAction(EntityId spriteId)
 {
 }
 
+void StaffFireAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("spriteId", _spriteId);
+}
+
 uint16_t StaffFireAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/StaffFireAction.h
+++ b/src/openrct2/actions/StaffFireAction.h
@@ -20,6 +20,8 @@ public:
     StaffFireAction() = default;
     StaffFireAction(EntityId spriteId);
 
+    void AcceptParameters(GameActionParameterVisitor& visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser& stream) override;

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 47;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 48;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;


### PR DESCRIPTION
Without this, plugins can call stafffire, but they can't set whom to fire.