### PR TITLE
Fix #16922. inability to place helix ups on certain tracks

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2642,7 +2642,7 @@ static void WindowRideConstructionUpdateWidgets(rct_window* w)
         {
             // Enable helix
             window_ride_construction_widgets[WIDX_SLOPE_DOWN_STEEP].type = WindowWidgetType::FlatBtn;
-            if (IsTrackEnabled(TRACK_SLOPE_STEEP_UP))
+            if (rideType != RIDE_TYPE_SPLASH_BOATS && rideType != RIDE_TYPE_RIVER_RAFTS)
                 window_ride_construction_widgets[WIDX_SLOPE_UP_STEEP].type = WindowWidgetType::FlatBtn;
         }
     }


### PR DESCRIPTION
Due to heavy reuse of widget index's and dual uses of items this was incorrectly grouped up in the SLOPE_STEEP_UP refactor #16836. The correct way to split up this is to create a HELIX_UP HELIX_DOWN which will be left for a future refactor