### PR TITLE
Object version part 1

### DIFF
--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -250,6 +250,7 @@ class Object
 {
 private:
     std::string _identifier;
+    std::string _version;
     ObjectEntryDescriptor _descriptor{};
     StringTable _stringTable;
     ImageTable _imageTable;
@@ -363,6 +364,14 @@ public:
 
     const std::vector<std::string>& GetAuthors() const;
     void SetAuthors(std::vector<std::string>&& authors);
+    const std::string& GetVersion() const
+    {
+        return _version;
+    }
+    void SetVersion(const std::string& version)
+    {
+        _version = version;
+    }
 
     const ImageTable& GetImageTable() const
     {

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -521,6 +521,7 @@ namespace ObjectFactory
             if (id == OpenRCT2::Audio::AudioObjectIdentifiers::Rct2cBase)
                 id = OpenRCT2::Audio::AudioObjectIdentifiers::Rct2Base;
 
+            auto version = Json::GetString(jRoot["version"]);
             ObjectEntryDescriptor descriptor;
             auto originalId = Json::GetString(jRoot["originalId"]);
             if (originalId.length() == 8 + 1 + 8 + 1 + 8)
@@ -539,8 +540,9 @@ namespace ObjectFactory
             {
                 descriptor = ObjectEntryDescriptor(objectType, id);
             }
-
+            descriptor.Version = version;
             result = CreateObject(objectType);
+            result->SetVersion(version);
             result->SetIdentifier(id);
             result->SetDescriptor(descriptor);
             result->MarkAsJsonObject();

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -121,6 +121,7 @@ public:
             item.Generation = object->GetGeneration();
             item.Identifier = object->GetIdentifier();
             item.ObjectEntry = object->GetObjectEntry();
+            item.Version = object->GetVersion();
             item.Path = path;
             item.Name = object->GetName();
             item.Authors = object->GetAuthors();

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -43,6 +43,7 @@ struct ObjectRepositoryItem
     rct_object_entry ObjectEntry;
     std::string Path;
     std::string Name;
+    std::string Version;
     std::vector<std::string> Authors;
     std::vector<ObjectSourceGame> Sources;
     std::shared_ptr<Object> LoadedObject{};

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -388,7 +388,7 @@ namespace OpenRCT2
                                 {
                                     cs.Write(DESCRIPTOR_JSON);
                                     cs.Write(entry.Identifier);
-                                    cs.Write(""); // reserved for version
+                                    cs.Write(entry.Version);
                                 }
                                 else
                                 {


### PR DESCRIPTION
Park file already loads object version string, but does not save it. This is part of a project to add object versioning to OpenRCT2.

Does park file version need a bump?

By design, dat objects get an empty string version, which evaluates to equal to itself but less than any other string.