### PR TITLE
fix object ghost follows invisible cursor when scroll with right-click

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#17104] Changing map size does not invalidate park size.
 - Fix: [#17197] Segfault when extracting files from the GOG installer.
 - Fix: [#17205] Map generator sometimes crashes when not all standard terrain objects are available.
+- Fix: [#17221] Object ghosts and tooltips follow invisible cursor when moving the viewport by right-click dragging.
 
 0.4.0 (2022-04-25)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1175,7 +1175,7 @@ void ProcessMouseTool(const ScreenCoordsXY& screenCoords)
 
         if (w == nullptr)
             tool_cancel();
-        else
+        else if (input_get_state() != InputState::ViewportRight)
             window_event_tool_update_call(w, gCurrentToolWidget.widget_index, screenCoords);
     }
 }

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -71,7 +71,8 @@ void WindowMapTooltipUpdateVisibility()
 
     // Check for cursor movement
     _cursorHoldDuration++;
-    if (abs(cursorChange.x) > 5 || abs(cursorChange.y) > 5 || (input_test_flag(INPUT_FLAG_5)))
+    if (abs(cursorChange.x) > 5 || abs(cursorChange.y) > 5 || (input_test_flag(INPUT_FLAG_5))
+        || input_get_state() == InputState::ViewportRight)
         _cursorHoldDuration = 0;
 
     _lastCursor = cursor;


### PR DESCRIPTION
Fix issue https://github.com/OpenRCT2/OpenRCT2/issues/17221
Object ghost and tool tips following invisible cursor when scrolling with right click (like vanilla RCT2)

Fix List

    Placing attraction or track
    Footpath tool
    Land rights tool
    Guest and staff pickup
    Placing park entrance and guest start point in the scenario editor
    Staff patrol area
    Select area in cut-away view tool
    Tile inspector