### PR TITLE
Use “car” instead of the ambiguous “vehicle”

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -935,11 +935,10 @@ static void WindowRideDrawTabVehicle(rct_drawpixelinfo* dpi, rct_window* w)
             screenCoords.y /= 4;
         }
 
-        const auto vehicle = ride_entry_get_vehicle_at_position(
-            ride->subtype, ride->num_cars_per_train, rideEntry->tab_vehicle);
-        rct_ride_entry_vehicle* rideVehicleEntry = &rideEntry->vehicles[vehicle];
+        const auto vehicle = ride_entry_get_vehicle_at_position(ride->subtype, ride->num_cars_per_train, rideEntry->TabCar);
+        CarEntry* rideVehicleEntry = &rideEntry->Cars[vehicle];
 
-        auto vehicleId = ((ride->colour_scheme_type & 3) == VEHICLE_COLOUR_SCHEME_PER_VEHICLE) ? rideEntry->tab_vehicle : 0;
+        auto vehicleId = ((ride->colour_scheme_type & 3) == VEHICLE_COLOUR_SCHEME_PER_VEHICLE) ? rideEntry->TabCar : 0;
         VehicleColour vehicleColour = ride_get_vehicle_colour(ride, vehicleId);
 
         // imageIndex represents a precision of 64
@@ -1490,7 +1489,7 @@ static void WindowRideInitViewport(rct_window* w)
     {
         auto vehId = ride->vehicles[viewSelectionIndex];
         rct_ride_entry* ride_entry = ride->GetRideEntry();
-        if (ride_entry != nullptr && ride_entry->tab_vehicle != 0)
+        if (ride_entry != nullptr && ride_entry->TabCar != 0)
         {
             Vehicle* vehicle = GetEntity<Vehicle>(vehId);
             if (vehicle == nullptr)
@@ -2923,8 +2922,8 @@ static void WindowRideVehicleScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
     int32_t startX = std::max(2, (widget->width() - ((ride->num_vehicles - 1) * 36)) / 2 - 25);
     int32_t startY = widget->height() - 4;
 
-    rct_ride_entry_vehicle* rideVehicleEntry = &rideEntry->vehicles[ride_entry_get_vehicle_at_position(
-        ride->subtype, ride->num_cars_per_train, 0)];
+    CarEntry* rideVehicleEntry = &rideEntry
+                                      ->Cars[ride_entry_get_vehicle_at_position(ride->subtype, ride->num_cars_per_train, 0)];
     startY += rideVehicleEntry->tab_height;
 
     // For each train
@@ -2939,8 +2938,7 @@ static void WindowRideVehicleScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
         static_assert(std::numeric_limits<decltype(ride->num_cars_per_train)>::max() <= std::size(trainCarImages));
         for (int32_t j = 0; j < ride->num_cars_per_train; j++)
         {
-            rideVehicleEntry = &rideEntry
-                                    ->vehicles[ride_entry_get_vehicle_at_position(ride->subtype, ride->num_cars_per_train, j)];
+            rideVehicleEntry = &rideEntry->Cars[ride_entry_get_vehicle_at_position(ride->subtype, ride->num_cars_per_train, j)];
             x += rideVehicleEntry->spacing / 17432;
             y -= (rideVehicleEntry->spacing / 2) / 17432;
 
@@ -4609,11 +4607,11 @@ static void WindowRideColourInvalidate(rct_window* w)
         {
             uint8_t vehicleTypeIndex = ride_entry_get_vehicle_at_position(ride->subtype, ride->num_cars_per_train, i);
 
-            if (rideEntry->vehicles[vehicleTypeIndex].flags & VEHICLE_ENTRY_FLAG_ENABLE_TRIM_COLOUR)
+            if (rideEntry->Cars[vehicleTypeIndex].flags & CAR_ENTRY_FLAG_ENABLE_TRIM_COLOUR)
             {
                 allowChangingTrimColour = true;
             }
-            if (rideEntry->vehicles[vehicleTypeIndex].flags & VEHICLE_ENTRY_FLAG_ENABLE_TERNARY_COLOUR)
+            if (rideEntry->Cars[vehicleTypeIndex].flags & CAR_ENTRY_FLAG_ENABLE_TERNARY_COLOUR)
             {
                 allowChangingTernaryColour = true;
             }
@@ -4822,9 +4820,9 @@ static void WindowRideColourScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, i
 
     // ?
     auto trainCarIndex = (ride->colour_scheme_type & 3) == RIDE_COLOUR_SCHEME_DIFFERENT_PER_CAR ? w->vehicleIndex
-                                                                                                : rideEntry->tab_vehicle;
+                                                                                                : rideEntry->TabCar;
 
-    rct_ride_entry_vehicle* rideVehicleEntry = &rideEntry->vehicles[ride_entry_get_vehicle_at_position(
+    CarEntry* rideVehicleEntry = &rideEntry->Cars[ride_entry_get_vehicle_at_position(
         ride->subtype, ride->num_cars_per_train, trainCarIndex)];
 
     screenCoords.y += rideVehicleEntry->tab_height;

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2500,9 +2500,8 @@ void Guest::GoToRideEntrance(Ride* ride)
     rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
     if (rideEntry != nullptr)
     {
-        if (rideEntry->vehicles[rideEntry->default_vehicle].flags & VEHICLE_ENTRY_FLAG_MINI_GOLF
-            || rideEntry->vehicles[rideEntry->default_vehicle].flags
-                & (VEHICLE_ENTRY_FLAG_CHAIRLIFT | VEHICLE_ENTRY_FLAG_GO_KART))
+        if (rideEntry->Cars[rideEntry->DefaultCar].flags & CAR_ENTRY_FLAG_MINI_GOLF
+            || rideEntry->Cars[rideEntry->DefaultCar].flags & (CAR_ENTRY_FLAG_CHAIRLIFT | CAR_ENTRY_FLAG_GO_KART))
         {
             shift_multiplier = 32;
         }
@@ -3552,7 +3551,7 @@ static void peep_update_ride_leave_entrance_spiral_slide(Guest* peep, Ride* ride
     peep->RideSubState = PeepRideSubState::ApproachSpiralSlide;
 }
 
-uint8_t Guest::GetWaypointedSeatLocation(const Ride& ride, rct_ride_entry_vehicle* vehicle_type, uint8_t track_direction) const
+uint8_t Guest::GetWaypointedSeatLocation(const Ride& ride, CarEntry* vehicle_type, uint8_t track_direction) const
 {
     // The seatlocation can be split into segments around the ride base
     // to decide the segment first split off the segmentable seat location
@@ -3596,7 +3595,7 @@ void Guest::UpdateRideLeaveEntranceWaypoints(const Ride& ride)
         return;
     }
     auto ride_entry = vehicle->GetRideEntry();
-    auto vehicle_type = &ride_entry->vehicles[vehicle->vehicle_type];
+    auto vehicle_type = &ride_entry->Cars[vehicle->vehicle_type];
 
     Var37 = (direction_entrance | GetWaypointedSeatLocation(ride, vehicle_type, direction_track) * 4) * 4;
 
@@ -3634,9 +3633,9 @@ void Guest::UpdateRideAdvanceThroughEntrance()
         uint16_t distanceThreshold = 16;
         if (ride_entry != nullptr)
         {
-            uint8_t vehicle = ride_entry->default_vehicle;
-            if (ride_entry->vehicles[vehicle].flags & VEHICLE_ENTRY_FLAG_MINI_GOLF
-                || ride_entry->vehicles[vehicle].flags & (VEHICLE_ENTRY_FLAG_CHAIRLIFT | VEHICLE_ENTRY_FLAG_GO_KART))
+            uint8_t vehicle = ride_entry->DefaultCar;
+            if (ride_entry->Cars[vehicle].flags & CAR_ENTRY_FLAG_MINI_GOLF
+                || ride_entry->Cars[vehicle].flags & (CAR_ENTRY_FLAG_CHAIRLIFT | CAR_ENTRY_FLAG_GO_KART))
             {
                 distanceThreshold = 28;
             }
@@ -3718,15 +3717,15 @@ void Guest::UpdateRideAdvanceThroughEntrance()
         return;
     }
 
-    rct_ride_entry_vehicle* vehicle_type = &ride_entry->vehicles[vehicle->vehicle_type];
+    CarEntry* vehicle_type = &ride_entry->Cars[vehicle->vehicle_type];
 
-    if (vehicle_type->flags & VEHICLE_ENTRY_FLAG_LOADING_WAYPOINTS)
+    if (vehicle_type->flags & CAR_ENTRY_FLAG_LOADING_WAYPOINTS)
     {
         UpdateRideLeaveEntranceWaypoints(*ride);
         return;
     }
 
-    if (vehicle_type->flags & VEHICLE_ENTRY_FLAG_DODGEM_CAR_PLACEMENT)
+    if (vehicle_type->flags & CAR_ENTRY_FLAG_DODGEM_CAR_PLACEMENT)
     {
         SetDestination(vehicle->GetLocation(), 15);
         RideSubState = PeepRideSubState::ApproachVehicle;
@@ -3795,9 +3794,9 @@ static void peep_go_to_ride_exit(Peep* peep, Ride* ride, int16_t x, int16_t y, i
     rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
     if (rideEntry != nullptr)
     {
-        rct_ride_entry_vehicle* vehicle_entry = &rideEntry->vehicles[rideEntry->default_vehicle];
-        if (vehicle_entry->flags & VEHICLE_ENTRY_FLAG_MINI_GOLF
-            || vehicle_entry->flags & (VEHICLE_ENTRY_FLAG_CHAIRLIFT | VEHICLE_ENTRY_FLAG_GO_KART))
+        CarEntry* vehicle_entry = &rideEntry->Cars[rideEntry->DefaultCar];
+        if (vehicle_entry->flags & CAR_ENTRY_FLAG_MINI_GOLF
+            || vehicle_entry->flags & (CAR_ENTRY_FLAG_CHAIRLIFT | CAR_ENTRY_FLAG_GO_KART))
         {
             shift_multiplier = 32;
         }
@@ -3939,7 +3938,7 @@ void Guest::UpdateRideFreeVehicleCheck()
         return;
     }
 
-    if (ride_entry->vehicles[0].flags & VEHICLE_ENTRY_FLAG_MINI_GOLF)
+    if (ride_entry->Cars[0].flags & CAR_ENTRY_FLAG_MINI_GOLF)
     {
         vehicle->mini_golf_flags &= ~MiniGolfFlag::Flag5;
 
@@ -4132,12 +4131,12 @@ void Guest::UpdateRideLeaveVehicle()
         return;
     }
 
-    rct_ride_entry_vehicle* vehicle_entry = &rideEntry->vehicles[vehicle->vehicle_type];
+    CarEntry* vehicle_entry = &rideEntry->Cars[vehicle->vehicle_type];
 
     assert(CurrentRideStation.ToUnderlying() < OpenRCT2::Limits::MaxStationsPerRide);
     auto& station = ride->GetStation(CurrentRideStation);
 
-    if (!(vehicle_entry->flags & VEHICLE_ENTRY_FLAG_LOADING_WAYPOINTS))
+    if (!(vehicle_entry->flags & CAR_ENTRY_FLAG_LOADING_WAYPOINTS))
     {
         TileCoordsXYZD exitLocation = station.Exit;
         CoordsXYZD platformLocation;
@@ -4181,14 +4180,14 @@ void Guest::UpdateRideLeaveVehicle()
 
             if (rideEntry != nullptr)
             {
-                vehicle_entry = &rideEntry->vehicles[rideEntry->default_vehicle];
+                vehicle_entry = &rideEntry->Cars[rideEntry->DefaultCar];
 
-                if (vehicle_entry->flags & VEHICLE_ENTRY_FLAG_GO_KART)
+                if (vehicle_entry->flags & CAR_ENTRY_FLAG_GO_KART)
                 {
                     shiftMultiplier = 9;
                 }
 
-                if (vehicle_entry->flags & (VEHICLE_ENTRY_FLAG_CHAIRLIFT | VEHICLE_ENTRY_FLAG_GO_KART))
+                if (vehicle_entry->flags & (CAR_ENTRY_FLAG_CHAIRLIFT | CAR_ENTRY_FLAG_GO_KART))
                 {
                     specialDirection = ((vehicle->sprite_direction + 3) / 8) + 1;
                     specialDirection &= 3;
@@ -4264,7 +4263,7 @@ void Guest::UpdateRideLeaveVehicle()
     }
 
     rideEntry = vehicle->GetRideEntry();
-    rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle->vehicle_type];
+    CarEntry* vehicleEntry = &rideEntry->Cars[vehicle->vehicle_type];
     if (vehicleEntry == nullptr)
         return;
 
@@ -4314,8 +4313,8 @@ void Guest::UpdateRidePrepareForExit()
     rct_ride_entry* rideEntry = ride->GetRideEntry();
     if (rideEntry != nullptr)
     {
-        rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[rideEntry->default_vehicle];
-        if (vehicleEntry->flags & (VEHICLE_ENTRY_FLAG_CHAIRLIFT | VEHICLE_ENTRY_FLAG_GO_KART))
+        CarEntry* vehicleEntry = &rideEntry->Cars[rideEntry->DefaultCar];
+        if (vehicleEntry->flags & (CAR_ENTRY_FLAG_CHAIRLIFT | CAR_ENTRY_FLAG_GO_KART))
         {
             shiftMultiplier = 32;
         }
@@ -4455,7 +4454,7 @@ void Guest::UpdateRideApproachVehicleWaypoints()
         return;
     }
 
-    rct_ride_entry_vehicle* vehicle_type = &ride_entry->vehicles[vehicle->vehicle_type];
+    CarEntry* vehicle_type = &ride_entry->Cars[vehicle->vehicle_type];
     Guard::Assert(waypoint < 3);
     targetLoc.x += vehicle_type->peep_loading_waypoints[Var37 / 4][waypoint].x;
     targetLoc.y += vehicle_type->peep_loading_waypoints[Var37 / 4][waypoint].y;
@@ -4521,7 +4520,7 @@ void Guest::UpdateRideApproachExitWaypoints()
         }
 
         rct_ride_entry* rideEntry = vehicle->GetRideEntry();
-        rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle->vehicle_type];
+        CarEntry* vehicleEntry = &rideEntry->Cars[vehicle->vehicle_type];
 
         Guard::Assert((Var37 & 3) < 3);
         targetLoc.x += vehicleEntry->peep_loading_waypoints[Var37 / 4][Var37 & 3].x;
@@ -4544,8 +4543,8 @@ void Guest::UpdateRideApproachExitWaypoints()
     auto rideEntry = get_ride_entry(ride->subtype);
     if (rideEntry != nullptr)
     {
-        auto vehicleEntry = &rideEntry->vehicles[rideEntry->default_vehicle];
-        if (vehicleEntry->flags & (VEHICLE_ENTRY_FLAG_CHAIRLIFT | VEHICLE_ENTRY_FLAG_GO_KART))
+        auto vehicleEntry = &rideEntry->Cars[rideEntry->DefaultCar];
+        if (vehicleEntry->flags & (CAR_ENTRY_FLAG_CHAIRLIFT | CAR_ENTRY_FLAG_GO_KART))
         {
             shift_multiplier = 32;
         }

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -202,7 +202,7 @@ struct PeepThought
 
 struct Guest;
 struct Staff;
-struct rct_ride_entry_vehicle;
+struct CarEntry;
 
 struct IntensityRange
 {
@@ -392,7 +392,7 @@ private:
     void UpdateRideAtEntrance();
     void UpdateRideAdvanceThroughEntrance();
     void UpdateRideLeaveEntranceWaypoints(const Ride& ride);
-    uint8_t GetWaypointedSeatLocation(const Ride& ride, rct_ride_entry_vehicle* vehicle_type, uint8_t track_direction) const;
+    uint8_t GetWaypointedSeatLocation(const Ride& ride, CarEntry* vehicle_type, uint8_t track_direction) const;
     void UpdateRideFreeVehicleCheck();
     void UpdateRideFreeVehicleEnterRide(Ride* ride);
     void UpdateRideApproachVehicle();

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -81,20 +81,20 @@ void RideObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
     _legacyType.max_cars_in_train = stream->ReadValue<uint8_t>();
     _legacyType.cars_per_flat_ride = stream->ReadValue<uint8_t>();
     _legacyType.zero_cars = stream->ReadValue<uint8_t>();
-    _legacyType.tab_vehicle = stream->ReadValue<uint8_t>();
-    _legacyType.default_vehicle = stream->ReadValue<uint8_t>();
-    _legacyType.front_vehicle = stream->ReadValue<uint8_t>();
-    _legacyType.second_vehicle = stream->ReadValue<uint8_t>();
-    _legacyType.rear_vehicle = stream->ReadValue<uint8_t>();
-    _legacyType.third_vehicle = stream->ReadValue<uint8_t>();
+    _legacyType.TabCar = stream->ReadValue<uint8_t>();
+    _legacyType.DefaultCar = stream->ReadValue<uint8_t>();
+    _legacyType.FrontCar = stream->ReadValue<uint8_t>();
+    _legacyType.SecondCar = stream->ReadValue<uint8_t>();
+    _legacyType.RearCar = stream->ReadValue<uint8_t>();
+    _legacyType.ThirdCar = stream->ReadValue<uint8_t>();
 
     _legacyType.BuildMenuPriority = 0;
     // Skip pad_019
     stream->Seek(1, STREAM_SEEK_CURRENT);
 
-    for (auto& vehicleEntry : _legacyType.vehicles)
+    for (auto& carEntry : _legacyType.Cars)
     {
-        ReadLegacyVehicle(context, stream, &vehicleEntry);
+        ReadLegacyCar(context, stream, &carEntry);
     }
     stream->Seek(4, STREAM_SEEK_CURRENT);
     _legacyType.excitement_multiplier = stream->ReadValue<int8_t>();
@@ -140,7 +140,7 @@ void RideObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
     }
 
     // Read peep loading positions
-    for (int32_t i = 0; i < RCT2::ObjectLimits::MaxVehiclesPerRideEntry; i++)
+    for (int32_t i = 0; i < RCT2::ObjectLimits::MaxCarTypesPerRideEntry; i++)
     {
         _peepLoadingWaypoints[i].clear();
         _peepLoadingPositions[i].clear();
@@ -151,12 +151,12 @@ void RideObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
             numPeepLoadingPositions = stream->ReadValue<uint16_t>();
         }
 
-        if (_legacyType.vehicles[i].flags & VEHICLE_ENTRY_FLAG_LOADING_WAYPOINTS)
+        if (_legacyType.Cars[i].flags & CAR_ENTRY_FLAG_LOADING_WAYPOINTS)
         {
-            _legacyType.vehicles[i].peep_loading_waypoint_segments = stream->ReadValue<int8_t>() == 0 ? 0 : 4;
+            _legacyType.Cars[i].peep_loading_waypoint_segments = stream->ReadValue<int8_t>() == 0 ? 0 : 4;
             if (_legacyType.ride_type[0] == RIDE_TYPE_ENTERPRISE)
             {
-                _legacyType.vehicles[i].peep_loading_waypoint_segments = 8;
+                _legacyType.Cars[i].peep_loading_waypoint_segments = 8;
             }
 
             Guard::Assert(((numPeepLoadingPositions - 1) % 8) == 0, "Malformed peep loading positions");
@@ -177,7 +177,7 @@ void RideObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
         }
         else
         {
-            _legacyType.vehicles[i].peep_loading_waypoint_segments = 0;
+            _legacyType.Cars[i].peep_loading_waypoint_segments = 0;
 
             auto data = stream->ReadArray<int8_t>(numPeepLoadingPositions);
             _peepLoadingPositions[i] = std::vector<int8_t>(data.get(), data.get() + numPeepLoadingPositions);
@@ -213,64 +213,62 @@ void RideObject::Load()
     _legacyType.images_offset = gfx_object_allocate_images(GetImageTable().GetImages(), GetImageTable().GetCount());
     _legacyType.vehicle_preset_list = &_presetColours;
 
-    int32_t cur_vehicle_images_offset = _legacyType.images_offset + RCT2::ObjectLimits::MaxRideTypesPerRideEntry;
-    for (int32_t i = 0; i < RCT2::ObjectLimits::MaxVehiclesPerRideEntry; i++)
+    int32_t currentCarImagesOffset = _legacyType.images_offset + RCT2::ObjectLimits::MaxRideTypesPerRideEntry;
+    for (int32_t i = 0; i < RCT2::ObjectLimits::MaxCarTypesPerRideEntry; i++)
     {
-        rct_ride_entry_vehicle* vehicleEntry = &_legacyType.vehicles[i];
-        if (vehicleEntry->GroupEnabled(SpriteGroupType::SlopeFlat))
+        CarEntry* carEntry = &_legacyType.Cars[i];
+        if (carEntry->GroupEnabled(SpriteGroupType::SlopeFlat))
         {
-            // RCT2 calculates num_vertical_frames and num_horizontal_frames and overwrites these properties on the vehicle
+            // RCT2 calculates num_vertical_frames and num_horizontal_frames and overwrites these properties on the car
             // entry. Immediately afterwards, the two were multiplied in order to calculate base_num_frames and were never used
             // again. This has been changed to use the calculation results directly - num_vertical_frames and
-            // num_horizontal_frames are no longer set on the vehicle entry.
+            // num_horizontal_frames are no longer set on the car entry.
             // 0x6DE946
-            vehicleEntry->base_num_frames = CalculateNumVerticalFrames(vehicleEntry)
-                * CalculateNumHorizontalFrames(vehicleEntry);
-            uint32_t baseImageId = cur_vehicle_images_offset;
+            carEntry->base_num_frames = CalculateNumVerticalFrames(carEntry) * CalculateNumHorizontalFrames(carEntry);
+            uint32_t baseImageId = currentCarImagesOffset;
             uint32_t imageIndex = baseImageId;
-            vehicleEntry->base_image_id = baseImageId;
+            carEntry->base_image_id = baseImageId;
 
             for (uint8_t spriteGroup = 0; spriteGroup < EnumValue(SpriteGroupType::Count); spriteGroup++)
             {
-                if (vehicleEntry->SpriteGroups[spriteGroup].Enabled())
+                if (carEntry->SpriteGroups[spriteGroup].Enabled())
                 {
-                    vehicleEntry->SpriteGroups[spriteGroup].imageId = imageIndex;
-                    const auto spriteCount = vehicleEntry->base_num_frames
-                        * vehicleEntry->NumRotationSprites(static_cast<SpriteGroupType>(spriteGroup))
+                    carEntry->SpriteGroups[spriteGroup].imageId = imageIndex;
+                    const auto spriteCount = carEntry->base_num_frames
+                        * carEntry->NumRotationSprites(static_cast<SpriteGroupType>(spriteGroup))
                         * SpriteGroupMultiplier[spriteGroup];
                     imageIndex += spriteCount;
                 }
             }
 
-            // No vehicle images
-            vehicleEntry->no_vehicle_images = imageIndex - cur_vehicle_images_offset;
+            carEntry->NumCarImages = imageIndex - currentCarImagesOffset;
 
-            // Move the offset over this vehicles images. Including peeps
-            cur_vehicle_images_offset = imageIndex + vehicleEntry->no_seating_rows * vehicleEntry->no_vehicle_images;
+            // Move the offset over this car’s images. Including peeps
+            currentCarImagesOffset = imageIndex + carEntry->no_seating_rows * carEntry->NumCarImages;
             // 0x6DEB0D
 
-            if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS))
+            if (!(carEntry->flags & CAR_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS))
             {
-                int32_t num_images = cur_vehicle_images_offset - baseImageId;
-                if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET)
+                int32_t num_images = currentCarImagesOffset - baseImageId;
+                if (carEntry->flags & CAR_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET)
                 {
                     num_images *= 2;
                 }
 
                 if (!gOpenRCT2NoGraphics)
                 {
-                    set_vehicle_type_image_max_sizes(vehicleEntry, num_images);
+                    set_vehicle_type_image_max_sizes(carEntry, num_images);
                 }
             }
 
             if (!_peepLoadingPositions[i].empty())
             {
-                vehicleEntry->peep_loading_positions = std::move(_peepLoadingPositions[i]);
+                carEntry->peep_loading_positions = std::move(_peepLoadingPositions[i]);
             }
 
             if (!_peepLoadingWaypoints[i].empty())
             {
-                vehicleEntry->peep_loading_waypoints = std::move(_peepLoadingWaypoints[i]);
+                carEntry->peep_loading_waypoints = std::move(_peepLoadingWaypoints[i]);
             }
         }
     }
@@ -343,56 +341,55 @@ void RideObject::SetRepositoryItem(ObjectRepositoryItem* item) const
     item->RideInfo.RideFlags = 0;
 }
 
-void RideObject::ReadLegacyVehicle(
-    [[maybe_unused]] IReadObjectContext* context, IStream* stream, rct_ride_entry_vehicle* vehicle)
+void RideObject::ReadLegacyCar([[maybe_unused]] IReadObjectContext* context, IStream* stream, CarEntry* car)
 {
-    vehicle->TabRotationMask = stream->ReadValue<uint16_t>();
+    car->TabRotationMask = stream->ReadValue<uint16_t>();
     stream->Seek(2 * 1, STREAM_SEEK_CURRENT);
-    vehicle->spacing = stream->ReadValue<uint32_t>();
-    vehicle->car_mass = stream->ReadValue<uint16_t>();
-    vehicle->tab_height = stream->ReadValue<int8_t>();
-    vehicle->num_seats = stream->ReadValue<uint8_t>();
+    car->spacing = stream->ReadValue<uint32_t>();
+    car->car_mass = stream->ReadValue<uint16_t>();
+    car->tab_height = stream->ReadValue<int8_t>();
+    car->num_seats = stream->ReadValue<uint8_t>();
     uint16_t spriteGroups = stream->ReadValue<uint16_t>();
-    vehicle->sprite_width = stream->ReadValue<uint8_t>();
-    vehicle->sprite_height_negative = stream->ReadValue<uint8_t>();
-    vehicle->sprite_height_positive = stream->ReadValue<uint8_t>();
-    vehicle->animation = stream->ReadValue<uint8_t>();
-    vehicle->flags = stream->ReadValue<uint32_t>();
-    vehicle->base_num_frames = stream->ReadValue<uint16_t>();
+    car->sprite_width = stream->ReadValue<uint8_t>();
+    car->sprite_height_negative = stream->ReadValue<uint8_t>();
+    car->sprite_height_positive = stream->ReadValue<uint8_t>();
+    car->animation = stream->ReadValue<uint8_t>();
+    car->flags = stream->ReadValue<uint32_t>();
+    car->base_num_frames = stream->ReadValue<uint16_t>();
     stream->Seek(15 * 4, STREAM_SEEK_CURRENT);
-    vehicle->no_seating_rows = stream->ReadValue<uint8_t>();
-    vehicle->spinning_inertia = stream->ReadValue<uint8_t>();
-    vehicle->spinning_friction = stream->ReadValue<uint8_t>();
-    vehicle->friction_sound_id = stream->ReadValue<OpenRCT2::Audio::SoundId>();
-    vehicle->log_flume_reverser_vehicle_type = stream->ReadValue<uint8_t>();
-    vehicle->sound_range = stream->ReadValue<uint8_t>();
-    vehicle->double_sound_frequency = stream->ReadValue<uint8_t>();
-    vehicle->powered_acceleration = stream->ReadValue<uint8_t>();
-    vehicle->powered_max_speed = stream->ReadValue<uint8_t>();
-    vehicle->PaintStyle = stream->ReadValue<uint8_t>();
-    vehicle->effect_visual = stream->ReadValue<uint8_t>();
-    vehicle->draw_order = stream->ReadValue<uint8_t>();
-    vehicle->num_vertical_frames_override = stream->ReadValue<uint8_t>();
+    car->no_seating_rows = stream->ReadValue<uint8_t>();
+    car->spinning_inertia = stream->ReadValue<uint8_t>();
+    car->spinning_friction = stream->ReadValue<uint8_t>();
+    car->friction_sound_id = stream->ReadValue<OpenRCT2::Audio::SoundId>();
+    car->ReversedCarIndex = stream->ReadValue<uint8_t>();
+    car->sound_range = stream->ReadValue<uint8_t>();
+    car->double_sound_frequency = stream->ReadValue<uint8_t>();
+    car->powered_acceleration = stream->ReadValue<uint8_t>();
+    car->powered_max_speed = stream->ReadValue<uint8_t>();
+    car->PaintStyle = stream->ReadValue<uint8_t>();
+    car->effect_visual = stream->ReadValue<uint8_t>();
+    car->draw_order = stream->ReadValue<uint8_t>();
+    car->num_vertical_frames_override = stream->ReadValue<uint8_t>();
     stream->Seek(4, STREAM_SEEK_CURRENT);
-    ReadLegacySpriteGroups(vehicle, spriteGroups);
+    ReadLegacySpriteGroups(car, spriteGroups);
 }
 
-uint8_t RideObject::CalculateNumVerticalFrames(const rct_ride_entry_vehicle* vehicleEntry)
+uint8_t RideObject::CalculateNumVerticalFrames(const CarEntry* vehicleEntry)
 {
     // 0x6DE90B
     uint8_t numVerticalFrames;
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES)
     {
         numVerticalFrames = vehicleEntry->num_vertical_frames_override;
     }
     else
     {
-        if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES))
+        if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES))
         {
-            if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_VEHICLE_ANIMATION
+            if (vehicleEntry->flags & CAR_ENTRY_FLAG_VEHICLE_ANIMATION
                 && vehicleEntry->animation != VEHICLE_ENTRY_ANIMATION_OBSERVATION_TOWER)
             {
-                if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS))
+                if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_DODGEM_INUSE_LIGHTS))
                 {
                     numVerticalFrames = 4;
                 }
@@ -415,15 +412,14 @@ uint8_t RideObject::CalculateNumVerticalFrames(const rct_ride_entry_vehicle* veh
     return numVerticalFrames;
 }
 
-uint8_t RideObject::CalculateNumHorizontalFrames(const rct_ride_entry_vehicle* vehicleEntry)
+uint8_t RideObject::CalculateNumHorizontalFrames(const CarEntry* vehicleEntry)
 {
     uint8_t numHorizontalFrames;
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SWINGING)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_SWINGING)
     {
-        if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SUSPENDED_SWING)
-            && !(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SLIDE_SWING))
+        if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_SUSPENDED_SWING) && !(vehicleEntry->flags & CAR_ENTRY_FLAG_SLIDE_SWING))
         {
-            if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING)
+            if (vehicleEntry->flags & CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING)
             {
                 numHorizontalFrames = 3;
             }
@@ -432,9 +428,7 @@ uint8_t RideObject::CalculateNumHorizontalFrames(const rct_ride_entry_vehicle* v
                 numHorizontalFrames = 5;
             }
         }
-        else if (
-            !(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SUSPENDED_SWING)
-            || !(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SLIDE_SWING))
+        else if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_SUSPENDED_SWING) || !(vehicleEntry->flags & CAR_ENTRY_FLAG_SLIDE_SWING))
         {
             numHorizontalFrames = 7;
         }
@@ -494,13 +488,13 @@ void RideObject::ReadJson(IReadObjectContext* context, json_t& root)
         if (IsRideTypeShopOrFacility(_legacyType.ride_type[0]))
         {
             // Standard car info for a shop
-            auto& car = _legacyType.vehicles[0];
+            auto& car = _legacyType.Cars[0];
             car.spacing = 544;
             car.SpriteGroups[EnumValue(SpriteGroupType::SlopeFlat)].spritePrecision = SpritePrecision::Sprites4;
             car.sprite_width = 1;
             car.sprite_height_negative = 1;
             car.sprite_height_positive = 1;
-            car.flags = VEHICLE_ENTRY_FLAG_SPINNING;
+            car.flags = CAR_ENTRY_FLAG_SPINNING;
             car.PaintStyle = VEHICLE_VISUAL_FLAT_RIDE_OR_CAR_RIDE;
             car.friction_sound_id = OpenRCT2::Audio::SoundId::Null;
             car.sound_range = 0xFF;
@@ -588,8 +582,8 @@ void RideObject::ReadJsonVehicleInfo([[maybe_unused]] IReadObjectContext* contex
     _legacyType.zero_cars = Json::GetNumber<uint8_t>(properties["numEmptyCars"]);
 
     // Train formation from car indices
-    _legacyType.default_vehicle = Json::GetNumber<uint8_t>(properties["defaultCar"]);
-    _legacyType.tab_vehicle = Json::GetNumber<uint8_t>(properties["tabCar"]);
+    _legacyType.DefaultCar = Json::GetNumber<uint8_t>(properties["defaultCar"]);
+    _legacyType.TabCar = Json::GetNumber<uint8_t>(properties["tabCar"]);
 
     float tabScale = Json::GetNumber<float>(properties["tabScale"]);
     if (tabScale != 0 && tabScale <= 0.5f)
@@ -601,22 +595,22 @@ void RideObject::ReadJsonVehicleInfo([[maybe_unused]] IReadObjectContext* contex
     json_t tailCars = Json::AsArray(properties["tailCars"]);
 
     // 0xFF means N/A.
-    _legacyType.front_vehicle = Json::GetNumber<uint8_t>(headCars[0], 0xFF);
-    _legacyType.second_vehicle = Json::GetNumber<uint8_t>(headCars[1], 0xFF);
-    _legacyType.third_vehicle = Json::GetNumber<uint8_t>(headCars[2], 0xFF);
-    _legacyType.rear_vehicle = Json::GetNumber<uint8_t>(tailCars[0], 0xFF);
+    _legacyType.FrontCar = Json::GetNumber<uint8_t>(headCars[0], 0xFF);
+    _legacyType.SecondCar = Json::GetNumber<uint8_t>(headCars[1], 0xFF);
+    _legacyType.ThirdCar = Json::GetNumber<uint8_t>(headCars[2], 0xFF);
+    _legacyType.RearCar = Json::GetNumber<uint8_t>(tailCars[0], 0xFF);
 
     auto cars = ReadJsonCars(context, properties["cars"]);
-    auto numCars = std::min(std::size(_legacyType.vehicles), cars.size());
+    auto numCars = std::min(std::size(_legacyType.Cars), cars.size());
     for (size_t i = 0; i < numCars; i++)
     {
-        _legacyType.vehicles[i] = cars[i];
+        _legacyType.Cars[i] = cars[i];
     }
 }
 
-std::vector<rct_ride_entry_vehicle> RideObject::ReadJsonCars([[maybe_unused]] IReadObjectContext* context, json_t& jCars)
+std::vector<CarEntry> RideObject::ReadJsonCars([[maybe_unused]] IReadObjectContext* context, json_t& jCars)
 {
-    std::vector<rct_ride_entry_vehicle> cars;
+    std::vector<CarEntry> cars;
 
     if (jCars.is_array())
     {
@@ -636,11 +630,11 @@ std::vector<rct_ride_entry_vehicle> RideObject::ReadJsonCars([[maybe_unused]] IR
     return cars;
 }
 
-rct_ride_entry_vehicle RideObject::ReadJsonCar([[maybe_unused]] IReadObjectContext* context, json_t& jCar)
+CarEntry RideObject::ReadJsonCar([[maybe_unused]] IReadObjectContext* context, json_t& jCar)
 {
     Guard::Assert(jCar.is_object(), "RideObject::ReadJsonCar expects parameter jCar to be object");
 
-    rct_ride_entry_vehicle car = {};
+    CarEntry car = {};
     car.TabRotationMask = Json::GetNumber<uint16_t>(jCar["rotationFrameMask"]);
     car.spacing = Json::GetNumber<uint32_t>(jCar["spacing"]);
     car.car_mass = Json::GetNumber<uint16_t>(jCar["mass"]);
@@ -656,12 +650,12 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar([[maybe_unused]] IReadObjectConte
     car.sprite_height_positive = Json::GetNumber<uint8_t>(jCar["spriteHeightPositive"]);
     car.animation = Json::GetNumber<uint8_t>(jCar["animation"]);
     car.base_num_frames = Json::GetNumber<uint16_t>(jCar["baseNumFrames"]);
-    car.no_vehicle_images = Json::GetNumber<uint32_t>(jCar["numImages"]);
+    car.NumCarImages = Json::GetNumber<uint32_t>(jCar["numImages"]);
     car.no_seating_rows = Json::GetNumber<uint8_t>(jCar["numSeatRows"]);
     car.spinning_inertia = Json::GetNumber<uint8_t>(jCar["spinningInertia"]);
     car.spinning_friction = Json::GetNumber<uint8_t>(jCar["spinningFriction"]);
     car.friction_sound_id = Json::GetEnum<OpenRCT2::Audio::SoundId>(jCar["frictionSoundId"], OpenRCT2::Audio::SoundId::Null);
-    car.log_flume_reverser_vehicle_type = Json::GetNumber<uint8_t>(jCar["logFlumeReverserVehicleType"]);
+    car.ReversedCarIndex = Json::GetNumber<uint8_t>(jCar["logFlumeReverserVehicleType"]);
     car.sound_range = Json::GetNumber<uint8_t>(jCar["soundRange"], 255);
     car.double_sound_frequency = Json::GetNumber<uint8_t>(jCar["doubleSoundFrequency"]);
     car.powered_acceleration = Json::GetNumber<uint8_t>(jCar["poweredAcceleration"]);
@@ -684,7 +678,7 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar([[maybe_unused]] IReadObjectConte
         auto jLoadingWaypoints = jCar["loadingWaypoints"];
         if (jLoadingWaypoints.is_array())
         {
-            car.flags |= VEHICLE_ENTRY_FLAG_LOADING_WAYPOINTS;
+            car.flags |= CAR_ENTRY_FLAG_LOADING_WAYPOINTS;
             car.peep_loading_waypoint_segments = Json::GetNumber<uint8_t>(jCar["numSegments"]);
 
             for (auto& jRoute : jLoadingWaypoints)
@@ -713,68 +707,68 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar([[maybe_unused]] IReadObjectConte
     car.flags |= Json::GetFlags<uint32_t>(
         jCar,
         {
-            { "isPoweredRideWithUnrestrictedGravity", VEHICLE_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY },
-            { "hasNoUpstopWheels", VEHICLE_ENTRY_FLAG_NO_UPSTOP_WHEELS },
-            { "hasNoUpstopWheelsBobsleigh", VEHICLE_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH },
-            { "isMiniGolf", VEHICLE_ENTRY_FLAG_MINI_GOLF },
-            { "isReverserBogie", VEHICLE_ENTRY_FLAG_REVERSER_BOGIE },
-            { "isReverserPassengerCar", VEHICLE_ENTRY_FLAG_REVERSER_PASSENGER_CAR },
-            { "hasInvertedSpriteSet", VEHICLE_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET },
-            { "hasDodgemInUseLights", VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS },
-            { "hasAdditionalColour2", VEHICLE_ENTRY_FLAG_ENABLE_TERNARY_COLOUR },
-            { "recalculateSpriteBounds", VEHICLE_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS },
-            { "overrideNumberOfVerticalFrames", VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES },
-            { "spriteBoundsIncludeInvertedSet", VEHICLE_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET },
-            { "hasAdditionalSpinningFrames", VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES },
-            { "isLift", VEHICLE_ENTRY_FLAG_LIFT },
-            { "hasAdditionalColour1", VEHICLE_ENTRY_FLAG_ENABLE_TRIM_COLOUR },
-            { "hasSwinging", VEHICLE_ENTRY_FLAG_SWINGING },
-            { "hasSpinning", VEHICLE_ENTRY_FLAG_SPINNING },
-            { "isPowered", VEHICLE_ENTRY_FLAG_POWERED },
-            { "hasScreamingRiders", VEHICLE_ENTRY_FLAG_RIDERS_SCREAM },
-            { "useSuspendedSwing", VEHICLE_ENTRY_FLAG_SUSPENDED_SWING },
-            { "useBoatHireCollisionDetection", VEHICLE_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION },
-            { "hasVehicleAnimation", VEHICLE_ENTRY_FLAG_VEHICLE_ANIMATION },
-            { "hasRiderAnimation", VEHICLE_ENTRY_FLAG_RIDER_ANIMATION },
-            { "useWoodenWildMouseSwing", VEHICLE_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING },
-            { "useSlideSwing", VEHICLE_ENTRY_FLAG_SLIDE_SWING },
-            { "isChairlift", VEHICLE_ENTRY_FLAG_CHAIRLIFT },
-            { "isWaterRide", VEHICLE_ENTRY_FLAG_WATER_RIDE },
-            { "isGoKart", VEHICLE_ENTRY_FLAG_GO_KART },
-            { "useDodgemCarPlacement", VEHICLE_ENTRY_FLAG_DODGEM_CAR_PLACEMENT },
+            { "isPoweredRideWithUnrestrictedGravity", CAR_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY },
+            { "hasNoUpstopWheels", CAR_ENTRY_FLAG_NO_UPSTOP_WHEELS },
+            { "hasNoUpstopWheelsBobsleigh", CAR_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH },
+            { "isMiniGolf", CAR_ENTRY_FLAG_MINI_GOLF },
+            { "isReverserBogie", CAR_ENTRY_FLAG_REVERSER_BOGIE },
+            { "isReverserPassengerCar", CAR_ENTRY_FLAG_REVERSER_PASSENGER_CAR },
+            { "hasInvertedSpriteSet", CAR_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET },
+            { "hasDodgemInUseLights", CAR_ENTRY_FLAG_DODGEM_INUSE_LIGHTS },
+            { "hasAdditionalColour2", CAR_ENTRY_FLAG_ENABLE_TERNARY_COLOUR },
+            { "recalculateSpriteBounds", CAR_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS },
+            { "overrideNumberOfVerticalFrames", CAR_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES },
+            { "spriteBoundsIncludeInvertedSet", CAR_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET },
+            { "hasAdditionalSpinningFrames", CAR_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES },
+            { "isLift", CAR_ENTRY_FLAG_LIFT },
+            { "hasAdditionalColour1", CAR_ENTRY_FLAG_ENABLE_TRIM_COLOUR },
+            { "hasSwinging", CAR_ENTRY_FLAG_SWINGING },
+            { "hasSpinning", CAR_ENTRY_FLAG_SPINNING },
+            { "isPowered", CAR_ENTRY_FLAG_POWERED },
+            { "hasScreamingRiders", CAR_ENTRY_FLAG_RIDERS_SCREAM },
+            { "useSuspendedSwing", CAR_ENTRY_FLAG_SUSPENDED_SWING },
+            { "useBoatHireCollisionDetection", CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION },
+            { "hasVehicleAnimation", CAR_ENTRY_FLAG_VEHICLE_ANIMATION },
+            { "hasRiderAnimation", CAR_ENTRY_FLAG_RIDER_ANIMATION },
+            { "useWoodenWildMouseSwing", CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING },
+            { "useSlideSwing", CAR_ENTRY_FLAG_SLIDE_SWING },
+            { "isChairlift", CAR_ENTRY_FLAG_CHAIRLIFT },
+            { "isWaterRide", CAR_ENTRY_FLAG_WATER_RIDE },
+            { "isGoKart", CAR_ENTRY_FLAG_GO_KART },
+            { "useDodgemCarPlacement", CAR_ENTRY_FLAG_DODGEM_CAR_PLACEMENT },
 
             // Obsolete flags that have been replaced with named and camelCased values, but kept for now for backward
             // compatibility.
-            { "VEHICLE_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY", VEHICLE_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY },
-            { "VEHICLE_ENTRY_FLAG_NO_UPSTOP_WHEELS", VEHICLE_ENTRY_FLAG_NO_UPSTOP_WHEELS },
-            { "VEHICLE_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH", VEHICLE_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH },
-            { "VEHICLE_ENTRY_FLAG_MINI_GOLF", VEHICLE_ENTRY_FLAG_MINI_GOLF },
-            { "VEHICLE_ENTRY_FLAG_4", VEHICLE_ENTRY_FLAG_REVERSER_BOGIE },
-            { "VEHICLE_ENTRY_FLAG_5", VEHICLE_ENTRY_FLAG_REVERSER_PASSENGER_CAR },
-            { "VEHICLE_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET", VEHICLE_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET },
-            { "VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS", VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS },
-            { "VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_2", VEHICLE_ENTRY_FLAG_ENABLE_TERNARY_COLOUR },
-            { "VEHICLE_ENTRY_FLAG_10", VEHICLE_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS },
-            { "VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES", VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES },
-            { "VEHICLE_ENTRY_FLAG_13", VEHICLE_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET },
-            { "VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES", VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES },
-            { "VEHICLE_ENTRY_FLAG_LIFT", VEHICLE_ENTRY_FLAG_LIFT },
-            { "VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_1", VEHICLE_ENTRY_FLAG_ENABLE_TRIM_COLOUR },
-            { "VEHICLE_ENTRY_FLAG_SWINGING", VEHICLE_ENTRY_FLAG_SWINGING },
-            { "VEHICLE_ENTRY_FLAG_SPINNING", VEHICLE_ENTRY_FLAG_SPINNING },
-            { "VEHICLE_ENTRY_FLAG_POWERED", VEHICLE_ENTRY_FLAG_POWERED },
-            { "VEHICLE_ENTRY_FLAG_RIDERS_SCREAM", VEHICLE_ENTRY_FLAG_RIDERS_SCREAM },
-            { "VEHICLE_ENTRY_FLAG_21", VEHICLE_ENTRY_FLAG_SUSPENDED_SWING },
-            { "VEHICLE_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION", VEHICLE_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION },
-            { "VEHICLE_ENTRY_FLAG_VEHICLE_ANIMATION", VEHICLE_ENTRY_FLAG_VEHICLE_ANIMATION },
-            { "VEHICLE_ENTRY_FLAG_RIDER_ANIMATION", VEHICLE_ENTRY_FLAG_RIDER_ANIMATION },
-            { "VEHICLE_ENTRY_FLAG_25", VEHICLE_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING },
-            { "VEHICLE_ENTRY_FLAG_SLIDE_SWING", VEHICLE_ENTRY_FLAG_SLIDE_SWING },
-            { "VEHICLE_ENTRY_FLAG_CHAIRLIFT", VEHICLE_ENTRY_FLAG_CHAIRLIFT },
-            { "VEHICLE_ENTRY_FLAG_WATER_RIDE", VEHICLE_ENTRY_FLAG_WATER_RIDE },
-            { "VEHICLE_ENTRY_FLAG_GO_KART", VEHICLE_ENTRY_FLAG_GO_KART },
-            { "VEHICLE_ENTRY_FLAG_DODGEM_CAR_PLACEMENT", VEHICLE_ENTRY_FLAG_DODGEM_CAR_PLACEMENT },
-            { "VEHICLE_ENTRY_FLAG_11", VEHICLE_ENTRY_FLAG_USE_16_ROTATION_FRAMES },
+            { "VEHICLE_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY", CAR_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY },
+            { "VEHICLE_ENTRY_FLAG_NO_UPSTOP_WHEELS", CAR_ENTRY_FLAG_NO_UPSTOP_WHEELS },
+            { "VEHICLE_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH", CAR_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH },
+            { "VEHICLE_ENTRY_FLAG_MINI_GOLF", CAR_ENTRY_FLAG_MINI_GOLF },
+            { "VEHICLE_ENTRY_FLAG_4", CAR_ENTRY_FLAG_REVERSER_BOGIE },
+            { "VEHICLE_ENTRY_FLAG_5", CAR_ENTRY_FLAG_REVERSER_PASSENGER_CAR },
+            { "VEHICLE_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET", CAR_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET },
+            { "VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS", CAR_ENTRY_FLAG_DODGEM_INUSE_LIGHTS },
+            { "VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_2", CAR_ENTRY_FLAG_ENABLE_TERNARY_COLOUR },
+            { "VEHICLE_ENTRY_FLAG_10", CAR_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS },
+            { "VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES", CAR_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES },
+            { "VEHICLE_ENTRY_FLAG_13", CAR_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET },
+            { "VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES", CAR_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES },
+            { "VEHICLE_ENTRY_FLAG_LIFT", CAR_ENTRY_FLAG_LIFT },
+            { "VEHICLE_ENTRY_FLAG_ENABLE_ADDITIONAL_COLOUR_1", CAR_ENTRY_FLAG_ENABLE_TRIM_COLOUR },
+            { "VEHICLE_ENTRY_FLAG_SWINGING", CAR_ENTRY_FLAG_SWINGING },
+            { "VEHICLE_ENTRY_FLAG_SPINNING", CAR_ENTRY_FLAG_SPINNING },
+            { "VEHICLE_ENTRY_FLAG_POWERED", CAR_ENTRY_FLAG_POWERED },
+            { "VEHICLE_ENTRY_FLAG_RIDERS_SCREAM", CAR_ENTRY_FLAG_RIDERS_SCREAM },
+            { "VEHICLE_ENTRY_FLAG_21", CAR_ENTRY_FLAG_SUSPENDED_SWING },
+            { "VEHICLE_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION", CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION },
+            { "VEHICLE_ENTRY_FLAG_VEHICLE_ANIMATION", CAR_ENTRY_FLAG_VEHICLE_ANIMATION },
+            { "VEHICLE_ENTRY_FLAG_RIDER_ANIMATION", CAR_ENTRY_FLAG_RIDER_ANIMATION },
+            { "VEHICLE_ENTRY_FLAG_25", CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING },
+            { "VEHICLE_ENTRY_FLAG_SLIDE_SWING", CAR_ENTRY_FLAG_SLIDE_SWING },
+            { "VEHICLE_ENTRY_FLAG_CHAIRLIFT", CAR_ENTRY_FLAG_CHAIRLIFT },
+            { "VEHICLE_ENTRY_FLAG_WATER_RIDE", CAR_ENTRY_FLAG_WATER_RIDE },
+            { "VEHICLE_ENTRY_FLAG_GO_KART", CAR_ENTRY_FLAG_GO_KART },
+            { "VEHICLE_ENTRY_FLAG_DODGEM_CAR_PLACEMENT", CAR_ENTRY_FLAG_DODGEM_CAR_PLACEMENT },
+            { "VEHICLE_ENTRY_FLAG_11", CAR_ENTRY_FLAG_USE_16_ROTATION_FRAMES },
         });
 
     // legacy sprite groups
@@ -784,23 +778,22 @@ rct_ride_entry_vehicle RideObject::ReadJsonCar([[maybe_unused]] IReadObjectConte
         uint16_t spriteFlags = Json::GetFlags<uint32_t>(
             jFrames,
             {
-                { "flat", VEHICLE_SPRITE_FLAG_FLAT },
-                { "gentleSlopes", VEHICLE_SPRITE_FLAG_GENTLE_SLOPES },
-                { "steepSlopes", VEHICLE_SPRITE_FLAG_STEEP_SLOPES },
-                { "verticalSlopes", VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES },
-                { "diagonalSlopes", VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES },
-                { "flatBanked", VEHICLE_SPRITE_FLAG_FLAT_BANKED },
-                { "inlineTwists", VEHICLE_SPRITE_FLAG_INLINE_TWISTS },
-                { "flatToGentleSlopeBankedTransitions", VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS },
-                { "diagonalGentleSlopeBankedTransitions", VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS },
-                { "gentleSlopeBankedTransitions", VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS },
-                { "gentleSlopeBankedTurns", VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS },
-                { "flatToGentleSlopeWhileBankedTransitions",
-                  VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS },
-                { "corkscrews", VEHICLE_SPRITE_FLAG_CORKSCREWS },
-                { "restraintAnimation", VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION },
-                { "curvedLiftHill", VEHICLE_SPRITE_FLAG_CURVED_LIFT_HILL },
-                { "VEHICLE_SPRITE_FLAG_15", VEHICLE_SPRITE_FLAG_USE_4_ROTATION_FRAMES },
+                { "flat", CAR_SPRITE_FLAG_FLAT },
+                { "gentleSlopes", CAR_SPRITE_FLAG_GENTLE_SLOPES },
+                { "steepSlopes", CAR_SPRITE_FLAG_STEEP_SLOPES },
+                { "verticalSlopes", CAR_SPRITE_FLAG_VERTICAL_SLOPES },
+                { "diagonalSlopes", CAR_SPRITE_FLAG_DIAGONAL_SLOPES },
+                { "flatBanked", CAR_SPRITE_FLAG_FLAT_BANKED },
+                { "inlineTwists", CAR_SPRITE_FLAG_INLINE_TWISTS },
+                { "flatToGentleSlopeBankedTransitions", CAR_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS },
+                { "diagonalGentleSlopeBankedTransitions", CAR_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS },
+                { "gentleSlopeBankedTransitions", CAR_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS },
+                { "gentleSlopeBankedTurns", CAR_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS },
+                { "flatToGentleSlopeWhileBankedTransitions", CAR_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS },
+                { "corkscrews", CAR_SPRITE_FLAG_CORKSCREWS },
+                { "restraintAnimation", CAR_SPRITE_FLAG_RESTRAINT_ANIMATION },
+                { "curvedLiftHill", CAR_SPRITE_FLAG_CURVED_LIFT_HILL },
+                { "VEHICLE_SPRITE_FLAG_15", CAR_SPRITE_FLAG_USE_4_ROTATION_FRAMES },
             });
         ReadLegacySpriteGroups(&car, spriteFlags);
         return car;
@@ -1073,83 +1066,83 @@ ShopItem RideObject::ParseShopItem(const std::string& s)
 }
 
 // Converts legacy sprite groups into OpenRCT2 sprite groups
-void RideObject::ReadLegacySpriteGroups(rct_ride_entry_vehicle* vehicle, uint16_t spriteGroups)
+void RideObject::ReadLegacySpriteGroups(CarEntry* vehicle, uint16_t spriteGroups)
 {
     auto baseSpritePrecision = SpritePrecision::Sprites32;
-    if (vehicle->flags & VEHICLE_ENTRY_FLAG_USE_16_ROTATION_FRAMES)
+    if (vehicle->flags & CAR_ENTRY_FLAG_USE_16_ROTATION_FRAMES)
         baseSpritePrecision = SpritePrecision::Sprites16;
-    if (vehicle->flags & VEHICLE_SPRITE_FLAG_USE_4_ROTATION_FRAMES)
+    if (vehicle->flags & CAR_SPRITE_FLAG_USE_4_ROTATION_FRAMES)
         baseSpritePrecision = SpritePrecision::Sprites4;
 
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_FLAT)
+    if (spriteGroups & CAR_SPRITE_FLAG_FLAT)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::SlopeFlat)].spritePrecision = baseSpritePrecision;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_GENTLE_SLOPES)
+    if (spriteGroups & CAR_SPRITE_FLAG_GENTLE_SLOPES)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes12)].spritePrecision = SpritePrecision::Sprites4;
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes25)].spritePrecision = baseSpritePrecision;
-        if (vehicle->flags & VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES)
+        if (vehicle->flags & CAR_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES)
             vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes25)].spritePrecision = SpritePrecision::Sprites4;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_STEEP_SLOPES)
+    if (spriteGroups & CAR_SPRITE_FLAG_STEEP_SLOPES)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes42)].spritePrecision = SpritePrecision::Sprites8;
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes60)].spritePrecision = baseSpritePrecision;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES)
+    if (spriteGroups & CAR_SPRITE_FLAG_VERTICAL_SLOPES)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes75)].spritePrecision = SpritePrecision::Sprites4;
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes90)].spritePrecision = baseSpritePrecision;
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::SlopesLoop)].spritePrecision = SpritePrecision::Sprites4;
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::SlopeInverted)].spritePrecision = SpritePrecision::Sprites4;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES)
+    if (spriteGroups & CAR_SPRITE_FLAG_DIAGONAL_SLOPES)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes8)].spritePrecision = SpritePrecision::Sprites4;
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes16)].spritePrecision = SpritePrecision::Sprites4;
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes50)].spritePrecision = SpritePrecision::Sprites4;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_FLAT_BANKED)
+    if (spriteGroups & CAR_SPRITE_FLAG_FLAT_BANKED)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::FlatBanked22)].spritePrecision = SpritePrecision::Sprites8;
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::FlatBanked45)].spritePrecision = baseSpritePrecision;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_INLINE_TWISTS)
+    if (spriteGroups & CAR_SPRITE_FLAG_INLINE_TWISTS)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::FlatBanked67)].spritePrecision = SpritePrecision::Sprites4;
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::FlatBanked90)].spritePrecision = SpritePrecision::Sprites4;
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::InlineTwists)].spritePrecision = SpritePrecision::Sprites4;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS)
+    if (spriteGroups & CAR_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes12Banked22)].spritePrecision = baseSpritePrecision;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS)
+    if (spriteGroups & CAR_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes8Banked22)].spritePrecision = SpritePrecision::Sprites4;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS)
+    if (spriteGroups & CAR_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes25Banked22)].spritePrecision = SpritePrecision::Sprites4;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS)
+    if (spriteGroups & CAR_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes25Banked45)].spritePrecision = baseSpritePrecision;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS)
+    if (spriteGroups & CAR_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Slopes12Banked45)].spritePrecision = SpritePrecision::Sprites4;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_CORKSCREWS)
+    if (spriteGroups & CAR_SPRITE_FLAG_CORKSCREWS)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::Corkscrews)].spritePrecision = SpritePrecision::Sprites4;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION)
+    if (spriteGroups & CAR_SPRITE_FLAG_RESTRAINT_ANIMATION)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::RestraintAnimation)].spritePrecision = SpritePrecision::Sprites4;
     }
-    if (spriteGroups & VEHICLE_SPRITE_FLAG_CURVED_LIFT_HILL)
+    if (spriteGroups & CAR_SPRITE_FLAG_CURVED_LIFT_HILL)
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::CurvedLiftHill)].spritePrecision = baseSpritePrecision;
     }

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -22,8 +22,8 @@ class RideObject final : public Object
 private:
     rct_ride_entry _legacyType = {};
     vehicle_colour_preset_list _presetColours = {};
-    std::vector<int8_t> _peepLoadingPositions[RCT2::ObjectLimits::MaxVehiclesPerRideEntry];
-    std::vector<std::array<CoordsXY, 3>> _peepLoadingWaypoints[RCT2::ObjectLimits::MaxVehiclesPerRideEntry];
+    std::vector<int8_t> _peepLoadingPositions[RCT2::ObjectLimits::MaxCarTypesPerRideEntry];
+    std::vector<std::array<CoordsXY, 3>> _peepLoadingWaypoints[RCT2::ObjectLimits::MaxCarTypesPerRideEntry];
 
 public:
     void* GetLegacyData() override
@@ -47,21 +47,21 @@ public:
     static uint8_t ParseRideType(const std::string& s);
 
 private:
-    void ReadLegacyVehicle(IReadObjectContext* context, OpenRCT2::IStream* stream, rct_ride_entry_vehicle* vehicle);
+    void ReadLegacyCar(IReadObjectContext* context, OpenRCT2::IStream* stream, CarEntry* car);
 
     void ReadJsonVehicleInfo(IReadObjectContext* context, json_t& properties);
-    std::vector<rct_ride_entry_vehicle> ReadJsonCars([[maybe_unused]] IReadObjectContext* context, json_t& jCars);
-    rct_ride_entry_vehicle ReadJsonCar([[maybe_unused]] IReadObjectContext* context, json_t& jCar);
+    std::vector<CarEntry> ReadJsonCars([[maybe_unused]] IReadObjectContext* context, json_t& jCars);
+    CarEntry ReadJsonCar([[maybe_unused]] IReadObjectContext* context, json_t& jCar);
     vehicle_colour_preset_list ReadJsonCarColours(json_t& jCarColours);
     std::vector<VehicleColour> ReadJsonColourConfiguration(json_t& jColourConfig);
 
-    static uint8_t CalculateNumVerticalFrames(const rct_ride_entry_vehicle* vehicleEntry);
-    static uint8_t CalculateNumHorizontalFrames(const rct_ride_entry_vehicle* vehicleEntry);
+    static uint8_t CalculateNumVerticalFrames(const CarEntry* vehicleEntry);
+    static uint8_t CalculateNumHorizontalFrames(const CarEntry* vehicleEntry);
 
     static bool IsRideTypeShopOrFacility(uint8_t rideType);
     static uint8_t ParseRideCategory(const std::string& s);
     static ShopItem ParseShopItem(const std::string& s);
     static colour_t ParseColour(const std::string& s);
 
-    void ReadLegacySpriteGroups(rct_ride_entry_vehicle* vehicle, uint16_t spriteGroups);
+    void ReadLegacySpriteGroups(CarEntry* vehicle, uint16_t spriteGroups);
 };

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -306,7 +306,7 @@ namespace RCT1
         int32_t velocity;           // 0x28
         int32_t acceleration;       // 0x2C
         uint8_t ride;               // 0x30
-        uint8_t vehicle_type;       // 0x31
+        uint8_t CarType;            // 0x31
         rct_vehicle_colour colours; // 0x32
         union
         {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2707,7 +2707,7 @@ namespace RCT1
             return;
 
         const auto& rct1Ride = _s4.rides[src->ride];
-        uint8_t vehicleEntryIndex = RCT1::GetVehicleSubEntryIndex(rct1Ride.vehicle_type, src->vehicle_type);
+        uint8_t vehicleEntryIndex = RCT1::GetVehicleSubEntryIndex(rct1Ride.vehicle_type, src->CarType);
 
         dst->ride = RideId::FromUnderlying(src->ride);
         dst->ride_subtype = RCTEntryIndexToOpenRCT2EntryIndex(ride->subtype);

--- a/src/openrct2/rct2/DATLimits.h
+++ b/src/openrct2/rct2/DATLimits.h
@@ -14,8 +14,8 @@ namespace RCT2::ObjectLimits
 {
     constexpr const uint8_t MaxCategoriesPerRide = 2;
     constexpr const uint8_t MaxRideTypesPerRideEntry = 3;
-    // The max number of different types of vehicle.
-    // Examples of vehicles here are the locomotive, tender and carriage of the Miniature Railway.
-    constexpr const uint8_t MaxVehiclesPerRideEntry = 4;
+    // The max number of different types of car.
+    // Examples of cars here are the locomotive, tender and carriage of the Miniature Railway.
+    constexpr const uint8_t MaxCarTypesPerRideEntry = 4;
     constexpr const uint8_t MaxShopItemsPerRideEntry = 2;
 } // namespace RCT2::ObjectLimits

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3109,7 +3109,7 @@ static Vehicle* vehicle_create_car(
     if (rideEntry == nullptr)
         return nullptr;
 
-    auto vehicleEntry = &rideEntry->vehicles[vehicleEntryIndex];
+    auto vehicleEntry = &rideEntry->Cars[vehicleEntryIndex];
     auto vehicle = CreateEntity<Vehicle>();
     if (vehicle == nullptr)
         return nullptr;
@@ -3123,7 +3123,7 @@ static Vehicle* vehicle_create_car(
     auto edx = vehicleEntry->spacing >> 1;
     *remainingDistance -= edx;
     vehicle->remaining_distance = *remainingDistance;
-    if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_GO_KART))
+    if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_GO_KART))
     {
         *remainingDistance -= edx;
     }
@@ -3161,7 +3161,7 @@ static Vehicle* vehicle_create_car(
         vehicle->peep[i] = EntityId::GetNull();
     }
 
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_DODGEM_CAR_PLACEMENT)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_DODGEM_CAR_PLACEMENT)
     {
         // loc_6DDCA4:
         vehicle->TrackSubposition = VehicleTrackSubposition::Default;
@@ -3198,12 +3198,12 @@ static Vehicle* vehicle_create_car(
     else
     {
         VehicleTrackSubposition subposition = VehicleTrackSubposition::Default;
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_CHAIRLIFT)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_CHAIRLIFT)
         {
             subposition = VehicleTrackSubposition::ChairliftGoingOut;
         }
 
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_GO_KART)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_GO_KART)
         {
             // Choose which lane Go Kart should start in
             subposition = VehicleTrackSubposition::GoKartsLeftLane;
@@ -3212,21 +3212,21 @@ static Vehicle* vehicle_create_car(
                 subposition = VehicleTrackSubposition::GoKartsRightLane;
             }
         }
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_MINI_GOLF)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_MINI_GOLF)
         {
             subposition = VehicleTrackSubposition::MiniGolfStart9;
             vehicle->var_D3 = 0;
             vehicle->mini_golf_current_animation = MiniGolfAnimation::Walk;
             vehicle->mini_golf_flags = 0;
         }
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_REVERSER_BOGIE)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_REVERSER_BOGIE)
         {
             if (vehicle->IsHead())
             {
                 subposition = VehicleTrackSubposition::ReverserRCFrontBogie;
             }
         }
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_REVERSER_PASSENGER_CAR)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_REVERSER_PASSENGER_CAR)
         {
             subposition = VehicleTrackSubposition::ReverserRCRearBogie;
         }
@@ -3271,12 +3271,12 @@ static Vehicle* vehicle_create_car(
         vehicle->SetTrackType(trackElement->GetTrackType());
         vehicle->SetTrackDirection(vehicle->sprite_direction >> 3);
         vehicle->track_progress = 31;
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_MINI_GOLF)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_MINI_GOLF)
         {
             vehicle->track_progress = 15;
         }
         vehicle->update_flags = VEHICLE_UPDATE_FLAG_COLLISION_DISABLED;
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET)
         {
             if (trackElement->IsInverted())
             {
@@ -3530,7 +3530,7 @@ bool Ride::CreateVehicles(const CoordsXYE& element, bool isApplying)
 
                 auto vehicleEntry = vehicle->Entry();
 
-                if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_DODGEM_CAR_PLACEMENT))
+                if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_DODGEM_CAR_PLACEMENT))
                 {
                     vehicle->UpdateTrackMotion(nullptr);
                 }
@@ -4611,7 +4611,7 @@ bool ride_has_any_track_elements(const Ride* ride)
  *
  *  rct2: 0x006847BA
  */
-void set_vehicle_type_image_max_sizes(rct_ride_entry_vehicle* vehicle_type, int32_t num_images)
+void set_vehicle_type_image_max_sizes(CarEntry* vehicle_type, int32_t num_images)
 {
     uint8_t bitmap[200][200] = { 0 };
 
@@ -4696,7 +4696,7 @@ void set_vehicle_type_image_max_sizes(rct_ride_entry_vehicle* vehicle_type, int3
 
     // Moved from object paint
 
-    if (vehicle_type->flags & VEHICLE_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET)
+    if (vehicle_type->flags & CAR_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET)
     {
         bl += 16;
     }
@@ -4810,24 +4810,24 @@ void ride_update_vehicle_colours(Ride* ride)
 uint8_t ride_entry_get_vehicle_at_position(int32_t rideEntryIndex, int32_t numCarsPerTrain, int32_t position)
 {
     rct_ride_entry* rideEntry = get_ride_entry(rideEntryIndex);
-    if (position == 0 && rideEntry->front_vehicle != 255)
+    if (position == 0 && rideEntry->FrontCar != 255)
     {
-        return rideEntry->front_vehicle;
+        return rideEntry->FrontCar;
     }
-    if (position == 1 && rideEntry->second_vehicle != 255)
+    if (position == 1 && rideEntry->SecondCar != 255)
     {
-        return rideEntry->second_vehicle;
+        return rideEntry->SecondCar;
     }
-    if (position == 2 && rideEntry->third_vehicle != 255)
+    if (position == 2 && rideEntry->ThirdCar != 255)
     {
-        return rideEntry->third_vehicle;
+        return rideEntry->ThirdCar;
     }
-    if (position == numCarsPerTrain - 1 && rideEntry->rear_vehicle != 255)
+    if (position == numCarsPerTrain - 1 && rideEntry->RearCar != 255)
     {
-        return rideEntry->rear_vehicle;
+        return rideEntry->RearCar;
     }
 
-    return rideEntry->default_vehicle;
+    return rideEntry->DefaultCar;
 }
 
 using namespace OpenRCT2::Entity::Yaw;
@@ -4956,7 +4956,7 @@ uint64_t ride_entry_get_supported_track_pieces(const rct_ride_entry* rideEntry)
     // Only check default vehicle; it's assumed the others will have correct sprites if this one does (I've yet to find an
     // exception, at least)
     auto supportedPieces = std::numeric_limits<uint64_t>::max();
-    auto defaultVehicle = rideEntry->GetDefaultVehicle();
+    auto defaultVehicle = rideEntry->GetDefaultCar();
     if (defaultVehicle != nullptr)
     {
         for (size_t i = 0; i < std::size(trackPieceRequiredSprites); i++)
@@ -5079,7 +5079,7 @@ void Ride::UpdateMaxVehicles()
     {
         return;
     }
-    rct_ride_entry_vehicle* vehicleEntry;
+    CarEntry* vehicleEntry;
     uint8_t numCarsPerTrain, numVehicles;
     int32_t maxNumTrains;
 
@@ -5104,7 +5104,7 @@ void Ride::UpdateMaxVehicles()
             int32_t totalMass = 0;
             for (int32_t i = 0; i < numCars; i++)
             {
-                vehicleEntry = &rideEntry->vehicles[ride_entry_get_vehicle_at_position(subtype, numCars, i)];
+                vehicleEntry = &rideEntry->Cars[ride_entry_get_vehicle_at_position(subtype, numCars, i)];
                 trainLength += vehicleEntry->spacing;
                 totalMass += vehicleEntry->car_mass;
             }
@@ -5142,7 +5142,7 @@ void Ride::UpdateMaxVehicles()
                 trainLength = 0;
                 for (int32_t i = 0; i < newCarsPerTrain; i++)
                 {
-                    vehicleEntry = &rideEntry->vehicles[ride_entry_get_vehicle_at_position(subtype, newCarsPerTrain, i)];
+                    vehicleEntry = &rideEntry->Cars[ride_entry_get_vehicle_at_position(subtype, newCarsPerTrain, i)];
                     trainLength += vehicleEntry->spacing;
                 }
 
@@ -5164,13 +5164,13 @@ void Ride::UpdateMaxVehicles()
                 }
                 else
                 {
-                    vehicleEntry = &rideEntry->vehicles[ride_entry_get_vehicle_at_position(subtype, newCarsPerTrain, 0)];
+                    vehicleEntry = &rideEntry->Cars[ride_entry_get_vehicle_at_position(subtype, newCarsPerTrain, 0)];
                     int32_t poweredMaxSpeed = vehicleEntry->powered_max_speed;
 
                     int32_t totalSpacing = 0;
                     for (int32_t i = 0; i < newCarsPerTrain; i++)
                     {
-                        vehicleEntry = &rideEntry->vehicles[ride_entry_get_vehicle_at_position(subtype, newCarsPerTrain, i)];
+                        vehicleEntry = &rideEntry->Cars[ride_entry_get_vehicle_at_position(subtype, newCarsPerTrain, i)];
                         totalSpacing += vehicleEntry->spacing;
                     }
 

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -123,7 +123,7 @@ using namespace OpenRCT2::Entity::Yaw;
 
 // clang-format off
 
-const rct_ride_entry_vehicle CableLiftVehicle = {
+const CarEntry CableLiftVehicle = {
     /* .TabRotationMask = */ 31,
     /* .spacing = */ 0,
     /* .car_mass = */ 0,

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -345,7 +345,7 @@ constexpr const uint64_t AllRideModesAvailable = EnumsToFlags(
     RideMode::Circus, RideMode::DownwardLaunch, RideMode::CrookedHouse, RideMode::FreefallDrop, RideMode::PoweredLaunch,
     RideMode::PoweredLaunchBlockSectioned);
 
-extern const rct_ride_entry_vehicle CableLiftVehicle;
+extern const CarEntry CableLiftVehicle;
 
 extern const uint16_t RideFilmLength[3];
 

--- a/src/openrct2/ride/RideEntry.h
+++ b/src/openrct2/ride/RideEntry.h
@@ -54,15 +54,15 @@ struct rct_ride_entry
     // Number of cars that can't hold passengers
     uint8_t zero_cars;
     // The index to the vehicle type displayed in the vehicle tab.
-    uint8_t tab_vehicle;
-    uint8_t default_vehicle;
-    // Convert from first - fourth vehicle to vehicle structure
-    uint8_t front_vehicle;
-    uint8_t second_vehicle;
-    uint8_t rear_vehicle;
-    uint8_t third_vehicle;
+    uint8_t TabCar;
+    uint8_t DefaultCar;
+    // Convert from first - fourth car to vehicle structure
+    uint8_t FrontCar;
+    uint8_t SecondCar;
+    uint8_t RearCar;
+    uint8_t ThirdCar;
     uint8_t BuildMenuPriority;
-    rct_ride_entry_vehicle vehicles[RCT2::ObjectLimits::MaxVehiclesPerRideEntry];
+    CarEntry Cars[RCT2::ObjectLimits::MaxCarTypesPerRideEntry];
     vehicle_colour_preset_list* vehicle_preset_list;
     int8_t excitement_multiplier;
     int8_t intensity_multiplier;
@@ -72,20 +72,20 @@ struct rct_ride_entry
     rct_string_id capacity;
     void* obj;
 
-    const rct_ride_entry_vehicle* GetVehicle(size_t id) const
+    const CarEntry* GetCar(size_t id) const
     {
-        if (id < std::size(vehicles))
+        if (id < std::size(Cars))
         {
-            return &vehicles[id];
+            return &Cars[id];
         }
         return nullptr;
     }
 
-    const rct_ride_entry_vehicle* GetDefaultVehicle() const
+    const CarEntry* GetDefaultCar() const
     {
-        return GetVehicle(default_vehicle);
+        return GetCar(DefaultCar);
     }
 };
 
-void set_vehicle_type_image_max_sizes(rct_ride_entry_vehicle* vehicle_type, int32_t num_images);
+void set_vehicle_type_image_max_sizes(CarEntry* vehicle_type, int32_t num_images);
 RideNaming get_ride_naming(const uint8_t rideType, rct_ride_entry* rideEntry);

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -282,7 +282,7 @@ static void ride_race_init_vehicle_speeds(Ride* ride)
 
         rct_ride_entry* rideEntry = vehicle->GetRideEntry();
 
-        vehicle->speed = (scenario_rand() & 15) - 8 + rideEntry->vehicles[vehicle->vehicle_type].powered_max_speed;
+        vehicle->speed = (scenario_rand() & 15) - 8 + rideEntry->Cars[vehicle->vehicle_type].powered_max_speed;
 
         if (vehicle->num_peeps != 0)
         {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -877,7 +877,7 @@ OpenRCT2::Audio::VehicleSoundParams Vehicle::CreateSoundParam(uint16_t priority)
     rct_ride_entry* rideType = GetRideEntry();
     if (rideType != nullptr)
     {
-        if (rideType->vehicles[vehicle_type].double_sound_frequency & 1)
+        if (rideType->Cars[vehicle_type].double_sound_frequency & 1)
         {
             frequency *= 2;
         }
@@ -1323,15 +1323,15 @@ bool Vehicle::OpenRestraints()
             continue;
         }
 
-        rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle->vehicle_type];
+        CarEntry* vehicleEntry = &rideEntry->Cars[vehicle->vehicle_type];
 
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SPINNING)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_SPINNING)
         {
             // If the vehicle is a spinner it must be spinning slow
             // For vehicles without additional frames there are 4 rotations it can unload from
             // For vehicles with additional frames it must be facing forward
             if (abs(vehicle->spin_speed) <= VEHICLE_MAX_SPIN_SPEED_FOR_STOPPING && !(vehicle->spin_sprite & 0x30)
-                && (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES) || !(vehicle->spin_sprite & 0xF8)))
+                && (!(vehicleEntry->flags & CAR_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES) || !(vehicle->spin_sprite & 0xF8)))
             {
                 vehicle->spin_speed = 0;
             }
@@ -1873,10 +1873,10 @@ void Vehicle::Update()
     if (curRide->lifecycle_flags & (RIDE_LIFECYCLE_BREAKDOWN_PENDING | RIDE_LIFECYCLE_BROKEN_DOWN))
     {
         _vehicleBreakdown = curRide->breakdown_reason_pending;
-        auto vehicleEntry = &rideEntry->vehicles[vehicle_type];
-        if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_POWERED) && curRide->breakdown_reason_pending == BREAKDOWN_SAFETY_CUT_OUT)
+        auto vehicleEntry = &rideEntry->Cars[vehicle_type];
+        if ((vehicleEntry->flags & CAR_ENTRY_FLAG_POWERED) && curRide->breakdown_reason_pending == BREAKDOWN_SAFETY_CUT_OUT)
         {
-            if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_WATER_RIDE) || (Pitch == 2 && velocity <= 0x20000))
+            if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_WATER_RIDE) || (Pitch == 2 && velocity <= 0x20000))
             {
                 SetUpdateFlag(VEHICLE_UPDATE_FLAG_ZERO_VELOCITY);
             }
@@ -2020,9 +2020,9 @@ void Vehicle::UpdateMovingToEndOfStation()
                 return;
             }
 
-            rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle_type];
+            CarEntry* vehicleEntry = &rideEntry->Cars[vehicle_type];
 
-            if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_POWERED))
+            if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_POWERED))
             {
                 if (velocity <= 131940)
                 {
@@ -2331,10 +2331,10 @@ void Vehicle::UpdateDodgemsMode()
     {
         return;
     }
-    rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle_type];
+    CarEntry* vehicleEntry = &rideEntry->Cars[vehicle_type];
 
     // Mark the dodgem as in use.
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS && animation_frame != 1)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_DODGEM_INUSE_LIGHTS && animation_frame != 1)
     {
         animation_frame = 1;
         Invalidate();
@@ -3110,8 +3110,8 @@ void Vehicle::UpdateDeparting()
 
         if (rideEntry->flags & RIDE_ENTRY_FLAG_PLAY_DEPART_SOUND)
         {
-            auto soundId = (rideEntry->vehicles[0].sound_range == 4) ? OpenRCT2::Audio::SoundId::Tram
-                                                                     : OpenRCT2::Audio::SoundId::TrainDeparting;
+            auto soundId = (rideEntry->Cars[0].sound_range == 4) ? OpenRCT2::Audio::SoundId::Tram
+                                                                 : OpenRCT2::Audio::SoundId::TrainDeparting;
 
             OpenRCT2::Audio::Play3D(soundId, GetLocation());
         }
@@ -3142,7 +3142,7 @@ void Vehicle::UpdateDeparting()
         }
     }
 
-    rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle_type];
+    CarEntry* vehicleEntry = &rideEntry->Cars[vehicle_type];
 
     switch (curRide->mode)
     {
@@ -3180,7 +3180,7 @@ void Vehicle::UpdateDeparting()
         case RideMode::RotatingLift:
         case RideMode::FreefallDrop:
         case RideMode::BoatHire:
-            if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_POWERED)
+            if (vehicleEntry->flags & CAR_ENTRY_FLAG_POWERED)
                 break;
 
             if (velocity <= 131940)
@@ -3770,8 +3770,7 @@ void Vehicle::UpdateTravelling()
         sub_state = 1;
 }
 
-void Vehicle::UpdateArrivingPassThroughStation(
-    const Ride& curRide, const rct_ride_entry_vehicle& vehicleEntry, bool stationBrakesWork)
+void Vehicle::UpdateArrivingPassThroughStation(const Ride& curRide, const CarEntry& vehicleEntry, bool stationBrakesWork)
 {
     if (sub_state == 0)
     {
@@ -3809,7 +3808,7 @@ void Vehicle::UpdateArrivingPassThroughStation(
     }
     else
     {
-        if (!(vehicleEntry.flags & VEHICLE_ENTRY_FLAG_POWERED) && velocity >= -131940)
+        if (!(vehicleEntry.flags & CAR_ENTRY_FLAG_POWERED) && velocity >= -131940)
         {
             acceleration = -3298;
         }
@@ -3907,7 +3906,7 @@ void Vehicle::UpdateArriving()
     }
 
     rct_ride_entry* rideEntry = GetRideEntry();
-    rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle_type];
+    CarEntry* vehicleEntry = &rideEntry->Cars[vehicle_type];
 
     UpdateArrivingPassThroughStation(*curRide, *vehicleEntry, stationBrakesWork);
 
@@ -3934,7 +3933,7 @@ void Vehicle::UpdateArriving()
     }
 
     var_C0++;
-    if ((curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_1) && (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_GO_KART) && (var_C0 < 40))
+    if ((curFlags & VEHICLE_UPDATE_MOTION_TRACK_FLAG_1) && (vehicleEntry->flags & CAR_ENTRY_FLAG_GO_KART) && (var_C0 < 40))
     {
         return;
     }
@@ -4254,7 +4253,7 @@ void Vehicle::UpdateMotionBoatHire()
     {
         return;
     }
-    if (vehicleEntry->flags & (VEHICLE_ENTRY_FLAG_VEHICLE_ANIMATION | VEHICLE_ENTRY_FLAG_RIDER_ANIMATION))
+    if (vehicleEntry->flags & (CAR_ENTRY_FLAG_VEHICLE_ANIMATION | CAR_ENTRY_FLAG_RIDER_ANIMATION))
     {
         UpdateAdditionalAnimation();
     }
@@ -4502,7 +4501,7 @@ void Vehicle::UpdateMotionBoatHire()
 
         int32_t eax = ((velocity >> 1) + edx) / curMass;
         int32_t ecx = -eax;
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_POWERED)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_POWERED)
         {
             eax = speed << 14;
             int32_t ebx = (speed * curMass) >> 2;
@@ -5446,7 +5445,7 @@ void Vehicle::UpdateSound()
     if (rideEntry == nullptr)
         return;
 
-    rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle_type];
+    CarEntry* vehicleEntry = &rideEntry->Cars[vehicle_type];
 
     int32_t ecx = abs(velocity) - 0x10000;
     if (ecx >= 0)
@@ -5503,7 +5502,7 @@ void Vehicle::UpdateSound()
             break;
 
         default:
-            if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_RIDERS_SCREAM))
+            if ((vehicleEntry->flags & CAR_ENTRY_FLAG_RIDERS_SCREAM))
             {
                 screamSound.id = UpdateScreamSound();
                 if (screamSound.id == OpenRCT2::Audio::SoundId::NoScream)
@@ -5589,7 +5588,7 @@ OpenRCT2::Audio::SoundId Vehicle::ProduceScreamSound(const int32_t totalNumPeeps
 {
     rct_ride_entry* rideEntry = GetRideEntry();
 
-    rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle_type];
+    CarEntry* vehicleEntry = &rideEntry->Cars[vehicle_type];
 
     if (scream_sound_id == OpenRCT2::Audio::SoundId::Null)
     {
@@ -5873,9 +5872,9 @@ int32_t Vehicle::UpdateMotionDodgems()
         eax /= mass;
     }
     rct_ride_entry* rideEntry = GetRideEntry();
-    rct_ride_entry_vehicle* vehicleEntry = &rideEntry->vehicles[vehicle_type];
+    CarEntry* vehicleEntry = &rideEntry->Cars[vehicle_type];
 
-    if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_POWERED))
+    if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_POWERED))
     {
         acceleration = -eax;
         return _vehicleMotionTrackFlags;
@@ -5969,7 +5968,7 @@ void Vehicle::UpdateTrackMotionUpStopCheck() const
     }
 
     // No up stops (coaster types)
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_NO_UPSTOP_WHEELS)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_NO_UPSTOP_WHEELS)
     {
         auto trackType = GetTrackType();
         if (!track_element_is_covered(trackType))
@@ -5997,7 +5996,7 @@ void Vehicle::UpdateTrackMotionUpStopCheck() const
             }
         }
     }
-    else if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH)
+    else if (vehicleEntry->flags & CAR_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH)
     {
         // No up stops bobsleigh type
         auto trackType = GetTrackType();
@@ -6090,7 +6089,7 @@ void Vehicle::CheckAndApplyBlockSectionStopSite()
         return;
 
     // Is chair lift type
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_CHAIRLIFT)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_CHAIRLIFT)
     {
         velocity = _vehicleBreakdown == 0 ? 0 : curRide->speed << 16;
         acceleration = 0;
@@ -6402,17 +6401,17 @@ void Vehicle::UpdateSwingingCar()
         return;
     }
     int16_t dx = 3185;
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SUSPENDED_SWING)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_SUSPENDED_SWING)
     {
         dx = 5006;
     }
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING)
     {
         dx = 1820;
     }
     int16_t cx = -dx;
 
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SLIDE_SWING)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_SLIDE_SWING)
     {
         dx = 5370;
         cx = -5370;
@@ -7066,7 +7065,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
         return false;
     }
 
-    if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
+    if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
     {
         CollisionDetectionTimer = 0;
 
@@ -7128,7 +7127,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
             if (collideVehicleEntry == nullptr)
                 continue;
 
-            if (!(collideVehicleEntry->flags & VEHICLE_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
+            if (!(collideVehicleEntry->flags & CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
                 continue;
 
             uint32_t x_diff = abs(vehicle2->x - loc.x);
@@ -7153,7 +7152,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
             if (x_diff + y_diff >= ecx)
                 continue;
 
-            if (!(collideVehicleEntry->flags & VEHICLE_ENTRY_FLAG_GO_KART))
+            if (!(collideVehicleEntry->flags & CAR_ENTRY_FLAG_GO_KART))
             {
                 collideVehicle = vehicle2;
                 mayCollide = true;
@@ -7273,7 +7272,7 @@ void Vehicle::ReverseReverserCar()
  */
 void Vehicle::Sub6DBF3E()
 {
-    rct_ride_entry_vehicle* vehicleEntry = Entry();
+    CarEntry* vehicleEntry = Entry();
 
     acceleration /= _vehicleUnkF64E10;
     if (TrackSubposition == VehicleTrackSubposition::ChairliftGoingBack)
@@ -7342,11 +7341,11 @@ void Vehicle::Sub6DBF3E()
     else
     {
         uint16_t cx = 17;
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_CHAIRLIFT)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_CHAIRLIFT)
         {
             cx = 6;
         }
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_GO_KART)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_GO_KART)
         {
             // Determine the stop positions for the karts. If in left lane it's further along the track than the right lane.
             // Since it's not possible to overtake when the race has ended, this does not check for overtake states (7 and
@@ -7389,7 +7388,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(uint16_t trackType, Ride* cur
             tileElement->AsTrack()->SetBlockBrakeClosed(true);
             if (trackType == TrackElemType::BlockBrakes || trackType == TrackElemType::EndStation)
             {
-                if (!(rideEntry->vehicles[0].flags & VEHICLE_ENTRY_FLAG_POWERED))
+                if (!(rideEntry->Cars[0].flags & CAR_ENTRY_FLAG_POWERED))
                 {
                     OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::BlockBrakeRelease, TrackLocation);
                 }
@@ -7480,13 +7479,12 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(uint16_t trackType, Ride* cur
     TrackLocation = location;
 
     // TODO check if getting the vehicle entry again is necessary
-    rct_ride_entry_vehicle* vehicleEntry = Entry();
+    CarEntry* vehicleEntry = Entry();
     if (vehicleEntry == nullptr)
     {
         return false;
     }
-    if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_GO_KART)
-        && TrackSubposition < VehicleTrackSubposition::GoKartsMovingToRightLane)
+    if ((vehicleEntry->flags & CAR_ENTRY_FLAG_GO_KART) && TrackSubposition < VehicleTrackSubposition::GoKartsMovingToRightLane)
     {
         trackType = tileElement->AsTrack()->GetTrackType();
         if (trackType == TrackElemType::Flat
@@ -7546,7 +7544,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(uint16_t trackType, Ride* cur
  *
  *  rct2: 0x006DAEB9
  */
-bool Vehicle::UpdateTrackMotionForwards(rct_ride_entry_vehicle* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry)
+bool Vehicle::UpdateTrackMotionForwards(CarEntry* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry)
 {
     EntityId otherVehicleIndex = EntityId::GetNull();
 loc_6DAEB9:
@@ -7631,7 +7629,7 @@ loc_6DAEB9:
         {
             if (track_progress == 32)
             {
-                vehicle_type = vehicleEntry->log_flume_reverser_vehicle_type;
+                vehicle_type = vehicleEntry->ReversedCarIndex;
                 vehicleEntry = Entry();
             }
         }
@@ -7710,7 +7708,7 @@ loc_6DAEB9:
 
         moveInfovehicleSpriteType = moveInfo->Pitch;
 
-        if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING) && moveInfo->Pitch != 0)
+        if ((vehicleEntry->flags & CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING) && moveInfo->Pitch != 0)
         {
             SwingSprite = 0;
             SwingPosition = 0;
@@ -7743,14 +7741,14 @@ loc_6DAEB9:
                     {
                         if (velocityDelta > 0xE0000)
                         {
-                            if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
+                            if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
                             {
                                 _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_COLLISION;
                             }
                         }
                     }
 
-                    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_GO_KART)
+                    if (vehicleEntry->flags & CAR_ENTRY_FLAG_GO_KART)
                     {
                         velocity -= velocity >> 2;
                     }
@@ -7944,7 +7942,7 @@ bool Vehicle::UpdateTrackMotionBackwardsGetNewTrack(uint16_t trackType, Ride* cu
  *
  *  rct2: 0x006DBA33
  */
-bool Vehicle::UpdateTrackMotionBackwards(rct_ride_entry_vehicle* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry)
+bool Vehicle::UpdateTrackMotionBackwards(CarEntry* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry)
 {
     EntityId otherVehicleIndex = EntityId::GetNull();
 
@@ -8022,7 +8020,7 @@ bool Vehicle::UpdateTrackMotionBackwards(rct_ride_entry_vehicle* vehicleEntry, R
             Pitch = moveInfo->Pitch;
             moveInfoVehicleSpriteType = moveInfo->Pitch;
 
-            if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING) && Pitch != 0)
+            if ((vehicleEntry->flags & CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING) && Pitch != 0)
             {
                 SwingSprite = 0;
                 SwingPosition = 0;
@@ -8050,14 +8048,14 @@ bool Vehicle::UpdateTrackMotionBackwards(rct_ride_entry_vehicle* vehicleEntry, R
                         {
                             if (abs(v4->velocity - v3->velocity) > 0xE0000)
                             {
-                                if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
+                                if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
                                 {
                                     _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_COLLISION;
                                 }
                             }
                         }
 
-                        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_GO_KART)
+                        if (vehicleEntry->flags & CAR_ENTRY_FLAG_GO_KART)
                         {
                             velocity -= velocity >> 2;
                             _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_2;
@@ -8091,7 +8089,7 @@ bool Vehicle::UpdateTrackMotionBackwards(rct_ride_entry_vehicle* vehicleEntry, R
  *
  *
  */
-void Vehicle::UpdateTrackMotionMiniGolfVehicle(Ride* curRide, rct_ride_entry* rideEntry, rct_ride_entry_vehicle* vehicleEntry)
+void Vehicle::UpdateTrackMotionMiniGolfVehicle(Ride* curRide, rct_ride_entry* rideEntry, CarEntry* vehicleEntry)
 {
     EntityId otherVehicleIndex = EntityId::GetNull();
     TileElement* tileElement = nullptr;
@@ -8378,7 +8376,7 @@ loc_6DC743:
     bank_rotation = moveInfo->bank_rotation;
     Pitch = moveInfo->Pitch;
 
-    if (rideEntry->vehicles[0].flags & VEHICLE_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING)
+    if (rideEntry->Cars[0].flags & CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING)
     {
         if (Pitch != 0)
         {
@@ -8494,7 +8492,7 @@ loc_6DCC2C:
     bank_rotation = moveInfo->bank_rotation;
     Pitch = moveInfo->Pitch;
 
-    if (rideEntry->vehicles[0].flags & VEHICLE_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING)
+    if (rideEntry->Cars[0].flags & CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING)
     {
         if (Pitch != 0)
         {
@@ -8543,7 +8541,7 @@ loc_6DCD6B:
         Vehicle* vEDI = gCurrentVehicle;
         if (abs(vEDI->velocity - vEBP->velocity) > 0xE0000)
         {
-            if (!(vehicleEntry->flags & VEHICLE_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
+            if (!(vehicleEntry->flags & CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
             {
                 _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_COLLISION;
             }
@@ -8626,7 +8624,7 @@ static constexpr int32_t GetAccelerationDecrease2(const int32_t velocity, const 
     return accelerationDecrease2;
 }
 
-int32_t Vehicle::UpdateTrackMotionMiniGolfCalculateAcceleration(const rct_ride_entry_vehicle& vehicleEntry)
+int32_t Vehicle::UpdateTrackMotionMiniGolfCalculateAcceleration(const CarEntry& vehicleEntry)
 {
     int32_t sumAcceleration = 0;
     int32_t numVehicles = 0;
@@ -8643,11 +8641,11 @@ int32_t Vehicle::UpdateTrackMotionMiniGolfCalculateAcceleration(const rct_ride_e
     newAcceleration -= velocity >> 12;
     newAcceleration -= GetAccelerationDecrease2(velocity, totalMass);
 
-    if (!(vehicleEntry.flags & VEHICLE_ENTRY_FLAG_POWERED))
+    if (!(vehicleEntry.flags & CAR_ENTRY_FLAG_POWERED))
     {
         return newAcceleration;
     }
-    if (vehicleEntry.flags & VEHICLE_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY)
+    if (vehicleEntry.flags & CAR_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY)
     {
         if (speed * 0x4000 < velocity)
         {
@@ -8666,14 +8664,14 @@ int32_t Vehicle::UpdateTrackMotionMiniGolfCalculateAcceleration(const rct_ride_e
         if (quarterForce != 0)
             poweredAcceleration /= quarterForce;
 
-        if (vehicleEntry.flags & VEHICLE_ENTRY_FLAG_WATER_RIDE)
+        if (vehicleEntry.flags & CAR_ENTRY_FLAG_WATER_RIDE)
         {
             if (poweredAcceleration < 0)
             {
                 poweredAcceleration >>= 4;
             }
 
-            if (vehicleEntry.flags & VEHICLE_ENTRY_FLAG_SPINNING)
+            if (vehicleEntry.flags & CAR_ENTRY_FLAG_SPINNING)
             {
                 spin_speed = std::clamp(spin_speed, VEHICLE_MIN_SPIN_SPEED_WATER_RIDE, VEHICLE_MAX_SPIN_SPEED_WATER_RIDE);
             }
@@ -8681,7 +8679,7 @@ int32_t Vehicle::UpdateTrackMotionMiniGolfCalculateAcceleration(const rct_ride_e
             if (Pitch != 0)
             {
                 poweredAcceleration = std::max(0, poweredAcceleration);
-                if (vehicleEntry.flags & VEHICLE_ENTRY_FLAG_SPINNING)
+                if (vehicleEntry.flags & CAR_ENTRY_FLAG_SPINNING)
                 {
                     if (Pitch == 2)
                     {
@@ -8710,7 +8708,7 @@ int32_t Vehicle::UpdateTrackMotionMiniGolf(int32_t* outStation)
         return 0;
 
     rct_ride_entry* rideEntry = GetRideEntry();
-    rct_ride_entry_vehicle* vehicleEntry = Entry();
+    CarEntry* vehicleEntry = Entry();
 
     gCurrentVehicle = this;
     _vehicleMotionTrackFlags = 0;
@@ -8788,9 +8786,9 @@ static uint8_t modified_speed(uint16_t trackType, VehicleTrackSubposition trackS
 }
 
 int32_t Vehicle::UpdateTrackMotionPoweredRideAcceleration(
-    rct_ride_entry_vehicle* vehicleEntry, uint32_t totalMass, const int32_t curAcceleration)
+    CarEntry* vehicleEntry, uint32_t totalMass, const int32_t curAcceleration)
 {
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY)
     {
         if (velocity > (speed * 0x4000))
         {
@@ -8816,19 +8814,19 @@ int32_t Vehicle::UpdateTrackMotionPoweredRideAcceleration(
         poweredAcceleration /= quarterForce;
     }
 
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_LIFT)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_LIFT)
     {
         poweredAcceleration *= 4;
     }
 
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_WATER_RIDE)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_WATER_RIDE)
     {
         if (poweredAcceleration < 0)
         {
             poweredAcceleration >>= 4;
         }
 
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SPINNING)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_SPINNING)
         {
             spin_speed = std::clamp(spin_speed, VEHICLE_MIN_SPIN_SPEED_WATER_RIDE, VEHICLE_MAX_SPIN_SPEED_WATER_RIDE);
         }
@@ -8840,7 +8838,7 @@ int32_t Vehicle::UpdateTrackMotionPoweredRideAcceleration(
                 poweredAcceleration = 0;
             }
 
-            if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SPINNING)
+            if (vehicleEntry->flags & CAR_ENTRY_FLAG_SPINNING)
             {
                 // If the vehicle is on the up slope kill the spin speedModifier
                 if (Pitch == 2)
@@ -8878,7 +8876,7 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
         return 0;
     }
 
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_MINI_GOLF)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_MINI_GOLF)
     {
         return UpdateTrackMotionMiniGolf(outStation);
     }
@@ -8916,18 +8914,17 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
         }
 
         // Swinging cars
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SWINGING)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_SWINGING)
         {
             car->UpdateSwingingCar();
         }
         // Spinning cars
-        if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SPINNING)
+        if (vehicleEntry->flags & CAR_ENTRY_FLAG_SPINNING)
         {
             car->UpdateSpinningCar();
         }
         // Rider sprites?? animation??
-        if ((vehicleEntry->flags & VEHICLE_ENTRY_FLAG_VEHICLE_ANIMATION)
-            || (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_RIDER_ANIMATION))
+        if ((vehicleEntry->flags & CAR_ENTRY_FLAG_VEHICLE_ANIMATION) || (vehicleEntry->flags & CAR_ENTRY_FLAG_RIDER_ANIMATION))
         {
             car->UpdateAdditionalAnimation();
         }
@@ -9041,7 +9038,7 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
     curAcceleration -= vehicle->velocity / 4096;
     curAcceleration -= GetAccelerationDecrease2(vehicle->velocity, totalMass);
 
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_POWERED)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_POWERED)
     {
         curAcceleration = vehicle->UpdateTrackMotionPoweredRideAcceleration(vehicleEntry, totalMass, curAcceleration);
     }
@@ -9091,14 +9088,14 @@ rct_ride_entry* Vehicle::GetRideEntry() const
     return get_ride_entry(ride_subtype);
 }
 
-rct_ride_entry_vehicle* Vehicle::Entry() const
+CarEntry* Vehicle::Entry() const
 {
     rct_ride_entry* rideEntry = GetRideEntry();
     if (rideEntry == nullptr)
     {
         return nullptr;
     }
-    return &rideEntry->vehicles[vehicle_type];
+    return &rideEntry->Cars[vehicle_type];
 }
 
 Ride* Vehicle::GetRide() const
@@ -9259,7 +9256,7 @@ void Vehicle::UpdateCrossings() const
 void Vehicle::Claxon() const
 {
     rct_ride_entry* rideEntry = GetRideEntry();
-    switch (rideEntry->vehicles[vehicle_type].sound_range)
+    switch (rideEntry->Cars[vehicle_type].sound_range)
     {
         case SOUND_RANGE_WHISTLE:
             OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::TrainWhistle, { x, y, z });

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -28,7 +28,7 @@ using track_type_t = uint16_t;
 
 struct Ride;
 struct rct_ride_entry;
-struct rct_ride_entry_vehicle;
+struct CarEntry;
 class DataSerialiser;
 struct paint_session;
 
@@ -228,7 +228,7 @@ struct Vehicle : EntityBase
     void SetMapToolbar() const;
     int32_t IsUsedInPairs() const;
     rct_ride_entry* GetRideEntry() const;
-    rct_ride_entry_vehicle* Entry() const;
+    CarEntry* Entry() const;
     Ride* GetRide() const;
     Vehicle* TrainHead() const;
     Vehicle* TrainTail() const;
@@ -312,8 +312,7 @@ private:
     void UpdateDepartingBoatHire();
     void UpdateTravellingBoatHireSetup();
     void UpdateBoatLocation();
-    void UpdateArrivingPassThroughStation(
-        const Ride& curRide, const rct_ride_entry_vehicle& vehicleEntry, bool stationBrakesWork);
+    void UpdateArrivingPassThroughStation(const Ride& curRide, const CarEntry& vehicleEntry, bool stationBrakesWork);
     void UpdateArriving();
     void UpdateUnloadingPassengers();
     void UpdateWaitingForCableLift();
@@ -331,10 +330,9 @@ private:
     void UpdateAdditionalAnimation();
     void CheckIfMissing();
     bool CurrentTowerElementIsTop();
-    bool UpdateTrackMotionForwards(rct_ride_entry_vehicle* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry);
-    bool UpdateTrackMotionBackwards(rct_ride_entry_vehicle* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry);
-    int32_t UpdateTrackMotionPoweredRideAcceleration(
-        rct_ride_entry_vehicle* vehicleEntry, uint32_t totalMass, const int32_t curAcceleration);
+    bool UpdateTrackMotionForwards(CarEntry* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry);
+    bool UpdateTrackMotionBackwards(CarEntry* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry);
+    int32_t UpdateTrackMotionPoweredRideAcceleration(CarEntry* vehicleEntry, uint32_t totalMass, const int32_t curAcceleration);
     int32_t NumPeepsUntilTrainTail() const;
     void InvalidateWindow();
     void TestReset();
@@ -361,9 +359,9 @@ private:
     void KillAllPassengersInTrain();
     void KillPassengers(Ride* curRide);
     void TrainReadyToDepart(uint8_t num_peeps_on_train, uint8_t num_used_seats);
-    int32_t UpdateTrackMotionMiniGolfCalculateAcceleration(const rct_ride_entry_vehicle& vehicleEntry);
+    int32_t UpdateTrackMotionMiniGolfCalculateAcceleration(const CarEntry& vehicleEntry);
     int32_t UpdateTrackMotionMiniGolf(int32_t* outStation);
-    void UpdateTrackMotionMiniGolfVehicle(Ride* curRide, rct_ride_entry* rideEntry, rct_ride_entry_vehicle* vehicleEntry);
+    void UpdateTrackMotionMiniGolfVehicle(Ride* curRide, rct_ride_entry* rideEntry, CarEntry* vehicleEntry);
     bool UpdateTrackMotionForwardsGetNewTrack(uint16_t trackType, Ride* curRide, rct_ride_entry* rideEntry);
     bool UpdateTrackMotionBackwardsGetNewTrack(uint16_t trackType, Ride* curRide, uint16_t* progress);
     bool UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* otherVehicleIndex);

--- a/src/openrct2/ride/VehicleEntry.h
+++ b/src/openrct2/ride/VehicleEntry.h
@@ -18,73 +18,73 @@
 
 enum : uint32_t
 {
-    VEHICLE_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY = 1
+    CAR_ENTRY_FLAG_POWERED_RIDE_UNRESTRICTED_GRAVITY = 1
         << 0, // Set on powered vehicles that do not slow down when going down a hill.
-    VEHICLE_ENTRY_FLAG_NO_UPSTOP_WHEELS = 1 << 1,
-    VEHICLE_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH = 1 << 2,
-    VEHICLE_ENTRY_FLAG_MINI_GOLF = 1 << 3,
-    VEHICLE_ENTRY_FLAG_REVERSER_BOGIE = 1 << 4,
-    VEHICLE_ENTRY_FLAG_REVERSER_PASSENGER_CAR = 1 << 5,
-    VEHICLE_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET = 1 << 6, // Set on vehicles that support running inverted for extended periods
-                                                         // of time, i.e. the Flying, Lay-down and Multi-dimension RCs.
-    VEHICLE_ENTRY_FLAG_DODGEM_INUSE_LIGHTS = 1
+    CAR_ENTRY_FLAG_NO_UPSTOP_WHEELS = 1 << 1,
+    CAR_ENTRY_FLAG_NO_UPSTOP_BOBSLEIGH = 1 << 2,
+    CAR_ENTRY_FLAG_MINI_GOLF = 1 << 3,
+    CAR_ENTRY_FLAG_REVERSER_BOGIE = 1 << 4,
+    CAR_ENTRY_FLAG_REVERSER_PASSENGER_CAR = 1 << 5,
+    CAR_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET = 1 << 6, // Set on vehicles that support running inverted for extended periods
+                                                     // of time, i.e. the Flying, Lay-down and Multi-dimension RCs.
+    CAR_ENTRY_FLAG_DODGEM_INUSE_LIGHTS = 1
         << 7, // When set the vehicle has an additional frame for when in use. Used only by dodgems.
-    VEHICLE_ENTRY_FLAG_ALLOW_DOORS_DEPRECATED = 1 << 8, // Not used any more - every vehicle will now work with doors.
-    VEHICLE_ENTRY_FLAG_ENABLE_TERNARY_COLOUR = 1 << 9,
-    VEHICLE_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS = 1 << 10, // Only used during loading of the objects.
-    VEHICLE_ENTRY_FLAG_USE_16_ROTATION_FRAMES = 1
+    CAR_ENTRY_FLAG_ALLOW_DOORS_DEPRECATED = 1 << 8, // Not used any more - every vehicle will now work with doors.
+    CAR_ENTRY_FLAG_ENABLE_TERNARY_COLOUR = 1 << 9,
+    CAR_ENTRY_FLAG_RECALCULATE_SPRITE_BOUNDS = 1 << 10, // Only used during loading of the objects.
+    CAR_ENTRY_FLAG_USE_16_ROTATION_FRAMES = 1
         << 11, // Instead of the default 32 rotation frames. Only used for boat hire and works only for non sloped sprites.
-    VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES = 1
+    CAR_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES = 1
         << 12, // Setting this will cause the game to set vehicleEntry->num_vertical_frames to
                // vehicleEntry->num_vertical_frames_override, rather than determining it itself.
-    VEHICLE_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET = 1
+    CAR_ENTRY_FLAG_SPRITE_BOUNDS_INCLUDE_INVERTED_SET = 1
         << 13, // Used together with HAS_INVERTED_SPRITE_SET and RECALCULATE_SPRITE_BOUNDS and includes the inverted sprites
                // into the function that recalculates the sprite bounds.
-    VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES = 1
+    CAR_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES = 1
         << 14, // 16x additional frames for vehicle. A spinning item with additional frames must always face forward to
                // load/unload. Spinning without can load/unload at 4 rotations.
-    VEHICLE_ENTRY_FLAG_LIFT = 1 << 15,
-    VEHICLE_ENTRY_FLAG_ENABLE_TRIM_COLOUR = 1 << 16,
-    VEHICLE_ENTRY_FLAG_SWINGING = 1 << 17,
-    VEHICLE_ENTRY_FLAG_SPINNING = 1 << 18,
-    VEHICLE_ENTRY_FLAG_POWERED = 1 << 19,
-    VEHICLE_ENTRY_FLAG_RIDERS_SCREAM = 1 << 20,
-    VEHICLE_ENTRY_FLAG_SUSPENDED_SWING = 1 << 21, // Suspended swinging coaster, or bobsleigh if SLIDE_SWING is also enabled.
-    VEHICLE_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION = 1 << 22,
-    VEHICLE_ENTRY_FLAG_VEHICLE_ANIMATION = 1 << 23, // Set on animated vehicles like the Multi-dimension coaster trains,
-                                                    // Miniature Railway locomotives and Helicycles.
-    VEHICLE_ENTRY_FLAG_RIDER_ANIMATION = 1 << 24,   // Set when the animation updates rider sprite positions.
-    VEHICLE_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING = 1 << 25,
-    VEHICLE_ENTRY_FLAG_LOADING_WAYPOINTS = 1
+    CAR_ENTRY_FLAG_LIFT = 1 << 15,
+    CAR_ENTRY_FLAG_ENABLE_TRIM_COLOUR = 1 << 16,
+    CAR_ENTRY_FLAG_SWINGING = 1 << 17,
+    CAR_ENTRY_FLAG_SPINNING = 1 << 18,
+    CAR_ENTRY_FLAG_POWERED = 1 << 19,
+    CAR_ENTRY_FLAG_RIDERS_SCREAM = 1 << 20,
+    CAR_ENTRY_FLAG_SUSPENDED_SWING = 1 << 21, // Suspended swinging coaster, or bobsleigh if SLIDE_SWING is also enabled.
+    CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION = 1 << 22,
+    CAR_ENTRY_FLAG_VEHICLE_ANIMATION = 1 << 23, // Set on animated vehicles like the Multi-dimension coaster trains,
+                                                // Miniature Railway locomotives and Helicycles.
+    CAR_ENTRY_FLAG_RIDER_ANIMATION = 1 << 24,   // Set when the animation updates rider sprite positions.
+    CAR_ENTRY_FLAG_WOODEN_WILD_MOUSE_SWING = 1 << 25,
+    CAR_ENTRY_FLAG_LOADING_WAYPOINTS = 1
         << 26, // Peep loading positions have x and y coordinates. Normal rides just have offsets.
-    VEHICLE_ENTRY_FLAG_SLIDE_SWING = 1
+    CAR_ENTRY_FLAG_SLIDE_SWING = 1
         << 27, // Set on dingy slides. They have there own swing value calculations and have a different amount of images.
                // Also set on bobsleighs together with the SUSPENDED_SWING flag.
-    VEHICLE_ENTRY_FLAG_CHAIRLIFT = 1 << 28,
-    VEHICLE_ENTRY_FLAG_WATER_RIDE = 1 << 29, // Set on rides where water would provide continuous propulsion.
-    VEHICLE_ENTRY_FLAG_GO_KART = 1 << 30,
-    VEHICLE_ENTRY_FLAG_DODGEM_CAR_PLACEMENT = 1u << 31,
+    CAR_ENTRY_FLAG_CHAIRLIFT = 1 << 28,
+    CAR_ENTRY_FLAG_WATER_RIDE = 1 << 29, // Set on rides where water would provide continuous propulsion.
+    CAR_ENTRY_FLAG_GO_KART = 1 << 30,
+    CAR_ENTRY_FLAG_DODGEM_CAR_PLACEMENT = 1u << 31,
 };
 
 enum : uint32_t
 {
-    VEHICLE_SPRITE_FLAG_FLAT = (1 << 0),
-    VEHICLE_SPRITE_FLAG_GENTLE_SLOPES = (1 << 1),
-    VEHICLE_SPRITE_FLAG_STEEP_SLOPES = (1 << 2),
-    VEHICLE_SPRITE_FLAG_VERTICAL_SLOPES = (1 << 3),
-    VEHICLE_SPRITE_FLAG_DIAGONAL_SLOPES = (1 << 4),
-    VEHICLE_SPRITE_FLAG_FLAT_BANKED = (1 << 5),
-    VEHICLE_SPRITE_FLAG_INLINE_TWISTS = (1 << 6),
-    VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS = (1 << 7),
-    VEHICLE_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS = (1 << 8),
-    VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS = (1 << 9),
-    VEHICLE_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS = (1 << 10),
-    VEHICLE_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS = (1 << 11),
-    VEHICLE_SPRITE_FLAG_CORKSCREWS = (1 << 12),
-    VEHICLE_SPRITE_FLAG_RESTRAINT_ANIMATION = (1 << 13),
-    VEHICLE_SPRITE_FLAG_CURVED_LIFT_HILL = (1 << 14),
+    CAR_SPRITE_FLAG_FLAT = (1 << 0),
+    CAR_SPRITE_FLAG_GENTLE_SLOPES = (1 << 1),
+    CAR_SPRITE_FLAG_STEEP_SLOPES = (1 << 2),
+    CAR_SPRITE_FLAG_VERTICAL_SLOPES = (1 << 3),
+    CAR_SPRITE_FLAG_DIAGONAL_SLOPES = (1 << 4),
+    CAR_SPRITE_FLAG_FLAT_BANKED = (1 << 5),
+    CAR_SPRITE_FLAG_INLINE_TWISTS = (1 << 6),
+    CAR_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_BANKED_TRANSITIONS = (1 << 7),
+    CAR_SPRITE_FLAG_DIAGONAL_GENTLE_SLOPE_BANKED_TRANSITIONS = (1 << 8),
+    CAR_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TRANSITIONS = (1 << 9),
+    CAR_SPRITE_FLAG_GENTLE_SLOPE_BANKED_TURNS = (1 << 10),
+    CAR_SPRITE_FLAG_FLAT_TO_GENTLE_SLOPE_WHILE_BANKED_TRANSITIONS = (1 << 11),
+    CAR_SPRITE_FLAG_CORKSCREWS = (1 << 12),
+    CAR_SPRITE_FLAG_RESTRAINT_ANIMATION = (1 << 13),
+    CAR_SPRITE_FLAG_CURVED_LIFT_HILL = (1 << 14),
     // Used only on lifts (the transport ride), to only use 4 rotation sprites instead of 32.
-    VEHICLE_SPRITE_FLAG_USE_4_ROTATION_FRAMES = (1 << 15),
+    CAR_SPRITE_FLAG_USE_4_ROTATION_FRAMES = (1 << 15),
 };
 
 enum class SpriteGroupType : uint8_t
@@ -139,7 +139,7 @@ struct VehicleSpriteGroup
 /**
  * Ride type vehicle structure.
  */
-struct rct_ride_entry_vehicle
+struct CarEntry
 {
     uint16_t TabRotationMask;
     uint32_t spacing;
@@ -154,12 +154,12 @@ struct rct_ride_entry_vehicle
     uint16_t base_num_frames; // The number of sprites of animation or swinging per rotation frame
     uint32_t base_image_id;
     VehicleSpriteGroup SpriteGroups[EnumValue(SpriteGroupType::Count)];
-    uint32_t no_vehicle_images;
+    uint32_t NumCarImages;
     uint8_t no_seating_rows;
     uint8_t spinning_inertia;
     uint8_t spinning_friction;
     OpenRCT2::Audio::SoundId friction_sound_id;
-    uint8_t log_flume_reverser_vehicle_type;
+    uint8_t ReversedCarIndex; // When the car is reversed (using a turntable or reverser), it will be changed to this car.
     uint8_t sound_range;
     uint8_t double_sound_frequency; // (Doubles the velocity when working out the sound frequency {used on go karts})
     uint8_t powered_acceleration;
@@ -168,7 +168,7 @@ struct rct_ride_entry_vehicle
     uint8_t effect_visual;
     uint8_t draw_order;
     uint8_t num_vertical_frames_override; // A custom number that can be used rather than letting RCT2 determine it.
-                                          // Needs the VEHICLE_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES flag to be set.
+                                          // Needs the CAR_ENTRY_FLAG_OVERRIDE_NUM_VERTICAL_FRAMES flag to be set.
     uint8_t peep_loading_waypoint_segments;
     std::vector<std::array<CoordsXY, 3>> peep_loading_waypoints = {};
     std::vector<int8_t> peep_loading_positions = {};

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -939,18 +939,18 @@ const vehicle_boundbox VehicleBoundboxes[16][224] = {
 #pragma region VehiclePaintUtil
 
 static void PaintVehicleRiders(
-    paint_session& session, const Vehicle* vehicle, const rct_ride_entry_vehicle* vehicleEntry, uint32_t baseImageId, int32_t z,
+    paint_session& session, const Vehicle* vehicle, const CarEntry* vehicleEntry, uint32_t baseImageId, int32_t z,
     const vehicle_boundbox& bb)
 {
-    baseImageId += vehicleEntry->no_vehicle_images;
+    baseImageId += vehicleEntry->NumCarImages;
     for (auto i = 0; i < 8; i++)
     {
         if (vehicle->num_peeps > (i * 2) && vehicleEntry->no_seating_rows > i)
         {
             auto offsetImageId = baseImageId;
-            if (i == 0 && (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_RIDER_ANIMATION))
+            if (i == 0 && (vehicleEntry->flags & CAR_ENTRY_FLAG_RIDER_ANIMATION))
             {
-                offsetImageId += (vehicleEntry->no_vehicle_images * vehicle->animation_frame);
+                offsetImageId += (vehicleEntry->NumCarImages * vehicle->animation_frame);
             }
 
             auto peepColour0 = vehicle->peep_tshirt_colours[i * 2];
@@ -964,7 +964,7 @@ static void PaintVehicleRiders(
             PaintAddImageAsChild(
                 session, imageId, { 0, 0, z }, { bb.length_x, bb.length_y, bb.length_z },
                 { bb.offset_x, bb.offset_y, bb.offset_z + z });
-            baseImageId += vehicleEntry->no_vehicle_images;
+            baseImageId += vehicleEntry->NumCarImages;
         }
     }
 }
@@ -972,7 +972,7 @@ static void PaintVehicleRiders(
 // 6D5214
 static void vehicle_sprite_paint(
     paint_session& session, const Vehicle* vehicle, int32_t spriteNum, const vehicle_boundbox& bb, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->draw_order >= std::size(VehicleBoundboxes))
     {
@@ -980,11 +980,11 @@ static void vehicle_sprite_paint(
     }
 
     auto baseImageId = static_cast<uint32_t>(spriteNum);
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_SPINNING_ADDITIONAL_FRAMES)
     {
         baseImageId += (vehicle->spin_sprite / 8) & 31;
     }
-    if (vehicleEntry->flags & VEHICLE_ENTRY_FLAG_VEHICLE_ANIMATION)
+    if (vehicleEntry->flags & CAR_ENTRY_FLAG_VEHICLE_ANIMATION)
     {
         baseImageId += vehicle->animation_frame;
     }
@@ -1009,7 +1009,7 @@ static void vehicle_sprite_paint(
 // 6D520E
 static void VehicleSpritePaintWithSwinging(
     paint_session& session, const Vehicle* vehicle, int32_t spriteNum, int32_t boundingBoxNum, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    const CarEntry* vehicleEntry)
 {
     vehicle_sprite_paint(
         session, vehicle, spriteNum + vehicle->SwingSprite, VehicleBoundboxes[vehicleEntry->draw_order][boundingBoxNum], z,
@@ -1017,8 +1017,7 @@ static void VehicleSpritePaintWithSwinging(
 }
 
 static void VehicleSpritePaintRestraints(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     int32_t boundingBoxNum = YawTo16(imageDirection);
     auto restraintFrame = ((vehicle->restraints_position - 64) / 64) * 4;
@@ -1035,8 +1034,7 @@ static void VehicleSpritePaintRestraints(
 
 // 6D51DE
 static void VehicleSpriteFlatUnbanked(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     // Restraint animations are only drawn for vehicles that are in a cardinal direction (north, east, south, west)
     if (vehicle->restraints_position >= 64 && vehicleEntry->GroupEnabled(SpriteGroupType::RestraintAnimation)
@@ -1052,8 +1050,7 @@ static void VehicleSpriteFlatUnbanked(
 
 // 6D4EE7
 static void vehicle_sprite_0_1(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::FlatBanked22))
     {
@@ -1069,8 +1066,7 @@ static void vehicle_sprite_0_1(
 
 // 6D4F34
 static void vehicle_sprite_0_2(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::FlatBanked45))
     {
@@ -1086,8 +1082,7 @@ static void vehicle_sprite_0_2(
 
 // 6D4F0C
 static void vehicle_sprite_0_3(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::FlatBanked22))
     {
@@ -1103,8 +1098,7 @@ static void vehicle_sprite_0_3(
 
 // 6D4F5C
 static void vehicle_sprite_0_4(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::FlatBanked45))
     {
@@ -1120,8 +1114,7 @@ static void vehicle_sprite_0_4(
 
 // 6D4F84
 static void vehicle_sprite_0_5(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1141,8 +1134,7 @@ static void vehicle_sprite_0_5(
 
 // 6D4FE4
 static void vehicle_sprite_0_6(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1162,8 +1154,7 @@ static void vehicle_sprite_0_6(
 
 // 6D5055
 static void vehicle_sprite_0_7(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1183,8 +1174,7 @@ static void vehicle_sprite_0_7(
 
 // 6D50C6
 static void vehicle_sprite_0_8(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1204,8 +1194,7 @@ static void vehicle_sprite_0_8(
 
 // 6D5137
 static void vehicle_sprite_0_9(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1225,8 +1214,7 @@ static void vehicle_sprite_0_9(
 
 // 6D4FB1
 static void vehicle_sprite_0_10(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1246,8 +1234,7 @@ static void vehicle_sprite_0_10(
 
 // 6D501B
 static void vehicle_sprite_0_11(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1267,8 +1254,7 @@ static void vehicle_sprite_0_11(
 
 // 6D508C
 static void vehicle_sprite_0_12(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1288,8 +1274,7 @@ static void vehicle_sprite_0_12(
 
 // 6D50FD
 static void vehicle_sprite_0_13(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1309,8 +1294,7 @@ static void vehicle_sprite_0_13(
 
 // 6D516E
 static void vehicle_sprite_0_14(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1330,8 +1314,7 @@ static void vehicle_sprite_0_14(
 
 // 6D4EE4
 static void vehicle_sprite_0_16(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     vehicleEntry--;
     vehicle_sprite_0_1(session, vehicle, imageDirection, z, vehicleEntry);
@@ -1339,8 +1322,7 @@ static void vehicle_sprite_0_16(
 
 // 6D4F31
 static void vehicle_sprite_0_17(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     vehicleEntry--;
     vehicle_sprite_0_2(session, vehicle, imageDirection, z, vehicleEntry);
@@ -1348,8 +1330,7 @@ static void vehicle_sprite_0_17(
 
 // 6D4F09
 static void vehicle_sprite_0_18(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     vehicleEntry--;
     vehicle_sprite_0_3(session, vehicle, imageDirection, z, vehicleEntry);
@@ -1357,8 +1338,7 @@ static void vehicle_sprite_0_18(
 
 // 6D4F59
 static void vehicle_sprite_0_19(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     vehicleEntry--;
     vehicle_sprite_0_4(session, vehicle, imageDirection, z, vehicleEntry);
@@ -1366,8 +1346,7 @@ static void vehicle_sprite_0_19(
 
 // 6D51D7
 static void VehiclePitchFlat(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     // 0x009A3DE4:
     switch (vehicle->bank_rotation)
@@ -1444,8 +1423,7 @@ static void VehiclePitchFlat(
 
 // 6D4614
 static void vehicle_sprite_1_0(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes12))
     {
@@ -1461,8 +1439,7 @@ static void vehicle_sprite_1_0(
 
 // 6D4662
 static void vehicle_sprite_1_1(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
@@ -1478,8 +1455,7 @@ static void vehicle_sprite_1_1(
 
 // 6D46DB
 static void vehicle_sprite_1_2(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
@@ -1495,8 +1471,7 @@ static void vehicle_sprite_1_2(
 
 // 6D467D
 static void vehicle_sprite_1_3(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
@@ -1512,8 +1487,7 @@ static void vehicle_sprite_1_3(
 
 // 6D46FD
 static void vehicle_sprite_1_4(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
@@ -1529,8 +1503,7 @@ static void vehicle_sprite_1_4(
 
 // 6D460D
 static void VehiclePitchUp12(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     // 0x009A3C04:
     switch (vehicle->bank_rotation)
@@ -1576,8 +1549,7 @@ static void VehiclePitchUp12(
 
 // 6D4791
 static void vehicle_sprite_2_0(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes25))
     {
@@ -1593,8 +1565,7 @@ static void vehicle_sprite_2_0(
 
 // 6D4833
 static void vehicle_sprite_2_1(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
@@ -1610,8 +1581,7 @@ static void vehicle_sprite_2_1(
 
 // 6D48D6
 static void vehicle_sprite_2_2(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -1632,8 +1602,7 @@ static void vehicle_sprite_2_2(
 
 // 6D4858
 static void vehicle_sprite_2_3(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
@@ -1649,8 +1618,7 @@ static void vehicle_sprite_2_3(
 
 // 6D4910
 static void vehicle_sprite_2_4(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -1670,8 +1638,7 @@ static void vehicle_sprite_2_4(
 
 // 6D476C
 static void VehiclePitchUp25(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     // 0x009A3CA4:
     switch (vehicle->bank_rotation)
@@ -1747,8 +1714,7 @@ static void VehiclePitchUp25(
 
 // 6D49DC
 static void VehiclePitchUp42(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes42))
     {
@@ -1764,8 +1730,7 @@ static void VehiclePitchUp42(
 
 // 6D4A31
 static void VehiclePitchUp60(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes60))
     {
@@ -1787,8 +1752,7 @@ static void VehiclePitchUp60(
 
 // 6D463D
 static void vehicle_sprite_5_0(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes12))
     {
@@ -1804,8 +1768,7 @@ static void vehicle_sprite_5_0(
 
 // 6D469B
 static void vehicle_sprite_5_1(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
@@ -1821,8 +1784,7 @@ static void vehicle_sprite_5_1(
 
 // 6D4722
 static void vehicle_sprite_5_2(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
@@ -1838,8 +1800,7 @@ static void vehicle_sprite_5_2(
 
 // 6D46B9
 static void vehicle_sprite_5_3(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
@@ -1855,8 +1816,7 @@ static void vehicle_sprite_5_3(
 
 // 6D4747
 static void vehicle_sprite_5_4(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
@@ -1872,8 +1832,7 @@ static void vehicle_sprite_5_4(
 
 // 6D4636
 static void VehiclePitchDown12(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     // 0x009A3C54:
     switch (vehicle->bank_rotation)
@@ -1950,8 +1909,7 @@ static void VehiclePitchDown12(
 
 // 6D47E4
 static void vehicle_sprite_6_0(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes25))
     {
@@ -1967,8 +1925,7 @@ static void vehicle_sprite_6_0(
 
 // 6D4880
 static void vehicle_sprite_6_1(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
@@ -1984,8 +1941,7 @@ static void vehicle_sprite_6_1(
 
 // 6D4953
 static void vehicle_sprite_6_2(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -2006,8 +1962,7 @@ static void vehicle_sprite_6_2(
 
 // 6D48AB
 static void vehicle_sprite_6_3(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
@@ -2023,8 +1978,7 @@ static void vehicle_sprite_6_3(
 
 // 6D4996
 static void vehicle_sprite_6_4(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -2045,8 +1999,7 @@ static void vehicle_sprite_6_4(
 
 // 6D47DD
 static void VehiclePitchDown25(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     // 0x009A3CF4:
     switch (vehicle->bank_rotation)
@@ -2122,8 +2075,7 @@ static void VehiclePitchDown25(
 
 // 6D4A05
 static void VehiclePitchDown42(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes42))
     {
@@ -2139,8 +2091,7 @@ static void VehiclePitchDown42(
 
 // 6D4A59
 static void VehiclePitchDown60(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes60))
     {
@@ -2160,8 +2111,7 @@ static void VehiclePitchDown60(
 
 // 6D4A81
 static void VehiclePitchUp75(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes75))
     {
@@ -2177,8 +2127,7 @@ static void VehiclePitchUp75(
 
 // 6D4AE8
 static void VehiclePitchUp90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes90))
     {
@@ -2198,8 +2147,7 @@ static void VehiclePitchUp90(
 
 // 6D4B57
 static void VehiclePitchUp105(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
@@ -2215,8 +2163,7 @@ static void VehiclePitchUp105(
 
 // 6D4BB7
 static void VehiclePitchUp120(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
@@ -2232,8 +2179,7 @@ static void VehiclePitchUp120(
 
 // 6D4C17
 static void VehiclePitchUp135(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
@@ -2249,8 +2195,7 @@ static void VehiclePitchUp135(
 
 // 6D4C77
 static void VehiclePitchUp150(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
@@ -2266,8 +2211,7 @@ static void VehiclePitchUp150(
 
 // 6D4CD7
 static void VehiclePitchUp165(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
@@ -2287,8 +2231,7 @@ static void VehiclePitchUp165(
 
 // 6D4D37
 static void VehiclePitchInverted(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::SlopeInverted))
     {
@@ -2308,8 +2251,7 @@ static void VehiclePitchInverted(
 
 // 6D4AA3
 static void VehiclePitchDown75(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -2333,8 +2275,7 @@ static void VehiclePitchDown75(
 
 // 6D4B0D
 static void VehiclePitchDown90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -2362,8 +2303,7 @@ static void VehiclePitchDown90(
 
 // 6D4B80
 static void VehiclePitchDown105(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -2383,8 +2323,7 @@ static void VehiclePitchDown105(
 
 // 6D4BE0
 static void VehiclePitchDown120(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -2404,8 +2343,7 @@ static void VehiclePitchDown120(
 
 // 6D4C40
 static void VehiclePitchDown135(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -2425,8 +2363,7 @@ static void VehiclePitchDown135(
 
 // 6D4CA0
 static void VehiclePitchDown150(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -2446,8 +2383,7 @@ static void VehiclePitchDown150(
 
 // 6D4D00
 static void VehiclePitchDown165(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -2471,8 +2407,7 @@ static void VehiclePitchDown165(
 
 // 6D51A5
 static void VehiclePitchCorkscrew(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -2500,8 +2435,7 @@ static void VehiclePitchCorkscrew(
 
 // 6D4D67
 static void vehicle_sprite_50_0(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes8))
     {
@@ -2517,8 +2451,7 @@ static void vehicle_sprite_50_0(
 
 // 6D4DB5
 static void vehicle_sprite_50_1(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
@@ -2534,8 +2467,7 @@ static void vehicle_sprite_50_1(
 
 // 6D4DD3
 static void vehicle_sprite_50_3(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
@@ -2551,8 +2483,7 @@ static void vehicle_sprite_50_3(
 
 // 6D4D60
 static void VehiclePitchUp8(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     // 0x009A3D44:
     switch (vehicle->bank_rotation)
@@ -2626,8 +2557,7 @@ static void VehiclePitchUp8(
 
 // 6D4E3A
 static void VehiclePitchUp16(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes16))
     {
@@ -2647,8 +2577,7 @@ static void VehiclePitchUp16(
 
 // 6D4E8F
 static void VehiclePitchUp50(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes50))
     {
@@ -2672,8 +2601,7 @@ static void VehiclePitchUp50(
 
 // 6D4D90
 static void vehicle_sprite_53_0(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes8))
     {
@@ -2689,8 +2617,7 @@ static void vehicle_sprite_53_0(
 
 // 6D4DF4
 static void vehicle_sprite_53_1(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
@@ -2706,8 +2633,7 @@ static void vehicle_sprite_53_1(
 
 // 6D4E15
 static void vehicle_sprite_53_3(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
@@ -2723,8 +2649,7 @@ static void vehicle_sprite_53_3(
 
 // 6D4D89
 static void VehiclePitchDown8(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     // 0x009A3D94:
     switch (vehicle->bank_rotation)
@@ -2798,8 +2723,7 @@ static void VehiclePitchDown8(
 
 // 6D4E63
 static void VehiclePitchDown16(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes16))
     {
@@ -2819,8 +2743,7 @@ static void VehiclePitchDown16(
 
 // 6D4EB8
 static void VehiclePitchDown50(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::Slopes50))
     {
@@ -2842,8 +2765,7 @@ static void VehiclePitchDown50(
 
 // 6D47DA
 static void VehiclePitchInvertingDown25(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     vehicleEntry--;
     VehiclePitchDown25(session, vehicle, imageDirection, z, vehicleEntry);
@@ -2851,8 +2773,7 @@ static void VehiclePitchInvertingDown25(
 
 // 6D4A02
 static void VehiclePitchInvertingDown42(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     vehicleEntry--;
     VehiclePitchDown42(session, vehicle, imageDirection, z, vehicleEntry);
@@ -2860,8 +2781,7 @@ static void VehiclePitchInvertingDown42(
 
 // 6D4A56
 static void VehiclePitchInvertingDown60(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     vehicleEntry--;
     VehiclePitchDown60(session, vehicle, imageDirection, z, vehicleEntry);
@@ -2873,8 +2793,7 @@ static void VehiclePitchInvertingDown60(
 
 // 6D4773
 static void VehiclePitchSpiralLift(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry)
 {
     if (vehicleEntry->GroupEnabled(SpriteGroupType::CurvedLiftHill))
     {
@@ -2892,8 +2811,7 @@ static void VehiclePitchSpiralLift(
 
 // 0x009A3B14:
 using vehicle_sprite_func = void (*)(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z,
-    const rct_ride_entry_vehicle* vehicleEntry);
+    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* vehicleEntry);
 
 // clang-format off
 static constexpr const vehicle_sprite_func PaintFunctionsByPitch[] = {
@@ -3095,8 +3013,7 @@ static void vehicle_visual_splash5_effect(paint_session& session, int32_t z, con
     PaintAddImageAsChild(session, image_id, { 0, 0, z }, { 1, 1, 0 }, { 0, 0, z });
 }
 
-void vehicle_visual_splash_effect(
-    paint_session& session, int32_t z, const Vehicle* vehicle, const rct_ride_entry_vehicle* vehicleEntry)
+void vehicle_visual_splash_effect(paint_session& session, int32_t z, const Vehicle* vehicle, const CarEntry* vehicleEntry)
 {
     switch (vehicleEntry->effect_visual)
     {
@@ -3125,8 +3042,7 @@ void vehicle_visual_splash_effect(
  *  rct2: 0x006D45F8
  */
 void vehicle_visual_default(
-    paint_session& session, int32_t imageDirection, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    paint_session& session, int32_t imageDirection, int32_t z, const Vehicle* vehicle, const CarEntry* vehicleEntry)
 {
     if (vehicle->Pitch < std::size(PaintFunctionsByPitch))
     {
@@ -3136,7 +3052,7 @@ void vehicle_visual_default(
 
 void Vehicle::Paint(paint_session& session, int32_t imageDirection) const
 {
-    const rct_ride_entry_vehicle* vehicleEntry;
+    const CarEntry* vehicleEntry;
 
     if (IsCrashedVehicle)
     {
@@ -3164,11 +3080,11 @@ void Vehicle::Paint(paint_session& session, int32_t imageDirection) const
             zOffset += 16;
         }
 
-        if (vehicleEntryIndex >= std::size(rideEntry->vehicles))
+        if (vehicleEntryIndex >= std::size(rideEntry->Cars))
         {
             return;
         }
-        vehicleEntry = &rideEntry->vehicles[vehicleEntryIndex];
+        vehicleEntry = &rideEntry->Cars[vehicleEntryIndex];
     }
 
     switch (vehicleEntry->PaintStyle)
@@ -3209,27 +3125,27 @@ void Vehicle::Paint(paint_session& session, int32_t imageDirection) const
     }
 }
 
-uint32_t rct_ride_entry_vehicle::NumRotationSprites(SpriteGroupType spriteGroup) const
+uint32_t CarEntry::NumRotationSprites(SpriteGroupType spriteGroup) const
 {
     return NumSpritesPrecision(SpriteGroups[static_cast<uint8_t>(spriteGroup)].spritePrecision);
 }
 
-int32_t rct_ride_entry_vehicle::SpriteByYaw(int32_t yaw, SpriteGroupType spriteGroup) const
+int32_t CarEntry::SpriteByYaw(int32_t yaw, SpriteGroupType spriteGroup) const
 {
     return YawToPrecision(yaw, SpriteGroups[static_cast<uint8_t>(spriteGroup)].spritePrecision);
 }
 
-bool rct_ride_entry_vehicle::GroupEnabled(SpriteGroupType spriteGroup) const
+bool CarEntry::GroupEnabled(SpriteGroupType spriteGroup) const
 {
     return SpriteGroups[static_cast<uint8_t>(spriteGroup)].Enabled();
 }
 
-uint32_t rct_ride_entry_vehicle::GroupImageId(SpriteGroupType spriteGroup) const
+uint32_t CarEntry::GroupImageId(SpriteGroupType spriteGroup) const
 {
     return SpriteGroups[static_cast<uint8_t>(spriteGroup)].imageId;
 }
 
-uint32_t rct_ride_entry_vehicle::SpriteOffset(SpriteGroupType spriteGroup, int32_t imageDirection, uint8_t rankIndex) const
+uint32_t CarEntry::SpriteOffset(SpriteGroupType spriteGroup, int32_t imageDirection, uint8_t rankIndex) const
 {
     return ((SpriteByYaw(imageDirection, spriteGroup) + NumRotationSprites(spriteGroup) * rankIndex) * base_num_frames)
         + GroupImageId(spriteGroup);

--- a/src/openrct2/ride/VehiclePaint.h
+++ b/src/openrct2/ride/VehiclePaint.h
@@ -12,7 +12,7 @@
 #include "../common.h"
 
 struct paint_session;
-struct rct_ride_entry_vehicle;
+struct CarEntry;
 struct Vehicle;
 
 struct vehicle_boundbox
@@ -28,34 +28,32 @@ struct vehicle_boundbox
 extern const vehicle_boundbox VehicleBoundboxes[16][224];
 
 void vehicle_visual_default(
-    paint_session& session, int32_t imageDirection, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry);
+    paint_session& session, int32_t imageDirection, int32_t z, const Vehicle* vehicle, const CarEntry* vehicleEntry);
 void vehicle_visual_roto_drop(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry);
+    const CarEntry* vehicleEntry);
 void vehicle_visual_observation_tower(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry);
+    const CarEntry* vehicleEntry);
 void vehicle_visual_river_rapids(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry);
+    const CarEntry* vehicleEntry);
 void vehicle_visual_reverser(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry);
+    const CarEntry* vehicleEntry);
 void vehicle_visual_splash_boats_or_water_coaster(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry);
+    const CarEntry* vehicleEntry);
 void vehicle_visual_launched_freefall(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry);
-void vehicle_visual_splash_effect(
-    paint_session& session, int32_t z, const Vehicle* vehicle, const rct_ride_entry_vehicle* vehicleEntry);
+    const CarEntry* vehicleEntry);
+void vehicle_visual_splash_effect(paint_session& session, int32_t z, const Vehicle* vehicle, const CarEntry* vehicleEntry);
 void vehicle_visual_virginia_reel(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry);
+    const CarEntry* vehicleEntry);
 void vehicle_visual_submarine(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry);
+    const CarEntry* vehicleEntry);
 void vehicle_visual_mini_golf_player(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle);
 void vehicle_visual_mini_golf_ball(

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -28,7 +28,7 @@
  */
 void vehicle_visual_reverser(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    const CarEntry* vehicleEntry)
 {
     Vehicle* v1 = GetEntity<Vehicle>(vehicle->prev_vehicle_on_ride);
     Vehicle* v2 = GetEntity<Vehicle>(vehicle->next_vehicle_on_ride);

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -165,7 +165,7 @@ static constexpr const uint32_t virginia_reel_track_pieces_flat_quarter_turn_1_t
  */
 void vehicle_visual_virginia_reel(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    const CarEntry* vehicleEntry)
 {
     imageDirection = OpenRCT2::Entity::Yaw::YawTo32(imageDirection);
     const uint8_t rotation = session.CurrentRotation;

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -36,7 +36,7 @@ static void PaintCircusTent(paint_session& session, const Ride& ride, uint8_t di
     {
         imageTemplate = ImageId::FromUInt32(imageFlags);
     }
-    auto imageIndex = rideEntry->vehicles[0].base_image_id + direction;
+    auto imageIndex = rideEntry->Cars[0].base_image_id + direction;
 
     PaintAddImageAsParent(
         session, imageTemplate.WithIndex(imageIndex), { al, cl, height + 3 }, { 24, 24, 47 }, { al + 16, cl + 16, height + 3 });

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -77,7 +77,7 @@ static void PaintCrookedHouseStructure(
 
     const auto& boundBox = crooked_house_data[segment];
     auto imageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_MISC]);
-    auto imageIndex = rideEntry->vehicles[0].base_image_id + direction;
+    auto imageIndex = rideEntry->Cars[0].base_image_id + direction;
     PaintAddImageAsParent(
         session, imageTemplate.WithIndex(imageIndex), { x_offset, y_offset, height + 3 }, { boundBox.length, 127 },
         { boundBox.offset, height + 3 });

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -57,7 +57,7 @@ static void PaintFerrisWheelRiders(
             continue;
 
         auto frameNum = (vehicle.Pitch + i * 4) % 128;
-        auto imageIndex = rideEntry.vehicles[0].base_image_id + 32 + direction * 128 + frameNum;
+        auto imageIndex = rideEntry.Cars[0].base_image_id + 32 + direction * 128 + frameNum;
         auto imageId = ImageId(imageIndex, vehicle.peep_tshirt_colours[i], vehicle.peep_tshirt_colours[i + 1]);
         PaintAddImageAsChild(session, imageId, offset, bbLength, bbOffset);
     }
@@ -92,7 +92,7 @@ static void PaintFerrisWheelStructure(
 
     auto imageOffset = vehicle != nullptr ? vehicle->Pitch % 8 : 0;
     auto leftSupportImageId = supportsImageTemplate.WithIndex(22150 + (direction & 1) * 2);
-    auto wheelImageId = wheelImageTemplate.WithIndex(rideEntry->vehicles[0].base_image_id + direction * 8 + imageOffset);
+    auto wheelImageId = wheelImageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + direction * 8 + imageOffset);
     auto rightSupportImageId = leftSupportImageId.WithIndexOffset(1);
 
     PaintAddImageAsParent(session, leftSupportImageId, offset, bbLength, bbOffset);

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -47,7 +47,7 @@ static void PaintHauntedHouseStructure(
 
     const auto& boundBox = haunted_house_data[part];
     auto imageTemplate = ImageId::FromUInt32(session.TrackColours[SCHEME_MISC]);
-    auto baseImageIndex = rideEntry->vehicles[0].base_image_id;
+    auto baseImageIndex = rideEntry->Cars[0].base_image_id;
     auto imageIndex = baseImageIndex + direction;
     PaintAddImageAsParent(
         session, imageTemplate.WithIndex(imageIndex), { xOffset, yOffset, height }, { boundBox.length, 127 },

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -44,7 +44,7 @@ static void PaintRiders(
         if (imageOffset >= 68)
             continue;
 
-        auto imageIndex = rideEntry.vehicles[0].base_image_id + 32 + imageOffset;
+        auto imageIndex = rideEntry.Cars[0].base_image_id + 32 + imageOffset;
         auto imageId = ImageId(imageIndex, vehicle.peep_tshirt_colours[peep], vehicle.peep_tshirt_colours[peep + 1]);
         PaintAddImageAsChild(session, imageId, offset, bbLength, bbOffset);
     }
@@ -90,7 +90,7 @@ static void PaintCarousel(
         imageTemplate = ImageId::FromUInt32(imageFlags);
     }
     auto imageOffset = rotationOffset & 0x1F;
-    auto imageId = imageTemplate.WithIndex(rideEntry->vehicles[0].base_image_id + imageOffset);
+    auto imageId = imageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + imageOffset);
     PaintAddImageAsParent(session, imageId, offset, bbLength, bbOffset);
 
     PaintRiders(session, ride, *rideEntry, *vehicle, rotationOffset, offset, bbLength, bbOffset);

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -1228,7 +1228,7 @@ void vehicle_visual_mini_golf_player(
     uint8_t frame = mini_golf_peep_animation_frames[EnumValue(vehicle->mini_golf_current_animation)][vehicle->animation_frame];
     uint32_t ebx = (frame << 2) + OpenRCT2::Entity::Yaw::YawTo4(imageDirection);
 
-    uint32_t image_id = rideEntry->vehicles[0].base_image_id + 1 + ebx;
+    uint32_t image_id = rideEntry->Cars[0].base_image_id + 1 + ebx;
     uint32_t peep_palette = peep->TshirtColour << 19 | peep->TrousersColour << 24 | 0x0A0000000;
     PaintAddImageAsParent(session, image_id | peep_palette, { 0, 0, z }, { 1, 1, 11 }, { 0, 0, z + 5 });
 }
@@ -1258,6 +1258,6 @@ void vehicle_visual_mini_golf_ball(
     if (rideEntry == nullptr)
         return;
 
-    uint32_t image_id = rideEntry->vehicles[0].base_image_id;
+    uint32_t image_id = rideEntry->Cars[0].base_image_id;
     PaintAddImageAsParent(session, image_id, { 0, 0, z }, { 1, 1, 0 }, { 0, 0, z + 3 });
 }

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -26,7 +26,7 @@ enum
 };
 
 static uint32_t GetObservationTowerVehicleBaseImageId(
-    const Vehicle* vehicle, const rct_ride_entry_vehicle* vehicleEntry, int32_t imageDirection)
+    const Vehicle* vehicle, const CarEntry* vehicleEntry, int32_t imageDirection)
 {
     uint32_t result = (vehicle->restraints_position / 64);
     if (vehicle->restraints_position >= 64)
@@ -63,7 +63,7 @@ static uint32_t GetObservationTowerVehicleBaseImageId(
  */
 void vehicle_visual_observation_tower(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    const CarEntry* vehicleEntry)
 {
     auto baseImageId = GetObservationTowerVehicleBaseImageId(vehicle, vehicleEntry, imageDirection);
     auto imageId0 = ImageId(

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -44,7 +44,7 @@ static void paint_space_rings_structure(
 
         int32_t frameNum = direction;
 
-        uint32_t baseImageId = rideEntry->vehicles[0].base_image_id;
+        uint32_t baseImageId = rideEntry->Cars[0].base_image_id;
         auto vehicle = GetEntity<Vehicle>(ride.vehicles[vehicleIndex]);
         if (ride.lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK && vehicle != nullptr)
         {

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -59,13 +59,13 @@ static void spiral_slide_paint_tile_right(
     uint32_t image_id = 0;
 
     if (direction == 0)
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_RIGHT_R0) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R0) | session.TrackColours[SCHEME_TRACK];
     if (direction == 1)
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_RIGHT_R1) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R1) | session.TrackColours[SCHEME_TRACK];
     if (direction == 2)
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_RIGHT_R2) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R2) | session.TrackColours[SCHEME_TRACK];
     if (direction == 3)
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_RIGHT_R3) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_RIGHT_R3) | session.TrackColours[SCHEME_TRACK];
 
     PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 16, 108 }, { 16, 0, height + 3 });
 }
@@ -81,13 +81,13 @@ static void spiral_slide_paint_tile_left(
     uint32_t image_id = 0;
 
     if (direction == 0)
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_LEFT_R0) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R0) | session.TrackColours[SCHEME_TRACK];
     if (direction == 1)
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_LEFT_R1) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R1) | session.TrackColours[SCHEME_TRACK];
     if (direction == 2)
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_LEFT_R2) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R2) | session.TrackColours[SCHEME_TRACK];
     if (direction == 3)
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_LEFT_R3) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_LEFT_R3) | session.TrackColours[SCHEME_TRACK];
 
     PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 16, 108 }, { 0, 16, height + 3 });
 }
@@ -104,33 +104,33 @@ static void spiral_slide_paint_tile_front(
 
     if (direction == 1)
     {
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_INSIDE_R1) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_INSIDE_R1) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 2, 16, 108 }, { -12, 0, height + 3 });
     }
     else if (direction == 2)
     {
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_INSIDE_R2) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_INSIDE_R2) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 2, 108 }, { 0, -12, height + 3 });
     }
 
     if (direction == 0)
     {
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_CENTRE_R0) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R0) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 8, 108 }, { 0, 8, height + 3 });
     }
     else if (direction == 1)
     {
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_CENTRE_R1) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R1) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 2, 16, 108 }, { 14, 0, height + 3 });
     }
     else if (direction == 2)
     {
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_CENTRE_R2) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R2) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 16, 2, 108 }, { 0, 14, height + 3 });
     }
     else if (direction == 3)
     {
-        image_id = (rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_CENTRE_R3) | session.TrackColours[SCHEME_TRACK];
+        image_id = (rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_CENTRE_R3) | session.TrackColours[SCHEME_TRACK];
         PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 8, 16, 108 }, { 8, 0, height + 3 });
     }
 
@@ -150,7 +150,7 @@ static void spiral_slide_paint_tile_front(
 
         if (slide_progress < 46)
         {
-            int32_t offset = rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_PEEP + 46 * direction;
+            int32_t offset = rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_PEEP + 46 * direction;
             CoordsXYZ boundingBox = { 0, 0, 108 };
             CoordsXYZ boundingBoxOffset = { 0, 0, static_cast<int16_t>(height + 3) };
 
@@ -212,17 +212,17 @@ static void paint_spiral_slide(
 
     if (stationObject != nullptr && !(stationObject->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS))
     {
-        uint32_t imageId = ((direction & 1) ? rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_BASE_B
-                                            : rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_BASE_A)
+        uint32_t imageId = ((direction & 1) ? rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_BASE_B
+                                            : rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_BASE_A)
             | session.TrackColours[SCHEME_SUPPORTS];
         PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 1 }, { 0, 0, height });
     }
 
     const uint32_t spiral_slide_fence_sprites[] = {
-        rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_FENCE_TOP_RIGHT,
-        rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_FENCE_BOTTOM_RIGHT,
-        rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_FENCE_BOTTOM_LEFT,
-        rideEntry->vehicles[0].base_image_id + SPIRAL_SLIDE_FENCE_TOP_LEFT,
+        rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_FENCE_TOP_RIGHT,
+        rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_FENCE_BOTTOM_RIGHT,
+        rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_FENCE_BOTTOM_LEFT,
+        rideEntry->Cars[0].base_image_id + SPIRAL_SLIDE_FENCE_TOP_LEFT,
     };
 
     track_paint_util_paint_fences(

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -27,7 +27,7 @@ static void PaintFacility(
     if (rideEntry == nullptr)
         return;
 
-    auto firstVehicleEntry = &rideEntry->vehicles[0];
+    auto firstVehicleEntry = &rideEntry->Cars[0];
     if (firstVehicleEntry == nullptr)
         return;
 

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -27,7 +27,7 @@ static void PaintShop(
     if (rideEntry == nullptr)
         return;
 
-    auto firstVehicleEntry = &rideEntry->vehicles[0];
+    auto firstVehicleEntry = &rideEntry->Cars[0];
     if (firstVehicleEntry == nullptr)
         return;
 

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -37,7 +37,7 @@ static void Paint3dCinemaDome(
         imageTemplate = ImageId::FromUInt32(imageFlags);
     }
 
-    auto imageId = imageTemplate.WithIndex(rideEntry->vehicles[0].base_image_id + direction);
+    auto imageId = imageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + direction);
     PaintAddImageAsParent(
         session, imageId, { xOffset, yOffset, height + 3 }, { 24, 24, 47 }, { xOffset + 16, yOffset + 16, height + 3 });
 

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -27,7 +27,7 @@ static void PaintEnterpriseRiders(
     if (imageOffset >= 12)
         return;
 
-    auto baseImageIndex = rideEntry.vehicles[0].base_image_id;
+    auto baseImageIndex = rideEntry.Cars[0].base_image_id;
     for (int32_t i = 0; i < 15; i++)
     {
         if (vehicle.num_peeps <= i)
@@ -75,7 +75,7 @@ static void PaintEnterpriseStructure(
     {
         imageTemplate = ImageId::FromUInt32(imageFlags);
     }
-    auto imageId = imageTemplate.WithIndex(rideEntry->vehicles[0].base_image_id + imageOffset);
+    auto imageId = imageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + imageOffset);
     PaintAddImageAsParent(session, imageId, offset, bbLength, bbOffset);
 
     if (vehicle != nullptr)

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -31,7 +31,7 @@ enum
  */
 void vehicle_visual_launched_freefall(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    const CarEntry* vehicleEntry)
 {
     auto imageFlags = SPRITE_ID_PALETTE_COLOUR_2(vehicle->colours.body_colour, vehicle->colours.trim_colour);
     if (vehicle->IsGhost())

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -110,7 +110,7 @@ static void PaintMagicCarpetRiders(
     if (session.DPI.zoom_level > ZoomLevel{ 1 })
         return;
 
-    auto baseImageIndex = rideEntry.vehicles[0].base_image_id + 4 + direction;
+    auto baseImageIndex = rideEntry.Cars[0].base_image_id + 4 + direction;
     for (uint8_t peepIndex = 0; peepIndex < vehicle.num_peeps; peepIndex += 2)
     {
         auto imageIndex = baseImageIndex + (peepIndex * 2);
@@ -180,7 +180,7 @@ static void PaintMagicCarpetVehicle(
     {
         imageTemplate = ImageId::FromUInt32(imageFlags);
     }
-    auto vehicleImageIndex = rideEntry->vehicles[0].base_image_id + direction;
+    auto vehicleImageIndex = rideEntry->Cars[0].base_image_id + direction;
     PaintAddImageAsChild(session, imageTemplate.WithIndex(vehicleImageIndex), offset, bbSize, bbOffset);
 
     auto* vehicle = GetFirstVehicle(ride);

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -50,7 +50,7 @@ static void PaintMotionSimulatorVehicle(
         }
     }
 
-    auto imageIndex = rideEntry->vehicles[0].base_image_id + direction;
+    auto imageIndex = rideEntry->Cars[0].base_image_id + direction;
     if (vehicle != nullptr)
     {
         if (vehicle->restraints_position >= 64)

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -35,7 +35,7 @@ enum
  */
 void vehicle_visual_roto_drop(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    const CarEntry* vehicleEntry)
 {
     imageDirection = OpenRCT2::Entity::Yaw::YawTo32(imageDirection);
 

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -88,13 +88,13 @@ static void PaintSwingingInverterShipStructure(
         }
     }
 
-    ImageIndex vehicleImageIndex = rideEntry->vehicles[0].base_image_id + SwingingInverterShipBaseSpriteOffset[direction];
+    ImageIndex vehicleImageIndex = rideEntry->Cars[0].base_image_id + SwingingInverterShipBaseSpriteOffset[direction];
     if (vehicle != nullptr)
     {
         int32_t rotation = static_cast<int8_t>(vehicle->Pitch);
         if (rotation != 0)
         {
-            vehicleImageIndex = rideEntry->vehicles[0].base_image_id + SwingingInverterShipAnimatingBaseSpriteOffset[direction];
+            vehicleImageIndex = rideEntry->Cars[0].base_image_id + SwingingInverterShipAnimatingBaseSpriteOffset[direction];
             if (direction & 2)
             {
                 rotation = -rotation;

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -111,7 +111,7 @@ static void PaintSwingingShipStructure(
     CoordsXYZ bbLength(bounds.length_x, bounds.length_y, 80);
     CoordsXYZ bbOffset(bounds.offset_x, bounds.offset_y, height + 7);
 
-    auto baseImageId = rideEntry->vehicles[0].base_image_id + SwingingShipBaseSpriteOffset[direction];
+    auto baseImageId = rideEntry->Cars[0].base_image_id + SwingingShipBaseSpriteOffset[direction];
     if (vehicle != nullptr)
     {
         int32_t rotation = static_cast<int8_t>(vehicle->Pitch);

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -64,7 +64,7 @@ static void PaintTopSpinSeat(
     if (armRotation >= std::size(TopSpinSeatHeightOffset))
         return;
 
-    const auto& vehicleEntry = rideEntry.vehicles[0];
+    const auto& vehicleEntry = rideEntry.Cars[0];
 
     ImageIndex seatImageIndex;
     if (vehicle != nullptr && vehicle->restraints_position >= 64)
@@ -122,7 +122,7 @@ static void PaintTopSpinVehicle(
     if (rideEntry == nullptr)
         return;
 
-    const auto& vehicleEntry = rideEntry->vehicles[0];
+    const auto& vehicleEntry = rideEntry->Cars[0];
 
     height += 3;
     uint8_t seatRotation = 0;

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -55,7 +55,7 @@ static void paint_twist_structure(
         imageTemplate = ImageId::FromUInt32(imageFlags);
     }
 
-    auto baseImageId = rideEntry->vehicles[0].base_image_id;
+    auto baseImageId = rideEntry->Cars[0].base_image_id;
     auto structureFrameNum = frameNum % 24;
     auto imageId = imageTemplate.WithIndex(baseImageId + structureFrameNum);
     PaintAddImageAsParent(

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -179,7 +179,7 @@ static constexpr const uint32_t river_rapids_track_pieces_25_deg_down_to_flat[][
  */
 void vehicle_visual_river_rapids(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    const CarEntry* vehicleEntry)
 {
     imageDirection = OpenRCT2::Entity::Yaw::YawTo32(imageDirection);
 

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -1256,7 +1256,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_splash_boats(int32_t trackType)
  */
 void vehicle_visual_splash_boats_or_water_coaster(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    const CarEntry* vehicleEntry)
 {
     auto* vehicleToPaint = vehicle->IsHead() ? GetEntity<Vehicle>(vehicle->next_vehicle_on_ride)
                                              : GetEntity<Vehicle>(vehicle->prev_vehicle_on_ride);

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -16,8 +16,7 @@
 #include "../Vehicle.h"
 #include "../VehiclePaint.h"
 
-static uint32_t SubmarineVehicleGetBaseImageId(
-    const Vehicle* vehicle, const rct_ride_entry_vehicle* vehicleEntry, int32_t imageDirection)
+static uint32_t SubmarineVehicleGetBaseImageId(const Vehicle* vehicle, const CarEntry* vehicleEntry, int32_t imageDirection)
 {
     uint32_t result = imageDirection;
     if (vehicle->restraints_position >= 64)
@@ -44,7 +43,7 @@ static uint32_t SubmarineVehicleGetBaseImageId(
  */
 void vehicle_visual_submarine(
     paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
-    const rct_ride_entry_vehicle* vehicleEntry)
+    const CarEntry* vehicleEntry)
 {
     auto baseImageId = SubmarineVehicleGetBaseImageId(vehicle, vehicleEntry, imageDirection);
     auto imageId0 = ImageId(

--- a/src/openrct2/scripting/bindings/object/ScObject.hpp
+++ b/src/openrct2/scripting/bindings/object/ScObject.hpp
@@ -331,7 +331,7 @@ namespace OpenRCT2::Scripting
             auto entry = GetEntry();
             if (entry != nullptr)
             {
-                return entry->no_vehicle_images;
+                return entry->NumCarImages;
             }
             return 0;
         }
@@ -381,7 +381,7 @@ namespace OpenRCT2::Scripting
             auto entry = GetEntry();
             if (entry != nullptr)
             {
-                return entry->log_flume_reverser_vehicle_type;
+                return entry->ReversedCarIndex;
             }
             return 0;
         }
@@ -472,15 +472,15 @@ namespace OpenRCT2::Scripting
             return static_cast<RideObject*>(objManager.GetLoadedObject(_objectType, _objectIndex));
         }
 
-        const rct_ride_entry_vehicle* GetEntry() const
+        const CarEntry* GetEntry() const
         {
             auto obj = GetObject();
             if (obj != nullptr)
             {
                 auto rideEntry = static_cast<rct_ride_entry*>(obj->GetLegacyData());
-                if (rideEntry != nullptr && _vehicleIndex < std::size(rideEntry->vehicles))
+                if (rideEntry != nullptr && _vehicleIndex < std::size(rideEntry->Cars))
                 {
-                    return rideEntry->GetVehicle(_vehicleIndex);
+                    return rideEntry->GetCar(_vehicleIndex);
                 }
             }
             return nullptr;
@@ -622,7 +622,7 @@ namespace OpenRCT2::Scripting
             auto entry = GetLegacyData();
             if (entry != nullptr)
             {
-                return entry->tab_vehicle;
+                return entry->TabCar;
             }
             return 0;
         }
@@ -632,7 +632,7 @@ namespace OpenRCT2::Scripting
             auto entry = GetLegacyData();
             if (entry != nullptr)
             {
-                return entry->default_vehicle;
+                return entry->DefaultCar;
             }
             return 0;
         }
@@ -642,7 +642,7 @@ namespace OpenRCT2::Scripting
             auto entry = GetLegacyData();
             if (entry != nullptr)
             {
-                return entry->front_vehicle;
+                return entry->FrontCar;
             }
             return 0;
         }
@@ -652,7 +652,7 @@ namespace OpenRCT2::Scripting
             auto entry = GetLegacyData();
             if (entry != nullptr)
             {
-                return entry->second_vehicle;
+                return entry->SecondCar;
             }
             return 0;
         }
@@ -662,7 +662,7 @@ namespace OpenRCT2::Scripting
             auto entry = GetLegacyData();
             if (entry != nullptr)
             {
-                return entry->rear_vehicle;
+                return entry->RearCar;
             }
             return 0;
         }
@@ -672,7 +672,7 @@ namespace OpenRCT2::Scripting
             auto entry = GetLegacyData();
             if (entry != nullptr)
             {
-                return entry->third_vehicle;
+                return entry->ThirdCar;
             }
             return 0;
         }
@@ -683,7 +683,7 @@ namespace OpenRCT2::Scripting
             auto entry = GetLegacyData();
             if (entry != nullptr)
             {
-                for (size_t i = 0; i < std::size(entry->vehicles); i++)
+                for (size_t i = 0; i < std::size(entry->Cars); i++)
                 {
                     result.push_back(std::make_shared<ScRideObjectVehicle>(static_cast<ObjectType>(_type), _index, i));
                 }


### PR DESCRIPTION
Currently, the word “vehicle” is used for both “train” and “car”. This is a first effort towards disambiguation.