### PR TITLE
Make "Object Selection" order more coherent

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.1 (in development)
 ------------------------------------------------------------------------
 - Feature: [#17011] Option to show ride vehicles as separate entries when selecting a ride to construct.
+- Change: [#16952] Make "Object Selection" order more coherent.
 - Fix: [#16934] Park size displayed incorrectly in Park window.
 - Fix: [#16974] Small scenery ghosts can be deleted.
 - Fix: [#17005] Unable to set patrol area for first staff member in park.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,7 +1,7 @@
 0.4.1 (in development)
 ------------------------------------------------------------------------
 - Feature: [#17011] Option to show ride vehicles as separate entries when selecting a ride to construct.
-- Change: [#16952] Make "Object Selection" order more coherent.
+- Change: [#16952] Make “Object Selection” order more coherent.
 - Fix: [#16934] Park size displayed incorrectly in Park window.
 - Fix: [#16974] Small scenery ghosts can be deleted.
 - Fix: [#17005] Unable to set patrol area for first staff member in park.

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -125,28 +125,40 @@ struct ObjectPageDesc
     bool IsAdvanced;
 };
 
+
+// Order of which the object tabs are displayed.
 static constexpr const ObjectPageDesc ObjectSelectionPages[] = {
-    { STR_OBJECT_SELECTION_RIDE_VEHICLES_ATTRACTIONS,   SPR_TAB_RIDE_16,            false },
-    { STR_OBJECT_SELECTION_SMALL_SCENERY,               SPR_TAB_SCENERY_TREES,      true  },
-    { STR_OBJECT_SELECTION_LARGE_SCENERY,               SPR_TAB_SCENERY_URBAN,      true  },
-    { STR_OBJECT_SELECTION_WALLS_FENCES,                SPR_TAB_SCENERY_WALLS,      true  },
-    { STR_OBJECT_SELECTION_PATH_SIGNS,                  SPR_TAB_SCENERY_SIGNAGE,    true  },
-    { STR_OBJECT_SELECTION_FOOTPATHS,                   SPR_G2_LEGACY_PATH_TAB,      true  },
-    { STR_OBJECT_SELECTION_PATH_EXTRAS,                 SPR_TAB_SCENERY_PATH_ITEMS, false },
-    { STR_OBJECT_SELECTION_SCENERY_GROUPS,              SPR_TAB_SCENERY_STATUES,    false },
-    { STR_OBJECT_SELECTION_PARK_ENTRANCE,               SPR_TAB_PARK,               false },
-    { STR_OBJECT_SELECTION_WATER,                       SPR_TAB_WATER,              false },
-
+    { STR_OBJECT_SELECTION_RIDE_VEHICLES_ATTRACTIONS, SPR_TAB_RIDE_16,            false },
+    { STR_OBJECT_SELECTION_STATIONS,                  SPR_G2_RIDE_STATION_TAB,    true  },
+    { STR_OBJECT_SELECTION_MUSIC,                     SPR_TAB_MUSIC_0,            true  },
+    { STR_OBJECT_SELECTION_SCENERY_GROUPS,            SPR_TAB_SCENERY_STATUES,    false },
+    { STR_OBJECT_SELECTION_SMALL_SCENERY,             SPR_TAB_SCENERY_TREES,      true  },
+    { STR_OBJECT_SELECTION_LARGE_SCENERY,             SPR_TAB_SCENERY_URBAN,      true  },
+    { STR_OBJECT_SELECTION_WALLS_FENCES,              SPR_TAB_SCENERY_WALLS,      true  },
+    { STR_OBJECT_SELECTION_FOOTPATH_SURFACES,         SPR_G2_PATH_SURFACE_TAB,    false },
+    { STR_OBJECT_SELECTION_FOOTPATH_RAILINGS,         SPR_G2_PATH_RAILINGS_TAB,   false },
+    { STR_OBJECT_SELECTION_FOOTPATHS,                 SPR_G2_LEGACY_PATH_TAB,     true  },
+    { STR_OBJECT_SELECTION_PATH_EXTRAS,               SPR_TAB_SCENERY_PATH_ITEMS, false },
+    { STR_OBJECT_SELECTION_PATH_SIGNS,                SPR_TAB_SCENERY_SIGNAGE,    true  },
+    { STR_OBJECT_SELECTION_PARK_ENTRANCE,             SPR_TAB_PARK,               false },
+    { STR_OBJECT_SELECTION_TERRAIN_SURFACES,          SPR_G2_TAB_LAND,            true  },
+    { STR_OBJECT_SELECTION_TERRAIN_EDGES,             SPR_G2_TERRAIN_EDGE_TAB,    true  },
+    { STR_OBJECT_SELECTION_WATER,                     SPR_TAB_WATER,              false },
     // Dummy place holder for string objects
-    { STR_NONE,                   static_cast<uint32_t>(SPR_NONE),                  false },
-
-    { STR_OBJECT_SELECTION_TERRAIN_SURFACES,            SPR_G2_TAB_LAND,            true  },
-    { STR_OBJECT_SELECTION_TERRAIN_EDGES,               SPR_G2_TERRAIN_EDGE_TAB,            true  },
-    { STR_OBJECT_SELECTION_STATIONS,                    SPR_G2_RIDE_STATION_TAB,               true  },
-    { STR_OBJECT_SELECTION_MUSIC,                       SPR_TAB_MUSIC_0,            false },
-    { STR_OBJECT_SELECTION_FOOTPATH_SURFACES,           SPR_G2_PATH_SURFACE_TAB,      false },
-    { STR_OBJECT_SELECTION_FOOTPATH_RAILINGS,           SPR_G2_PATH_RAILINGS_TAB,   false },
+    { STR_NONE,                 static_cast<uint32_t>(SPR_NONE),                  false },
 };
+
+// clang-format on
+// Order of which the contents of each tab is displayed.
+ObjectType static TabOrder[] = {
+    ObjectType::Ride,         ObjectType::Station,         ObjectType::Music,
+    ObjectType::SceneryGroup, ObjectType::SmallScenery,    ObjectType::LargeScenery,
+    ObjectType::Walls,        ObjectType::FootpathSurface, ObjectType::FootpathRailings,
+    ObjectType::Paths,        ObjectType::PathBits,        ObjectType::Banners,
+    ObjectType::ParkEntrance, ObjectType::TerrainSurface,  ObjectType::TerrainEdge,
+    ObjectType::Water,        ObjectType::ScenarioText,
+};
+// clang-format off
 
 #pragma region Widgets
 
@@ -1413,7 +1425,7 @@ private:
     ObjectType GetSelectedObjectType()
     {
         auto tab = selected_tab;
-        return static_cast<ObjectType>(tab);
+        return TabOrder[tab];
     }
 
     /**

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -41,7 +41,6 @@
 #include <string>
 #include <vector>
 
-// clang-format off
 enum
 {
     FILTER_RCT1 = (1 << 0),
@@ -63,8 +62,10 @@ enum
     FILTER_SELECTED = (1 << 14),
     FILTER_NONSELECTED = (1 << 15),
 
-    FILTER_RIDES = FILTER_RIDE_TRANSPORT | FILTER_RIDE_GENTLE | FILTER_RIDE_COASTER | FILTER_RIDE_THRILL | FILTER_RIDE_WATER | FILTER_RIDE_STALL,
-    FILTER_ALL = FILTER_RIDES | FILTER_RCT1 | FILTER_AA | FILTER_LL | FILTER_RCT2 | FILTER_WW | FILTER_TT | FILTER_OO | FILTER_CUSTOM | FILTER_SELECTED | FILTER_NONSELECTED,
+    FILTER_RIDES = FILTER_RIDE_TRANSPORT | FILTER_RIDE_GENTLE | FILTER_RIDE_COASTER | FILTER_RIDE_THRILL | FILTER_RIDE_WATER
+        | FILTER_RIDE_STALL,
+    FILTER_ALL = FILTER_RIDES | FILTER_RCT1 | FILTER_AA | FILTER_LL | FILTER_RCT2 | FILTER_WW | FILTER_TT | FILTER_OO
+        | FILTER_CUSTOM | FILTER_SELECTED | FILTER_NONSELECTED,
 };
 
 enum
@@ -125,7 +126,7 @@ struct ObjectPageDesc
     bool IsAdvanced;
 };
 
-
+// clang-format off
 // Order of which the object tabs are displayed.
 static constexpr const ObjectPageDesc ObjectSelectionPages[] = {
     { STR_OBJECT_SELECTION_RIDE_VEHICLES_ATTRACTIONS, SPR_TAB_RIDE_16,            false },
@@ -144,11 +145,9 @@ static constexpr const ObjectPageDesc ObjectSelectionPages[] = {
     { STR_OBJECT_SELECTION_TERRAIN_SURFACES,          SPR_G2_TAB_LAND,            true  },
     { STR_OBJECT_SELECTION_TERRAIN_EDGES,             SPR_G2_TERRAIN_EDGE_TAB,    true  },
     { STR_OBJECT_SELECTION_WATER,                     SPR_TAB_WATER,              false },
-    // Dummy place holder for string objects
-    { STR_NONE,                 static_cast<uint32_t>(SPR_NONE),                  false },
 };
-
 // clang-format on
+
 // Order of which the contents of each tab is displayed.
 ObjectType static TabOrder[] = {
     ObjectType::Ride,         ObjectType::Station,         ObjectType::Music,
@@ -156,9 +155,8 @@ ObjectType static TabOrder[] = {
     ObjectType::Walls,        ObjectType::FootpathSurface, ObjectType::FootpathRailings,
     ObjectType::Paths,        ObjectType::PathBits,        ObjectType::Banners,
     ObjectType::ParkEntrance, ObjectType::TerrainSurface,  ObjectType::TerrainEdge,
-    ObjectType::Water,        ObjectType::ScenarioText,
+    ObjectType::Water,
 };
-// clang-format off
 
 #pragma region Widgets
 
@@ -192,6 +190,7 @@ validate_global_widx(WC_EDITOR_OBJECT_SELECTION, WIDX_TAB_1);
 
 static bool _window_editor_object_selection_widgets_initialised;
 
+// clang-format off
 static std::vector<rct_widget> _window_editor_object_selection_widgets = {
     WINDOW_SHIM(WINDOW_TITLE, WW, WH),
     MakeWidget({  0, 43}, {WW,  357}, WindowWidgetType::Resize,       WindowColour::Secondary                                                                  ),
@@ -1424,8 +1423,8 @@ private:
 
     ObjectType GetSelectedObjectType()
     {
-        auto tab = selected_tab;
-        return TabOrder[tab];
+        const bool inBounds = selected_tab >= 0 && selected_tab < static_cast<int16_t>(std::size(TabOrder));
+        return inBounds ? TabOrder[selected_tab] : ObjectType::Ride;
     }
 
     /**


### PR DESCRIPTION
This might take a short bit for people to get used to, but it's a lot more coherent and makes more sense in the end.
Better off doing this change before the release of 0.4.0 than after, so people will not be used to the old layout just yet.

I have done a poll on 03/12/2021 after doing a poll in the following discord servers:
Here's the poll results:
Original (A): https://cdn.discordapp.com/attachments/493167642853638164/916449391693418556/144671111-7cdf2e75-2252-4bc8-a59f-14b63ca8325d.png
Suggestion 1 (B): https://user-images.githubusercontent.com/1516893/144676419-b635ee89-4a3b-4055-b638-8b8385ef1463.png
Suggestion 2 (C) [In this PR]: https://user-images.githubusercontent.com/1516893/144680713-092c7f9f-e3a0-4745-9cdb-a8155c2b791a.png

- Marcel's server: 4A, 0B, 5C
- Deurklink's server: 1A, 2B, 13C
- Roller Coasters & Friends: 0A, 2B, 4C
- New Element: 0A, 10B, 1C
My vote: B

Totals (incl my own): 5A, 15B, 23C

This PR is for Order C. If you prefer another one. Or have suggestions on another order let me know. 