### PR TITLE
Fix segfault when extracting files from the GOG installer

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,7 +17,7 @@
 - Fix: [#17080] “Remove litter” cheat does not empty litter bins.
 - Fix: [#17099] Object selection thumbnail box is one pixel too tall.
 - Fix: [#17104] Changing map size does not invalidate park size.
-- Fix: Segfault when extracting files from the GOG installer.
+- Fix [#17197]: Segfault when extracting files from the GOG installer.
 
 0.4.0 (2022-04-25)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#17080] “Remove litter” cheat does not empty litter bins.
 - Fix: [#17099] Object selection thumbnail box is one pixel too tall.
 - Fix: [#17104] Changing map size does not invalidate park size.
+- Fix: Segfault when extracting files from the GOG installer.
 
 0.4.0 (2022-04-25)
 ------------------------------------------------------------------------

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -744,7 +744,7 @@ namespace Config
         return ContextOpenCommonFileDialog(installerPath, desc, 4096);
     }
 
-    static bool ExtractGogInstaller(u8string_view installerPath, u8string_view targetPath)
+    static bool ExtractGogInstaller(const u8string& installerPath, const u8string& targetPath)
     {
         std::string path;
         std::string output;
@@ -755,7 +755,8 @@ namespace Config
             return false;
         }
         int32_t exit_status = Platform::Execute(
-            String::Format("%s '%s' --exclude-temp --output-dir '%s'", path.c_str(), installerPath, targetPath), &output);
+            String::Format("%s '%s' --exclude-temp --output-dir '%s'", path.c_str(), installerPath.c_str(), targetPath.c_str()),
+            &output);
         log_info("Exit status %d", exit_status);
         return exit_status == 0;
     }


### PR DESCRIPTION
Caused by one of my refactors. Discovered when writing the docs.