### PR TITLE
Fix #13857: Removal price underflowing

### DIFF
--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -231,8 +231,8 @@ void SmallSceneryObject::ReadJson(IReadObjectContext* context, json_t& root)
     {
         _legacyType.height = Json::GetNumber<uint8_t>(properties["height"]);
         _legacyType.tool_id = Cursor::FromString(Json::GetString(properties["cursor"]), CursorID::StatueDown);
-        _legacyType.price = Json::GetNumber<uint16_t>(properties["price"]) * 10;
-        _legacyType.removal_price = Json::GetNumber<uint16_t>(properties["removalPrice"]) * 10;
+        _legacyType.price = Json::GetNumber<int16_t>(properties["price"]) * 10;
+        _legacyType.removal_price = Json::GetNumber<int16_t>(properties["removalPrice"]) * 10;
         _legacyType.animation_delay = Json::GetNumber<uint16_t>(properties["animationDelay"]);
         _legacyType.animation_mask = Json::GetNumber<uint16_t>(properties["animationMask"]);
         _legacyType.num_frames = Json::GetNumber<uint16_t>(properties["numFrames"]);


### PR DESCRIPTION
I don't know why those fields were being read as unsigned, their counterparts in LargeScenery were not.

This seems to fix it, another solution is likely to read it as unsigned and then cast to signed, my guess is that converting from 16 to 32 implicitly made them not overflow, but just interpret the MSB as positive.