### PR TITLE
Mark plugins that errored in main as started

### DIFF
--- a/src/openrct2/scripting/Plugin.cpp
+++ b/src/openrct2/scripting/Plugin.cpp
@@ -97,7 +97,6 @@ void Plugin::Start()
     {
         auto val = std::string(duk_safe_to_string(_context, -1));
         duk_pop(_context);
-        _hasStarted = false;
         throw std::runtime_error("[" + _metadata.Name + "] " + val);
     }
     duk_pop(_context);


### PR DESCRIPTION
This is to make sure plugin still runs stop / clean up code before it is unloaded. Otherwise context menu items etc. are not removed.