### PR TITLE
Remove hard cap of 0x80 scenery items in a group

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -752,9 +752,8 @@ public:
             {
                 SceneryTabInfo tabInfo;
                 tabInfo.SceneryGroupIndex = scenerySetIndex;
-                for (size_t i = 0; i < sceneryGroupEntry->entry_count; i++)
+                for (const auto& sceneryEntry : sceneryGroupEntry->SceneryEntries)
                 {
-                    const auto& sceneryEntry = sceneryGroupEntry->scenery_entries[i];
                     if (IsSceneryAvailableToBuild(sceneryEntry))
                     {
                         tabInfo.Entries.push_back(sceneryEntry);

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -611,7 +611,7 @@ void scenery_set_not_invented(const ScenerySelection& sceneryItem)
 bool scenery_group_is_invented(int32_t sgIndex)
 {
     const auto sgEntry = get_scenery_group_entry(sgIndex);
-    if (sgEntry == nullptr || sgEntry->entry_count == 0)
+    if (sgEntry == nullptr || sgEntry->SceneryEntries.empty())
     {
         return false;
     }
@@ -636,12 +636,11 @@ bool scenery_group_is_invented(int32_t sgIndex)
 void scenery_group_set_invented(int32_t sgIndex)
 {
     const auto sgEntry = get_scenery_group_entry(sgIndex);
-    if (sgEntry != nullptr && sgEntry->entry_count > 0)
+    if (sgEntry != nullptr)
     {
-        for (auto i = 0; i < sgEntry->entry_count; i++)
+        for (const auto& entry : sgEntry->SceneryEntries)
         {
-            auto sceneryEntryIndex = sgEntry->scenery_entries[i];
-            scenery_set_invented(sceneryEntryIndex);
+            scenery_set_invented(entry);
         }
     }
 }
@@ -656,9 +655,9 @@ void set_all_scenery_groups_not_invented()
             continue;
         }
 
-        for (int32_t j = 0; j < scenery_set->entry_count; ++j)
+        for (const auto& sceneryEntry : scenery_set->SceneryEntries)
         {
-            scenery_set_not_invented(scenery_set->scenery_entries[j]);
+            scenery_set_not_invented(sceneryEntry);
         }
     }
 }
@@ -780,10 +779,9 @@ static void research_mark_item_as_researched(const ResearchItem& item)
         const auto sgEntry = get_scenery_group_entry(item.entryIndex);
         if (sgEntry != nullptr)
         {
-            for (auto i = 0; i < sgEntry->entry_count; i++)
+            for (const auto& sceneryEntry : sgEntry->SceneryEntries)
             {
-                auto sceneryEntryIndex = sgEntry->scenery_entries[i];
-                scenery_set_invented(sceneryEntryIndex);
+                scenery_set_invented(sceneryEntry);
             }
         }
     }

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -118,7 +118,7 @@ void SceneryGroupObject::UpdateEntryIndexes()
         auto sceneryType = GetSceneryType(ori->Type);
         if (sceneryType.has_value())
         {
-            _legacyType.SceneryEntries.emplace_back( sceneryType.value(), entryIndex );
+            _legacyType.SceneryEntries.emplace_back(sceneryType.value(), entryIndex);
         }
     }
 }

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -42,7 +42,7 @@ void SceneryGroupObject::ReadLegacy(IReadObjectContext* context, IStream* stream
 {
     stream->Seek(6, STREAM_SEEK_CURRENT);
     stream->Seek(0x80 * 2, STREAM_SEEK_CURRENT);
-    _legacyType.entry_count = stream->ReadValue<uint8_t>();
+    stream->Seek(1, STREAM_SEEK_CURRENT); // entry_count
     stream->Seek(1, STREAM_SEEK_CURRENT); // pad_107;
     _legacyType.priority = stream->ReadValue<uint8_t>();
     stream->Seek(1, STREAM_SEEK_CURRENT); // pad_109;
@@ -58,7 +58,7 @@ void SceneryGroupObject::Load()
     GetStringTable().Sort();
     _legacyType.name = language_allocate_object_string(GetName());
     _legacyType.image = gfx_object_allocate_images(GetImageTable().GetImages(), GetImageTable().GetCount());
-    _legacyType.entry_count = 0;
+    _legacyType.SceneryEntries.clear();
 }
 
 void SceneryGroupObject::Unload()
@@ -103,7 +103,7 @@ void SceneryGroupObject::UpdateEntryIndexes()
     auto& objectRepository = context->GetObjectRepository();
     auto& objectManager = context->GetObjectManager();
 
-    _legacyType.entry_count = 0;
+    _legacyType.SceneryEntries.clear();
     for (const auto& objectEntry : _items)
     {
         auto ori = objectRepository.FindObject(objectEntry);
@@ -118,8 +118,7 @@ void SceneryGroupObject::UpdateEntryIndexes()
         auto sceneryType = GetSceneryType(ori->Type);
         if (sceneryType.has_value())
         {
-            _legacyType.scenery_entries[_legacyType.entry_count] = { sceneryType.value(), entryIndex };
-            _legacyType.entry_count++;
+            _legacyType.SceneryEntries.push_back({ sceneryType.value(), entryIndex });
         }
     }
 }

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -118,7 +118,7 @@ void SceneryGroupObject::UpdateEntryIndexes()
         auto sceneryType = GetSceneryType(ori->Type);
         if (sceneryType.has_value())
         {
-            _legacyType.SceneryEntries.emplace_back(sceneryType.value(), entryIndex);
+            _legacyType.SceneryEntries.push_back({ sceneryType.value(), entryIndex });
         }
     }
 }

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -118,7 +118,7 @@ void SceneryGroupObject::UpdateEntryIndexes()
         auto sceneryType = GetSceneryType(ori->Type);
         if (sceneryType.has_value())
         {
-            _legacyType.SceneryEntries.push_back({ sceneryType.value(), entryIndex });
+            _legacyType.SceneryEntries.emplace_back( sceneryType.value(), entryIndex );
         }
     }
 }

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -437,10 +437,7 @@ static std::vector<ScenerySelection> GetAllMiscScenery()
         const auto* sgEntry = get_scenery_group_entry(i);
         if (sgEntry != nullptr)
         {
-            for (size_t j = 0; j < sgEntry->entry_count; j++)
-            {
-                nonMiscScenery.push_back(sgEntry->scenery_entries[j]);
-            }
+            nonMiscScenery.insert(nonMiscScenery.end(), sgEntry->SceneryEntries.begin(), sgEntry->SceneryEntries.end());
         }
     }
     for (uint8_t sceneryType = SCENERY_TYPE_SMALL; sceneryType < SCENERY_TYPE_COUNT; sceneryType++)

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -191,8 +191,7 @@ struct rct_scenery_group_entry
 {
     rct_string_id name;
     uint32_t image;
-    ScenerySelection scenery_entries[0x80];
-    uint8_t entry_count;
+    std::vector<ScenerySelection> SceneryEntries;
     uint8_t priority;
     uint32_t entertainer_costumes;
 };


### PR DESCRIPTION
I'm sure no one would ever exceed this but if they do well now its unlimited (it always was for json objects but would likely cause crashes)