### PR TITLE
Load Spiral Slide images from the object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,9 @@ set(TITLE_SEQUENCE_VERSION "0.4.0")
 set(TITLE_SEQUENCE_URL  "https://github.com/OpenRCT2/title-sequences/releases/download/v${TITLE_SEQUENCE_VERSION}/title-sequences.zip")
 set(TITLE_SEQUENCE_SHA1 "4ab0065e5a4d9f9c77d94718bbdfcfcd5a389da0")
 
-set(OBJECTS_VERSION "1.2.7")
+set(OBJECTS_VERSION "1.2.8")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
-set(OBJECTS_SHA1 "23bdabf6bac872367b01288032ad4d4ef5d7100c")
+set(OBJECTS_SHA1 "b340ce21d617d36850ba168efcce11bc374e6e85")
 
 set(REPLAYS_VERSION "0.0.67")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Improved: [#16999] The maximum price for the park entry has been raised to £999.
 - Improved: [#17050] Transparency can be enabled directly without needing see-through enabled first.
 - Improved: [#17059] Show Tile Inspector usage hint when nothing is selected.
+- Improved: [#17199] Allow creation of Spiral Slide reskins.
 - Change: [#16952] Make “Object Selection” order more coherent.
 - Removed: [#16864] Title sequence editor (replaced by plug-in).
 - Fix: [#13997] Placing a track design interferes with other players building a ride.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -45,8 +45,8 @@
     <LibsSha1 Condition="'$(Platform)'=='ARM64'">fa5f067fcfb5e76c4d4fb6f2211b422cbbe25f26</LibsSha1>
     <TitleSequencesUrl>https://github.com/OpenRCT2/title-sequences/releases/download/v0.4.0/title-sequences.zip</TitleSequencesUrl>
     <TitleSequencesSha1>4ab0065e5a4d9f9c77d94718bbdfcfcd5a389da0</TitleSequencesSha1>
-    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.2.7/objects.zip</ObjectsUrl>
-    <ObjectsSha1>23bdabf6bac872367b01288032ad4d4ef5d7100c</ObjectsSha1>
+    <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.2.8/objects.zip</ObjectsUrl>
+    <ObjectsSha1>b340ce21d617d36850ba168efcce11bc374e6e85</ObjectsSha1>
     <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.67/replays.zip</ReplaysUrl>
     <ReplaysSha1>0CA2DB3BEE021F0402D3E0F0E9EDB142CCEAFFC6</ReplaysSha1>
   </PropertyGroup>

--- a/shell.nix
+++ b/shell.nix
@@ -15,8 +15,8 @@ let
   objects-src = pkgs.fetchFromGitHub {
     owner = "OpenRCT2";
     repo = "objects";
-    rev = "v1.2.7";
-    sha256 = "d8b8e27cab5decb2f4c16f3b57dbbc0860c49d609b099c3ecd1d6338a85eada3";
+    rev = "v1.2.8";
+    sha256 = "3ff8ce135c6a6690c7b6e4b23a57f43092f6ce4bf72de4d6952e1b669c09ddc9";
   };
 
   title-sequences-src = pkgs.fetchFromGitHub {

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -12,55 +12,60 @@
 #include "../../paint/Paint.h"
 #include "../../paint/Supports.h"
 #include "../Ride.h"
+#include "../RideEntry.h"
 #include "../Track.h"
 #include "../TrackPaint.h"
 
 enum
 {
-    SPIRAL_SLIDE_LEFT_R0 = 20548,
-    SPIRAL_SLIDE_CENTRE_R0 = 20549,
-    SPIRAL_SLIDE_RIGHT_R0 = 20550,
+    SPIRAL_SLIDE_LEFT_R0 = 0,
+    SPIRAL_SLIDE_CENTRE_R0 = 1,
+    SPIRAL_SLIDE_RIGHT_R0 = 2,
 
-    SPIRAL_SLIDE_LEFT_R1 = 20551,
-    SPIRAL_SLIDE_CENTRE_R1 = 20552,
-    SPIRAL_SLIDE_RIGHT_R1 = 20553,
+    SPIRAL_SLIDE_LEFT_R1 = 3,
+    SPIRAL_SLIDE_CENTRE_R1 = 4,
+    SPIRAL_SLIDE_RIGHT_R1 = 5,
 
-    SPIRAL_SLIDE_LEFT_R2 = 20554,
-    SPIRAL_SLIDE_CENTRE_R2 = 20555,
-    SPIRAL_SLIDE_RIGHT_R2 = 20556,
+    SPIRAL_SLIDE_LEFT_R2 = 6,
+    SPIRAL_SLIDE_CENTRE_R2 = 7,
+    SPIRAL_SLIDE_RIGHT_R2 = 8,
 
-    SPIRAL_SLIDE_LEFT_R3 = 20557,
-    SPIRAL_SLIDE_CENTRE_R3 = 20558,
-    SPIRAL_SLIDE_RIGHT_R3 = 20559,
+    SPIRAL_SLIDE_LEFT_R3 = 9,
+    SPIRAL_SLIDE_CENTRE_R3 = 10,
+    SPIRAL_SLIDE_RIGHT_R3 = 11,
 
-    SPIRAL_SLIDE_INSIDE_R1 = 20560,
-    SPIRAL_SLIDE_INSIDE_R2 = 20561,
+    SPIRAL_SLIDE_INSIDE_R1 = 12,
+    SPIRAL_SLIDE_INSIDE_R2 = 13,
 
-    SPIRAL_SLIDE_BASE_A = 20562,
-    SPIRAL_SLIDE_BASE_B = 20563,
+    SPIRAL_SLIDE_BASE_A = 14,
+    SPIRAL_SLIDE_BASE_B = 15,
 
-    SPIRAL_SLIDE_FENCE_TOP_RIGHT = 20564,
-    SPIRAL_SLIDE_FENCE_BOTTOM_RIGHT = 20565,
-    SPIRAL_SLIDE_FENCE_BOTTOM_LEFT = 20566,
-    SPIRAL_SLIDE_FENCE_TOP_LEFT = 20567,
+    SPIRAL_SLIDE_FENCE_TOP_RIGHT = 16,
+    SPIRAL_SLIDE_FENCE_BOTTOM_RIGHT = 17,
+    SPIRAL_SLIDE_FENCE_BOTTOM_LEFT = 18,
+    SPIRAL_SLIDE_FENCE_TOP_LEFT = 19,
 
-    SPIRAL_SLIDE_PEEP = 20568, // 46 sprites per direction
+    SPIRAL_SLIDE_PEEP = 20, // 46 sprites per direction
 };
 
 static void spiral_slide_paint_tile_right(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
+    auto rideEntry = ride.GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
+
     uint32_t image_id = 0;
 
     if (direction == 0)
-        image_id = SPIRAL_SLIDE_RIGHT_R0 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_RIGHT_R0) | session.TrackColours[SCHEME_TRACK];
     if (direction == 1)
-        image_id = SPIRAL_SLIDE_RIGHT_R1 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_RIGHT_R1) | session.TrackColours[SCHEME_TRACK];
     if (direction == 2)
-        image_id = SPIRAL_SLIDE_RIGHT_R2 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_RIGHT_R2) | session.TrackColours[SCHEME_TRACK];
     if (direction == 3)
-        image_id = SPIRAL_SLIDE_RIGHT_R3 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_RIGHT_R3) | session.TrackColours[SCHEME_TRACK];
 
     PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 16, 108 }, { 16, 0, height + 3 });
 }
@@ -69,16 +74,20 @@ static void spiral_slide_paint_tile_left(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
+    auto rideEntry = ride.GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
+
     uint32_t image_id = 0;
 
     if (direction == 0)
-        image_id = SPIRAL_SLIDE_LEFT_R0 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_LEFT_R0) | session.TrackColours[SCHEME_TRACK];
     if (direction == 1)
-        image_id = SPIRAL_SLIDE_LEFT_R1 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_LEFT_R1) | session.TrackColours[SCHEME_TRACK];
     if (direction == 2)
-        image_id = SPIRAL_SLIDE_LEFT_R2 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_LEFT_R2) | session.TrackColours[SCHEME_TRACK];
     if (direction == 3)
-        image_id = SPIRAL_SLIDE_LEFT_R3 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_LEFT_R3) | session.TrackColours[SCHEME_TRACK];
 
     PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 16, 108 }, { 0, 16, height + 3 });
 }
@@ -87,37 +96,41 @@ static void spiral_slide_paint_tile_front(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
+    auto rideEntry = ride.GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
+
     uint32_t image_id = 0;
 
     if (direction == 1)
     {
-        image_id = SPIRAL_SLIDE_INSIDE_R1 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_INSIDE_R1) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 2, 16, 108 }, { -12, 0, height + 3 });
     }
     else if (direction == 2)
     {
-        image_id = SPIRAL_SLIDE_INSIDE_R2 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_INSIDE_R2) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 2, 108 }, { 0, -12, height + 3 });
     }
 
     if (direction == 0)
     {
-        image_id = SPIRAL_SLIDE_CENTRE_R0 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_CENTRE_R0) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 8, 108 }, { 0, 8, height + 3 });
     }
     else if (direction == 1)
     {
-        image_id = SPIRAL_SLIDE_CENTRE_R1 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_CENTRE_R1) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 2, 16, 108 }, { 14, 0, height + 3 });
     }
     else if (direction == 2)
     {
-        image_id = SPIRAL_SLIDE_CENTRE_R2 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_CENTRE_R2) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 2, 108 }, { 0, 14, height + 3 });
     }
     else if (direction == 3)
     {
-        image_id = SPIRAL_SLIDE_CENTRE_R3 | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_CENTRE_R3) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 8, 16, 108 }, { 8, 0, height + 3 });
     }
 
@@ -137,7 +150,7 @@ static void spiral_slide_paint_tile_front(
 
         if (slide_progress < 46)
         {
-            int32_t offset = SPIRAL_SLIDE_PEEP + 46 * direction;
+            int32_t offset = rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_PEEP + 46 * direction;
             CoordsXYZ boundingBox = { 0, 0, 108 };
             CoordsXYZ boundingBoxOffset = { 0, 0, static_cast<int16_t>(height + 3) };
 
@@ -177,13 +190,6 @@ static void spiral_slide_paint_tile_front(
     }
 }
 
-static constexpr const uint32_t spiral_slide_fence_sprites[] = {
-    SPIRAL_SLIDE_FENCE_TOP_RIGHT,
-    SPIRAL_SLIDE_FENCE_BOTTOM_RIGHT,
-    SPIRAL_SLIDE_FENCE_BOTTOM_LEFT,
-    SPIRAL_SLIDE_FENCE_TOP_LEFT,
-};
-
 /**
  * rct: 0x007485C8
  */
@@ -191,6 +197,10 @@ static void paint_spiral_slide(
     paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
+    auto rideEntry = ride.GetRideEntry();
+    if (rideEntry == nullptr)
+        return;
+
     trackSequence = track_map_2x2[direction][trackSequence];
 
     int32_t edges = edges_2x2[trackSequence];
@@ -202,10 +212,18 @@ static void paint_spiral_slide(
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
-        uint32_t imageId = ((direction & 1) ? SPIRAL_SLIDE_BASE_B : SPIRAL_SLIDE_BASE_A)
+        uint32_t imageId = ((direction & 1) ? rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_BASE_B
+                                            : rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_BASE_A)
             | session.TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
     }
+
+    const uint32_t spiral_slide_fence_sprites[] = {
+        rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_FENCE_TOP_RIGHT,
+        rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_FENCE_BOTTOM_RIGHT,
+        rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_FENCE_BOTTOM_LEFT,
+        rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_FENCE_TOP_LEFT,
+    };
 
     track_paint_util_paint_fences(
         session, edges, session.MapPosition, trackElement, ride, session.TrackColours[SCHEME_TRACK], height,


### PR DESCRIPTION
Requires an objects release.

This allows creating new buildings (and fences) for the Spiral Slide. This also makes the Spiral Slide behave more like the other flat rides, like the Crooked House, Haunted House, etc. where the building is stored as a vehicle.