### PR TITLE
Fix thumbnail box size in object selection window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Fix: [#17005] Unable to set patrol area for first staff member in park.
 - Fix: [#17073] Corrupt ride window and random crashes when trains have more than 144 cars.
 - Fix: [#17080] “Remove litter” cheat does not empty litter bins.
+- Fix: [#17099] Object selection thumbnail box is one pixel too tall.
 - Improved: [#16978] Tree placement is more natural during map generation.
 - Improved: [#16999] The maximum price for the park entry has been raised to £999.
 - Improved: [#17050] Transparency can be enabled directly without needing see-through enabled first.

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -185,7 +185,7 @@ static std::vector<rct_widget> _window_editor_object_selection_widgets = {
     MakeWidget({  0, 43}, {WW,  357}, WindowWidgetType::Resize,       WindowColour::Secondary                                                                  ),
     MakeWidget({470, 22}, {122,  14}, WindowWidgetType::Button,       WindowColour::Primary,   STR_OBJECT_SELECTION_ADVANCED, STR_OBJECT_SELECTION_ADVANCED_TIP),
     MakeWidget({  4, 60}, {288, 327}, WindowWidgetType::Scroll,       WindowColour::Secondary, SCROLL_VERTICAL                                                 ),
-    MakeWidget({391, 45}, {114, 115}, WindowWidgetType::FlatBtn,      WindowColour::Secondary                                                                  ),
+    MakeWidget({391, 45}, {114, 114}, WindowWidgetType::FlatBtn,      WindowColour::Secondary                                                                  ),
     MakeWidget({470, 22}, {122,  14}, WindowWidgetType::Button,       WindowColour::Primary,   STR_INSTALL_NEW_TRACK_DESIGN,  STR_INSTALL_NEW_TRACK_DESIGN_TIP ),
     MakeWidget({350, 22}, {114,  14}, WindowWidgetType::Button,       WindowColour::Primary,   STR_OBJECT_FILTER,             STR_OBJECT_FILTER_TIP            ),
     MakeWidget({  4, 45}, {211,  14}, WindowWidgetType::TextBox,     WindowColour::Secondary                                                                  ),


### PR DESCRIPTION
The thumbnail box in the object selection window is 1 pixel too tall, showing a row of black pixels below the thumbnail.

![image](https://user-images.githubusercontent.com/2348094/166063654-24950561-bdb7-4922-a91b-afdb4e7e159d.png)

This pr shrinks it back down to the size that fits well for the 112x112 thumbnails

![image](https://user-images.githubusercontent.com/2348094/166063618-c4a29fb9-7d66-4d9d-8b9a-7acad7ea5de8.png)

No clue if this is an original bug, but I noticed it yesterday and its been bugging me since ;-P