### PR TITLE
Fix scenery window colors defaulting to black

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -830,19 +830,6 @@ public:
         window_invalidate_by_class(WC_SCENERY);
     }
 
-    void SetDefaultPlacementConfiguration()
-    {
-        gWindowSceneryRotation = 3;
-        gWindowSceneryPrimaryColour = COLOUR_BORDEAUX_RED;
-        gWindowScenerySecondaryColour = COLOUR_YELLOW;
-        gWindowSceneryTertiaryColour = COLOUR_DARK_BROWN;
-
-        Init();
-
-        gWindowSceneryTabSelections.clear();
-        gWindowSceneryActiveTabIndex = 0;
-    }
-
 private:
     int32_t GetNumColumns() const
     {
@@ -1394,11 +1381,19 @@ void WindowSceneryResetSelectedSceneryItems()
 
 void WindowScenerySetDefaultPlacementConfiguration()
 {
+    gWindowSceneryRotation = 3;
+    gWindowSceneryPrimaryColour = COLOUR_BORDEAUX_RED;
+    gWindowScenerySecondaryColour = COLOUR_YELLOW;
+    gWindowSceneryTertiaryColour = COLOUR_DARK_BROWN;
+
     auto* w = static_cast<SceneryWindow*>(window_find_by_class(WC_SCENERY));
     if (w != nullptr)
     {
-        w->SetDefaultPlacementConfiguration();
+        w->Init();
     }
+
+    gWindowSceneryTabSelections.clear();
+    gWindowSceneryActiveTabIndex = 0;
 }
 
 void WindowSceneryInit()


### PR DESCRIPTION
It looks like [d219a99](https://github.com/OpenRCT2/OpenRCT2/commit/d219a99b5676db2f4c169a8220febad2758b82bb) caused the code to set the colors (and other defaults) to only get called if the scenery window was open, but the function that checked if it was open was only ever called when the scenery window *couldn't* be open (on first start and loading a park). I just moved everything to the function that does get called.

I left the `Init` call in, but I don't think it ever gets called through here (it will get called when the player actually opens the window). Also, should I add a changelog entry?

I don't know off-hand if this issue happened with any of the other window->class conversions.