### PR TITLE
Update CI images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,16 +109,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [win32, NT5.1]
+        platform: [win32]
         include:
           - platform: win32
             platform_name: win32
             cache_key: windows-mingw
-            build_flags: -DBUILD_SHARED_LIBS=ON -DENABLE_SCRIPTING=OFF
-          - platform: NT5.1
-            platform_name: win32, NT5.1
-            cache_key: windows-mingw-nt51
-            build_flags: -DDISABLE_HTTP=Off -DENABLE_SCRIPTING=ON -DCMAKE_CXX_FLAGS="-Wno-error=cast-function-type -Wno-error=unused-function" -DSTATIC=on -DMINGW_TARGET_NT5_1=ON
+            build_flags: -DBUILD_SHARED_LIBS=ON -DENABLE_SCRIPTING=ON
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,8 +285,8 @@ jobs:
       - name: Run Tests
         run: . scripts/setenv -q && run-tests
       - name: Upload artifacts (openrct2.org)
-        if: matrix.distro == 'bionic' # Need to get openrct2.org updated before other distros can be enabled
         run: |
+          # Build identification code: https://github.com/Limetric/OpenRCT2.org/blob/e5b738f3dadcc5a3b78e8dfd434756ff31eaa1d3/src/misc/releaseAsset.js#L94-L116
           . scripts/setenv -q
           if [[ "$OPENRCT2_PUSH" == "true" ]]; then
             upload-build artifacts/OpenRCT2-${{ runner.os }}-${{ matrix.distro }}-${{ matrix.platform }}.tar.gz linux-${{ matrix.platform }} $OPENRCT2_VERSION $OPENRCT2_SHA1 $OPENRCT2_BRANCH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     name: Windows (${{ matrix.platform_name }}) using mingw
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:4-mingw
+    container: openrct2/openrct2-build:8-mingw
     strategy:
       fail-fast: false
       matrix:
@@ -251,11 +251,15 @@ jobs:
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz" -DWITH_TESTS=off
           - platform: x86_64
             distro: focal
-            image: openrct2/openrct2-build:5-focal
+            image: openrct2/openrct2-build:8-focal
+            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz"
+          - platform: x86_64
+            distro: jammy
+            image: openrct2/openrct2-build:8-jammy
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz"
           - platform: x86_64
             distro: bullseye
-            image: openrct2/openrct2-build:5-bullseye
+            image: openrct2/openrct2-build:8-bullseye
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz"
           - platform: i686
             distro: bionic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,8 +258,8 @@ jobs:
             image: openrct2/openrct2-build:8-bullseye
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz"
           - platform: i686
-            distro: bionic
-            image: openrct2/openrct2-build:4-bionic32
+            distro: focal
+            image: openrct2/openrct2-build:8-focal32
             build_flags: -DFORCE32=ON -DENABLE_SCRIPTING=OFF -DCMAKE_CXX_FLAGS="-m32 -g -gz" -DWITH_TESTS=off
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
     name: Linux (x64, AppImage)
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:0.3.1-bionic
+    container: openrct2/openrct2-build:8-focal
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -358,7 +358,7 @@ jobs:
     name: Linux (Debug, [http, network, OpenGL] disabled) using clang
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:0.3.1-bionic
+    container: openrct2/openrct2-build:8-jammy
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -374,7 +374,7 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:4-android
+    container: openrct2/openrct2-build:8-android
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
I expect failure due to functions deprecated in latest OpenSSL available in Jammy, need to fix that.