### PR TITLE
Fix implicit floating point cast imprecision error

### DIFF
--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -364,7 +364,8 @@ static void mapgen_place_trees()
             }
 
             // Use tree:land ratio except when near an oasis
-            if (static_cast<float>(util_rand()) / 0xFFFFFFFF > std::max(treeToLandRatio, oasisScore))
+            constexpr static auto randModulo = 0xFFFF;
+            if (static_cast<float>(util_rand() & randModulo) / randModulo > std::max(treeToLandRatio, oasisScore))
                 continue;
 
             // Use fractal noise to group tiles that are likely to spawn trees together


### PR DESCRIPTION
This fix essentially limits the returned random values to 2 bytes, which floats can cover in its entirety, and should not have any noticeable effect on its distribution.

> error: implicit conversion from 'unsigned int' to 'float' changes value from 4294967295 to 4294967296

This value was picked since it's the maximum value that the mersenne twister engine returns. It happens to be too large for floating points to store the value accurately. The previous number is 256 lower, and the next number is 512 higher. This is what the compiler warned about. You can observe this here, by entering the value 4294967295 and pressing the -1 and +1 buttons: https://www.h-schmidt.net/FloatConverter/IEEE754.html

Strangely, this error only showed up on a later PR after this code was introduced.