### PR TITLE
Force Android app to always use landscape orientation

### DIFF
--- a/src/openrct2-android/app/src/main/AndroidManifest.xml
+++ b/src/openrct2-android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,8 @@
         </activity>
         <activity
             android:name=".GameActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize">
+            android:configChanges="keyboardHidden|orientation|screenSize"
+            android:screenOrientation="landscape">
 
         </activity>
     </application>


### PR DESCRIPTION
This avoids the UI being _totally_ messed up. Now it’s only incredibly awkward ;-)

~~I will need to test this first.~~ Seems to work correctly.