### PR TITLE
Fix #16988 add search prefixes to doc directory search

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -188,6 +188,7 @@ The following people are not part of the development team, but have been contrib
 * Alexander Czarnecki (alcz/zuczek4793)
 * Lawrence De Mol (lawrencedemol)
 * Erik Wouters (EWouters)
+* Christopher Sund (csunday95)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -124,9 +124,7 @@ namespace Platform
     {
         const auto prefixes = GetPathSearchPrefixes();
         static const utf8* searchLocations[] = {
-            "./doc",
-            "/usr/share/doc/openrct2",
-            DOCDIR,
+            "doc/openrct2", "share/doc/openrct2", "/usr/share/doc/openrct2", "./doc", DOCDIR,
         };
         for (const auto& searchPrefix : prefixes)
         {
@@ -136,6 +134,7 @@ namespace Platform
                 log_verbose("Looking for OpenRCT2 doc path at %s", prefixedPath.c_str());
                 if (Path::DirectoryExists(prefixedPath))
                 {
+                    log_verbose("Docs directory located at %s", prefixedPath.c_str());
                     return prefixedPath;
                 }
             }

--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -112,9 +112,11 @@ namespace Platform
     {
         std::vector<std::string> prefixes;
         auto exePath = Platform::GetCurrentExecutablePath();
-        prefixes.push_back(Path::GetDirectory(exePath));
+        const auto exeDirectory = Path::GetDirectory(exePath);
+        prefixes.push_back("");
         prefixes.push_back(GetCurrentWorkingDirectory());
         prefixes.push_back("/");
+        prefixes.push_back(Path::GetDirectory(exeDirectory));
         return prefixes;
     }
 

--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -108,7 +108,7 @@ namespace Platform
         return exePath;
     }
 
-    static std::vector<std::string> GetPathSearchPrefixes() 
+    static std::vector<std::string> GetPathSearchPrefixes()
     {
         std::vector<std::string> prefixes;
         auto exePath = Platform::GetCurrentExecutablePath();


### PR DESCRIPTION
Note: trying to figure out how to test if this fixes the AppImage, but I'm having issues building it locally
 - fix #16988 
 - built appimage was previously searching only in absolute directories,
   and when doc dir was not found, defaulted to install path
 - search login now matches search prefixes from GetInstallPath()