### PR TITLE
Never researched option

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -587,7 +587,7 @@ STR_1199    :{COMMA16} person on ride
 STR_1200    :{COMMA16} people on ride
 STR_1201    :Nobody in queue line
 STR_1202    :1 person in queue line
-STR_1203    :{COMMA16} people in queue line
+STR_1203    :{COMMA32} people in queue line
 STR_1204    :{COMMA16} minute queue time
 STR_1205    :{COMMA16} minutes queue time
 STR_1206    :{WINDOW_COLOUR_2}Wait for:

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -587,7 +587,7 @@ STR_1199    :{COMMA16} person on ride
 STR_1200    :{COMMA16} people on ride
 STR_1201    :Nobody in queue line
 STR_1202    :1 person in queue line
-STR_1203    :{COMMA32} people in queue line
+STR_1203    :{COMMA16} people in queue line
 STR_1204    :{COMMA16} minute queue time
 STR_1205    :{COMMA16} minutes queue time
 STR_1206    :{WINDOW_COLOUR_2}Wait for:
@@ -1956,8 +1956,8 @@ STR_2742    :css50.dat not found
 STR_2743    :Copy ‘data/css17.dat’ from your RCT1 installation to ‘data/css50.dat’ in your RCT2 installation, or make sure the path to RCT1 in the Advanced tab is correct.
 STR_2749    :My new scenario
 # New strings used in the cheats window previously these were ???
-STR_2750    :Move all items to top
-STR_2751    :Move all items to bottom
+STR_2750    :Move all bottom items to top
+STR_2751    :Move all top items to bottom
 STR_2752    :Clear grass
 STR_2753    :Mow grass
 STR_2754    :Water plants
@@ -3677,6 +3677,8 @@ STR_6485    :See-Through vehicles toggle
 STR_6486    :See-Through guests toggle
 STR_6487    :See-Through staff toggle
 STR_6488    :{RED}Guests are complaining about the length of the queues in your park.{NEWLINE}Consider shortening problematic queues, or increase the ride’s throughput.
+STR_6489    :{WINDOW_COLOUR_2}Items unavailable during scenario play:
+STR_6490	:Move all right items to top
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -121,7 +121,7 @@ static ResearchItem _editorInventionsListDraggedItem;
 // clang-format on
 
 static void WindowEditorInventionsListDragOpen(ResearchItem* researchItem);
-static void MoveResearchItem(ResearchItem* beforeItem, int32_t scrollIndexFrom, int32_t scrollIndexTo);
+static void MoveResearchItem(ResearchItem* beforeItem, int32_t scrollIndex);
 
 /**
  *

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1540,11 +1540,11 @@ void EditorLoadSelectedObjects()
                         rct_ride_entry* rideEntry = get_ride_entry(entryIndex);
                         uint8_t rideType = ride_entry_get_first_non_null_ride_type(rideEntry);
                         ResearchCategory category = static_cast<ResearchCategory>(GetRideTypeDescriptor(rideType).Category);
-                        research_insert_ride_entry(rideType, entryIndex, category, true);
+                        research_insert_ride_entry(rideType, entryIndex, category, ResearchStatusType::Invented);
                     }
                     else if (objectType == ObjectType::SceneryGroup)
                     {
-                        research_insert_scenery_group_entry(entryIndex, true);
+                        research_insert_scenery_group_entry(entryIndex, ResearchStatusType::Invented);
                     }
                 }
             }

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1237,7 +1237,7 @@ static int32_t cc_load_object(InteractiveConsole& console, const arguments_t& ar
                 if (rideType != RIDE_TYPE_NULL)
                 {
                     ResearchCategory category = GetRideTypeDescriptor(rideType).GetResearchCategory();
-                    research_insert_ride_entry(rideType, groupIndex, category, true);
+                    research_insert_ride_entry(rideType, groupIndex, category, ResearchStatusType::Invented);
                 }
             }
 
@@ -1247,7 +1247,7 @@ static int32_t cc_load_object(InteractiveConsole& console, const arguments_t& ar
         }
         else if (objectType == ObjectType::SceneryGroup)
         {
-            research_insert_scenery_group_entry(groupIndex, true);
+            research_insert_scenery_group_entry(groupIndex, ResearchStatusType::Invented);
 
             gSilentResearch = true;
             research_reset_current_item();

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3948,6 +3948,9 @@ enum : uint16_t
 
     STR_PEEPS_COMPLAINING_ABOUT_QUEUE_LENGTH_WARNING = 6488,
 
+    STR_INVENTION_NEVER_INVENTED_ITEMS = 6489,
+    STR_INVENTION_NEVER_INVENTED_ITEMS_BUTTON = 6490,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -512,7 +512,7 @@ void research_populate_list_random()
             continue;
         }
 
-        auto statusType = static_cast<ResearchStatusType>(static_cast<uint32_t>((scenario_rand() & 0xFF) > 12) + 1);
+        auto statusType = static_cast<ResearchStatusType>((scenario_rand() & 0xFF) > 12);
         for (auto rideType : rideEntry->ride_type)
         {
             if (rideType != RIDE_TYPE_NULL)
@@ -532,7 +532,7 @@ void research_populate_list_random()
             continue;
         }
 
-        auto statusType = static_cast<ResearchStatusType>(static_cast<uint32_t>((scenario_rand() & 0xFF) > 85) + 1);
+        auto statusType = static_cast<ResearchStatusType>((scenario_rand() & 0xFF) > 85);
         research_insert_scenery_group_entry(i, statusType);
     }
 }
@@ -849,7 +849,7 @@ static void ResearchAddAllMissingItems(bool isResearched)
         const auto* rideEntry = get_ride_entry(i);
         if (rideEntry != nullptr)
         {
-            research_insert_ride_entry(i, static_cast<ResearchStatusType>(static_cast<uint32_t>(isResearched) + 1));
+            research_insert_ride_entry(i, static_cast<ResearchStatusType>(isResearched));
         }
     }
 
@@ -858,7 +858,7 @@ static void ResearchAddAllMissingItems(bool isResearched)
         const auto* groupEntry = get_scenery_group_entry(i);
         if (groupEntry != nullptr)
         {
-            research_insert_scenery_group_entry(i, static_cast<ResearchStatusType>(static_cast<uint32_t>(isResearched) + 1));
+            research_insert_scenery_group_entry(i, static_cast<ResearchStatusType>(isResearched));
         }
     }
 }

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -48,9 +48,9 @@ enum class ResearchCategory : uint8_t
 
 enum class ResearchStatusType : uint8_t
 {
-    NeverInvented,
     Unvinvented,
-    Invented
+    Invented,
+    NeverInvented
 };
 
 struct ResearchItem

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -46,6 +46,13 @@ enum class ResearchCategory : uint8_t
     SceneryGroup = 6,
 };
 
+enum class ResearchStatusType : uint8_t
+{
+    NeverInvented,
+    Unvinvented,
+    Invented
+};
+
 struct ResearchItem
 {
     union
@@ -118,6 +125,7 @@ extern uint8_t gResearchExpectedDay;
 extern std::optional<ResearchItem> gResearchLastItem;
 extern std::optional<ResearchItem> gResearchNextItem;
 
+extern std::vector<ResearchItem> gResearchItemsNeverInvented;
 extern std::vector<ResearchItem> gResearchItemsUninvented;
 extern std::vector<ResearchItem> gResearchItemsInvented;
 extern uint8_t gResearchUncompletedCategories;
@@ -130,12 +138,13 @@ void research_reset_current_item();
 void research_populate_list_random();
 
 void research_finish_item(ResearchItem* researchItem);
-void research_insert(ResearchItem&& item, bool researched);
+void research_insert(ResearchItem&& item, ResearchStatusType statusType);
 void ResearchRemove(const ResearchItem& researchItem);
 
-bool research_insert_ride_entry(uint8_t rideType, ObjectEntryIndex entryIndex, ResearchCategory category, bool researched);
-void research_insert_ride_entry(ObjectEntryIndex entryIndex, bool researched);
-bool research_insert_scenery_group_entry(ObjectEntryIndex entryIndex, bool researched);
+bool research_insert_ride_entry(
+    uint8_t rideType, ObjectEntryIndex entryIndex, ResearchCategory category, ResearchStatusType statusType);
+void research_insert_ride_entry(ObjectEntryIndex entryIndex, ResearchStatusType statusType);
+bool research_insert_scenery_group_entry(ObjectEntryIndex entryIndex, ResearchStatusType statusType);
 
 void ride_type_set_invented(uint32_t rideType);
 void ride_entry_set_invented(ObjectEntryIndex rideEntryIndex);
@@ -158,6 +167,7 @@ void ResearchFix();
 
 void research_items_make_all_unresearched();
 void research_items_make_all_researched();
+void research_items_unlock_unavailable();
 void research_items_shuffle();
 /**
  * Determines if a newly invented ride entry should be listed as a new ride

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -823,7 +823,7 @@ namespace OpenRCT2
 
         void ReadWriteResearchChunk(OrcaStream& os)
         {
-            os.ReadWriteChunk(ParkFileChunkType::RESEARCH, [](OrcaStream::ChunkStream& cs) {
+            os.ReadWriteChunk(ParkFileChunkType::RESEARCH, [&](OrcaStream::ChunkStream& cs) {
                 // Research status
                 cs.ReadWrite(gResearchFundingLevel);
                 cs.ReadWrite(gResearchPriorities);
@@ -835,6 +835,10 @@ namespace OpenRCT2
                 ReadWriteResearchItem(cs, gResearchNextItem);
 
                 // Invention list
+                if (os.GetHeader().MinVersion >= 0xB)
+                    cs.ReadWriteVector(
+                        gResearchItemsNeverInvented, [&cs](ResearchItem& item) { ReadWriteResearchItem(cs, item); });
+
                 cs.ReadWriteVector(gResearchItemsUninvented, [&cs](ResearchItem& item) { ReadWriteResearchItem(cs, item); });
                 cs.ReadWriteVector(gResearchItemsInvented, [&cs](ResearchItem& item) { ReadWriteResearchItem(cs, item); });
             });

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -8,10 +8,10 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 0xA;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 0xB;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t PARK_FILE_MIN_VERSION = 0x9;
+    constexpr uint32_t PARK_FILE_MIN_VERSION = 0xB;
 
     constexpr uint32_t PARK_FILE_MAGIC = 0x4B524150; // PARK
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1873,7 +1873,7 @@ namespace RCT1
             // The first six scenery groups are always available
             for (uint8_t i = 0; i < 6; i++)
             {
-                research_insert_scenery_group_entry(i, true);
+                research_insert_scenery_group_entry(i, ResearchStatusType::Invented);
             }
 
             bool researched = true;
@@ -1905,7 +1905,8 @@ namespace RCT1
                         if (sceneryGroupEntryIndex != OBJECT_ENTRY_INDEX_IGNORE
                             && sceneryGroupEntryIndex != OBJECT_ENTRY_INDEX_NULL)
                         {
-                            research_insert_scenery_group_entry(sceneryGroupEntryIndex, researched);
+                            research_insert_scenery_group_entry(
+                                sceneryGroupEntryIndex, static_cast<ResearchStatusType>(static_cast<uint32_t>(researched) + 1));
                         }
                         break;
                     }
@@ -1962,7 +1963,8 @@ namespace RCT1
                             if (!_researchRideEntryUsed[ownRideEntryIndex])
                             {
                                 _researchRideEntryUsed[ownRideEntryIndex] = true;
-                                research_insert_ride_entry(ownRideEntryIndex, researched);
+                                research_insert_ride_entry(
+                                    ownRideEntryIndex, static_cast<ResearchStatusType>(static_cast<uint32_t>(researched) + 1));
                             }
                         }
 
@@ -2093,7 +2095,8 @@ namespace RCT1
             if (!_researchRideEntryUsed[rideEntryIndex])
             {
                 _researchRideEntryUsed[rideEntryIndex] = true;
-                research_insert_ride_entry(rideEntryIndex, researched);
+                research_insert_ride_entry(
+                    rideEntryIndex, static_cast<ResearchStatusType>(static_cast<uint32_t>(researched) + 1));
             }
         }
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1906,7 +1906,7 @@ namespace RCT1
                             && sceneryGroupEntryIndex != OBJECT_ENTRY_INDEX_NULL)
                         {
                             research_insert_scenery_group_entry(
-                                sceneryGroupEntryIndex, static_cast<ResearchStatusType>(static_cast<uint32_t>(researched) + 1));
+                                sceneryGroupEntryIndex, static_cast<ResearchStatusType>(researched));
                         }
                         break;
                     }
@@ -1963,8 +1963,7 @@ namespace RCT1
                             if (!_researchRideEntryUsed[ownRideEntryIndex])
                             {
                                 _researchRideEntryUsed[ownRideEntryIndex] = true;
-                                research_insert_ride_entry(
-                                    ownRideEntryIndex, static_cast<ResearchStatusType>(static_cast<uint32_t>(researched) + 1));
+                                research_insert_ride_entry(ownRideEntryIndex, static_cast<ResearchStatusType>(researched));
                             }
                         }
 
@@ -2095,8 +2094,7 @@ namespace RCT1
             if (!_researchRideEntryUsed[rideEntryIndex])
             {
                 _researchRideEntryUsed[rideEntryIndex] = true;
-                research_insert_ride_entry(
-                    rideEntryIndex, static_cast<ResearchStatusType>(static_cast<uint32_t>(researched) + 1));
+                research_insert_ride_entry(rideEntryIndex, static_cast<ResearchStatusType>(researched));
             }
         }
 


### PR DESCRIPTION
I have added a never-researched category to the inventionslist. It allows to add rides (or scenery groups) into the scenario, to use in constructing the scenario, without them being available to the player when they play the scenario. For instance, a scenario could be that there's a small park that has a single wooden rollercoaster operating "made by a now bankrupt manufactorer", meaning you can't build another wooden coaster. 