### PR TITLE
Fix unable to save landscape in editor

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -127,7 +127,7 @@ static void MoveResearchItem(ResearchItem* beforeItem, int32_t scrollIndex);
 static void ResearchRidesSetup()
 {
     // Reset all objects to not required
-    for (ObjectType objectType = ObjectType::Ride; objectType < ObjectType::Count; objectType++)
+    for (auto objectType : TransientObjectTypes)
     {
         auto maxObjects = object_entry_group_counts[EnumValue(objectType)];
         for (int32_t i = 0; i < maxObjects; i++)

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -72,12 +72,14 @@ namespace Editor
 
         // Unload objects first, the repository is re-populated which owns the objects.
         auto& objectManager = context->GetObjectManager();
-        objectManager.UnloadAllTransient();
+        objectManager.UnloadAll();
 
         // Scan objects if necessary
         const auto& localisationService = context->GetLocalisationService();
         auto& objectRepository = context->GetObjectRepository();
         objectRepository.LoadOrConstruct(localisationService.GetCurrentLanguage());
+
+        Audio::LoadAudioObjects();
 
         // Reset loaded objects to just defaults
         // Load minimum required objects (like surface and edge)

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -113,9 +113,9 @@ void setup_in_use_selection_flags()
 {
     auto& objectMgr = OpenRCT2::GetContext()->GetObjectManager();
 
-    for (uint8_t objectType = 0; objectType < EnumValue(ObjectType::Count); objectType++)
+    for (auto objectType : TransientObjectTypes)
     {
-        for (int32_t i = 0; i < object_entry_group_counts[objectType]; i++)
+        for (int32_t i = 0; i < object_entry_group_counts[EnumValue(objectType)]; i++)
         {
             Editor::ClearSelectedObject(static_cast<ObjectType>(objectType), i, ObjectSelectionFlags::AllFlags);
 
@@ -374,8 +374,11 @@ void unload_unselected_objects()
         if (!(_objectSelectionFlags[i] & ObjectSelectionFlags::Selected))
         {
             auto descriptor = ObjectEntryDescriptor(items[i]);
-            remove_selected_objects_from_research(descriptor);
-            objectsToUnload.push_back(descriptor);
+            if (!IsIntransientObjectType(items[i].Type))
+            {
+                remove_selected_objects_from_research(descriptor);
+                objectsToUnload.push_back(descriptor);
+            }
         }
     }
     object_manager_unload_objects(objectsToUnload);

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -88,7 +88,11 @@ namespace OpenRCT2::Audio
                 }
             }
         }
+        LoadAudioObjects();
+    }
 
+    void LoadAudioObjects()
+    {
         auto& objManager = GetContext()->GetObjectManager();
         auto* baseAudio = objManager.LoadObject(AudioObjectIdentifiers::Rct2Base);
         if (baseAudio != nullptr)

--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -175,6 +175,8 @@ namespace OpenRCT2::Audio
      */
     void Init();
 
+    void LoadAudioObjects();
+
     /**
      * Loads the ride sounds and info.
      * rct2: 0x006BA8E0


### PR DESCRIPTION
Audio objects were being unloaded, while they were still in the loaded object list.