### PR TITLE
Hide primary/secondary remap button on broken large scenery

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -573,9 +573,11 @@ public:
             {
                 auto* sceneryEntry = GetLargeSceneryEntry(tabSelectedScenery.EntryIndex);
 
-                if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR)
+                if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR
+                    && !(sceneryEntry->flags & LARGE_SCENERY_FLAG_HIDE_PRIMARY_REMAP_BUTTON))
                     widgets[WIDX_SCENERY_PRIMARY_COLOUR_BUTTON].type = WindowWidgetType::ColourBtn;
-                if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_SECONDARY_COLOUR)
+                if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_SECONDARY_COLOUR
+                    && !(sceneryEntry->flags & LARGE_SCENERY_FLAG_HIDE_SECONDARY_REMAP_BUTTON))
                     widgets[WIDX_SCENERY_SECONDARY_COLOUR_BUTTON].type = WindowWidgetType::ColourBtn;
                 if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_TERTIARY_COLOUR)
                     widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].type = WindowWidgetType::ColourBtn;

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -99,10 +99,15 @@ void LargeSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
     // This meant some custom large scenery objects did not get exported with the required flags, because they still
     // functioned, but without the ability to change the colours when the object was selected in the scenery window.
     // OpenRCT2 changes the rendering so that the flags are required, we therefore have to assume all custom objects
-    // can be recoloured. The minor drawback to this, is that some custom large scenery will have the option to change
-    // the primary and secondary colour, however no effect will be seen.
-    _legacyType.flags |= LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR;
-    _legacyType.flags |= LARGE_SCENERY_FLAG_HAS_SECONDARY_COLOUR;
+    // can be recoloured.
+    if (!(_legacyType.flags & LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR))
+    {
+        _legacyType.flags |= LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR | LARGE_SCENERY_FLAG_HIDE_PRIMARY_REMAP_BUTTON;
+    }
+    if (!(_legacyType.flags & LARGE_SCENERY_FLAG_HAS_SECONDARY_COLOUR))
+    {
+        _legacyType.flags |= LARGE_SCENERY_FLAG_HAS_SECONDARY_COLOUR | LARGE_SCENERY_FLAG_HIDE_SECONDARY_REMAP_BUTTON;
+    }
 }
 
 void LargeSceneryObject::Load()

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -77,7 +77,7 @@ enum LARGE_SCENERY_TEXT_FLAGS
 struct LargeSceneryEntry : SceneryEntryBase
 {
     CursorID tool_id;
-    uint8_t flags;
+    uint16_t flags;
     money32 price;
     money32 removal_price;
     LargeSceneryTile* tiles;
@@ -89,13 +89,15 @@ struct LargeSceneryEntry : SceneryEntryBase
 
 enum LARGE_SCENERY_FLAGS
 {
-    LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR = (1 << 0),   // 0x1
-    LARGE_SCENERY_FLAG_HAS_SECONDARY_COLOUR = (1 << 1), // 0x2
-    LARGE_SCENERY_FLAG_3D_TEXT = (1 << 2),              // 0x4
-    LARGE_SCENERY_FLAG_ANIMATED = (1 << 3),             // 0x8
-    LARGE_SCENERY_FLAG_PHOTOGENIC = (1 << 4),           // 0x10
-    LARGE_SCENERY_FLAG_IS_TREE = (1 << 5),              // 0x20
-    LARGE_SCENERY_FLAG_HAS_TERTIARY_COLOUR = (1 << 6),  // 0x40
+    LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR = (1 << 0),          // 0x1
+    LARGE_SCENERY_FLAG_HAS_SECONDARY_COLOUR = (1 << 1),        // 0x2
+    LARGE_SCENERY_FLAG_3D_TEXT = (1 << 2),                     // 0x4
+    LARGE_SCENERY_FLAG_ANIMATED = (1 << 3),                    // 0x8
+    LARGE_SCENERY_FLAG_PHOTOGENIC = (1 << 4),                  // 0x10
+    LARGE_SCENERY_FLAG_IS_TREE = (1 << 5),                     // 0x20
+    LARGE_SCENERY_FLAG_HAS_TERTIARY_COLOUR = (1 << 6),         // 0x40
+    LARGE_SCENERY_FLAG_HIDE_PRIMARY_REMAP_BUTTON = (1 << 7),   // 0x80
+    LARGE_SCENERY_FLAG_HIDE_SECONDARY_REMAP_BUTTON = (1 << 8), // 0x100
 };
 
 #pragma pack(pop)


### PR DESCRIPTION
I wasn’t entirely happy that the fix in https://github.com/OpenRCT2/OpenRCT2/pull/16842 meant that all custom large scenery suddenly had remap buttons enabled. This suppresses the button but leaves the rest of the fix intact, which IMO makes for a better finish.