### PR TITLE
Add UpdateRotating field to RTD

### DIFF
--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -167,7 +167,7 @@ using RideUpdateMeasurementsSpecialElementsFunc = void (*)(Ride* ride, const tra
 using MusicTrackOffsetLengthFunc = std::pair<size_t, size_t> (*)(const Ride& ride);
 using SpecialElementRatingAdjustmentFunc = void (*)(const Ride* ride, int32_t& excitement, int32_t& intensity, int32_t& nausea);
 
-using UpdateRotatingFunction = void (*)(Vehicle* vehicle);
+using UpdateRotatingFunction = void (*)(Vehicle& vehicle);
 enum class RideConstructionWindowContext : uint8_t
 {
     Default,

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -167,6 +167,7 @@ using RideUpdateMeasurementsSpecialElementsFunc = void (*)(Ride* ride, const tra
 using MusicTrackOffsetLengthFunc = std::pair<size_t, size_t> (*)(const Ride& ride);
 using SpecialElementRatingAdjustmentFunc = void (*)(const Ride* ride, int32_t& excitement, int32_t& intensity, int32_t& nausea);
 
+using UpdateRotatingFunction = void (*)(Vehicle* vehicle);
 enum class RideConstructionWindowContext : uint8_t
 {
     Default,
@@ -220,6 +221,8 @@ struct RideTypeDescriptor
 
     // json name lookup
     std::string_view Name;
+
+    UpdateRotatingFunction UpdateRotating = UpdateRotatingDefault;
 
     LightFXAddLightsMagicVehicleFunction LightFXAddLightsMagicVehicle = nullptr;
     StartRideMusicFunction StartRideMusic = OpenRCT2::RideAudio::DefaultStartRideMusicChannel;
@@ -436,6 +439,7 @@ constexpr const RideTypeDescriptor DummyRTD =
     SET_FIELD(ColourPreview, { static_cast<uint32_t>(SPR_NONE), static_cast<uint32_t>(SPR_NONE) }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "invalid"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -4830,16 +4830,16 @@ void Vehicle::UpdateSimulatorOperating()
     var_C0 = 0;
 }
 
-void UpdateRotatingDefault(Vehicle* vehicle)
+void UpdateRotatingDefault(Vehicle& vehicle)
 {
     if (_vehicleBreakdown == 0)
         return;
 
-    auto curRide = vehicle->GetRide();
+    auto curRide = vehicle.GetRide();
     if (curRide == nullptr)
         return;
 
-    auto rideEntry = vehicle->GetRideEntry();
+    auto rideEntry = vehicle.GetRideEntry();
     if (rideEntry == nullptr)
     {
         return;
@@ -4848,18 +4848,18 @@ void UpdateRotatingDefault(Vehicle* vehicle)
     const uint8_t* timeToSpriteMap;
     if (rideEntry->flags & RIDE_ENTRY_FLAG_ALTERNATIVE_ROTATION_MODE_1)
     {
-        timeToSpriteMap = Rotation1TimeToSpriteMaps[vehicle->sub_state];
+        timeToSpriteMap = Rotation1TimeToSpriteMaps[vehicle.sub_state];
     }
     else if (rideEntry->flags & RIDE_ENTRY_FLAG_ALTERNATIVE_ROTATION_MODE_2)
     {
-        timeToSpriteMap = Rotation2TimeToSpriteMaps[vehicle->sub_state];
+        timeToSpriteMap = Rotation2TimeToSpriteMaps[vehicle.sub_state];
     }
     else
     {
-        timeToSpriteMap = Rotation3TimeToSpriteMaps[vehicle->sub_state];
+        timeToSpriteMap = Rotation3TimeToSpriteMaps[vehicle.sub_state];
     }
 
-    int32_t time = vehicle->current_time;
+    int32_t time = vehicle.current_time;
     if (_vehicleBreakdown == BREAKDOWN_CONTROL_FAILURE)
     {
         time += (curRide->breakdown_sound_modifier >> 6) + 1;
@@ -4869,22 +4869,22 @@ void UpdateRotatingDefault(Vehicle* vehicle)
     uint8_t sprite = timeToSpriteMap[static_cast<uint32_t>(time)];
     if (sprite != 0xFF)
     {
-        vehicle->current_time = static_cast<uint16_t>(time);
-        if (sprite == vehicle->Pitch)
+        vehicle.current_time = static_cast<uint16_t>(time);
+        if (sprite == vehicle.Pitch)
             return;
-        vehicle->Pitch = sprite;
-        vehicle->Invalidate();
+        vehicle.Pitch = sprite;
+        vehicle.Invalidate();
         return;
     }
 
-    vehicle->current_time = -1;
-    vehicle->NumRotations++;
+    vehicle.current_time = -1;
+    vehicle.NumRotations++;
     if (_vehicleBreakdown != BREAKDOWN_CONTROL_FAILURE)
     {
         bool shouldStop = true;
         if (curRide->status != RideStatus::Closed)
         {
-            sprite = vehicle->NumRotations + 1;
+            sprite = vehicle.NumRotations + 1;
 
             if (sprite < curRide->rotations)
                 shouldStop = false;
@@ -4892,32 +4892,32 @@ void UpdateRotatingDefault(Vehicle* vehicle)
 
         if (shouldStop)
         {
-            if (vehicle->sub_state == 2)
+            if (vehicle.sub_state == 2)
             {
-                vehicle->SetState(Vehicle::Status::Arriving);
-                vehicle->var_C0 = 0;
+                vehicle.SetState(Vehicle::Status::Arriving);
+                vehicle.var_C0 = 0;
                 return;
             }
-            vehicle->sub_state++;
+            vehicle.sub_state++;
             UpdateRotatingDefault(vehicle);
             return;
         }
     }
 
-    vehicle->sub_state = 1;
+    vehicle.sub_state = 1;
     UpdateRotatingDefault(vehicle);
 }
 
-void UpdateRotatingEnterprise(Vehicle* vehicle)
+void UpdateRotatingEnterprise(Vehicle& vehicle)
 {
     if (_vehicleBreakdown == 0)
         return;
 
-    auto curRide = vehicle->GetRide();
+    auto curRide = vehicle.GetRide();
     if (curRide == nullptr)
         return;
 
-    auto rideEntry = vehicle->GetRideEntry();
+    auto rideEntry = vehicle.GetRideEntry();
     if (rideEntry == nullptr)
     {
         return;
@@ -4926,18 +4926,18 @@ void UpdateRotatingEnterprise(Vehicle* vehicle)
     const uint8_t* timeToSpriteMap;
     if (rideEntry->flags & RIDE_ENTRY_FLAG_ALTERNATIVE_ROTATION_MODE_1)
     {
-        timeToSpriteMap = Rotation1TimeToSpriteMaps[vehicle->sub_state];
+        timeToSpriteMap = Rotation1TimeToSpriteMaps[vehicle.sub_state];
     }
     else if (rideEntry->flags & RIDE_ENTRY_FLAG_ALTERNATIVE_ROTATION_MODE_2)
     {
-        timeToSpriteMap = Rotation2TimeToSpriteMaps[vehicle->sub_state];
+        timeToSpriteMap = Rotation2TimeToSpriteMaps[vehicle.sub_state];
     }
     else
     {
-        timeToSpriteMap = Rotation3TimeToSpriteMaps[vehicle->sub_state];
+        timeToSpriteMap = Rotation3TimeToSpriteMaps[vehicle.sub_state];
     }
 
-    int32_t time = vehicle->current_time;
+    int32_t time = vehicle.current_time;
     if (_vehicleBreakdown == BREAKDOWN_CONTROL_FAILURE)
     {
         time += (curRide->breakdown_sound_modifier >> 6) + 1;
@@ -4947,22 +4947,22 @@ void UpdateRotatingEnterprise(Vehicle* vehicle)
     uint8_t sprite = timeToSpriteMap[static_cast<uint32_t>(time)];
     if (sprite != 0xFF)
     {
-        vehicle->current_time = static_cast<uint16_t>(time);
-        if (sprite == vehicle->Pitch)
+        vehicle.current_time = static_cast<uint16_t>(time);
+        if (sprite == vehicle.Pitch)
             return;
-        vehicle->Pitch = sprite;
-        vehicle->Invalidate();
+        vehicle.Pitch = sprite;
+        vehicle.Invalidate();
         return;
     }
 
-    vehicle->current_time = -1;
-    vehicle->NumRotations++;
+    vehicle.current_time = -1;
+    vehicle.NumRotations++;
     if (_vehicleBreakdown != BREAKDOWN_CONTROL_FAILURE)
     {
         bool shouldStop = true;
         if (curRide->status != RideStatus::Closed)
         {
-            sprite = vehicle->NumRotations + 1;
+            sprite = vehicle.NumRotations + 1;
             sprite += 9;
 
             if (sprite < curRide->rotations)
@@ -4971,26 +4971,26 @@ void UpdateRotatingEnterprise(Vehicle* vehicle)
 
         if (shouldStop)
         {
-            if (vehicle->sub_state == 2)
+            if (vehicle.sub_state == 2)
             {
-                vehicle->SetState(Vehicle::Status::Arriving);
-                vehicle->var_C0 = 0;
+                vehicle.SetState(Vehicle::Status::Arriving);
+                vehicle.var_C0 = 0;
                 return;
             }
-            vehicle->sub_state++;
+            vehicle.sub_state++;
             UpdateRotatingEnterprise(vehicle);
             return;
         }
     }
 
-    if (vehicle->sub_state == 2)
+    if (vehicle.sub_state == 2)
     {
-        vehicle->SetState(Vehicle::Status::Arriving);
-        vehicle->var_C0 = 0;
+        vehicle.SetState(Vehicle::Status::Arriving);
+        vehicle.var_C0 = 0;
         return;
     }
 
-    vehicle->sub_state = 1;
+    vehicle.sub_state = 1;
     UpdateRotatingEnterprise(vehicle);
 }
 
@@ -5008,7 +5008,7 @@ void Vehicle::UpdateRotating()
         return;
 
     const auto& rtd = GetRideTypeDescriptor(curRide->type);
-    rtd.UpdateRotating(this);
+    rtd.UpdateRotating(*this);
 }
 
 /**

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -4844,8 +4844,8 @@ void UpdateRotatingEnterprise(Vehicle& vehicle)
         vehicle.var_C0 = 0;
         return;
     }
-    vehicle.sub_state = 1;
-    vehicle.UpdateRotating();
+
+    UpdateRotatingDefault(vehicle);
 }
 
 /**

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -4832,166 +4832,20 @@ void Vehicle::UpdateSimulatorOperating()
 
 void UpdateRotatingDefault(Vehicle& vehicle)
 {
-    if (_vehicleBreakdown == 0)
-        return;
-
-    auto curRide = vehicle.GetRide();
-    if (curRide == nullptr)
-        return;
-
-    auto rideEntry = vehicle.GetRideEntry();
-    if (rideEntry == nullptr)
-    {
-        return;
-    }
-
-    const uint8_t* timeToSpriteMap;
-    if (rideEntry->flags & RIDE_ENTRY_FLAG_ALTERNATIVE_ROTATION_MODE_1)
-    {
-        timeToSpriteMap = Rotation1TimeToSpriteMaps[vehicle.sub_state];
-    }
-    else if (rideEntry->flags & RIDE_ENTRY_FLAG_ALTERNATIVE_ROTATION_MODE_2)
-    {
-        timeToSpriteMap = Rotation2TimeToSpriteMaps[vehicle.sub_state];
-    }
-    else
-    {
-        timeToSpriteMap = Rotation3TimeToSpriteMaps[vehicle.sub_state];
-    }
-
-    int32_t time = vehicle.current_time;
-    if (_vehicleBreakdown == BREAKDOWN_CONTROL_FAILURE)
-    {
-        time += (curRide->breakdown_sound_modifier >> 6) + 1;
-    }
-    time++;
-
-    uint8_t sprite = timeToSpriteMap[static_cast<uint32_t>(time)];
-    if (sprite != 0xFF)
-    {
-        vehicle.current_time = static_cast<uint16_t>(time);
-        if (sprite == vehicle.Pitch)
-            return;
-        vehicle.Pitch = sprite;
-        vehicle.Invalidate();
-        return;
-    }
-
-    vehicle.current_time = -1;
-    vehicle.NumRotations++;
-    if (_vehicleBreakdown != BREAKDOWN_CONTROL_FAILURE)
-    {
-        bool shouldStop = true;
-        if (curRide->status != RideStatus::Closed)
-        {
-            sprite = vehicle.NumRotations + 1;
-
-            if (sprite < curRide->rotations)
-                shouldStop = false;
-        }
-
-        if (shouldStop)
-        {
-            if (vehicle.sub_state == 2)
-            {
-                vehicle.SetState(Vehicle::Status::Arriving);
-                vehicle.var_C0 = 0;
-                return;
-            }
-            vehicle.sub_state++;
-            UpdateRotatingDefault(vehicle);
-            return;
-        }
-    }
-
     vehicle.sub_state = 1;
-    UpdateRotatingDefault(vehicle);
+    vehicle.UpdateRotating();
 }
 
 void UpdateRotatingEnterprise(Vehicle& vehicle)
 {
-    if (_vehicleBreakdown == 0)
-        return;
-
-    auto curRide = vehicle.GetRide();
-    if (curRide == nullptr)
-        return;
-
-    auto rideEntry = vehicle.GetRideEntry();
-    if (rideEntry == nullptr)
-    {
-        return;
-    }
-
-    const uint8_t* timeToSpriteMap;
-    if (rideEntry->flags & RIDE_ENTRY_FLAG_ALTERNATIVE_ROTATION_MODE_1)
-    {
-        timeToSpriteMap = Rotation1TimeToSpriteMaps[vehicle.sub_state];
-    }
-    else if (rideEntry->flags & RIDE_ENTRY_FLAG_ALTERNATIVE_ROTATION_MODE_2)
-    {
-        timeToSpriteMap = Rotation2TimeToSpriteMaps[vehicle.sub_state];
-    }
-    else
-    {
-        timeToSpriteMap = Rotation3TimeToSpriteMaps[vehicle.sub_state];
-    }
-
-    int32_t time = vehicle.current_time;
-    if (_vehicleBreakdown == BREAKDOWN_CONTROL_FAILURE)
-    {
-        time += (curRide->breakdown_sound_modifier >> 6) + 1;
-    }
-    time++;
-
-    uint8_t sprite = timeToSpriteMap[static_cast<uint32_t>(time)];
-    if (sprite != 0xFF)
-    {
-        vehicle.current_time = static_cast<uint16_t>(time);
-        if (sprite == vehicle.Pitch)
-            return;
-        vehicle.Pitch = sprite;
-        vehicle.Invalidate();
-        return;
-    }
-
-    vehicle.current_time = -1;
-    vehicle.NumRotations++;
-    if (_vehicleBreakdown != BREAKDOWN_CONTROL_FAILURE)
-    {
-        bool shouldStop = true;
-        if (curRide->status != RideStatus::Closed)
-        {
-            sprite = vehicle.NumRotations + 1;
-            sprite += 9;
-
-            if (sprite < curRide->rotations)
-                shouldStop = false;
-        }
-
-        if (shouldStop)
-        {
-            if (vehicle.sub_state == 2)
-            {
-                vehicle.SetState(Vehicle::Status::Arriving);
-                vehicle.var_C0 = 0;
-                return;
-            }
-            vehicle.sub_state++;
-            UpdateRotatingEnterprise(vehicle);
-            return;
-        }
-    }
-
     if (vehicle.sub_state == 2)
     {
         vehicle.SetState(Vehicle::Status::Arriving);
         vehicle.var_C0 = 0;
         return;
     }
-
     vehicle.sub_state = 1;
-    UpdateRotatingEnterprise(vehicle);
+    vehicle.UpdateRotating();
 }
 
 /**
@@ -5006,6 +4860,73 @@ void Vehicle::UpdateRotating()
     auto curRide = GetRide();
     if (curRide == nullptr)
         return;
+
+    auto rideEntry = GetRideEntry();
+    if (rideEntry == nullptr)
+    {
+        return;
+    }
+
+    const uint8_t* timeToSpriteMap;
+    if (rideEntry->flags & RIDE_ENTRY_FLAG_ALTERNATIVE_ROTATION_MODE_1)
+    {
+        timeToSpriteMap = Rotation1TimeToSpriteMaps[sub_state];
+    }
+    else if (rideEntry->flags & RIDE_ENTRY_FLAG_ALTERNATIVE_ROTATION_MODE_2)
+    {
+        timeToSpriteMap = Rotation2TimeToSpriteMaps[sub_state];
+    }
+    else
+    {
+        timeToSpriteMap = Rotation3TimeToSpriteMaps[sub_state];
+    }
+
+    int32_t time = current_time;
+    if (_vehicleBreakdown == BREAKDOWN_CONTROL_FAILURE)
+    {
+        time += (curRide->breakdown_sound_modifier >> 6) + 1;
+    }
+    time++;
+
+    uint8_t sprite = timeToSpriteMap[static_cast<uint32_t>(time)];
+    if (sprite != 0xFF)
+    {
+        current_time = static_cast<uint16_t>(time);
+        if (sprite == Pitch)
+            return;
+        Pitch = sprite;
+        Invalidate();
+        return;
+    }
+
+    current_time = -1;
+    NumRotations++;
+    if (_vehicleBreakdown != BREAKDOWN_CONTROL_FAILURE)
+    {
+        bool shouldStop = true;
+        if (curRide->status != RideStatus::Closed)
+        {
+            sprite = NumRotations + 1;
+            if (curRide->type == RIDE_TYPE_ENTERPRISE)
+                sprite += 9;
+
+            if (sprite < curRide->rotations)
+                shouldStop = false;
+        }
+
+        if (shouldStop)
+        {
+            if (sub_state == 2)
+            {
+                SetState(Vehicle::Status::Arriving);
+                var_C0 = 0;
+                return;
+            }
+            sub_state++;
+            UpdateRotating();
+            return;
+        }
+    }
 
     const auto& rtd = GetRideTypeDescriptor(curRide->type);
     rtd.UpdateRotating(*this);

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -373,6 +373,9 @@ private:
 };
 static_assert(sizeof(Vehicle) <= 512);
 
+void UpdateRotatingDefault(Vehicle* vehicle);
+void UpdateRotatingEnterprise(Vehicle* vehicle);
+
 struct train_ref
 {
     Vehicle* head;

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -272,6 +272,9 @@ struct Vehicle : EntityBase
     void Serialise(DataSerialiser& stream);
     void Paint(paint_session& session, int32_t imageDirection) const;
 
+    friend void UpdateRotatingDefault(Vehicle& vehicle);
+    friend void UpdateRotatingEnterprise(Vehicle& vehicle);
+
 private:
     bool SoundCanPlay() const;
     uint16_t GetSoundPriority() const;

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -373,8 +373,8 @@ private:
 };
 static_assert(sizeof(Vehicle) <= 512);
 
-void UpdateRotatingDefault(Vehicle* vehicle);
-void UpdateRotatingEnterprise(Vehicle* vehicle);
+void UpdateRotatingDefault(Vehicle& vehicle);
+void UpdateRotatingEnterprise(Vehicle& vehicle);
 
 struct train_ref
 {

--- a/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
+++ b/src/openrct2/ride/coaster/meta/MineTrainCoaster.h
@@ -53,6 +53,7 @@ constexpr const RideTypeDescriptor MineTrainCoasterRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINE_TRAIN_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINE_TRAIN_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "mine_train_rc"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_MineTrainCoaster),
 };
 // clang-format on

--- a/src/openrct2/ride/coaster/meta/WaterCoaster.h
+++ b/src/openrct2/ride/coaster/meta/WaterCoaster.h
@@ -54,6 +54,7 @@ constexpr const RideTypeDescriptor WaterCoasterRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_WATER_COASTER_TRACK, SPR_RIDE_DESIGN_PREVIEW_WATER_COASTER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "water_coaster"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_BoatHire),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/gentle/meta/CarRide.h
+++ b/src/openrct2/ride/gentle/meta/CarRide.h
@@ -58,6 +58,7 @@ constexpr const RideTypeDescriptor CarRideRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "car_ride"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_BoatHire),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/Circus.h
+++ b/src/openrct2/ride/gentle/meta/Circus.h
@@ -50,6 +50,7 @@ constexpr const RideTypeDescriptor CircusRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "circus"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::CircusStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/gentle/meta/Dodgems.h
+++ b/src/openrct2/ride/gentle/meta/Dodgems.h
@@ -55,6 +55,7 @@ constexpr const RideTypeDescriptor DodgemsRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_DODGEMS_TRACK, SPR_RIDE_DESIGN_PREVIEW_DODGEMS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "dodgems"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_BoatHire),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/GhostTrain.h
+++ b/src/openrct2/ride/gentle/meta/GhostTrain.h
@@ -59,6 +59,7 @@ constexpr const RideTypeDescriptor GhostTrainRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GHOST_TRAIN_TRACK, SPR_RIDE_DESIGN_PREVIEW_GHOST_TRAIN_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "ghost_train"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_MineTrainCoaster),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/gentle/meta/Maze.h
+++ b/src/openrct2/ride/gentle/meta/Maze.h
@@ -52,6 +52,7 @@ constexpr const RideTypeDescriptor MazeRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "maze"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Maze),

--- a/src/openrct2/ride/gentle/meta/MiniGolf.h
+++ b/src/openrct2/ride/gentle/meta/MiniGolf.h
@@ -52,6 +52,7 @@ constexpr const RideTypeDescriptor MiniGolfRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_GOLF_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_GOLF_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "mini_golf"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/gentle/meta/MiniHelicopters.h
+++ b/src/openrct2/ride/gentle/meta/MiniHelicopters.h
@@ -59,6 +59,7 @@ constexpr const RideTypeDescriptor MiniHelicoptersRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINI_HELICOPTERS_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINI_HELICOPTERS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "mini_helicopters"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_BoatHire),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonorailCycles.h
+++ b/src/openrct2/ride/gentle/meta/MonorailCycles.h
@@ -55,6 +55,7 @@ constexpr const RideTypeDescriptor MonorailCyclesRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MONORAIL_CYCLES_TRACK, SPR_RIDE_DESIGN_PREVIEW_MONORAIL_CYCLES_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "monorail_cycles"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_BoatHire),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/MonsterTrucks.h
+++ b/src/openrct2/ride/gentle/meta/MonsterTrucks.h
@@ -57,6 +57,7 @@ constexpr const RideTypeDescriptor MonsterTrucksRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_CAR_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "monster_trucks"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_BoatHire),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/ObservationTower.h
+++ b/src/openrct2/ride/gentle/meta/ObservationTower.h
@@ -54,6 +54,7 @@ constexpr const RideTypeDescriptor ObservationTowerRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_OBSERVATION_TOWER_TRACK, SPR_RIDE_DESIGN_PREVIEW_OBSERVATION_TOWER_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "observation_tower"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_ObservationTower),
 };
 // clang-format on

--- a/src/openrct2/ride/gentle/meta/SpiralSlide.h
+++ b/src/openrct2/ride/gentle/meta/SpiralSlide.h
@@ -53,6 +53,7 @@ constexpr const RideTypeDescriptor SpiralSlideRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPIRAL_SLIDE_TRACK, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "spiral_slide"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/shops/meta/CashMachine.h
+++ b/src/openrct2/ride/shops/meta/CashMachine.h
@@ -47,6 +47,7 @@ constexpr const RideTypeDescriptor CashMachineRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::CashMachine),
     SET_FIELD(Name, "cash_machine"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/shops/meta/DrinkStall.h
+++ b/src/openrct2/ride/shops/meta/DrinkStall.h
@@ -48,6 +48,7 @@ constexpr const RideTypeDescriptor DrinkStallRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Drink),
     SET_FIELD(Name, "drink_stall"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/shops/meta/FirstAid.h
+++ b/src/openrct2/ride/shops/meta/FirstAid.h
@@ -48,6 +48,7 @@ constexpr const RideTypeDescriptor FirstAidRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::FirstAid),
     SET_FIELD(Name, "first_aid"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/shops/meta/FoodStall.h
+++ b/src/openrct2/ride/shops/meta/FoodStall.h
@@ -48,6 +48,7 @@ constexpr const RideTypeDescriptor FoodStallRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Food),
     SET_FIELD(Name, "food_stall"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/shops/meta/InformationKiosk.h
+++ b/src/openrct2/ride/shops/meta/InformationKiosk.h
@@ -48,6 +48,7 @@ constexpr const RideTypeDescriptor InformationKioskRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::InfoKiosk),
     SET_FIELD(Name, "information_kiosk"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/shops/meta/Shop.h
+++ b/src/openrct2/ride/shops/meta/Shop.h
@@ -48,6 +48,7 @@ constexpr const RideTypeDescriptor ShopRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Shop),
     SET_FIELD(Name, "shop"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/shops/meta/Toilets.h
+++ b/src/openrct2/ride/shops/meta/Toilets.h
@@ -48,6 +48,7 @@ constexpr const RideTypeDescriptor ToiletsRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Toilets),
     SET_FIELD(Name, "toilets"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/thrill/meta/Enterprise.h
+++ b/src/openrct2/ride/thrill/meta/Enterprise.h
@@ -50,6 +50,7 @@ constexpr const RideTypeDescriptor EnterpriseRTD =
     SET_FIELD(ColourPreview, { 0, 0 }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "enterprise"),
+    SET_FIELD(UpdateRotating, UpdateRotatingEnterprise),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/thrill/meta/GoKarts.h
+++ b/src/openrct2/ride/thrill/meta/GoKarts.h
@@ -55,6 +55,7 @@ constexpr const RideTypeDescriptor GoKartsRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_GO_KARTS_TRACK, SPR_RIDE_DESIGN_PREVIEW_GO_KARTS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "go_karts"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_BoatHire),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Chairlift.h
+++ b/src/openrct2/ride/transport/meta/Chairlift.h
@@ -56,6 +56,7 @@ constexpr const RideTypeDescriptor ChairliftRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_CHAIRLIFT_TRACK, SPR_RIDE_DESIGN_PREVIEW_CHAIRLIFT_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "chairlift"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_ChairLift),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/transport/meta/MiniatureRailway.h
+++ b/src/openrct2/ride/transport/meta/MiniatureRailway.h
@@ -56,6 +56,7 @@ constexpr const RideTypeDescriptor MiniatureRailwayRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MINIATURE_RAILWAY_TRACK, SPR_RIDE_DESIGN_PREVIEW_MINIATURE_RAILWAY_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "miniature_railway"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_MiniatureRailway),
 };
 // clang-format on

--- a/src/openrct2/ride/transport/meta/Monorail.h
+++ b/src/openrct2/ride/transport/meta/Monorail.h
@@ -59,6 +59,7 @@ constexpr const RideTypeDescriptor MonorailRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_MONORAIL_TRACK, SPR_RIDE_DESIGN_PREVIEW_MONORAIL_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "monorail"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_Monorail),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/BoatHire.h
+++ b/src/openrct2/ride/water/meta/BoatHire.h
@@ -55,6 +55,7 @@ constexpr const RideTypeDescriptor BoatHireRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_BOAT_HIRE_TRACK, SPR_RIDE_DESIGN_PREVIEW_BOAT_HIRE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "boat_hire"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_BoatHire),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/LogFlume.h
+++ b/src/openrct2/ride/water/meta/LogFlume.h
@@ -55,6 +55,7 @@ constexpr const RideTypeDescriptor LogFlumeRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_LOG_FLUME_TRACK, SPR_RIDE_DESIGN_PREVIEW_LOG_FLUME_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "log_flume"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/water/meta/RiverRapids.h
+++ b/src/openrct2/ride/water/meta/RiverRapids.h
@@ -55,6 +55,7 @@ constexpr const RideTypeDescriptor RiverRapidsRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_RIVER_RAPIDS_TRACK, SPR_RIDE_DESIGN_PREVIEW_RIVER_RAPIDS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "river_rapids"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, nullptr),
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::DefaultStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),

--- a/src/openrct2/ride/water/meta/SplashBoats.h
+++ b/src/openrct2/ride/water/meta/SplashBoats.h
@@ -56,6 +56,7 @@ constexpr const RideTypeDescriptor SplashBoatsRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SPLASH_BOATS_TRACK, SPR_RIDE_DESIGN_PREVIEW_SPLASH_BOATS_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "splash_boats"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_BoatHire),
 };
 // clang-format on

--- a/src/openrct2/ride/water/meta/SubmarineRide.h
+++ b/src/openrct2/ride/water/meta/SubmarineRide.h
@@ -54,6 +54,7 @@ constexpr const RideTypeDescriptor SubmarineRideRTD =
     SET_FIELD(ColourPreview, { SPR_RIDE_DESIGN_PREVIEW_SUBMARINE_RIDE_TRACK, SPR_RIDE_DESIGN_PREVIEW_SUBMARINE_RIDE_SUPPORTS }),
     SET_FIELD(ColourKey, RideColourKey::Ride),
     SET_FIELD(Name, "submarine_ride"),
+    SET_FIELD(UpdateRotating, UpdateRotatingDefault),
     SET_FIELD(LightFXAddLightsMagicVehicle, LightFxAddLightsMagicVehicle_BoatHire),
 };
 // clang-format on


### PR DESCRIPTION
Enterprise has a special behavior for rotating, so I've added a UpdateRotating field to the RTD. This creates some code duplication and also UpdateRotating field for a toilets does not make sense, but this could be simplified with an OperatingMode refactor, i.e. make it into a class delegates that modifies the vehicle structure.

For the sake of eliminating all references to RIDE_TYPE_*, this is what it is.