### PR TITLE
Fix guests never thinking that they're being watched

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#17099] Object selection thumbnail box is one pixel too tall.
 - Fix: [#17104] Changing map size does not invalidate park size.
 - Fix: [#17197] Segfault when extracting files from the GOG installer.
+- Fix: [#17218] Guests never think they're being watched
 
 0.4.0 (2022-04-25)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -331,6 +331,7 @@ rct_window* WindowGuestOpen(Peep* peep)
         window->list_information_type = 0;
         window->picked_peep_frame = 0;
         window->highlighted_item = 0;
+        window->guestWatchTimer = 0;
         WindowGuestDisableWidgets(window);
         window->min_width = windowWidth;
         window->min_height = 157;
@@ -1045,18 +1046,18 @@ void WindowGuestOverviewUpdate(rct_window* w)
 
     w->list_information_type += 2;
 
-    if ((w->highlighted_item & 0xFFFF) == 0xFFFF)
-        w->highlighted_item &= 0xFFFF0000;
+    if (w->guestWatchTimer == 0xFFFF)
+        w->guestWatchTimer = 0;
     else
-        w->highlighted_item++;
+        w->guestWatchTimer++;
 
     // Disable peep watching thought for multiplayer as it's client specific
     if (network_get_mode() == NETWORK_MODE_NONE)
     {
-        // Create the "I have the strangest feeling I am being watched thought"
-        if ((w->highlighted_item & 0xFFFF) >= 3840)
+        // Create the "I have the strangest feeling someone is watching me" thought
+        if (w->guestWatchTimer >= 3840)
         {
-            if (!(w->highlighted_item & 0x3FF))
+            if (!(w->guestWatchTimer & 0x3FF))
             {
                 int32_t random = util_rand() & 0xFFFF;
                 if (random <= 0x2AAA)

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1046,14 +1046,14 @@ void WindowGuestOverviewUpdate(rct_window* w)
 
     w->list_information_type += 2;
 
-    if (w->guestWatchTimer == 0xFFFF)
-        w->guestWatchTimer = 0;
-    else
-        w->guestWatchTimer++;
-
     // Disable peep watching thought for multiplayer as it's client specific
     if (network_get_mode() == NETWORK_MODE_NONE)
     {
+        if (w->guestWatchTimer == 0xFFFF)
+            w->guestWatchTimer = 0;
+        else
+            w->guestWatchTimer++;
+
         // Create the "I have the strangest feeling someone is watching me" thought
         if (w->guestWatchTimer >= 3840)
         {

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -94,6 +94,7 @@ struct rct_window
         const scenario_index_entry* highlighted_scenario;
         uint16_t var_496;
     };
+    uint32_t guestWatchTimer; // Timer for "someone is watching me" thought
     int16_t selected_tab{};
     int16_t var_4AE{};
     EntityId viewport_target_sprite{ EntityId::GetNull() };


### PR DESCRIPTION
This actually fixes two issues:

1. Guests never think that they're being watched
2. The animation for the guest overview tab updates twice per call (especially obvious on guests with a balloon)

The way it is before this PR, both `w->var_496` and `w->highlighted_item` are in a union. Since the animation is updated first, this means `w->highlighted_item` gets reset to 0 when it hits 24 (old line 1029), AND `w->var_496` gets updated twice per call (old lines 1028 and 1051), making the tab animation run too fast and preventing the timer from ever reaching the minimum time of 3840.

This PR fixes both by just adding a separate variable outside of the union for the timer.