### PR TITLE
Close #17019: Fix missing version information in builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Git describe for shallow checkout
+        id: ghd
+        uses: proudust/gh-describe@v1
+      - name: Update GA environment
+        run: echo "OPENRCT2_DESCRIBE=${{ steps.ghd.outputs.describe }}" >> $GITHUB_ENV
       - name: Install MSVC problem matcher
         uses: ammaraskar/msvc-problem-matcher@master
       - name: Build OpenRCT2

--- a/scripts/build
+++ b/scripts/build
@@ -17,6 +17,8 @@ if [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
         fileversion=$OPENRCT2_VERSION.$OPENRCT2_BUILD
         productversion="$fileversion-${OPENRCT2_SHA1_SHORT}"
         fileversion=${fileversion//./,}
+        # FILEVERSION in the resource file can only take up to 4 digits in the version string, so we remove the surplus of version numbers
+        fileversion=$(echo $fileversion | cut -f1-4 -d",")
         echo "#define OPENRCT2_FILE_VERSION $fileversion" > "resources/version.h"
         echo "#define OPENRCT2_PRODUCT_VERSION \"$productversion\"" >> "resources/version.h"
         cat "resources/version.h"

--- a/scripts/setenv
+++ b/scripts/setenv
@@ -14,7 +14,6 @@ fi
 echo -e "\033[0;36mSetting up environment for OpenRCT2...\033[0m"
 
 # Get the build number (number of commits since last tag)
-export OPENRCT2_DESCRIBE=$(git describe HEAD)
 get_build_number()
 {
     local pattern='.+-([0-9]+)-.+'


### PR DESCRIPTION
Since we moved from AppVeyor to GitHub Actions, the updating of version information has been broken. To make `git describe` work again, I've added the `proudust/gh-describe` Action (fetched from github, so no full history is required on checkout), and the result it stored in the environment variables, which then gets used by the build scripts.

Then, another issue was raised. With releases that have 4 numbers in the version already, like 0.3.5.1, any build until the next release will have 5 numbers (e.g. 0.3.5.1.900), which is not accepted for `FILEVERSION`. As a solution, the file version will be cut of to only 4 numbers. The full version info, including commit, is present in the `PRODUCTVERSION` however. This is reflected in the Details tab.

![details](https://user-images.githubusercontent.com/9705046/164336292-470e7bf5-6cad-4c99-9064-f4e0599b1b7d.png)

Now the build logs will also include this bit once again:

```
Patching version.h...
#define OPENRCT2_FILE_VERSION 0,3,5,1
#define OPENRCT2_PRODUCT_VERSION "0.3.5.1.900-3c06194"
```
