### PR TITLE
Remove double check in LandSetHeightAction

### DIFF
--- a/src/openrct2/actions/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/LandSetHeightAction.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2022 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -133,14 +133,6 @@ GameActions::Result LandSetHeightAction::Query() const
         {
             clearResult.Error = GameActions::Status::Disallowed;
             return clearResult;
-        }
-
-        tileElement = CheckUnremovableObstructions(reinterpret_cast<TileElement*>(surfaceElement), zCorner);
-        if (tileElement != nullptr)
-        {
-            auto res = GameActions::Result(GameActions::Status::Disallowed, STR_NONE, STR_NONE);
-            map_obstruction_set_error_text(tileElement, res);
-            return res;
         }
     }
     auto res = GameActions::Result();
@@ -317,37 +309,6 @@ TileElement* LandSetHeightAction::CheckFloatingStructures(TileElement* surfaceEl
             {
                 return ++surfaceElement;
             }
-        }
-    }
-    return nullptr;
-}
-
-TileElement* LandSetHeightAction::CheckUnremovableObstructions(TileElement* surfaceElement, uint8_t zCorner) const
-{
-    for (auto* tileElement : TileElementsView(_coords))
-    {
-        const auto elementType = tileElement->GetType();
-
-        // Wall's and Small Scenery are removed and therefore do not need checked
-        if (elementType == TileElementType::Wall)
-            continue;
-        if (elementType == TileElementType::SmallScenery)
-            continue;
-        if (tileElement->IsGhost())
-            continue;
-        if (tileElement == surfaceElement)
-            continue;
-        if (tileElement > surfaceElement)
-        {
-            if (zCorner > tileElement->base_height)
-            {
-                return tileElement;
-            }
-            continue;
-        }
-        if (_height < tileElement->clearance_height)
-        {
-            return tileElement;
         }
     }
     return nullptr;

--- a/src/openrct2/actions/LandSetHeightAction.h
+++ b/src/openrct2/actions/LandSetHeightAction.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2022 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
@@ -35,7 +35,6 @@ private:
     void SmallSceneryRemoval() const;
     rct_string_id CheckRideSupports() const;
     TileElement* CheckFloatingStructures(TileElement* surfaceElement, uint8_t zCorner) const;
-    TileElement* CheckUnremovableObstructions(TileElement* surfaceElement, uint8_t zCorner) const;
     money32 GetSurfaceHeightChangeCost(SurfaceElement* surfaceElement) const;
     void SetSurfaceHeight(TileElement* surfaceElement) const;
 


### PR DESCRIPTION
I was fiddling around with the set land height code and put a breakpoint in this bit of code to see where it was useful. The breakpoint never triggered. After further inspection, it appears that everything this piece of code does is already done before. Removing it should not change any behaviour (aside from a very small potential speedup).
 
More technical description: Removes the second check for obstructions when changing land height. Any clearance violations should already be caught by MapCanConstructWithClearAt, right above this call (relevant code is in [ConstructionClearance.cpp#L150-169](https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/world/ConstructionClearance.cpp#L152), the clearFunc supplied filters out surfaces and small scenery). Since this was the only use of CheckUnemovableObstructions, I've also removed that function.