### PR TITLE
Limit inline sprites to <= 32x32

### DIFF
--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -759,7 +759,7 @@ static void ttf_process_format_code(rct_drawpixelinfo* dpi, const FmtString::tok
         case FormatToken::InlineSprite:
         {
             auto g1 = gfx_get_g1_element(token.parameter & 0x7FFFF);
-            if (g1 != nullptr)
+            if (g1 != nullptr && g1->width <= 32 && g1->height <= 32)
             {
                 if (!(info->flags & TEXT_DRAW_FLAG_NO_DRAW))
                 {


### PR DESCRIPTION
This is to prevent abuse of the feature in the master server list.

![image](https://user-images.githubusercontent.com/1482259/163676664-4350a18b-9923-4451-b16d-7f19720eb4cb.png)
