### PR TITLE
Show better errors when loading scenery groups

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -587,7 +587,7 @@ public:
         if (!(object_selection_flags & ObjectSelectionFlags::Selected))
             inputFlags |= INPUT_FLAG_EDITOR_OBJECT_SELECT;
 
-        _maxObjectsWasHit = false;
+        _gSceneryGroupPartialSelectError = false;
         if (!window_editor_object_selection_select_object(0, inputFlags, listItem->repositoryItem))
         {
             rct_string_id error_title = (inputFlags & INPUT_FLAG_EDITOR_OBJECT_SELECT) ? STR_UNABLE_TO_SELECT_THIS_OBJECT
@@ -604,10 +604,18 @@ public:
             Invalidate();
         }
 
-        if (_maxObjectsWasHit)
+        if (_gSceneryGroupPartialSelectError)
         {
-            context_show_error(
-                STR_WARNING_TOO_MANY_OBJECTS_SELECTED, STR_NOT_ALL_OBJECTS_IN_THIS_SCENERY_GROUP_COULD_BE_SELECTED, {});
+            if (gGameCommandErrorText == STR_OBJECT_SELECTION_ERR_TOO_MANY_OF_TYPE_SELECTED)
+            {
+                context_show_error(
+                    STR_WARNING_TOO_MANY_OBJECTS_SELECTED, STR_NOT_ALL_OBJECTS_IN_THIS_SCENERY_GROUP_COULD_BE_SELECTED, {});
+            }
+            else
+            {
+                context_show_error(
+                    gGameCommandErrorText, STR_NOT_ALL_OBJECTS_IN_THIS_SCENERY_GROUP_COULD_BE_SELECTED, Formatter::Common());
+            }
         }
     }
 

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -33,7 +33,7 @@
 #include <iterator>
 #include <vector>
 
-bool _maxObjectsWasHit;
+bool _gSceneryGroupPartialSelectError;
 std::vector<uint8_t> _objectSelectionFlags;
 int32_t _numSelectedObjectsForType[EnumValue(ObjectType::Count)];
 static int32_t _numAvailableObjectsForType[EnumValue(ObjectType::Count)];
@@ -581,7 +581,7 @@ bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_
         {
             if (!window_editor_object_selection_select_object(++isMasterObject, flags, sgEntry))
             {
-                _maxObjectsWasHit = true;
+                _gSceneryGroupPartialSelectError = true;
             }
         }
     }

--- a/src/openrct2/EditorObjectSelectionSession.h
+++ b/src/openrct2/EditorObjectSelectionSession.h
@@ -23,7 +23,7 @@ enum EDITOR_INPUT_FLAGS
     INPUT_FLAG_EDITOR_OBJECT_ALWAYS_REQUIRED = (1 << 3)
 };
 
-extern bool _maxObjectsWasHit;
+extern bool _gSceneryGroupPartialSelectError;
 extern std::vector<uint8_t> _objectSelectionFlags;
 extern int32_t _numSelectedObjectsForType[EnumValue(ObjectType::Count)];
 


### PR DESCRIPTION
Instead of just removing the specific error and replacing them with STR_WARNING_TOO_MANY_OBJECTS_SELECTED this will now print the specific error. 

I did notice through this that some of the error messages make no sense such as "Data for the following object not found:" and then it doesn't actually tell you which object. 

In general this code is a mess due to abuse of global variables but didn't feel like I wanted to try tackle this today.