### PR TITLE
Fix #16308: Crash when trying to place down a ride on Android

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -186,6 +186,7 @@ The following people are not part of the development team, but have been contrib
 * Rik Smeets (rik-smeets)
 * Charles Machalow (csm10495)
 * Alexander Czarnecki (alcz/zuczek4793)
+* Lawrence De Mol (lawrencedemol)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -63,6 +63,7 @@
 - Fix: [#16162] Go Karts speeds are not correctly randomised, they only go very fast or very slow.
 - Fix: [#16188] Medium-size banked turns on the Twister and Vertical Roller Coaster have incorrect support placement (partly original bug).
 - Fix: [#16264, #16572] Placing saved track design crashes game.
+- Fix  [#16308] Crash when trying to place down a ride on Android.
 - Fix: [#16327] Crash on malformed network packet.
 - Fix: [#16449] [Plugin] Viewport doesn't hide when switching tabs.
 - Fix: [#16450] Banner style not copied when using tile inspector.

--- a/src/openrct2/actions/GameActionResult.h
+++ b/src/openrct2/actions/GameActionResult.h
@@ -70,7 +70,12 @@ namespace GameActions
         CoordsXYZ Position = { LOCATION_NULL, LOCATION_NULL, LOCATION_NULL };
         money32 Cost = 0;
         ExpenditureType Expenditure = ExpenditureType::Count;
-        std::shared_ptr<void> ResultData;
+
+        // Any_cast throws a bad_any_cast exception on Android
+        // To avoid this in the Android release, a shared void pointer is used to store the result data.
+        // Other platforms still use Any as this provides type checks
+        std::shared_ptr<void> ResultDataPtr;
+        std::any ResultData;
 
         Result() = default;
         Result(GameActions::Status error, rct_string_id title, rct_string_id message, uint8_t* args = nullptr);
@@ -82,13 +87,21 @@ namespace GameActions
         // is still just uint32_t, this guarantees the data is associated with the correct type.
         template<typename T> void SetData(const T&& data)
         {
-            ResultData = std::make_shared<T>(data);
+#ifdef __ANDROID__
+            ResultDataPtr = std::make_shared<T>(data);
+#else
+            ResultData = std::forward<const T&&>(data);
+#endif
         }
 
         template<typename T> T GetData() const
         {
-            T* res = static_cast<T*>(ResultData.get());
-            return *res;
+#ifdef __ANDROID__
+            return *static_cast<T*>(ResultDataPtr.get());;
+#else
+            // This function will throw std::bad_any_cast if the type mismatches.
+            return std::any_cast<T>(ResultData);
+#endif
         }
     };
 

--- a/src/openrct2/actions/GameActionResult.h
+++ b/src/openrct2/actions/GameActionResult.h
@@ -70,7 +70,7 @@ namespace GameActions
         CoordsXYZ Position = { LOCATION_NULL, LOCATION_NULL, LOCATION_NULL };
         money32 Cost = 0;
         ExpenditureType Expenditure = ExpenditureType::Count;
-        std::any ResultData;
+        std::shared_ptr<void> ResultData;
 
         Result() = default;
         Result(GameActions::Status error, rct_string_id title, rct_string_id message, uint8_t* args = nullptr);
@@ -82,13 +82,13 @@ namespace GameActions
         // is still just uint32_t, this guarantees the data is associated with the correct type.
         template<typename T> void SetData(const T&& data)
         {
-            ResultData = std::forward<const T&&>(data);
+            ResultData = std::make_shared<T>(data);
         }
 
-        // This function will throw std::bad_any_cast if the type mismatches.
         template<typename T> T GetData() const
         {
-            return std::any_cast<T>(ResultData);
+            T* res = static_cast<T*>(ResultData.get());
+            return *res;
         }
     };
 

--- a/src/openrct2/actions/GameActionResult.h
+++ b/src/openrct2/actions/GameActionResult.h
@@ -71,11 +71,14 @@ namespace GameActions
         money32 Cost = 0;
         ExpenditureType Expenditure = ExpenditureType::Count;
 
+#ifdef __ANDROID__
         // Any_cast throws a bad_any_cast exception on Android
         // To avoid this in the Android release, a shared void pointer is used to store the result data.
+        std::shared_ptr<void> ResultData;
+#else
         // Other platforms still use Any as this provides type checks
-        std::shared_ptr<void> ResultDataPtr;
         std::any ResultData;
+#endif
 
         Result() = default;
         Result(GameActions::Status error, rct_string_id title, rct_string_id message, uint8_t* args = nullptr);
@@ -88,7 +91,7 @@ namespace GameActions
         template<typename T> void SetData(const T&& data)
         {
 #ifdef __ANDROID__
-            ResultDataPtr = std::make_shared<T>(data);
+            ResultData = std::make_shared<T>(data);
 #else
             ResultData = std::forward<const T&&>(data);
 #endif
@@ -97,7 +100,8 @@ namespace GameActions
         template<typename T> T GetData() const
         {
 #ifdef __ANDROID__
-            return *static_cast<T*>(ResultDataPtr.get());;
+            return *static_cast<T*>(ResultData.get());
+            ;
 #else
             // This function will throw std::bad_any_cast if the type mismatches.
             return std::any_cast<T>(ResultData);


### PR DESCRIPTION
This pull request solves the crashes on Android when placing down any ride, adding staff, adding scenery,... See https://github.com/OpenRCT2/OpenRCT2/issues/16308 for a detailed description.

On Android the any_cast throws a bad_any_cast exception eventhough the data stored is of the same type as the target type.
I solved this by changing the any type to a shared void*. This should not change any functionality but now the Android version works as expected. By using a shared_ptr, the memory should be released once there are no more references to this object.

In the screenshots you can see the stacktrace of the crash when placing a ride and the content of the ResultData object when debugging from my phone.

![afbeelding](https://user-images.githubusercontent.com/49515073/159369964-3265a86c-4a57-4668-b18a-f6f0162d648b.png)
![afbeelding](https://user-images.githubusercontent.com/49515073/159369994-551a406a-7177-4ad5-aa2e-37214032c442.png)
