### PR TITLE
Update copyright date in Windows executables

### DIFF
--- a/resources/OpenRCT2.rc
+++ b/resources/OpenRCT2.rc
@@ -45,7 +45,7 @@ BEGIN
             VALUE "CompanyName", "OpenRCT2 Team"
             VALUE "FileDescription", "Main executable for OpenRCT2"
             VALUE "FileVersion", OPENRCT2_PRODUCT_VERSION
-            VALUE "LegalCopyright", "Copyright (c) 2014-2019 OpenRCT2 developers"
+            VALUE "LegalCopyright", "Copyright (c) 2014-2022 OpenRCT2 developers"
             VALUE "ProductName", "OpenRCT2"
             VALUE "ProductVersion", OPENRCT2_PRODUCT_VERSION
         END


### PR DESCRIPTION
Noticed how the copyright date is not right when inspecting the Windows executables:

![image](https://user-images.githubusercontent.com/9705046/164198086-aa75ea3a-b25a-4064-b06f-10cc15b272dc.png)