### PR TITLE
Add UpdateRideApproachVehicleWaypoints to RTD

### DIFF
--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -400,7 +400,9 @@ private:
     void UpdateRideLeaveVehicle();
     void UpdateRideApproachExit();
     void UpdateRideInExit();
+
     void UpdateRideApproachVehicleWaypoints();
+
     void UpdateRideApproachExitWaypoints();
     void UpdateRideApproachSpiralSlide();
     void UpdateRideOnSpiralSlide();
@@ -424,6 +426,9 @@ private:
     bool FindVehicleToEnter(Ride* ride, std::vector<uint8_t>& car_array);
     void GoToRideEntrance(Ride* ride);
 };
+
+void UpdateRideApproachVehicleWaypointsMotionSimulator(Guest&, const CoordsXY&, int16_t&);
+void UpdateRideApproachVehicleWaypointsDefault(Guest&, const CoordsXY&, int16_t&);
 
 static_assert(sizeof(Guest) <= 512);
 

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -157,6 +157,7 @@ struct UpkeepCostsDescriptor
 };
 
 using RideTrackGroup = OpenRCT2::BitSet<TRACK_GROUP_COUNT>;
+using UpdateRideApproachVehicleWaypointsFunction = void (*)(Guest&, const CoordsXY&, int16_t&);
 using RideMusicUpdateFunction = void (*)(Ride*);
 using PeepUpdateRideLeaveEntranceFunc = void (*)(Guest*, Ride*, CoordsXYZD&);
 using StartRideMusicFunction = void (*)(const OpenRCT2::RideAudio::ViewportRideMusicInstance&);
@@ -240,6 +241,8 @@ struct RideTypeDescriptor
     RideUpdateMeasurementsSpecialElementsFunc UpdateMeasurementsSpecialElements = RideUpdateMeasurementsSpecialElements_Default;
 
     MusicTrackOffsetLengthFunc MusicTrackOffsetLength = OpenRCT2::RideAudio::RideMusicGetTrackOffsetLength_Default;
+
+    UpdateRideApproachVehicleWaypointsFunction UpdateRideApproachVehicleWaypoints = UpdateRideApproachVehicleWaypointsDefault;
 
     bool HasFlag(uint64_t flag) const;
     void GetAvailableTrackPieces(RideTrackGroup& res) const;

--- a/src/openrct2/ride/thrill/meta/MotionSimulator.h
+++ b/src/openrct2/ride/thrill/meta/MotionSimulator.h
@@ -50,5 +50,18 @@ constexpr const RideTypeDescriptor MotionSimulatorRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "motion_simulator"),
+    SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
+    SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
+    SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),
+    SET_FIELD(MusicUpdateFunction, DefaultMusicUpdate),
+    SET_FIELD(Classification, RideClassification::Ride),
+    SET_FIELD(UpdateLeaveEntrance, PeepUpdateRideLeaveEntranceDefault),
+    SET_FIELD(SpecialElementRatingAdjustment, SpecialTrackElementRatingsAjustment_Default),
+    SET_FIELD(GetGuestWaypointLocation, GetGuestWaypointLocationDefault),
+    SET_FIELD(ConstructionWindowContext, RideConstructionWindowContext::Default),
+    SET_FIELD(RideUpdate, nullptr),
+    SET_FIELD(UpdateMeasurementsSpecialElements, RideUpdateMeasurementsSpecialElements_Default),
+    SET_FIELD(MusicTrackOffsetLength, OpenRCT2::RideAudio::RideMusicGetTrackOffsetLength_Default),
+    SET_FIELD(UpdateRideApproachVehicleWaypoints, UpdateRideApproachVehicleWaypointsMotionSimulator),
 };
 // clang-format on


### PR DESCRIPTION
Enterprise and Motion simulator have some special behavior for the waypoints. There are some other instances in Guest.cpp where `ride->type` is checked directly against a `RIDE_TYPE` enum entry. We could create a class delegate that handles all the different calls for the Guest class to avoid adding multiple fields...