### PR TITLE
Use fractal noise for more natural tree placement

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Fix: [#17005] Unable to set patrol area for first staff member in park.
 - Fix: [#17073] Corrupt ride window and random crashes when trains have more than 144 cars.
 - Fix: [#17080] “Remove litter” cheat does not empty litter bins.
+- Improved: [#16978] Tree placement is more natural during map generation.
 - Improved: [#16999] The maximum price for the park entry has been raised to £999.
 - Improved: [#17050] Transparency can be enabled directly without needing see-through enabled first.
 - Removed: [#16864] Title sequence editor (replaced by plug-in).

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -423,6 +423,15 @@ uint32_t util_rand()
     return _prng();
 }
 
+// Returns a random floating point number from the Standard Normal Distribution; mean of 0 and standard deviation of 1.
+// TODO: In C++20 this can be templated, where the standard deviation is passed as a value template argument.
+float util_rand_normal_distributed()
+{
+    thread_local std::mt19937 _prng{ std::random_device{}() };
+    thread_local std::normal_distribution<float> _distributor{ 0.0f, 1.0f };
+    return _distributor(_prng);
+}
+
 constexpr size_t CHUNK = 128 * 1024;
 
 // Compress the source to gzip-compatible stream, write to dest.

--- a/src/openrct2/util/Util.h
+++ b/src/openrct2/util/Util.h
@@ -42,6 +42,7 @@ char* strcasestr(const char* haystack, const char* needle);
 bool str_is_null_or_empty(const char* str);
 
 uint32_t util_rand();
+float util_rand_normal_distributed();
 
 bool util_gzip_compress(FILE* source, FILE* dest);
 std::vector<uint8_t> Gzip(const void* data, const size_t dataLen);

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -338,8 +338,10 @@ static void mapgen_place_trees()
                 continue;
 
             // Use fractal noise to group tiles that are likely to spawn trees together
-            float noiseValue = std::clamp(fractal_noise(x, y, 0.025f, 8, 2.0f, 0.65f), -1.0f, 1.0f);
-            if (noiseValue < 0.0f)
+            float noiseValue = fractal_noise(x, y, 0.025f, 2, 2.0f, 0.65f);
+            // Reduces the range to rarely stray further than 0.5 from the mean.
+            float noiseOffset = util_rand_normal_distributed() * 0.25f;
+            if (noiseValue < noiseOffset)
                 continue;
 
             ObjectEntryIndex treeObjectEntryIndex = OBJECT_ENTRY_INDEX_NULL;


### PR DESCRIPTION
With this PR, the way trees are randomly placed during map generation is improved by using fractal noise to determine whether to place one, instead of completely randomly picking tiles to place trees on. This way, trees are more placed in groups rather than spread out evenly all over the map.

Trees are still 75% less likely to be placed on surfaces with a sandy surface.

A couple examples:

| Before | After |
| --- | --- |
|![before - desert](https://user-images.githubusercontent.com/9705046/163477526-9c317abe-ef18-4716-ad83-8851e956c714.png)|![after - desert](https://user-images.githubusercontent.com/9705046/163477557-3f1fe12f-5545-4e5d-a241-64ac42f983a9.png)|
|![before - dirt](https://user-images.githubusercontent.com/9705046/163477537-be561c7b-0254-4114-8668-3485255c7309.png)|![after - dirt](https://user-images.githubusercontent.com/9705046/163477553-8b1dba8a-2c70-4cea-8132-6b9c3c57c7c2.png)|
|![before - sand](https://user-images.githubusercontent.com/9705046/163477540-05734e8d-2f34-423f-834e-ac83c280b9ab.png)|![after - sand](https://user-images.githubusercontent.com/9705046/163477551-77ef08ef-faba-4a7f-92d6-c8fbffa07b8d.png)|
|![before - grass](https://user-images.githubusercontent.com/9705046/163477544-39561ee7-2944-47a4-ade3-f7fd9bae90be.png)|![after - grass](https://user-images.githubusercontent.com/9705046/163477548-08c5a70f-c33b-48d6-aff4-6d58d7fe13f0.png)|
