### PR TITLE
Log exception when an error occurs

### DIFF
--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -2300,7 +2300,7 @@ int32_t scenario_save(u8string_view path, int32_t flags)
     }
     catch (const std::exception& e)
     {
-        log_warning(e.what());
+        log_error(e.what());
     }
 
     gfx_invalidate_screen();

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -2298,8 +2298,9 @@ int32_t scenario_save(u8string_view path, int32_t flags)
         parkFile->Save(path);
         result = true;
     }
-    catch (const std::exception&)
+    catch (const std::exception& e)
     {
+        log_warning(e.what());
     }
 
     gfx_invalidate_screen();


### PR DESCRIPTION
While debugging, I ran into an issue where saving a park didn't work because of some missing object, but there was no indication on what it failed on. With this it's at least getting logged.