### PR TITLE
Add UpdateLeaveEntrance field to the RTD

### DIFF
--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -475,3 +475,7 @@ void increment_guests_in_park();
 void increment_guests_heading_for_park();
 void decrement_guests_in_park();
 void decrement_guests_heading_for_park();
+
+void PeepUpdateRideLeaveEntranceMaze(Guest* peep, Ride* ride, CoordsXYZD& entrance_loc);
+void PeepUpdateRideLeaveEntranceSpiralSlide(Guest* peep, Ride* ride, CoordsXYZD& entrance_loc);
+void PeepUpdateRideLeaveEntranceDefault(Guest* peep, Ride* ride, CoordsXYZD& entrance_loc);

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -22,6 +22,7 @@
 #include "../audio/audio.h"
 #include "../common.h"
 #include "../core/BitSet.hpp"
+#include "../entity/Guest.h"
 #include "../localisation/StringIds.h"
 #include "../sprites.h"
 #include "../util/Util.h"
@@ -151,6 +152,7 @@ struct UpkeepCostsDescriptor
 
 using RideTrackGroup = OpenRCT2::BitSet<TRACK_GROUP_COUNT>;
 using RideMusicUpdateFunction = void (*)(Ride*);
+using PeepUpdateRideLeaveEntranceFunc = void (*)(Guest*, Ride*, CoordsXYZD&);
 struct RideTypeDescriptor
 {
     uint8_t AlternateType;
@@ -203,6 +205,8 @@ struct RideTypeDescriptor
 
     RideMusicUpdateFunction MusicUpdateFunction = DefaultMusicUpdate;
     RideClassification Classification = RideClassification::Ride;
+
+    PeepUpdateRideLeaveEntranceFunc UpdateLeaveEntrance = PeepUpdateRideLeaveEntranceDefault;
 
     bool HasFlag(uint64_t flag) const;
     void GetAvailableTrackPieces(RideTrackGroup& res) const;
@@ -395,6 +399,10 @@ constexpr const RideTypeDescriptor DummyRTD =
     SET_FIELD(ColourPreview, { static_cast<uint32_t>(SPR_NONE), static_cast<uint32_t>(SPR_NONE) }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "invalid"),
+    SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),
+    SET_FIELD(MusicUpdateFunction, DefaultMusicUpdate),
+    SET_FIELD(Classification, RideClassification::Ride),
+    SET_FIELD(UpdateLeaveEntrance, PeepUpdateRideLeaveEntranceDefault),
 };
 // clang-format on
 

--- a/src/openrct2/ride/gentle/meta/Maze.h
+++ b/src/openrct2/ride/gentle/meta/Maze.h
@@ -52,5 +52,8 @@ constexpr const RideTypeDescriptor MazeRTD =
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "maze"),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Maze),
+    SET_FIELD(MusicUpdateFunction, DefaultMusicUpdate),
+    SET_FIELD(Classification, RideClassification::Ride),
+    SET_FIELD(UpdateLeaveEntrance, PeepUpdateRideLeaveEntranceMaze),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpiralSlide.h
+++ b/src/openrct2/ride/gentle/meta/SpiralSlide.h
@@ -53,5 +53,9 @@ constexpr const RideTypeDescriptor SpiralSlideRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_SLIDE_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "spiral_slide"),
+    SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),
+    SET_FIELD(MusicUpdateFunction, DefaultMusicUpdate),
+    SET_FIELD(Classification, RideClassification::Ride),
+    SET_FIELD(UpdateLeaveEntrance, PeepUpdateRideLeaveEntranceSpiralSlide),
 };
 // clang-format on


### PR DESCRIPTION
Spiral slide and Maze have special behaviours when guests are exiting the entrance, so the solution is to add a UpdateLeaveEntrance field to the RTD...