### PR TITLE
Fix park size

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.1 (in development)
 ------------------------------------------------------------------------
+- Fix: [#16934] Park size displayed incorrectly in Park window.
 - Fix: [#16974] Small scenery ghosts can be deleted.
 - Fix: [#17005] Unable to set patrol area for first staff member in park.
 - Fix: [#17073] Corrupt ride window and random crashes when trains have more than 144 cars.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -91,7 +91,6 @@
 - Fix: [#16869] Soft Toy Stall cannot be recoloured, but shows a recolouring option anyway (original bug).
 - Fix: [#16995] Native Linux dialog windows do not open if the path contains single quotes.
 - Fix: [objects#165] Glitch when Bengal Tiger Cars go through a corner.
-- Fix: [#16934] Park size displayed incorrectly in Park window.
 
 0.3.5.1 (2021-11-21)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -91,6 +91,7 @@
 - Fix: [#16869] Soft Toy Stall cannot be recoloured, but shows a recolouring option anyway (original bug).
 - Fix: [#16995] Native Linux dialog windows do not open if the path contains single quotes.
 - Fix: [objects#165] Glitch when Bengal Tiger Cars go through a corner.
+- Fix: [#16934] Park size displayed incorrectly in Park window.
 
 0.3.5.1 (2021-11-21)
 ------------------------------------------------------------------------

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -8,10 +8,10 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 0xA;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 0xB;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t PARK_FILE_MIN_VERSION = 0x9;
+    constexpr uint32_t PARK_FILE_MIN_VERSION = 0xB;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -49,7 +49,7 @@ using namespace OpenRCT2;
 uint64_t gParkFlags;
 uint16_t gParkRating;
 money16 gParkEntranceFee;
-uint16_t gParkSize;
+uint32_t gParkSize;
 money16 gLandPrice;
 money16 gConstructionRightsPrice;
 
@@ -342,9 +342,9 @@ void Park::Update(const Date& date)
     GenerateGuests();
 }
 
-int32_t Park::CalculateParkSize() const
+uint32_t Park::CalculateParkSize() const
 {
-    int32_t tiles = 0;
+    uint32_t tiles = 0;
     tile_element_iterator it;
     tile_element_iterator_begin(&it);
     do
@@ -789,7 +789,7 @@ int32_t park_is_open()
     return GetContext()->GetGameState()->GetPark().IsOpen();
 }
 
-int32_t park_calculate_size()
+uint32_t park_calculate_size()
 {
     auto tiles = GetContext()->GetGameState()->GetPark().CalculateParkSize();
     if (tiles != gParkSize)

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -65,7 +65,7 @@ namespace OpenRCT2
         void Initialise();
         void Update(const Date& date);
 
-        int32_t CalculateParkSize() const;
+        uint32_t CalculateParkSize() const;
         int32_t CalculateParkRating() const;
         money64 CalculateParkValue() const;
         money64 CalculateCompanyValue() const;
@@ -90,7 +90,7 @@ namespace OpenRCT2
 extern uint64_t gParkFlags;
 extern uint16_t gParkRating;
 extern money16 gParkEntranceFee;
-extern uint16_t gParkSize;
+extern uint32_t gParkSize;
 extern money16 gLandPrice;
 extern money16 gConstructionRightsPrice;
 
@@ -110,7 +110,7 @@ void set_forced_park_rating(int32_t rating);
 int32_t get_forced_park_rating();
 
 int32_t park_is_open();
-int32_t park_calculate_size();
+uint32_t park_calculate_size();
 
 void update_park_fences(const CoordsXY& coords);
 void update_park_fences_around_tile(const CoordsXY& coords);


### PR DESCRIPTION
Prevent very large parks from showing incorrect park size, or as I like to call it: increase park size.. size. 
Tested with old parks, loads fine.

Also someone, please tell me how to get rid of my old commits for previous PR?
I've tried everything, even:

git checkout develop
git pull upstream develop
git reset --hard upstream/develop
git push origin develop --force

I checked, and saw the changes were gone, created a new branch, and checked to see the changes were gone.. and yet here, they're suddenly back
