### PR TITLE
Remove unused function WritePackedObjects

### DIFF
--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -351,25 +351,6 @@ public:
         }
     }
 
-    void WritePackedObjects(IStream* stream, std::vector<const ObjectRepositoryItem*>& objects) override
-    {
-        log_verbose("packing %u objects", objects.size());
-        for (const auto& object : objects)
-        {
-            Guard::ArgumentNotNull(object);
-
-            log_verbose("exporting object %.8s", object->ObjectEntry.name);
-            if (IsObjectCustom(object))
-            {
-                WritePackedObject(stream, &object->ObjectEntry);
-            }
-            else
-            {
-                log_warning("Refusing to pack vanilla/expansion object \"%s\"", object->ObjectEntry.name);
-            }
-        }
-    }
-
 private:
     void ClearItems()
     {

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -92,7 +92,6 @@ struct IObjectRepository
         ObjectGeneration generation, std::string_view objectName, const void* data, size_t dataSize) abstract;
 
     virtual void ExportPackedObject(OpenRCT2::IStream* stream) abstract;
-    virtual void WritePackedObjects(OpenRCT2::IStream* stream, std::vector<const ObjectRepositoryItem*>& objects) abstract;
 };
 
 [[nodiscard]] std::unique_ptr<IObjectRepository> CreateObjectRepository(


### PR DESCRIPTION
ObjectRepository::WritePackedObjects has zero calls to it.
ObjectRepository is the only extension of IObjectRepository which
defines this function, so it can be removed from both