### PR TITLE
Fix #17187: Text input window does not resize correctly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#17099] Object selection thumbnail box is one pixel too tall.
 - Fix: [#17104] Changing map size does not invalidate park size.
 - Fix: [#17157] Crash when browsing “Up” to folder with CJK characters in its name.
+- Fix: [#17187] Text input window does not resize correctly.
 - Fix: [#17197] Segfault when extracting files from the GOG installer.
 - Fix: [#17205] Map generator sometimes crashes when not all standard terrain objects are available.
 - Fix: [#17221] Object ghosts and tooltips follow invisible cursor when moving the viewport by right-click dragging.

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -170,8 +170,7 @@ public:
         int32_t newHeight = CalculateWindowHeight(_buffer.data());
         if (newHeight != height)
         {
-            Invalidate();
-            window_set_resize(this, WW, height, WW, height);
+            window_set_resize(this, WW, newHeight, WW, newHeight);
         }
 
         widgets[WIDX_OKAY].top = newHeight - 22;


### PR DESCRIPTION
window_set_resize() already invalidates, so no need to call it twice.

Supersedes #17262.

When merging, make sure it includes the Co-authored-by line. Or use non-squashed merge.