### PR TITLE
Fix #7709: Spinning Wild Mouse brakes inconsistency

### DIFF
--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6631,6 +6631,20 @@ void Vehicle::CheckAndApplyBlockSectionStopSite()
 void Vehicle::UpdateVelocity()
 {
     int32_t nextVelocity = acceleration + velocity;
+    auto trackType = GetTrackType();
+    if (trackType == TrackElemType::Brakes)
+    {
+        auto targetVelocity = brake_speed << 16;
+        if (nextVelocity < 0 && velocity < 0)
+        {
+            targetVelocity = -targetVelocity;
+        }
+        if ((nextVelocity < targetVelocity && velocity > targetVelocity)
+            || (nextVelocity > targetVelocity && velocity < targetVelocity))
+        {
+            nextVelocity = targetVelocity;
+        }
+    }
     if (HasUpdateFlag(VEHICLE_UPDATE_FLAG_ZERO_VELOCITY))
     {
         nextVelocity = 0;


### PR DESCRIPTION
Brakes can brake too hard on lightweight vehicles, making them lose a lot of speed within a single frame. Since brakes can't be release halfway a simulation step, this meas they will often (pretty much always) lose more speed than what the brake was set to, and do so inconsistently (as described in #7709). This PR prevents overshooting the target speed while braking, making brakes far more consistent and predictable on coasters with single cars.
Although the same problem also exists with boosters, it is less likely to cause problems (due to higher speeds) and changing that has a higher potential to break older saves.

Tested for both forwards and backwards movement. Trains lose speed normally (due friction and drag) after brakes release.
Park file I used for testing: [Brake Testing.zip](https://github.com/OpenRCT2/OpenRCT2/files/8506305/Brake.Testing.zip)
![Happy park (sb) 2022-04-18 15-28-11](https://user-images.githubusercontent.com/13868449/163825930-a063407e-92e4-44c7-8ae5-3c533335f38b.png)
Vertical drop coaster has brakes set to 28km/h and then 6km/h, wild mouse with giga cars 28km/h (2nd example from #7709), and woodie has all brakes set to 14km/h.

Because of the release coming very soon, I haven't added a changelog entry yet, nor bumped the network version. It will likely also require rerecording of the replays.