### PR TITLE
Close #17073: Writing out of bounds when trains have over 144 cars

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.1 (in development)
 ------------------------------------------------------------------------
 - Fix: [#16974] Small scenery ghosts can be deleted.
+- Fix: [#17073] Corrupt ride window and random crashes when trains have more than 144 cars.
 - Improved: [#17050] Transparency can be enabled directly without needing see-through enabled first.
 - Removed: [#16864] Title sequence editor (replaced by plug-in).
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
 #include <openrct2/Input.h>
+#include <openrct2/Limits.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/actions/GameAction.h>
 #include <openrct2/actions/ParkSetParameterAction.h>
@@ -2903,8 +2904,6 @@ struct VehicleDrawInfo
     ImageId imageId;
 };
 
-static VehicleDrawInfo _sprites_to_draw[144];
-
 /**
  *
  *  rct2: 0x006B2502
@@ -2931,11 +2930,13 @@ static void WindowRideVehicleScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
     // For each train
     for (int32_t i = 0; i < ride->num_vehicles; i++)
     {
-        VehicleDrawInfo* nextSpriteToDraw = _sprites_to_draw;
+        VehicleDrawInfo trainCarImages[OpenRCT2::Limits::MaxCarsPerTrain];
+        VehicleDrawInfo* nextSpriteToDraw = trainCarImages;
         int32_t x = startX;
         int32_t y = startY;
 
         // For each car in train
+        static_assert(std::numeric_limits<decltype(ride->num_cars_per_train)>::max() <= std::size(trainCarImages));
         for (int32_t j = 0; j < ride->num_cars_per_train; j++)
         {
             rideVehicleEntry = &rideEntry
@@ -2985,7 +2986,7 @@ static void WindowRideVehicleScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
         }
 
         VehicleDrawInfo* current = nextSpriteToDraw;
-        while (--current >= _sprites_to_draw)
+        while (--current >= trainCarImages)
             gfx_draw_sprite(dpi, current->imageId, { current->x, current->y });
 
         startX += 36;


### PR DESCRIPTION
This fixes some of the unclear "openrct2.exe openrct2.exe openrct2.exe openrct2.exe openrct2.exe" etc crash logs we've been getting. The array was not large enough to hold more than 144 cars. Now the array is long enough, and a `static_assert` ensures that it will stay that way or generate an error during compile time.

This fixes:
 - https://github.com/OpenRCT2/OpenRCT2/issues/17066
 - https://github.com/OpenRCT2/OpenRCT2/issues/16927
 - https://github.com/OpenRCT2/OpenRCT2/issues/17051
 - https://github.com/OpenRCT2/OpenRCT2/issues/16758
 - https://github.com/OpenRCT2/OpenRCT2/issues/16702

And maybe more, I went back 3 months on the issue tracker.