### PR TITLE
Don't prompt to 'Save game as' when saving a loaded saved game (excepting autosaves)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,7 @@
 - Feature: [objects#205] Add additional glass roofs.
 - Feature: [objects#209] Add the Steel Roller Coaster train and 2-across Inverted Train from RollerCoaster Tycoon 1.
 - Improved: [#15358] Park and scenario names can now contain up to 128 characters.
+- Improved: [#16819] Don't prompt to 'Save game as' when saving a loaded saved game (excepting autosaves).
 - Improved: [#16840] Add support for rectangular heightmaps.
 - Improved: [#17575] You can now search for Authors in Object Selection.
 - Improved: [#17806] Added warning when using RCT1 objects without RCT1 linked.

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -1000,6 +1000,7 @@ static void WindowLoadsaveSelect(rct_window* w, const char* path)
             {
                 gScenarioSavePath = pathBuffer;
                 gCurrentLoadedPath = pathBuffer;
+                gIsAutosaveLoaded = false;
                 gFirstTimeSaving = false;
 
                 window_close_by_class(WindowClass::Loadsave);

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -80,6 +80,8 @@ float gDayNightCycle = 0;
 bool gInUpdateCode = false;
 bool gInMapInitCode = false;
 std::string gCurrentLoadedPath;
+bool gIsAutosave = false;
+bool gIsAutosaveLoaded = false;
 
 bool gLoadKeepWindowsOpen = false;
 
@@ -561,7 +563,7 @@ void reset_all_sprite_quadrant_placements()
 
 void save_game()
 {
-    if (!gFirstTimeSaving)
+    if (!gFirstTimeSaving && !gIsAutosaveLoaded)
     {
         const auto savePath = Path::WithExtension(gScenarioSavePath, ".park");
         save_game_with_name(savePath);
@@ -591,10 +593,11 @@ void save_game_cmd(u8string_view name /* = {} */)
 void save_game_with_name(u8string_view name)
 {
     log_verbose("Saving to %s", u8string(name).c_str());
-    if (scenario_save(name, 0x80000000 | (gConfigGeneral.save_plugin_data ? 1 : 0)))
+    if (scenario_save(name, gConfigGeneral.save_plugin_data ? 1 : 0))
     {
         log_verbose("Saved to %s", u8string(name).c_str());
         gCurrentLoadedPath = name;
+        gIsAutosaveLoaded = false;
         gScreenAge = 0;
     }
 }
@@ -726,6 +729,8 @@ static void game_load_or_quit_no_save_prompt_callback(int32_t result, const utf8
         context_load_park_from_file(path);
         game_load_scripts();
         game_notify_map_changed();
+        gIsAutosaveLoaded = gIsAutosave;
+        gFirstTimeSaving = false;
     }
 }
 

--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -144,6 +144,8 @@ extern float gDayNightCycle;
 extern bool gInUpdateCode;
 extern bool gInMapInitCode;
 extern std::string gCurrentLoadedPath;
+extern bool gIsAutosave;
+extern bool gIsAutosaveLoaded;
 
 extern bool gLoadKeepWindowsOpen;
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -457,7 +457,7 @@ namespace OpenRCT2
 
         void ReadWriteGeneralChunk(OrcaStream& os)
         {
-            auto found = os.ReadWriteChunk(ParkFileChunkType::GENERAL, [this](OrcaStream::ChunkStream& cs) {
+            auto found = os.ReadWriteChunk(ParkFileChunkType::GENERAL, [this, &os](OrcaStream::ChunkStream& cs) {
                 // Only GAME_PAUSED_NORMAL from gGamePaused is relevant.
                 if (cs.GetMode() == OrcaStream::Mode::READING)
                 {
@@ -508,6 +508,11 @@ namespace OpenRCT2
                 cs.ReadWrite(gWidePathTileLoopPosition);
 
                 ReadWriteRideRatingCalculationData(cs, gRideRatingUpdateState);
+
+                if (os.GetHeader().TargetVersion >= 14)
+                {
+                    cs.ReadWrite(gIsAutosave);
+                }
             });
             if (!found)
             {
@@ -2286,7 +2291,8 @@ int32_t scenario_save(u8string_view path, int32_t flags)
         log_verbose("saving game");
     }
 
-    if (!(flags & S6_SAVE_FLAG_AUTOMATIC))
+    gIsAutosave = flags & S6_SAVE_FLAG_AUTOMATIC;
+    if (!gIsAutosave)
     {
         window_close_construction_windows();
     }


### PR DESCRIPTION
After loading a save game and choosing 'Save game', the 'Save game as' window would open the first time every time after loading the save. I find this counterintuitive: it would be like opening an existing text document, hitting 'Save' and then getting prompted where you would like to save the text file. 

With the changes in this PR, the game will be saved using the existing save path, except when an autosave is loaded which the player probably doesn't want to overwrite.

_I proposed this on [Discord](https://discord.com/channels/264137540670324737/691735032531779684/952529673529733131), but there wasn't much discussion on it there. Feel free to discuss here._