### PR TITLE
Remove unused preprocessor placeholder

### DIFF
--- a/src/openrct2/Version.h
+++ b/src/openrct2/Version.h
@@ -74,10 +74,6 @@
 #    error Unknown platform!
 #endif
 
-#ifndef OPENRCT2_CUSTOM_INFO
-#    define OPENRCT2_CUSTOM_INFO ""
-#endif
-
 extern const char gVersionInfoFull[];
 extern const char gVersionInfoTag[];
 struct NewVersionInfo

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -472,8 +472,6 @@ static void PrintLaunchInformation()
     Console::WriteLine();
     Console::WriteFormat("%s (%s)", OPENRCT2_PLATFORM, OPENRCT2_ARCHITECTURE);
     Console::WriteLine();
-    Console::WriteFormat("@ %s", OPENRCT2_CUSTOM_INFO);
-    Console::WriteLine();
     Console::WriteLine();
 
     // Print current time


### PR DESCRIPTION
This define used to be `__DATE__ " " __TIME__`, but was replaced by a placeholder in https://github.com/OpenRCT2/OpenRCT2/pull/6864. As mentioned there, it was intended to be set by the build tool, but this was never done. Meanwhile, we already have the git commit hash and branch information logged right above this, so this define doesn't really serve any purpose any more.