### PR TITLE
Add dependency check action

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -13,9 +13,9 @@ on:
       - closed
       - reopened
       - synchronize
-  # Schedule a check for every 2 hours.
+  # Schedule a check for every 2 hours (23rd minute).
   schedule:
-    - cron: '0 0/2 * * *'
+    - cron: '23 */2 * * *'
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,29 @@
+name: Dependency check
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+  # Schedule a check for every 2 hours.
+  schedule:
+    - cron: '0 0/2 * * *'
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          label: requires dependency
+          check_issues: off
+          keywords: depends on, blocked by, requires, needs


### PR DESCRIPTION
This GitHub Action checks for dependencies for PRs, and can prevent merges when a dependency is not yet merged.

Simply stating `depends on #1234` is enough to trigger this Action. You can reference PRs in other repositories too, so for instance a PR that requires a new object release can reference the objects PR that adds the required changes.

You can see how this Action works here: https://github.com/Broxzier/OpenRCT2/pull/10 (# 10 "depended" on # 9)

![image](https://user-images.githubusercontent.com/9705046/168153489-d110d790-dc96-4607-800a-490a9452c193.png)

For this PR, I have disabled the comment that you will see in the linked test PR. The label and GitHub Actions check are likely enough. I've also increased the cronjob to run every 2 hours instead of once a day.
![image](https://user-images.githubusercontent.com/9705046/168152798-7216502e-2c44-42ad-8007-4f05c911dfae.png)