### PR TITLE
Fix: Cut-Away View+Giant Screenshot results in most of the image being transparent area

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -192,6 +192,7 @@ The following people are not part of the development team, but have been contrib
 * Lawrence De Mol (lawrencedemol)
 * Erik Wouters (EWouters)
 * Hoby R. (hobyr)
+* Huu Kim Nguyen (CoderUndefined)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.2 (in development)
 ------------------------------------------------------------------------
+- Change: [#17319] Giant screenshots are now cropped to the horizontal view-clipping selection.
 - Change: [#17499] Update error text when using vehicle incompatible with TD6 and add error when using incompatible track elements.
 
 0.4.1 (2022-07-04)


### PR DESCRIPTION
The previously mentioned bug occurs when the user attempts to take a giant screenshot while using the cut-away view. The actual dimensions of the giant screenshot remained the same, but only the potion is visible that is set with the cut-away view. This results in a very large blank area on the screenshot.

This behavior was changed so that when a giant screenshot is taken with cut-away view enabled, only the small  portion is taken and all surrounding blank area is removed from the giant screenshot. The z-height of the objects are taken into account.

It is achieved by limiting the viewport size of the giant viewport, using the coordinates provided by the cut-away view when it is enabled.

Screenshots can be provided if necessary, as some of them are too tall to fit in this post.