### PR TITLE
Fix #16565: Ducks/birds always spawn at the edge of the old map limit

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -185,6 +185,7 @@ The following people are not part of the development team, but have been contrib
 * Gal B. (GalBr)
 * Rik Smeets (rik-smeets)
 * Charles Machalow (csm10495)
+* Alexander Czarnecki (alcz/zuczek4793)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -303,7 +303,7 @@ void Duck::Create(const CoordsXY& pos)
     switch (direction)
     {
         case 0:
-            targetPos.x = 8191 - (scenario_rand() & 0x3F);
+            targetPos.x = GetMapSizeMaxXY().x - (scenario_rand() & 0x3F);
             break;
         case 1:
             targetPos.y = scenario_rand() & 0x3F;
@@ -312,7 +312,7 @@ void Duck::Create(const CoordsXY& pos)
             targetPos.x = scenario_rand() & 0x3F;
             break;
         case 3:
-            targetPos.y = 8191 - (scenario_rand() & 0x3F);
+            targetPos.y = GetMapSizeMaxXY().y - (scenario_rand() & 0x3F);
             break;
     }
     duck->sprite_direction = direction << 3;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "22"
+#define NETWORK_STREAM_VERSION "23"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Fix #16565: birds/ducks spawning at fixed 255-sized map boundary.

Instead spawn at actual map boundary (MapSizeMaxXY) where applicable