### PR TITLE
Fix #16808: Incorrect serialisation of track design object

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -64,6 +64,7 @@
 - Fix: [#16591] [Plugin] setInterval and setTimeout is not disposed when map unloads.
 - Fix: [#16711] [Plugin] Car.rideObject overflowing with more than 256 ride types.
 - Fix: [#16779] Fix case where title music doesn't unmute properly.
+- Fix: [#16808] Incorrect track design serialisation causing vehicle object replacement.
 - Fix: [objects#165] Glitch when Bengal Tiger Cars go through a corner.
 
 0.3.5.1 (2021-11-21)

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "21"
+#define NETWORK_STREAM_VERSION "22"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -582,7 +582,7 @@ void TrackDesign::Serialise(DataSerialiser& stream)
     stream << DS_TAG(track_rail_colour);
     stream << DS_TAG(track_support_colour);
     stream << DS_TAG(flags2);
-    stream << DS_TAG(vehicle_object.Entry);
+    stream << DS_TAG(vehicle_object);
     stream << DS_TAG(space_required_x);
     stream << DS_TAG(space_required_y);
     stream << DS_TAG(vehicle_additional_colour);


### PR DESCRIPTION
This could potentially cause the replacement vehicle object code to kick in unexpectedly