### PR TITLE
[Plugin] Add APIs for track segments and track iteration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,7 +328,7 @@ else ()
     # Compiler flags
     set(DEBUG_LEVEL 0 CACHE STRING "Select debug level for compilation. Use value in range 0–3.")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstrict-aliasing -Werror -Wundef -Wmissing-declarations -Winit-self -Wall -Wextra -Wshadow")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas -Wno-missing-braces -Wno-comment -Wnonnull -Wno-unused-parameter")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas -Wno-missing-braces -Wno-comment -Wnonnull -Wno-unused-parameter -Wno-attributes")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG=${DEBUG_LEVEL}")
 
     if(APPLE)

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -224,6 +224,8 @@ declare global {
         getAllObjects(type: ObjectType): LoadedObject[];
         getAllObjects(type: "ride"): RideObject[];
 
+        getTrackSegment(type: number): TrackSegment | undefined;
+
         /**
          * Gets a random integer within the specified range using the game's pseudo-
          * random number generator. This is part of the game state and shared across
@@ -1126,6 +1128,29 @@ declare global {
         length: number;
         entrance: CoordsXYZD;
         exit: CoordsXYZD;
+    }
+
+    interface TrackSegment {
+        /**
+         * The track segment type.
+         */
+        readonly type: number;
+
+        /**
+         * Gets the localised description of the track segment.
+         */
+        readonly description: string;
+
+        /**
+         * Gets a list of the elements that make up the track segment.
+         */
+        readonly elements: TrackSegmentElement;
+    }
+
+    interface TrackSegmentElement {
+        x: number;
+        y: number;
+        z: number;
     }
 
     type EntityType =

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -224,6 +224,10 @@ declare global {
         getAllObjects(type: ObjectType): LoadedObject[];
         getAllObjects(type: "ride"): RideObject[];
 
+        /**
+         * Gets the {@link TrackSegment} for the given type.
+         * @param type The track segment type.
+         */
         getTrackSegment(type: number): TrackSegment | undefined;
 
         /**
@@ -631,6 +635,14 @@ declare global {
         getAllEntitiesOnTile(type: "car", tilePos: CoordsXY): Car[];
         getAllEntitiesOnTile(type: "litter", tilePos: CoordsXY): Litter[];
         createEntity(type: EntityType, initializer: object): Entity;
+
+        /**
+         * Gets a {@link TrackIterator} for the given track element. This can be used to
+         * iterate through a ride's circuit, segment by segment.
+         * @param location The tile coordinates.
+         * @param elementIndex The index of the track element on the tile.
+         */
+        getTrackIterator(location: CoordsXY, elementIndex: number): TrackIterator | undefined;
     }
 
     type TileElementType =
@@ -711,6 +723,7 @@ declare global {
         hasChainLift: boolean;
         isInverted: boolean;
         hasCableLift: boolean;
+        isHighlighted: boolean;
     }
 
     interface SmallSceneryElement extends BaseTileElement {
@@ -1144,13 +1157,34 @@ declare global {
         /**
          * Gets a list of the elements that make up the track segment.
          */
-        readonly elements: TrackSegmentElement;
+        readonly elements: TrackSegmentElement[];
     }
 
-    interface TrackSegmentElement {
-        x: number;
-        y: number;
-        z: number;
+    interface TrackSegmentElement implements CoordsXYZ {
+    }
+
+    interface TrackIterator {
+        /**
+         * The position and direction of the current track segment, from the first element.
+         */
+         readonly position: CoordsXYZD;
+
+        /**
+         * The current track segment or undefined if at the beginning or end of a disconnected circuit.
+         */
+        readonly segment: TrackSegment | undefined;
+
+        /**
+         * Moves the iterator to the previous track segment.
+         * @returns true if there is a previous segment, otherwise false.
+         */
+        previous(): boolean;
+
+        /**
+         * Moves the iterator to the next track segment.
+         * @returns true if there is a next segment, otherwise false.
+         */
+        next(): boolean;
     }
 
     type EntityType =

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -649,6 +649,7 @@ declare global {
         "surface" | "footpath" | "track" | "small_scenery" | "wall" | "entrance" | "large_scenery" | "banner";
 
     type Direction = 0 | 1 | 2 | 3;
+    type Direction8 = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
 
     type TileElement =
         SurfaceElement | FootpathElement | TrackElement | SmallSceneryElement | WallElement | EntranceElement
@@ -1153,6 +1154,38 @@ declare global {
          * Gets the localised description of the track segment.
          */
         readonly description: string;
+
+        /**
+         * The relative starting Z position.
+         */
+        readonly beginZ: number;
+
+         /**
+         * The relative starting direction. Usually 0, but will be 4
+         * for diagonal pieces.
+         */
+        readonly beginDirection: Direction8;
+
+        /**
+         * The relative ending X position.
+         */
+        readonly endX: number;
+        
+        /**
+         * The relative ending Y position.
+         */
+        readonly endY: number;
+
+        /**
+         * The relative ending Z position. Negative numbers indicate
+         * that the track ends upside down.
+         */
+         readonly endZ: number;
+
+        /**
+         * The relative ending direction.
+         */
+         readonly endDirection: Direction8;
 
         /**
          * Gets a list of the elements that make up the track segment.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1244,7 +1244,7 @@ declare global {
     interface TrackIterator {
         /**
          * The position and direction of the current track segment. Usually this is the position of the
-         * element of the segment, however for some segments, it may be offset.
+         * first element of the segment, however for some segments, it may be offset.
          */
         readonly position: CoordsXYZD;
 

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1165,14 +1165,25 @@ declare global {
 
     interface TrackIterator {
         /**
-         * The position and direction of the current track segment, from the first element.
+         * The position and direction of the current track segment. Usually this is the position of the
+         * element of the segment, however for some segments, it may be offset.
          */
          readonly position: CoordsXYZD;
 
         /**
-         * The current track segment or undefined if at the beginning or end of a disconnected circuit.
+         * The current track segment.
          */
         readonly segment: TrackSegment | undefined;
+
+        /**
+         * Gets the position of where the previous track element should start.
+         */
+        readonly previousPosition: CoordsXYZD | undefined;
+
+        /**
+         * Gets the position of where the next track element should start.
+         */
+        readonly nextPosition: CoordsXYZD | undefined;
 
         /**
          * Moves the iterator to the previous track segment.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -228,7 +228,7 @@ declare global {
          * Gets the {@link TrackSegment} for the given type.
          * @param type The track segment type.
          */
-        getTrackSegment(type: number): TrackSegment | undefined;
+        getTrackSegment(type: number): TrackSegment | null;
 
         /**
          * Gets a random integer within the specified range using the game's pseudo-
@@ -642,7 +642,7 @@ declare global {
          * @param location The tile coordinates.
          * @param elementIndex The index of the track element on the tile.
          */
-        getTrackIterator(location: CoordsXY, elementIndex: number): TrackIterator | undefined;
+        getTrackIterator(location: CoordsXY, elementIndex: number): TrackIterator | null;
     }
 
     type TileElementType =
@@ -1251,17 +1251,17 @@ declare global {
         /**
          * The current track segment.
          */
-        readonly segment: TrackSegment | undefined;
+        readonly segment: TrackSegment | null;
 
         /**
          * Gets the position of where the previous track element should start.
          */
-        readonly previousPosition: CoordsXYZD | undefined;
+        readonly previousPosition: CoordsXYZD | null;
 
         /**
          * Gets the position of where the next track element should start.
          */
-        readonly nextPosition: CoordsXYZD | undefined;
+        readonly nextPosition: CoordsXYZD | null;
 
         /**
          * Moves the iterator to the previous track segment.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1160,17 +1160,27 @@ declare global {
          */
         readonly beginZ: number;
 
-         /**
-         * The relative starting direction. Usually 0, but will be 4
-         * for diagonal pieces.
-         */
+        /**
+        * The relative starting direction. Usually 0, but will be 4
+        * for diagonal segments.
+        */
         readonly beginDirection: Direction8;
+
+        /**
+         * The slope angle the segment starts with.
+         */
+        readonly beginAngle: number;
+
+        /**
+         * The kind of banking the segment starts with.
+         */
+        readonly beginBank: TrackBanking;
 
         /**
          * The relative ending X position.
          */
         readonly endX: number;
-        
+
         /**
          * The relative ending Y position.
          */
@@ -1180,12 +1190,30 @@ declare global {
          * The relative ending Z position. Negative numbers indicate
          * that the track ends upside down.
          */
-         readonly endZ: number;
+        readonly endZ: number;
 
         /**
          * The relative ending direction.
          */
-         readonly endDirection: Direction8;
+        readonly endDirection: Direction8;
+
+
+        /**
+         * The slope angle the segment ends with.
+         */
+        readonly endAngle: number;
+
+        /**
+         * The kind of banking the segment ends with.
+         */
+        readonly endBank: TrackBanking;
+
+        /**
+         * The length of the segment in RCT track length units.
+         *
+         * *1 metre = 1 / (2 ^ 16)*
+         */
+        readonly length: number;
 
         /**
          * Gets a list of the elements that make up the track segment.
@@ -1193,7 +1221,14 @@ declare global {
         readonly elements: TrackSegmentElement[];
     }
 
-    interface TrackSegmentElement implements CoordsXYZ {
+    enum TrackBanking {
+        None = 0,
+        Left = 2,
+        Right = 4,
+        UpsideDown = 15
+    }
+
+    interface TrackSegmentElement extends CoordsXYZ {
     }
 
     interface TrackIterator {
@@ -1201,7 +1236,7 @@ declare global {
          * The position and direction of the current track segment. Usually this is the position of the
          * element of the segment, however for some segments, it may be offset.
          */
-         readonly position: CoordsXYZD;
+        readonly position: CoordsXYZD;
 
         /**
          * The current track segment.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1169,7 +1169,7 @@ declare global {
         /**
          * The slope angle the segment starts with.
          */
-        readonly beginAngle: number;
+        readonly beginAngle: TrackSlope;
 
         /**
          * The kind of banking the segment starts with.
@@ -1201,7 +1201,7 @@ declare global {
         /**
          * The slope angle the segment ends with.
          */
-        readonly endAngle: number;
+        readonly endAngle: TrackSlope;
 
         /**
          * The kind of banking the segment ends with.
@@ -1219,6 +1219,16 @@ declare global {
          * Gets a list of the elements that make up the track segment.
          */
         readonly elements: TrackSegmentElement[];
+    }
+
+    enum TrackSlope {
+        None = 0,
+        Up25 = 2,
+        Up60 = 4,
+        Down25 = 6,
+        Down60 = 8,
+        Up90 = 10,
+        Down90 = 18
     }
 
     enum TrackBanking {

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -468,6 +468,7 @@
     <ClInclude Include="scripting\bindings\network\ScPlayer.hpp" />
     <ClInclude Include="scripting\bindings\network\ScPlayerGroup.hpp" />
     <ClInclude Include="scripting\bindings\ride\ScRideStation.hpp" />
+    <ClInclude Include="scripting\bindings\ride\ScTrackIterator.h" />
     <ClInclude Include="scripting\bindings\ride\ScTrackSegment.h" />
     <ClInclude Include="scripting\bindings\world\ScParkMessage.hpp" />
     <ClInclude Include="scripting\bindings\world\ScTileElement.hpp" />
@@ -926,6 +927,7 @@
     <ClCompile Include="scripting\bindings\network\ScPlayerGroup.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScRide.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScRideStation.cpp" />
+    <ClCompile Include="scripting\bindings\ride\ScTrackIterator.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScTrackSegment.cpp" />
     <ClCompile Include="scripting\bindings\world\ScMap.cpp" />
     <ClCompile Include="scripting\bindings\world\ScPark.cpp" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -468,6 +468,7 @@
     <ClInclude Include="scripting\bindings\network\ScPlayer.hpp" />
     <ClInclude Include="scripting\bindings\network\ScPlayerGroup.hpp" />
     <ClInclude Include="scripting\bindings\ride\ScRideStation.hpp" />
+    <ClInclude Include="scripting\bindings\ride\ScTrackSegment.h" />
     <ClInclude Include="scripting\bindings\world\ScParkMessage.hpp" />
     <ClInclude Include="scripting\bindings\world\ScTileElement.hpp" />
     <ClInclude Include="scripting\Duktape.hpp" />
@@ -925,6 +926,7 @@
     <ClCompile Include="scripting\bindings\network\ScPlayerGroup.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScRide.cpp" />
     <ClCompile Include="scripting\bindings\ride\ScRideStation.cpp" />
+    <ClCompile Include="scripting\bindings\ride\ScTrackSegment.cpp" />
     <ClCompile Include="scripting\bindings\world\ScMap.cpp" />
     <ClCompile Include="scripting\bindings\world\ScPark.cpp" />
     <ClCompile Include="scripting\bindings\world\ScParkMessage.cpp" />

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -664,6 +664,25 @@ bool TrackTypeHasSpeedSetting(track_type_t trackType)
     return trackType == TrackElemType::Brakes || trackType == TrackElemType::Booster;
 }
 
+std::optional<CoordsXYZD> GetTrackSegmentOrigin(const CoordsXYE& posEl)
+{
+    auto trackEl = posEl.element->AsTrack();
+    if (trackEl == nullptr)
+        return {};
+
+    const auto& ted = GetTrackElementDescriptor(trackEl->GetTrackType());
+    auto direction = trackEl->GetDirection();
+    auto coords = CoordsXYZ(posEl.x, posEl.y, trackEl->GetBaseZ());
+
+    // Subtract the current sequence's offset
+    const auto* trackBlock = &ted.Block[trackEl->GetSequenceIndex()];
+    CoordsXY trackBlockOffset = { trackBlock->x, trackBlock->y };
+    coords += trackBlockOffset.Rotate(direction_reverse(direction));
+    coords.z -= trackBlock->z;
+
+    return CoordsXYZD(coords, direction);
+}
+
 uint8_t TrackElement::GetSeatRotation() const
 {
     const auto* ride = get_ride(GetRideIndex());

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -14,6 +14,8 @@
 #include "../world/Map.h"
 #include "../world/TileElement.h"
 
+#include <optional>
+
 constexpr const uint32_t RideConstructionSpecialPieceSelected = 0x10000;
 
 constexpr const int32_t BLOCK_BRAKE_BASE_SPEED = 0x20364;
@@ -581,3 +583,4 @@ bool track_remove_station_element(const CoordsXYZD& loc, RideId rideIndex, int32
 money32 maze_set_track(const CoordsXYZD& coords, uint8_t flags, bool initialPlacement, RideId rideIndex, uint8_t mode);
 
 bool TrackTypeHasSpeedSetting(track_type_t trackType);
+std::optional<CoordsXYZD> GetTrackSegmentOrigin(const CoordsXYE& posEl);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -413,6 +413,7 @@ void ScriptEngine::Initialise()
     ScRideObjectVehicle::Register(ctx);
     ScTile::Register(ctx);
     ScTileElement::Register(ctx);
+    ScTrackSegment::Register(ctx);
     ScEntity::Register(ctx);
     ScLitter::Register(ctx);
     ScVehicle::Register(ctx);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -413,6 +413,7 @@ void ScriptEngine::Initialise()
     ScRideObjectVehicle::Register(ctx);
     ScTile::Register(ctx);
     ScTileElement::Register(ctx);
+    ScTrackIterator::Register(ctx);
     ScTrackSegment::Register(ctx);
     ScEntity::Register(ctx);
     ScLitter::Register(ctx);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -440,12 +440,80 @@ void ScriptEngine::Initialise()
     dukglue_register_global(ctx, std::make_shared<ScProfiler>(ctx), "profiler");
     dukglue_register_global(ctx, std::make_shared<ScScenario>(), "scenario");
 
+    RegisterConstants();
+
     _initialised = true;
     _transientPluginsEnabled = false;
     _transientPluginsStarted = false;
 
     LoadSharedStorage();
     ClearParkStorage();
+}
+
+class ConstantBuilder
+{
+private:
+    duk_context* _ctx;
+    DukValue _obj;
+
+public:
+    ConstantBuilder(duk_context* ctx)
+        : _ctx(ctx)
+    {
+        duk_push_global_object(_ctx);
+        _obj = DukValue::take_from_stack(_ctx);
+    }
+
+    ConstantBuilder& Namespace(std::string_view ns)
+    {
+        auto flags = DUK_DEFPROP_ENUMERABLE | DUK_DEFPROP_HAVE_WRITABLE | DUK_DEFPROP_HAVE_ENUMERABLE
+            | DUK_DEFPROP_HAVE_CONFIGURABLE | DUK_DEFPROP_HAVE_VALUE;
+
+        // Create a new object for namespace
+        duk_push_global_object(_ctx);
+        duk_push_lstring(_ctx, ns.data(), ns.size());
+        duk_push_object(_ctx);
+
+        // Keep a reference to the namespace object
+        duk_dup_top(_ctx);
+        _obj = DukValue::take_from_stack(_ctx);
+
+        // Place the namespace object into the global context
+        duk_def_prop(_ctx, -3, flags);
+        duk_pop(_ctx);
+
+        return *this;
+    }
+
+    ConstantBuilder& Constant(std::string_view name, int32_t value)
+    {
+        auto flags = DUK_DEFPROP_ENUMERABLE | DUK_DEFPROP_HAVE_WRITABLE | DUK_DEFPROP_HAVE_ENUMERABLE
+            | DUK_DEFPROP_HAVE_CONFIGURABLE | DUK_DEFPROP_HAVE_VALUE;
+        _obj.push();
+        duk_push_lstring(_ctx, name.data(), name.size());
+        duk_push_int(_ctx, value);
+        duk_def_prop(_ctx, -3, flags);
+        duk_pop(_ctx);
+        return *this;
+    }
+};
+
+void ScriptEngine::RegisterConstants()
+{
+    ConstantBuilder builder(_context);
+    builder.Namespace("TrackSlope")
+        .Constant("None", TRACK_SLOPE_NONE)
+        .Constant("Up25", TRACK_SLOPE_UP_25)
+        .Constant("Up60", TRACK_SLOPE_UP_60)
+        .Constant("Down25", TRACK_SLOPE_DOWN_25)
+        .Constant("Down60", TRACK_SLOPE_DOWN_60)
+        .Constant("Up90", TRACK_SLOPE_UP_90)
+        .Constant("Down90", TRACK_SLOPE_DOWN_90);
+    builder.Namespace("TrackBanking")
+        .Constant("None", TRACK_BANK_NONE)
+        .Constant("BankLeft", TRACK_BANK_LEFT)
+        .Constant("BankRight", TRACK_BANK_RIGHT)
+        .Constant("UpsideDown", TRACK_BANK_UPSIDE_DOWN);
 }
 
 void ScriptEngine::RefreshPlugins()

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 53;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 54;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -252,6 +252,7 @@ namespace OpenRCT2::Scripting
 #    endif
 
     private:
+        void RegisterConstants();
         void RefreshPlugins();
         std::vector<std::string> GetPluginFiles() const;
         void UnregisterPlugin(std::string_view path);

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -224,7 +224,7 @@ namespace OpenRCT2::Scripting
             auto ctx = GetContext()->GetScriptEngine().GetContext();
             if (type >= TrackElemType::Count)
             {
-                return ToDuk(ctx, undefined);
+                return ToDuk(ctx, nullptr);
             }
             else
             {

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -23,6 +23,7 @@
 #    include "../game/ScConfiguration.hpp"
 #    include "../game/ScDisposable.hpp"
 #    include "../object/ScObject.hpp"
+#    include "../ride/ScTrackSegment.h"
 
 #    include <cstdio>
 #    include <memory>
@@ -216,6 +217,19 @@ namespace OpenRCT2::Scripting
                 duk_error(ctx, DUK_ERR_ERROR, "Invalid object type.");
             }
             return result;
+        }
+
+        DukValue getTrackSegment(track_type_t type)
+        {
+            auto ctx = GetContext()->GetScriptEngine().GetContext();
+            if (type >= TrackElemType::Count)
+            {
+                return ToDuk(ctx, undefined);
+            }
+            else
+            {
+                return GetObjectAsDukValue(ctx, std::make_shared<ScTrackSegment>(type));
+            }
         }
 
         int32_t getRandom(int32_t min, int32_t max)
@@ -457,6 +471,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_method(ctx, &ScContext::captureImage, "captureImage");
             dukglue_register_method(ctx, &ScContext::getObject, "getObject");
             dukglue_register_method(ctx, &ScContext::getAllObjects, "getAllObjects");
+            dukglue_register_method(ctx, &ScContext::getTrackSegment, "getTrackSegment");
             dukglue_register_method(ctx, &ScContext::getRandom, "getRandom");
             dukglue_register_method_varargs(ctx, &ScContext::formatString, "formatString");
             dukglue_register_method(ctx, &ScContext::subscribe, "subscribe");

--- a/src/openrct2/scripting/bindings/ride/ScTrackIterator.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackIterator.cpp
@@ -1,0 +1,122 @@
+/*****************************************************************************
+ * Copyright (c) 2022 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "ScTrackIterator.h"
+
+#    include "../../../Context.h"
+#    include "../../../ride/Ride.h"
+#    include "../../../ride/TrackData.h"
+#    include "../../ScriptEngine.h"
+#    include "ScTrackSegment.h"
+
+using namespace OpenRCT2::Scripting;
+using namespace OpenRCT2::TrackMetaData;
+
+std::shared_ptr<ScTrackIterator> ScTrackIterator::FromElement(const CoordsXY& position, int32_t elementIndex)
+{
+    auto el = map_get_nth_element_at(position, elementIndex);
+    auto origin = GetTrackSegmentOrigin(CoordsXYE(position, el));
+    if (!origin)
+        return nullptr;
+
+    auto trackEl = el->AsTrack();
+    return std::make_shared<ScTrackIterator>(*origin, trackEl->GetTrackType(), trackEl->GetRideIndex());
+}
+
+ScTrackIterator::ScTrackIterator(const CoordsXYZD& position, track_type_t type, RideId ride)
+    : _position(position)
+    , _type(type)
+    , _ride(ride)
+{
+}
+
+void ScTrackIterator::Register(duk_context* ctx)
+{
+    dukglue_register_property(ctx, &ScTrackIterator::position_get, nullptr, "position");
+    dukglue_register_property(ctx, &ScTrackIterator::segment_get, nullptr, "segment");
+    dukglue_register_method(ctx, &ScTrackIterator::previous, "previous");
+    dukglue_register_method(ctx, &ScTrackIterator::next, "next");
+}
+
+DukValue ScTrackIterator::position_get() const
+{
+    auto& scriptEngine = GetContext()->GetScriptEngine();
+    auto ctx = scriptEngine.GetContext();
+    return ToDuk(ctx, _position);
+}
+
+DukValue ScTrackIterator::segment_get() const
+{
+    auto& scriptEngine = GetContext()->GetScriptEngine();
+    auto ctx = scriptEngine.GetContext();
+
+    if (_type >= TrackElemType::Count)
+        return ToDuk(ctx, undefined);
+
+    return GetObjectAsDukValue(ctx, std::make_shared<ScTrackSegment>(_type));
+}
+
+bool ScTrackIterator::previous()
+{
+    auto& ted = GetTrackElementDescriptor(_type);
+    auto& seq0 = ted.Block;
+    auto pos = _position + CoordsXYZ(seq0->x, seq0->y, seq0->z);
+
+    auto el = map_get_track_element_at(pos);
+    if (el == nullptr)
+        return false;
+
+    auto posEl = CoordsXYE(pos.x, pos.y, reinterpret_cast<TileElement*>(el));
+    track_begin_end tbe{};
+    auto value = track_block_get_previous(posEl, &tbe);
+    if (tbe.begin_element != nullptr)
+    {
+        auto prev = CoordsXYE(tbe.begin_x, tbe.begin_y, tbe.begin_element);
+        auto origin = GetTrackSegmentOrigin(prev);
+        if (origin)
+        {
+            _position = *origin;
+            _type = prev.element->AsTrack()->GetTrackType();
+            return value;
+        }
+    }
+    return false;
+}
+
+bool ScTrackIterator::next()
+{
+    auto& ted = GetTrackElementDescriptor(_type);
+    auto& seq0 = ted.Block;
+    auto pos = _position + CoordsXYZ(seq0->x, seq0->y, seq0->z);
+
+    auto el = map_get_track_element_at(pos);
+    if (el == nullptr)
+        return false;
+
+    auto posEl = CoordsXYE(_position.x, _position.y, reinterpret_cast<TileElement*>(el));
+    CoordsXYE next;
+    int32_t z{};
+    int32_t direction = -1;
+    auto value = track_block_get_next(&posEl, &next, &z, &direction);
+    if (next.element != nullptr)
+    {
+        auto origin = GetTrackSegmentOrigin(next);
+        if (origin)
+        {
+            _position = *origin;
+            _type = next.element->AsTrack()->GetTrackType();
+            return value;
+        }
+    }
+    return false;
+}
+
+#endif

--- a/src/openrct2/scripting/bindings/ride/ScTrackIterator.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackIterator.cpp
@@ -61,7 +61,7 @@ DukValue ScTrackIterator::segment_get() const
     auto ctx = scriptEngine.GetContext();
 
     if (_type >= TrackElemType::Count)
-        return ToDuk(ctx, undefined);
+        return ToDuk(ctx, nullptr);
 
     return GetObjectAsDukValue(ctx, std::make_shared<ScTrackSegment>(_type));
 }
@@ -77,7 +77,7 @@ DukValue ScTrackIterator::previousPosition_get() const
 
     auto el = map_get_track_element_at_of_type_seq(pos, _type, 0);
     if (el == nullptr)
-        return ToDuk(ctx, undefined);
+        return ToDuk(ctx, nullptr);
 
     auto posEl = CoordsXYE(pos.x, pos.y, reinterpret_cast<TileElement*>(el));
     track_begin_end tbe{};
@@ -97,7 +97,7 @@ DukValue ScTrackIterator::nextPosition_get() const
 
     auto el = map_get_track_element_at_of_type_seq(pos, _type, 0);
     if (el == nullptr)
-        return ToDuk(ctx, undefined);
+        return ToDuk(ctx, nullptr);
 
     auto posEl = CoordsXYE(_position.x, _position.y, reinterpret_cast<TileElement*>(el));
     CoordsXYE next;

--- a/src/openrct2/scripting/bindings/ride/ScTrackIterator.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackIterator.h
@@ -35,6 +35,9 @@ namespace OpenRCT2::Scripting
     private:
         DukValue position_get() const;
         DukValue segment_get() const;
+        DukValue previousPosition_get() const;
+        DukValue nextPosition_get() const;
+
         bool previous();
         bool next();
     };

--- a/src/openrct2/scripting/bindings/ride/ScTrackIterator.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackIterator.h
@@ -24,7 +24,7 @@ namespace OpenRCT2::Scripting
     private:
         CoordsXYZD _position;
         track_type_t _type;
-        RideId _ride;
+        [[maybe_unused]] RideId _ride;
 
     public:
         static std::shared_ptr<ScTrackIterator> FromElement(const CoordsXY& position, int32_t elementIndex);

--- a/src/openrct2/scripting/bindings/ride/ScTrackIterator.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackIterator.h
@@ -1,0 +1,44 @@
+/*****************************************************************************
+ * Copyright (c) 2022 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "../../../Identifiers.h"
+#    include "../../../world/TileElement.h"
+#    include "../../Duktape.hpp"
+
+#    include <cstdint>
+
+namespace OpenRCT2::Scripting
+{
+    class ScTrackIterator
+    {
+    private:
+        CoordsXYZD _position;
+        track_type_t _type;
+        RideId _ride;
+
+    public:
+        static std::shared_ptr<ScTrackIterator> FromElement(const CoordsXY& position, int32_t elementIndex);
+        static void Register(duk_context* ctx);
+
+        ScTrackIterator(const CoordsXYZD& position, track_type_t type, RideId ride);
+
+    private:
+        DukValue position_get() const;
+        DukValue segment_get() const;
+        bool previous();
+        bool next();
+    };
+
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -1,0 +1,71 @@
+/*****************************************************************************
+ * Copyright (c) 2022 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "ScTrackSegment.h"
+
+#    include "../../../Context.h"
+#    include "../../../ride/TrackData.h"
+#    include "../../ScriptEngine.h"
+
+using namespace OpenRCT2::Scripting;
+using namespace OpenRCT2::TrackMetaData;
+
+ScTrackSegment::ScTrackSegment(track_type_t type)
+    : _type(type)
+{
+}
+
+void ScTrackSegment::Register(duk_context* ctx)
+{
+    dukglue_register_property(ctx, &ScTrackSegment::type_get, nullptr, "type");
+    dukglue_register_property(ctx, &ScTrackSegment::description_get, nullptr, "description");
+    dukglue_register_property(ctx, &ScTrackSegment::elements_get, nullptr, "elements");
+}
+
+int32_t ScTrackSegment::type_get() const
+{
+    return _type;
+}
+
+std::string ScTrackSegment::description_get() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return language_get_string(ted.Description);
+}
+
+DukValue ScTrackSegment::elements_get() const
+{
+    auto& scriptEngine = GetContext()->GetScriptEngine();
+    auto ctx = scriptEngine.GetContext();
+
+    const auto& ted = GetTrackElementDescriptor(_type);
+
+    duk_push_array(ctx);
+
+    duk_uarridx_t index = 0;
+    for (auto* block = ted.Block; block->index != 0xFF; block++)
+    {
+        duk_push_object(ctx);
+        duk_push_number(ctx, block->x);
+        duk_put_prop_string(ctx, -2, "x");
+        duk_push_number(ctx, block->y);
+        duk_put_prop_string(ctx, -2, "y");
+        duk_push_number(ctx, block->z);
+        duk_put_prop_string(ctx, -2, "z");
+
+        duk_put_prop_index(ctx, -2, index);
+        index++;
+    }
+
+    return DukValue::take_from_stack(ctx);
+}
+
+#endif

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -28,6 +28,12 @@ void ScTrackSegment::Register(duk_context* ctx)
     dukglue_register_property(ctx, &ScTrackSegment::type_get, nullptr, "type");
     dukglue_register_property(ctx, &ScTrackSegment::description_get, nullptr, "description");
     dukglue_register_property(ctx, &ScTrackSegment::elements_get, nullptr, "elements");
+    dukglue_register_property(ctx, &ScTrackSegment::beginZ, nullptr, "beginZ");
+    dukglue_register_property(ctx, &ScTrackSegment::beginDirection, nullptr, "beginDirection");
+    dukglue_register_property(ctx, &ScTrackSegment::endX, nullptr, "endX");
+    dukglue_register_property(ctx, &ScTrackSegment::endY, nullptr, "endY");
+    dukglue_register_property(ctx, &ScTrackSegment::endZ, nullptr, "endZ");
+    dukglue_register_property(ctx, &ScTrackSegment::endDirection, nullptr, "endDirection");
 }
 
 int32_t ScTrackSegment::type_get() const
@@ -39,6 +45,42 @@ std::string ScTrackSegment::description_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return language_get_string(ted.Description);
+}
+
+int32_t ScTrackSegment::beginZ() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.Coordinates.z_begin;
+}
+
+int32_t ScTrackSegment::beginDirection() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.Coordinates.rotation_begin;
+}
+
+int32_t ScTrackSegment::endX() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.Coordinates.x;
+}
+
+int32_t ScTrackSegment::endY() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.Coordinates.y;
+}
+
+int32_t ScTrackSegment::endZ() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.Coordinates.z_end;
+}
+
+int32_t ScTrackSegment::endDirection() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.Coordinates.rotation_end;
 }
 
 DukValue ScTrackSegment::elements_get() const

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -60,6 +60,18 @@ int32_t ScTrackSegment::beginDirection_get() const
     return ted.Coordinates.rotation_begin;
 }
 
+int32_t ScTrackSegment::beginAngle_get() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.Definition.vangle_start;
+}
+
+int32_t ScTrackSegment::beginBank_get() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.Definition.bank_start;
+}
+
 int32_t ScTrackSegment::endX_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
@@ -82,6 +94,18 @@ int32_t ScTrackSegment::endDirection_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Coordinates.rotation_end;
+}
+
+int32_t ScTrackSegment::endAngle_get() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.Definition.vangle_end;
+}
+
+int32_t ScTrackSegment::endBank_get() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.Definition.bank_end;
 }
 
 int32_t ScTrackSegment::length_get() const

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -28,12 +28,13 @@ void ScTrackSegment::Register(duk_context* ctx)
     dukglue_register_property(ctx, &ScTrackSegment::type_get, nullptr, "type");
     dukglue_register_property(ctx, &ScTrackSegment::description_get, nullptr, "description");
     dukglue_register_property(ctx, &ScTrackSegment::elements_get, nullptr, "elements");
-    dukglue_register_property(ctx, &ScTrackSegment::beginZ, nullptr, "beginZ");
-    dukglue_register_property(ctx, &ScTrackSegment::beginDirection, nullptr, "beginDirection");
-    dukglue_register_property(ctx, &ScTrackSegment::endX, nullptr, "endX");
-    dukglue_register_property(ctx, &ScTrackSegment::endY, nullptr, "endY");
-    dukglue_register_property(ctx, &ScTrackSegment::endZ, nullptr, "endZ");
-    dukglue_register_property(ctx, &ScTrackSegment::endDirection, nullptr, "endDirection");
+    dukglue_register_property(ctx, &ScTrackSegment::beginZ_get, nullptr, "beginZ");
+    dukglue_register_property(ctx, &ScTrackSegment::beginDirection_get, nullptr, "beginDirection");
+    dukglue_register_property(ctx, &ScTrackSegment::endX_get, nullptr, "endX");
+    dukglue_register_property(ctx, &ScTrackSegment::endY_get, nullptr, "endY");
+    dukglue_register_property(ctx, &ScTrackSegment::endZ_get, nullptr, "endZ");
+    dukglue_register_property(ctx, &ScTrackSegment::endDirection_get, nullptr, "endDirection");
+    dukglue_register_property(ctx, &ScTrackSegment::length_get, nullptr, "length");
 }
 
 int32_t ScTrackSegment::type_get() const
@@ -47,40 +48,46 @@ std::string ScTrackSegment::description_get() const
     return language_get_string(ted.Description);
 }
 
-int32_t ScTrackSegment::beginZ() const
+int32_t ScTrackSegment::beginZ_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Coordinates.z_begin;
 }
 
-int32_t ScTrackSegment::beginDirection() const
+int32_t ScTrackSegment::beginDirection_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Coordinates.rotation_begin;
 }
 
-int32_t ScTrackSegment::endX() const
+int32_t ScTrackSegment::endX_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Coordinates.x;
 }
 
-int32_t ScTrackSegment::endY() const
+int32_t ScTrackSegment::endY_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Coordinates.y;
 }
 
-int32_t ScTrackSegment::endZ() const
+int32_t ScTrackSegment::endZ_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Coordinates.z_end;
 }
 
-int32_t ScTrackSegment::endDirection() const
+int32_t ScTrackSegment::endDirection_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Coordinates.rotation_end;
+}
+
+int32_t ScTrackSegment::length_get() const
+{
+    const auto& ted = GetTrackElementDescriptor(_type);
+    return ted.PieceLength;
 }
 
 DukValue ScTrackSegment::elements_get() const

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -34,10 +34,14 @@ namespace OpenRCT2::Scripting
         std::string description_get() const;
         int32_t beginZ_get() const;
         int32_t beginDirection_get() const;
+        int32_t beginAngle_get() const;
+        int32_t beginBank_get() const;
         int32_t endX_get() const;
         int32_t endY_get() const;
         int32_t endZ_get() const;
         int32_t endDirection_get() const;
+        int32_t endAngle_get() const;
+        int32_t endBank_get() const;
         int32_t length_get() const;
         DukValue elements_get() const;
     };

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -1,0 +1,40 @@
+/*****************************************************************************
+ * Copyright (c) 2022 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "../../../world/TileElement.h"
+#    include "../../Duktape.hpp"
+
+#    include <cstdint>
+#    include <string>
+
+namespace OpenRCT2::Scripting
+{
+    class ScTrackSegment
+    {
+    private:
+        track_type_t _type;
+
+    public:
+        ScTrackSegment(track_type_t type);
+
+        static void Register(duk_context* ctx);
+
+    private:
+        int32_t type_get() const;
+        std::string description_get() const;
+        DukValue elements_get() const;
+    };
+
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -32,6 +32,12 @@ namespace OpenRCT2::Scripting
     private:
         int32_t type_get() const;
         std::string description_get() const;
+        int32_t beginZ() const;
+        int32_t beginDirection() const;
+        int32_t endX() const;
+        int32_t endY() const;
+        int32_t endZ() const;
+        int32_t endDirection() const;
         DukValue elements_get() const;
     };
 

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -32,12 +32,13 @@ namespace OpenRCT2::Scripting
     private:
         int32_t type_get() const;
         std::string description_get() const;
-        int32_t beginZ() const;
-        int32_t beginDirection() const;
-        int32_t endX() const;
-        int32_t endY() const;
-        int32_t endZ() const;
-        int32_t endDirection() const;
+        int32_t beginZ_get() const;
+        int32_t beginDirection_get() const;
+        int32_t endX_get() const;
+        int32_t endY_get() const;
+        int32_t endZ_get() const;
+        int32_t endDirection_get() const;
+        int32_t length_get() const;
         DukValue elements_get() const;
     };
 

--- a/src/openrct2/scripting/bindings/world/ScMap.cpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.cpp
@@ -31,6 +31,7 @@
 #    include "../entity/ScStaff.hpp"
 #    include "../entity/ScVehicle.hpp"
 #    include "../ride/ScRide.hpp"
+#    include "../ride/ScTrackIterator.h"
 #    include "../world/ScTile.hpp"
 
 namespace OpenRCT2::Scripting
@@ -303,6 +304,16 @@ namespace OpenRCT2::Scripting
         return res;
     }
 
+    DukValue ScMap::getTrackIterator(const DukValue& dukPosition, int32_t elementIndex) const
+    {
+        auto position = FromDuk<CoordsXY>(dukPosition);
+        auto trackIterator = ScTrackIterator::FromElement(position, elementIndex);
+        if (trackIterator == nullptr)
+            return ToDuk(_context, undefined);
+
+        return GetObjectAsDukValue(_context, trackIterator);
+    }
+
     void ScMap::Register(duk_context* ctx)
     {
         dukglue_register_property(ctx, &ScMap::size_get, nullptr, "size");
@@ -315,6 +326,7 @@ namespace OpenRCT2::Scripting
         dukglue_register_method(ctx, &ScMap::getAllEntities, "getAllEntities");
         dukglue_register_method(ctx, &ScMap::getAllEntitiesOnTile, "getAllEntitiesOnTile");
         dukglue_register_method(ctx, &ScMap::createEntity, "createEntity");
+        dukglue_register_method(ctx, &ScMap::getTrackIterator, "getTrackIterator");
     }
 
     DukValue ScMap::GetEntityAsDukValue(const EntityBase* sprite) const

--- a/src/openrct2/scripting/bindings/world/ScMap.hpp
+++ b/src/openrct2/scripting/bindings/world/ScMap.hpp
@@ -14,6 +14,7 @@
 #    include "../../../common.h"
 #    include "../../Duktape.hpp"
 #    include "../ride/ScRide.hpp"
+#    include "../ride/ScTrackIterator.h"
 #    include "../world/ScTile.hpp"
 
 namespace OpenRCT2::Scripting
@@ -45,6 +46,8 @@ namespace OpenRCT2::Scripting
         std::vector<DukValue> getAllEntitiesOnTile(const std::string& type, const DukValue& tilePos) const;
 
         DukValue createEntity(const std::string& type, const DukValue& initializer);
+
+        DukValue getTrackIterator(const DukValue& position, int32_t elementIndex) const;
 
         static void Register(duk_context* ctx);
 

--- a/src/openrct2/scripting/bindings/world/ScTileElement.cpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.cpp
@@ -1075,6 +1075,27 @@ namespace OpenRCT2::Scripting
         Invalidate();
     }
 
+    DukValue ScTileElement::isHighlighted_get() const
+    {
+        auto ctx = GetContext()->GetScriptEngine().GetContext();
+        auto el = _element->AsTrack();
+        if (el != nullptr)
+            duk_push_boolean(ctx, el->IsHighlighted());
+        else
+            duk_push_null(ctx);
+        return DukValue::take_from_stack(ctx);
+    }
+    void ScTileElement::isHighlighted_set(bool value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto el = _element->AsTrack();
+        if (el != nullptr)
+        {
+            el->SetHighlight(value);
+            Invalidate();
+        }
+    }
+
     DukValue ScTileElement::object_get() const
     {
         auto& scriptEngine = GetContext()->GetScriptEngine();
@@ -2045,6 +2066,7 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScTileElement::hasChainLift_get, &ScTileElement::hasChainLift_set, "hasChainLift");
         dukglue_register_property(ctx, &ScTileElement::isInverted_get, &ScTileElement::isInverted_set, "isInverted");
         dukglue_register_property(ctx, &ScTileElement::hasCableLift_get, &ScTileElement::hasCableLift_set, "hasCableLift");
+        dukglue_register_property(ctx, &ScTileElement::isHighlighted_get, &ScTileElement::isHighlighted_set, "isHighlighted");
 
         // Small Scenery only
         dukglue_register_property(ctx, &ScTileElement::age_get, &ScTileElement::age_set, "age");

--- a/src/openrct2/scripting/bindings/world/ScTileElement.hpp
+++ b/src/openrct2/scripting/bindings/world/ScTileElement.hpp
@@ -114,6 +114,9 @@ namespace OpenRCT2::Scripting
         DukValue hasCableLift_get() const;
         void hasCableLift_set(bool value);
 
+        DukValue isHighlighted_get() const;
+        void isHighlighted_set(bool value);
+
         DukValue object_get() const;
         void object_set(const DukValue& value);
 


### PR DESCRIPTION
```ts
interface Context {
    getTrackSegment(type: number): TrackSegment | null;
}

interface GameMap {
    getTrackIterator(location: CoordsXY, elementIndex: number): TrackIterator | null;
}

interface TrackSegment {
    readonly type: number;
    readonly description: string;
    readonly beginZ: number;
    readonly beginDirection: Direction8;
    readonly endX: number;
    readonly endY: number;
    readonly endZ: number;
    readonly endDirection: Direction8;
    readonly elements: TrackSegmentElement[];
}

interface TrackSegmentElement implements CoordsXYZ {
}

interface TrackIterator {
    readonly position: CoordsXYZD;
    readonly segment: TrackSegment | null;
    readonly previousPosition: CoordsXYZD | null;
    readonly nextPosition: CoordsXYZD | null;

    previous(): boolean;
    next(): boolean;
}
```

Demo script:
https://gist.github.com/IntelOrca/680cbcd9d0df497396a342f155c51691