### PR TITLE
Fix #16050: Scenery window positioning

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -32,7 +32,8 @@ constexpr int32_t WINDOW_SCENERY_MIN_WIDTH = 634;
 constexpr int32_t WINDOW_SCENERY_MIN_HEIGHT = 180;
 constexpr int32_t SCENERY_BUTTON_WIDTH = 66;
 constexpr int32_t SCENERY_BUTTON_HEIGHT = 80;
-constexpr int32_t SceneryTabWidth = 31;
+constexpr int32_t TabWidth = 31;
+constexpr int32_t MaxTabs = 32;
 
 constexpr uint8_t SceneryContentScrollIndex = 0;
 
@@ -734,8 +735,7 @@ public:
     {
         _tabEntries.clear();
 
-        auto maxTabs = 32;
-        for (ObjectEntryIndex scenerySetIndex = 0; scenerySetIndex < maxTabs - 1; scenerySetIndex++)
+        for (ObjectEntryIndex scenerySetIndex = 0; scenerySetIndex < MaxTabs - 1; scenerySetIndex++)
         {
             const auto* sceneryGroupEntry = get_scenery_group_entry(scenerySetIndex);
             if (sceneryGroupEntry != nullptr && scenery_group_is_invented(scenerySetIndex))
@@ -816,7 +816,7 @@ public:
         }
 
         // Set required width
-        _requiredWidth = static_cast<int32_t>(_tabEntries.size()) * SceneryTabWidth + 5;
+        _requiredWidth = static_cast<int32_t>(_tabEntries.size()) * TabWidth + 5;
 
         SortTabs();
         PrepareWidgets();
@@ -1024,7 +1024,7 @@ private:
         for (const auto& tabInfo : _tabEntries)
         {
             auto widget = MakeTab(pos, STR_STRING_DEFINED_TOOLTIP);
-            pos.x += 31;
+            pos.x += TabWidth;
 
             if (tabInfo.SceneryGroupIndex == OBJECT_ENTRY_INDEX_NULL)
             {

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -730,12 +730,6 @@ public:
         OnMouseDown(WIDX_SCENERY_TAB_1 + tabId);
     }
 
-    // Used after removing objects, in order to avoid crashes.
-    void ResetSelectedSceneryItems()
-    {
-        gWindowSceneryTabSelections.clear();
-    }
-
     void Init()
     {
         _tabEntries.clear();
@@ -1383,11 +1377,8 @@ void WindowScenerySetSelectedTab(const ObjectEntryIndex sceneryGroupIndex)
 // Used after removing objects, in order to avoid crashes.
 void WindowSceneryResetSelectedSceneryItems()
 {
-    auto* w = static_cast<SceneryWindow*>(window_find_by_class(WC_SCENERY));
-    if (w != nullptr)
-    {
-        w->ResetSelectedSceneryItems();
-    }
+    gWindowSceneryTabSelections.clear();
+    gWindowSceneryActiveTabIndex = 0;
 }
 
 void WindowScenerySetDefaultPlacementConfiguration()
@@ -1397,8 +1388,7 @@ void WindowScenerySetDefaultPlacementConfiguration()
     gWindowScenerySecondaryColour = COLOUR_YELLOW;
     gWindowSceneryTertiaryColour = COLOUR_DARK_BROWN;
 
-    gWindowSceneryTabSelections.clear();
-    gWindowSceneryActiveTabIndex = 0;
+    WindowSceneryResetSelectedSceneryItems();
 }
 
 void WindowSceneryInit()

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -675,7 +675,7 @@ rct_window* window_bring_to_front_by_number(rct_windowclass cls, rct_windownumbe
 rct_window* WindowCreate(
     std::unique_ptr<rct_window>&& w, rct_windowclass cls, ScreenCoordsXY pos, int32_t width, int32_t height, uint32_t flags);
 template<typename T, typename std::enable_if<std::is_base_of<rct_window, T>::value>::type* = nullptr>
-T* WindowCreate(rct_windowclass cls, const ScreenCoordsXY& pos, int32_t width, int32_t height, uint32_t flags = 0)
+T* WindowCreate(rct_windowclass cls, const ScreenCoordsXY& pos = {}, int32_t width = 0, int32_t height = 0, uint32_t flags = 0)
 {
     return static_cast<T*>(WindowCreate(std::make_unique<T>(), cls, pos, width, height, flags));
 }


### PR DESCRIPTION
This fix supersedes #16095. Some parts of that PR are used here, but many changes weren't necessary for the fix.

The scenery window already handles the number of tabs, but that is only known after construction, while the size of the window is already required by `WindowCreate`. This PR makes the position and size arguments of `WindowCreate` optional.

In this case, it removes the `WF_NO_SCROLLING` flag from the call to `WindowCreate`, but that seems to have no use for the scenery window anyway.