### PR TITLE
Suppress OpenSSL 3.0 deprecation warnings

### DIFF
--- a/src/openrct2/core/Crypt.OpenSSL.cpp
+++ b/src/openrct2/core/Crypt.OpenSSL.cpp
@@ -9,6 +9,9 @@
 
 #if !defined(DISABLE_NETWORK) && (!defined(_WIN32) || (defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600))
 
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 #    include "Crypt.h"
 
 #    include <openssl/evp.h>
@@ -349,5 +352,7 @@ namespace Crypt
         return std::make_unique<OpenSSLRsaKey>();
     }
 } // namespace Crypt
+
+#    pragma GCC diagnostic pop
 
 #endif // DISABLE_NETWORK


### PR DESCRIPTION
This is intended as a temporary measure to get it to compile again with OpenSSL v3.0+. Of course, the longer term plan is to properly migrate the now-deprecated APIs.