### PR TITLE
chore: update macOS dependencies, remove workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,9 +128,9 @@ if (MACOS_USE_DEPENDENCIES)
     # if we're building on macOS, then we need the dependencies
     include(cmake/download.cmake)
     
-    set(MACOS_DYLIBS_VERSION "29")
+    set(MACOS_DYLIBS_VERSION "31")
     set(MACOS_DYLIBS_ZIPFILE "openrct2-libs-v${MACOS_DYLIBS_VERSION}-universal-macos-dylibs.zip")
-    set(MACOS_DYLIBS_SHA1 "86cf2db4d87173112a00042418d0d18cae360e41")
+    set(MACOS_DYLIBS_SHA1 "b1162cf91cd98949f88edd8aa22102fc82f1c6f4")
     set(MACOS_DYLIBS_DIR "${ROOT_DIR}/lib/macos")
     set(MACOS_DYLIBS_URL "https://github.com/OpenRCT2/Dependencies/releases/download/v${MACOS_DYLIBS_VERSION}/${MACOS_DYLIBS_ZIPFILE}")
 

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -35,17 +35,6 @@ file(GLOB_RECURSE OPENRCT2_UI_HEADERS
 if (APPLE)
     file(GLOB_RECURSE OPENRCT2_UI_MM_SOURCES "${CMAKE_CURRENT_LIST_DIR}/*.mm")
     set_source_files_properties(${OPENRCT2_UI_MM_SOURCES} PROPERTIES COMPILE_FLAGS "-x objective-c++ -fmodules")
-    if ("${CMAKE_OSX_ARCHITECTURES}" MATCHES "arm64")
-        # cross-compilation workaround for SDL2
-        # This has been addressed upstream in https://github.com/libsdl-org/SDL/commit/bf1d7a3a15a6c090188974bec8ca84eb1903d4f7
-        # Remove this workaround after:
-        # 1) a new SDL release is made containing that fix
-        # 2) The vcpkg port is updated to use that release
-        # 3) A new Dependencies release is made with that latest vcpkg version
-        # 4) That new release is used in this build
-        set(SDL_DISABLE_IMMINTRIN_H "-DSDL_DISABLE_IMMINTRIN_H")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SDL_DISABLE_IMMINTRIN_H}")
-    endif ()
 endif ()
 
 # Outputs


### PR DESCRIPTION
Thanks @tupaschoal for the Dependencies release!

This change is simply pulling in the latest version and removing the previously required workaround. I can test this on my M1 (I just got one for work, but don't have the game assets loaded) if needed, but this would have revealed itself as an undefined symbol linker error if the original issue was still present after the workaround was removed. In other words, CI passing makes me quite confident in this change on its own.