### PR TITLE
Revert some of #16477 and implement correctly

### DIFF
--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -119,7 +119,7 @@ GameActions::Result MazePlaceTrackAction::Query() const
 
     const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
     money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Price) >> 16));
-    res.Cost = ((canBuild.Cost + price) / 2) * 10;
+    res.Cost = canBuild.Cost + (price / 2) * 10;
 
     return res;
 }
@@ -161,7 +161,7 @@ GameActions::Result MazePlaceTrackAction::Execute() const
 
     const auto& ted = GetTrackElementDescriptor(TrackElemType::Maze);
     money32 price = (((ride->GetRideTypeDescriptor().BuildCosts.TrackPrice * ted.Price) >> 16));
-    res.Cost = ((canBuild.Cost + price) / 2) * 10;
+    res.Cost = canBuild.Cost + (price / 2) * 10;
 
     auto startLoc = _loc.ToTileStart();
 

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -162,7 +162,6 @@ GameActions::Result TrackPlaceAction::Query() const
         }
     }
 
-    money32 cost = 0;
     const auto& ted = GetTrackElementDescriptor(_trackType);
     const rct_preview_track* trackBlock = ted.Block;
     uint32_t numElements = 0;
@@ -213,6 +212,8 @@ GameActions::Result TrackPlaceAction::Query() const
     // If that is not the case, then perform the remaining checks
     trackBlock = ted.Block;
 
+    money32 costs = 0;
+    int32_t supportCosts = 0; // Note this is not money32 it requires / 2 * 10 to be money32
     for (int32_t blockIndex = 0; trackBlock->index != 0xFF; trackBlock++, blockIndex++)
     {
         auto rotatedTrack = CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(_origin.direction), trackBlock->z };
@@ -257,7 +258,7 @@ GameActions::Result TrackPlaceAction::Query() const
             canBuild.ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
             return canBuild;
         }
-        cost += canBuild.Cost;
+        costs += canBuild.Cost;
 
         // When building a level crossing, remove any pre-existing path furniture.
         if (crossingMode == CREATE_CROSSING_MODE_TRACK_OVER_PATH)
@@ -393,14 +394,14 @@ GameActions::Result TrackPlaceAction::Query() const
             supportHeight = (10 * COORDS_Z_STEP);
         }
 
-        cost += ((supportHeight / (2 * COORDS_Z_STEP)) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice);
+        supportCosts += ((supportHeight / (2 * COORDS_Z_STEP)) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice);
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
     price *= ted.Price;
 
     price >>= 16;
-    res.Cost = ((cost + price) / 2) * 10;
+    res.Cost = costs + ((supportCosts + price) / 2) * 10;
     res.SetData(std::move(resultData));
 
     return res;
@@ -437,7 +438,8 @@ GameActions::Result TrackPlaceAction::Execute() const
     const auto& ted = GetTrackElementDescriptor(_trackType);
     const auto& wallEdges = ted.SequenceElementAllowedWallEdges;
 
-    money32 cost = 0;
+    money32 costs = 0;
+    int32_t supportCosts = 0; // Note this is not money32 it requires / 2 * 10 to be money32
     const rct_preview_track* trackBlock = ted.Block;
     for (int32_t blockIndex = 0; trackBlock->index != 0xFF; trackBlock++, blockIndex++)
     {
@@ -473,7 +475,7 @@ GameActions::Result TrackPlaceAction::Execute() const
             canBuild.ErrorTitle = STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE;
             return canBuild;
         }
-        cost += canBuild.Cost;
+        costs += canBuild.Cost;
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST) && !gCheatsDisableClearanceChecks)
         {
@@ -522,7 +524,7 @@ GameActions::Result TrackPlaceAction::Execute() const
             supportHeight = (10 * COORDS_Z_STEP);
         }
 
-        cost += (supportHeight / (2 * COORDS_Z_STEP)) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice;
+        supportCosts += (supportHeight / (2 * COORDS_Z_STEP)) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice;
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
@@ -697,7 +699,7 @@ GameActions::Result TrackPlaceAction::Execute() const
     price *= ted.Price;
 
     price >>= 16;
-    res.Cost = ((cost + price) / 2) * 10;
+    res.Cost = costs + ((supportCosts + price) / 2) * 10;
     res.SetData(std::move(resultData));
 
     return res;

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -151,7 +151,7 @@ GameActions::Result TrackRemoveAction::Query() const
     res.Position.y = startLoc.y;
     res.Position.z = startLoc.z;
 
-    money32 cost = 0;
+    int32_t supportCosts = 0; // Note this is not money32 it requires / 2 * 10 to be money32
 
     trackBlock = ted.Block;
     for (; trackBlock->index != 255; trackBlock++)
@@ -226,19 +226,20 @@ GameActions::Result TrackRemoveAction::Query() const
             _support_height = 10;
         }
 
-        cost += (_support_height / 2) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice;
+        supportCosts += (_support_height / 2) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice;
     }
 
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
     price *= ted.Price;
     price >>= 16;
-    price = (price + cost) / 2;
+    price = ((supportCosts + price) / 2) * 10;
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)
-        price *= -7;
-    else
-        price *= -10;
+    {
+        // 70% modifier for opened rides
+        price = (static_cast<money64>(price) * 45875) / 65536;
+    }
 
-    res.Cost = price;
+    res.Cost = -price;
     return res;
 }
 
@@ -332,7 +333,8 @@ GameActions::Result TrackRemoveAction::Execute() const
     res.Position.x = startLoc.x;
     res.Position.y = startLoc.y;
     res.Position.z = startLoc.z;
-    money32 cost = 0;
+
+    int32_t supportCosts = 0; // Note this is not money32 it requires / 2 * 10 to be money32
 
     trackBlock = ted.Block;
     for (; trackBlock->index != 255; trackBlock++)
@@ -402,7 +404,7 @@ GameActions::Result TrackRemoveAction::Execute() const
             _support_height = 10;
         }
 
-        cost += (_support_height / 2) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice;
+        supportCosts += (_support_height / 2) * ride->GetRideTypeDescriptor().BuildCosts.SupportPrice;
 
         // If the removed tile is a station modify station properties.
         // Don't do this if the ride is simulating and the tile is a ghost to prevent desyncs.
@@ -482,12 +484,13 @@ GameActions::Result TrackRemoveAction::Execute() const
     money32 price = ride->GetRideTypeDescriptor().BuildCosts.TrackPrice;
     price *= ted.Price;
     price >>= 16;
-    price = (price + cost) / 2;
+    price = ((supportCosts + price) / 2) * 10;
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_EVER_BEEN_OPENED)
-        price *= -7;
-    else
-        price *= -10;
+    {
+        // 70% modifier for opened rides
+        price = (static_cast<money64>(price) * 45875) / 65536;
+    }
 
-    res.Cost = price;
+    res.Cost = -price;
     return res;
 }


### PR DESCRIPTION
#16477 tried to fix the discrepency of prices between construct / destruct but in the process multiplied all costs by 10. ~~This reverts those changes and fixes the root issue that the 70% calc was being done in a way that looses accuracy.~~ Actually on even closer inspection the issue was just around the costs.

Will need a good bit of testing. Should make the money32 pr easier to understand
