### PR TITLE
Close #17050: Transparency can be toggled directly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.1 (in development)
 ------------------------------------------------------------------------
 - Fix: [#16974] Small scenery ghosts can be deleted.
+- Improved: [#17050] Transparency can be enabled directly without needing see-through enabled first.
 - Removed: [#16864] Title sequence editor (replaced by plug-in).
 
 0.4.0 (2022-04-25)

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -156,6 +156,17 @@ public:
     }
 
 private:
+    uint32_t ToggleTransparency(uint32_t wflags, uint32_t transparencyFlag, uint32_t seeThroughFlag)
+    {
+        wflags ^= transparencyFlag;
+        if (wflags & transparencyFlag)
+        {
+            wflags |= seeThroughFlag;
+        }
+        SaveInConfig(wflags);
+        return wflags;
+    }
+
     void ToggleViewportFlag(rct_widgetindex widgetIndex)
     {
         uint32_t wflags = 0;
@@ -187,34 +198,22 @@ private:
                 wflags ^= VIEWPORT_FLAG_HIDE_SUPPORTS;
                 break;
             case WIDX_INVISIBLE_RIDES:
-                wflags ^= VIEWPORT_FLAG_INVISIBLE_RIDES;
-                gConfigGeneral.invisible_rides = wflags & VIEWPORT_FLAG_INVISIBLE_RIDES;
-                config_save_default();
+                wflags = ToggleTransparency(wflags, VIEWPORT_FLAG_INVISIBLE_RIDES, VIEWPORT_FLAG_HIDE_RIDES);
                 break;
             case WIDX_INVISIBLE_VEHICLES:
-                wflags ^= VIEWPORT_FLAG_INVISIBLE_VEHICLES;
-                gConfigGeneral.invisible_vehicles = wflags & VIEWPORT_FLAG_INVISIBLE_VEHICLES;
-                config_save_default();
+                wflags = ToggleTransparency(wflags, VIEWPORT_FLAG_INVISIBLE_VEHICLES, VIEWPORT_FLAG_HIDE_VEHICLES);
                 break;
             case WIDX_INVISIBLE_SCENERY:
-                wflags ^= VIEWPORT_FLAG_INVISIBLE_SCENERY;
-                gConfigGeneral.invisible_scenery = wflags & VIEWPORT_FLAG_INVISIBLE_SCENERY;
-                config_save_default();
+                wflags = ToggleTransparency(wflags, VIEWPORT_FLAG_INVISIBLE_SCENERY, VIEWPORT_FLAG_HIDE_SCENERY);
                 break;
             case WIDX_INVISIBLE_VEGETATION:
-                wflags ^= VIEWPORT_FLAG_INVISIBLE_VEGETATION;
-                gConfigGeneral.invisible_trees = wflags & VIEWPORT_FLAG_INVISIBLE_VEGETATION;
-                config_save_default();
+                wflags = ToggleTransparency(wflags, VIEWPORT_FLAG_INVISIBLE_VEGETATION, VIEWPORT_FLAG_HIDE_VEGETATION);
                 break;
             case WIDX_INVISIBLE_PATHS:
-                wflags ^= VIEWPORT_FLAG_INVISIBLE_PATHS;
-                gConfigGeneral.invisible_paths = wflags & VIEWPORT_FLAG_INVISIBLE_PATHS;
-                config_save_default();
+                wflags = ToggleTransparency(wflags, VIEWPORT_FLAG_INVISIBLE_PATHS, VIEWPORT_FLAG_HIDE_PATHS);
                 break;
             case WIDX_INVISIBLE_SUPPORTS:
-                wflags ^= VIEWPORT_FLAG_INVISIBLE_SUPPORTS;
-                gConfigGeneral.invisible_supports = wflags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS;
-                config_save_default();
+                wflags = ToggleTransparency(wflags, VIEWPORT_FLAG_INVISIBLE_SUPPORTS, VIEWPORT_FLAG_HIDE_SUPPORTS);
                 break;
             case WIDX_HIDE_GUESTS:
                 wflags ^= VIEWPORT_FLAG_HIDE_GUESTS;
@@ -231,6 +230,17 @@ private:
 
         w->viewport->flags = wflags;
         w->Invalidate();
+    }
+
+    void SaveInConfig(uint32_t wflags)
+    {
+        gConfigGeneral.invisible_rides = wflags & VIEWPORT_FLAG_INVISIBLE_RIDES;
+        gConfigGeneral.invisible_vehicles = wflags & VIEWPORT_FLAG_INVISIBLE_VEHICLES;
+        gConfigGeneral.invisible_scenery = wflags & VIEWPORT_FLAG_INVISIBLE_SCENERY;
+        gConfigGeneral.invisible_trees = wflags & VIEWPORT_FLAG_INVISIBLE_VEGETATION;
+        gConfigGeneral.invisible_paths = wflags & VIEWPORT_FLAG_INVISIBLE_PATHS;
+        gConfigGeneral.invisible_supports = wflags & VIEWPORT_FLAG_INVISIBLE_SUPPORTS;
+        config_save_default();
     }
 };
 


### PR DESCRIPTION
When toggling on the transparency flag, it now also sets the see-through flag. When disabling the see-through flag, it clears the transparency flag.

I also took the opportunity to move some common code into member functions.

Before:

https://user-images.githubusercontent.com/2963232/165075225-f527056d-bd9e-4bd7-a262-5e12254d68e5.mp4

After:

~~https://user-images.githubusercontent.com/9705046/165490125-581dd009-7055-44d3-9b91-06ffac9d52af.mp4~~

https://user-images.githubusercontent.com/9705046/165505944-3496ffdc-f3e3-4de7-91c0-d3690b6038cf.mp4
