### PR TITLE
fix vertical sprite count math

### DIFF
--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -243,7 +243,7 @@ void RideObject::Load()
                 if (vehicleEntry->sprite_flags & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES)
                 {
                     vehicleEntry->vertical_slope_image_id = image_index;
-                    b = vehicleEntry->base_num_frames * ((3 * numRotationFrames) + (5 * NumOrthogonalDirections));
+                    b = vehicleEntry->base_num_frames * ((2 * numRotationFrames) + (13 * NumOrthogonalDirections));
                     image_index += b;
                 }
 


### PR DESCRIPTION
The sprite group has 13 vehicle angles in 4 directions, plus two ranks of sprites at two vehicle angles, not 5 vehicle angles in 4 directions plus three ranks of sprites. Both come to the correct total of 116 sprites when using 32 as numRotationFrames.