### PR TITLE
Fixed > 4 to >= 4 in min height check for shore generation

### DIFF
--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -486,7 +486,7 @@ static void mapgen_set_height(mapgen_settings* settings)
             surfaceElement->base_height = std::max(2, baseHeight * 2);
 
             // If base height is below water level, lower it to create more natural shorelines
-            if (surfaceElement->base_height > 4 && surfaceElement->base_height <= settings->water_level)
+            if (surfaceElement->base_height >= 4 && surfaceElement->base_height <= settings->water_level)
                 surfaceElement->base_height -= 2;
 
             surfaceElement->clearance_height = surfaceElement->base_height;


### PR DESCRIPTION
Fixes a slight bug identified by @Broxzier in [17280](https://github.com/OpenRCT2/OpenRCT2/pull/17242#issuecomment-1136391394)