### PR TITLE
Proposed improvement for water & shorelines in map generation

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Improved: [#17050] Transparency can be enabled directly without needing see-through enabled first.
 - Improved: [#17059] Show Tile Inspector usage hint when nothing is selected.
 - Improved: [#17199] Allow creation of Spiral Slide reskins.
+- Improved: [#17242] More natural looking shorelines in map generator.
 - Change: [#16952] Make “Object Selection” order more coherent.
 - Removed: [#16864] Title sequence editor (replaced by plug-in).
 - Fix: [#13997] Placing a track design interferes with other players building a ride.

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -93,7 +93,7 @@ static constexpr const std::string_view BaseTerrain[] = {
 static void mapgen_place_trees();
 static void mapgen_set_water_level(int32_t waterLevel);
 static void mapgen_smooth_height(int32_t iterations);
-static void mapgen_set_height();
+static void mapgen_set_height(mapgen_settings* settings);
 
 static float fractal_noise(int32_t x, int32_t y, float frequency, int32_t octaves, float lacunarity, float persistence);
 static void mapgen_simplex(mapgen_settings* settings);
@@ -209,7 +209,7 @@ void mapgen_generate(mapgen_settings* settings)
     mapgen_smooth_height(2 + (util_rand() % 6));
 
     // Set the game map to the height map
-    mapgen_set_height();
+    mapgen_set_height(settings);
     delete[] _height;
 
     // Set the tile slopes so that there are no cliffs
@@ -461,7 +461,7 @@ static void mapgen_smooth_height(int32_t iterations)
 /**
  * Sets the height of the actual game map tiles to the height map.
  */
-static void mapgen_set_height()
+static void mapgen_set_height(mapgen_settings* settings)
 {
     int32_t x, y, heightX, heightY, mapSize;
 
@@ -484,6 +484,11 @@ static void mapgen_set_height()
             if (surfaceElement == nullptr)
                 continue;
             surfaceElement->base_height = std::max(2, baseHeight * 2);
+
+            // If base height is below water level, lower it to create more natural shorelines
+            if (surfaceElement->base_height > 4 && surfaceElement->base_height <= settings->water_level)
+                surfaceElement->base_height -= 2;
+
             surfaceElement->clearance_height = surfaceElement->base_height;
 
             uint8_t currentSlope = surfaceElement->GetSlope();


### PR DESCRIPTION
The current shorelines created by the map generator can be a bit strange in appearance because the water "overfills" up to the height of the surrounding land. A more natural appearance is to have the shore slope down towards the water, thus always having bodies of water appear _below_ the height surrounding land. This sloped down shoreline appearance is used in (from what I can tell) all the original scenarios as well as TTD/OpenTTD.

My proposed solution: at the step of map generation where each tile is being filled with water, if a tile is selected to be filled with water, then move its base height down a level and fill the water up 1 less than what it would do previously. Because this adjustment creates a sheer cliff, run the map smoothing algorithm again to create a smoothed out natural looking shoreline.

**Current Shoreline Behavior:**
![image](https://user-images.githubusercontent.com/8496492/169448523-c73c33ed-bec8-4213-aefb-878d855d02c0.png)

**New Shoreline Behavior:**
![image](https://user-images.githubusercontent.com/8496492/169448623-89f01ef8-3199-4cb5-8352-41475d1dd6ec.png)

Any feedback or thoughts on how this might be done better is very welcome!



