### PR TITLE
fix #17187 Text input window does not resize correctly

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -888,7 +888,7 @@ static void WindowEditorObjectiveOptionsMainPaint(rct_window* w, rct_drawpixelin
 
     // Scenario details value
     screenCoords = w->windowPos + ScreenCoordsXY{ 16, w->widgets[WIDX_DETAILS].top + 10 };
-    width = w->widgets[WIDX_DETAILS].left - 4 - 24; //Fixed textbox out of bounds
+    width = w->widgets[WIDX_DETAILS].left - 4 - 24; // Fixed textbox out of bounds
 
     ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -888,7 +888,7 @@ static void WindowEditorObjectiveOptionsMainPaint(rct_window* w, rct_drawpixelin
 
     // Scenario details value
     screenCoords = w->windowPos + ScreenCoordsXY{ 16, w->widgets[WIDX_DETAILS].top + 10 };
-    width = w->widgets[WIDX_DETAILS].left - 4;
+    width = w->widgets[WIDX_DETAILS].left - 4 - 24; //Fixed textbox out of bounds
 
     ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -172,7 +172,7 @@ public:
         {
             Invalidate();
             window_set_resize(this, WW, height, WW, height);
-            height = newHeight; // need to update newHeight
+            height = newHeight;
         }
 
         widgets[WIDX_OKAY].top = newHeight - 22;

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -172,6 +172,7 @@ public:
         {
             Invalidate();
             window_set_resize(this, WW, height, WW, height);
+            height = newHeight; //need to update newHeight
         }
 
         widgets[WIDX_OKAY].top = newHeight - 22;

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -172,7 +172,7 @@ public:
         {
             Invalidate();
             window_set_resize(this, WW, height, WW, height);
-            height = newHeight; //need to update newHeight
+            height = newHeight; // need to update newHeight
         }
 
         widgets[WIDX_OKAY].top = newHeight - 22;


### PR DESCRIPTION
fix #17187

This is the result of fixing the bug
![fix](https://user-images.githubusercontent.com/15816034/169668370-44bab6db-5948-4be9-b17f-17233f683887.gif)





Additionally, fixed an issue where the scenario description horizontal size would encroach on the button. (like vanilla RCT2)

old:
![old](https://user-images.githubusercontent.com/15816034/169668293-8ba9c305-01ea-4565-8a42-a5d352cda6b5.png)

new:
![new](https://user-images.githubusercontent.com/15816034/169668292-37662f46-df62-46ee-a94b-7e062bc79cf2.png)

