### PR TITLE
Fix an assertion error in InitialiseListItems

### DIFF
--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -793,17 +793,19 @@ static void InitialiseListItems(rct_window* w)
             _listItems.pop_back();
 
             // Remove empty headings
-            for (auto it = _listItems.begin(); it != _listItems.end(); it++)
+            for (auto it = _listItems.begin(); it != _listItems.end();)
             {
                 const auto& listItem = *it;
                 if (listItem.type == ListItemType::Heading)
                 {
-                    if ((it + 1) == _listItems.end() || (it + 1)->type == ListItemType::Heading)
+                    auto nextIt = std::next(it);
+                    if (nextIt == _listItems.end() || nextIt->type == ListItemType::Heading)
                     {
                         it = _listItems.erase(it);
-                        it--;
+                        continue;
                     }
                 }
+                ++it;
             }
         }
     }


### PR DESCRIPTION
Fixes a minor mistake in `InitialiseListItems` triggeing an assertion error in Debug builds under specific circumstances.

To reproduce:
1. Ensure Progressive Scenario Unlocking is **enabled**.
2. Point OpenRCT2 at a RCT1/Deluxe directory and restart.
3. After a restart, shut down the game again and delete `rct1_path` from the config to disassociate RCT1/Deluxe from OpenRCT2.
4. Open the game again and open the Scenarios menu.
5. A `Expression: can't decrement vector iterator before begin` assertion (would have) showed.