### PR TITLE
Fix #17104: Changing map size does not invalidate park size

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -189,6 +189,7 @@ The following people are not part of the development team, but have been contrib
 * Alexander Czarnecki (alcz/zuczek4793)
 * Lawrence De Mol (lawrencedemol)
 * Erik Wouters (EWouters)
+* Hoby R. (hobyr)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#17073] Corrupt ride window and random crashes when trains have more than 144 cars.
 - Fix: [#17080] “Remove litter” cheat does not empty litter bins.
 - Fix: [#17099] Object selection thumbnail box is one pixel too tall.
+- Fix: [#17104] Changing map size does not invalidate park size.
 - Improved: [#16978] Tree placement is more natural during map generation.
 - Improved: [#16992] The checkbox in the visibility column of the Tile Inspector has been replaced with an eye symbol.
 - Improved: [#16999] The maximum price for the park entry has been raised to £999.

--- a/src/openrct2/actions/ChangeMapSizeAction.cpp
+++ b/src/openrct2/actions/ChangeMapSizeAction.cpp
@@ -14,6 +14,7 @@
 #include "../ui/UiContext.h"
 #include "../ui/WindowManager.h"
 #include "../windows/Intent.h"
+#include "../world/Park.h"
 
 ChangeMapSizeAction::ChangeMapSizeAction(const TileCoordsXY& targetSize)
     : _targetSize(targetSize)
@@ -68,6 +69,7 @@ GameActions::Result ChangeMapSizeAction::Execute() const
     auto* ctx = OpenRCT2::GetContext();
     auto uiContext = ctx->GetUiContext();
     auto* windowManager = uiContext->GetWindowManager();
+    park_calculate_size();
 
     windowManager->BroadcastIntent(Intent(INTENT_ACTION_MAP));
     gfx_invalidate_screen();


### PR DESCRIPTION
Added park_calculate_size() to ChangeMapSizeAction::Execute() method.