### PR TITLE
Implement RIDE_FLAG_INCLINE_REQUIRES_LIFT and RIDE_FLAG_GENTLE_INCLINE_ONLY

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -486,12 +486,16 @@ static void WindowRideConstructionResize(rct_window* w)
                 | (1ULL << WIDX_LEVEL) | (1ULL << WIDX_SLOPE_UP) | (1ULL << WIDX_SLOPE_UP_STEEP);
         }
     }
-    // Disable lift hill toggle and banking if track is uphill and ride type requires lift on uphill slopes
-    if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_UP_INCLINE_REQUIRES_LIFT) && !gCheatsEnableAllDrawableTrackPieces
-        && ((_previousTrackSlopeEnd == TRACK_SLOPE_UP_25 || _previousTrackSlopeEnd == TRACK_SLOPE_UP_60)
-            || (_currentTrackSlopeEnd == TRACK_SLOPE_UP_25 || _currentTrackSlopeEnd == TRACK_SLOPE_UP_60)))
-        disabledWidgets |= 1ULL << WIDX_CHAIN_LIFT | (1ULL << WIDX_BANK_LEFT) | (1ULL << WIDX_BANK_RIGHT);
-
+    if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_UP_INCLINE_REQUIRES_LIFT) && !gCheatsEnableAllDrawableTrackPieces)
+    {
+        // Disable lift hill toggle and banking if track is uphill and ride type requires lift on uphill slopes
+        if (_previousTrackSlopeEnd == TRACK_SLOPE_UP_25 || _previousTrackSlopeEnd == TRACK_SLOPE_UP_60
+            || _currentTrackSlopeEnd == TRACK_SLOPE_UP_25 || _currentTrackSlopeEnd == TRACK_SLOPE_UP_60)
+            disabledWidgets |= 1ULL << WIDX_CHAIN_LIFT | (1ULL << WIDX_BANK_LEFT) | (1ULL << WIDX_BANK_RIGHT);
+        if ((_previousTrackSlopeEnd != TRACK_SLOPE_NONE || _previousTrackBankEnd != TRACK_BANK_NONE)
+            && !(_currentTrackLiftHill & CONSTRUCTION_LIFT_HILL_SELECTED))
+            disabledWidgets |= (1ULL << WIDX_SLOPE_UP);
+    }
     if (_rideConstructionState == RideConstructionState::State0)
     {
         disabledWidgets |= (1ULL << WIDX_CONSTRUCT) | (1ULL << WIDX_DEMOLISH) | (1ULL << WIDX_PREVIOUS_SECTION)
@@ -2624,14 +2628,7 @@ static void WindowRideConstructionUpdateWidgets(rct_window* w)
     if (IsTrackEnabled(TRACK_SLOPE))
     {
         window_ride_construction_widgets[WIDX_SLOPE_DOWN].type = WindowWidgetType::FlatBtn;
-
-        if (!ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_UP_INCLINE_REQUIRES_LIFT)
-            || ((_previousTrackSlopeEnd == TRACK_SLOPE_NONE && _previousTrackBankEnd == TRACK_BANK_NONE)
-                || (_currentTrackLiftHill & CONSTRUCTION_LIFT_HILL_SELECTED))
-            || gCheatsEnableAllDrawableTrackPieces)
-        {
-            window_ride_construction_widgets[WIDX_SLOPE_UP].type = WindowWidgetType::FlatBtn;
-        }
+        window_ride_construction_widgets[WIDX_SLOPE_UP].type = WindowWidgetType::FlatBtn;
     }
     if (IsTrackEnabled(TRACK_HELIX_SMALL) && _currentTrackBankEnd != TRACK_BANK_NONE
         && _currentTrackSlopeEnd == TRACK_SLOPE_NONE && _currentTrackCurve >= TRACK_CURVE_LEFT

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -486,11 +486,11 @@ static void WindowRideConstructionResize(rct_window* w)
                 | (1ULL << WIDX_LEVEL) | (1ULL << WIDX_SLOPE_UP) | (1ULL << WIDX_SLOPE_UP_STEEP);
         }
     }
-    // Disable lift hill toggle if track is uphill and ride type requires lift on uphill slopes
+    // Disable lift hill toggle and banking if track is uphill and ride type requires lift on uphill slopes
     if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_UP_INCLINE_REQUIRES_LIFT) && !gCheatsEnableAllDrawableTrackPieces
         && ((_previousTrackSlopeEnd == TRACK_SLOPE_UP_25 || _previousTrackSlopeEnd == TRACK_SLOPE_UP_60)
             || (_currentTrackSlopeEnd == TRACK_SLOPE_UP_25 || _currentTrackSlopeEnd == TRACK_SLOPE_UP_60)))
-        disabledWidgets |= 1ULL << WIDX_CHAIN_LIFT;
+        disabledWidgets |= 1ULL << WIDX_CHAIN_LIFT | (1ULL << WIDX_BANK_LEFT) | (1ULL << WIDX_BANK_RIGHT);
 
     if (_rideConstructionState == RideConstructionState::State0)
     {

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2634,14 +2634,15 @@ static void WindowRideConstructionUpdateWidgets(rct_window* w)
         }
     }
     if (IsTrackEnabled(TRACK_HELIX_SMALL) && _currentTrackBankEnd != TRACK_BANK_NONE
-        && _currentTrackSlopeEnd == TRACK_SLOPE_NONE && _currentTrackCurve >= TRACK_CURVE_LEFT && _currentTrackCurve <= TRACK_CURVE_RIGHT_SMALL)
+        && _currentTrackSlopeEnd == TRACK_SLOPE_NONE && _currentTrackCurve >= TRACK_CURVE_LEFT
+        && _currentTrackCurve <= TRACK_CURVE_RIGHT_SMALL)
     {
-            // Enable helix
-            window_ride_construction_widgets[WIDX_SLOPE_DOWN_STEEP].type = WindowWidgetType::FlatBtn;
-            if ((gCheatsEnableAllDrawableTrackPieces
-                 || !ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_UP_INCLINE_REQUIRES_LIFT))
-                && rideType != RIDE_TYPE_SPLASH_BOATS && rideType != RIDE_TYPE_RIVER_RAFTS)
-                window_ride_construction_widgets[WIDX_SLOPE_UP_STEEP].type = WindowWidgetType::FlatBtn;
+        // Enable helix
+        window_ride_construction_widgets[WIDX_SLOPE_DOWN_STEEP].type = WindowWidgetType::FlatBtn;
+        if ((gCheatsEnableAllDrawableTrackPieces
+             || !ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_UP_INCLINE_REQUIRES_LIFT))
+            && rideType != RIDE_TYPE_SPLASH_BOATS && rideType != RIDE_TYPE_RIVER_RAFTS)
+            window_ride_construction_widgets[WIDX_SLOPE_UP_STEEP].type = WindowWidgetType::FlatBtn;
     }
     else if (IsTrackEnabled(TRACK_SLOPE_STEEP))
     {

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -274,6 +274,7 @@ enum ride_type_flags : uint64_t
     RIDE_TYPE_FLAG_SUPPORTS_LEVEL_CROSSINGS = (1ULL << 49),
     RIDE_TYPE_FLAG_IS_SUSPENDED = (1ULL << 50),
     RIDE_TYPE_FLAG_HAS_LANDSCAPE_DOORS = (1ULL << 51),
+    RIDE_TYPE_FLAG_UP_INCLINE_REQUIRES_LIFT = (1ULL << 52),
 };
 
 // Set on ride types that have a main colour, additional colour and support colour.


### PR DESCRIPTION
This is part of my alpine coaster but I was asked to submit it as a separate PR. This PR adds two new ride flags RIDE_FLAG_INCLINE_REQUIRES_LIFT, which forces chain lift on all uphill slopes, and RIDE_FLAG_GENTLE_INCLINE_ONLY, which disables building uphill steep slopes (but allows downhill steep slopes). See #16825 for the rationale behind adding these flags.

I decided to make it two flags instead of one so that I can remove the special case for the splash boats, which don't have lift pieces but disallow building upward steep slopes (this was previously hardcoded into the ride construction window). A side effect of this change is that "Enable all drawable track pieces" will now allow building upward steep slopes on the splash boats, but I don't think that's a problem since it is a cheat and those track pieces are drawable.

I have checked that the two flags work independently (i.e, if you have only RIDE_FLAG_INCLINE_REQUIRES_LIFT set, you can build steep lifts), however RIDE_FLAG_GENTLE_INCLINE_ONLY does not function properly if vertical slopes are available (it blocks the building of downward vertical slopes as well as upward ones). I couldn't find a clean way to fix this, so I think it's best left unless someone comes up with a ride that actually needs to use this flag in conjunction with vertical slopes.
