### PR TITLE
fix object ghost follows invisible cursor when scroll with right-click

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#17104] Changing map size does not invalidate park size.
 - Fix: [#17197] Segfault when extracting files from the GOG installer.
 - Fix: [#17205] Map generator sometimes crashes when not all standard terrain objects are available.
+- Fix: [#17244] Object ghosts and tooltips follow invisible cursor when moving the viewport by right-click dragging.
 
 0.4.0 (2022-04-25)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,7 +21,7 @@
 - Fix: [#17104] Changing map size does not invalidate park size.
 - Fix: [#17197] Segfault when extracting files from the GOG installer.
 - Fix: [#17205] Map generator sometimes crashes when not all standard terrain objects are available.
-- Fix: [#17244] Object ghosts and tooltips follow invisible cursor when moving the viewport by right-click dragging.
+- Fix: [#17246] Object ghosts and tooltips follow invisible cursor when moving the viewport by right-click dragging.
 
 0.4.0 (2022-04-25)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1175,7 +1175,7 @@ void ProcessMouseTool(const ScreenCoordsXY& screenCoords)
 
         if (w == nullptr)
             tool_cancel();
-        else
+        else if (input_get_state() != InputState::ViewportRight)
             window_event_tool_update_call(w, gCurrentToolWidget.widget_index, screenCoords);
     }
 }
@@ -1447,7 +1447,6 @@ static void InputUpdateTooltip(rct_window* w, rct_widgetindex widgetIndex, const
                 WindowTooltipOpen(w, widgetIndex, screenCoords);
             }
         }
-
         gTooltipTimeout = 0;
         gTooltipCursor = screenCoords;
     }


### PR DESCRIPTION
Object ghost and tool tips following invisible cursor when scrolling with right click (like vanilla RCT2)

fix issue #17221