### PR TITLE
Fix #16392: Scenery on sloped surface is placed at wrong height.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,9 +68,9 @@ set(OBJECTS_VERSION "1.3.2")
 set(OBJECTS_URL  "https://github.com/OpenRCT2/objects/releases/download/v${OBJECTS_VERSION}/objects.zip")
 set(OBJECTS_SHA1 "040a99a8626ad7a7f43f8c8a17c3f4e1375b218f")
 
-set(REPLAYS_VERSION "0.0.67")
+set(REPLAYS_VERSION "0.0.68")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "0CA2DB3BEE021F0402D3E0F0E9EDB142CCEAFFC6")
+set(REPLAYS_SHA1 "FC8EFE3FCA71F75D79728494ACC42DB49B18B529")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#16662] Show a warning message when g2.dat is mismatched.
 - Change: [#17319] Giant screenshots are now cropped to the horizontal view-clipping selection.
 - Change: [#17499] Update error text when using vehicle incompatible with TD6 and add error when using incompatible track elements.
+- Fix: [#16392] Scenery on sloped surface is placed at wrong height.
 - Fix: [#16476] The game sometimes crashes when demolishing a maze.
 - Fix: [#17444] “Manta Ray” boats slowed down too much in “Ayers Rock” scenario (original bug).
 - Fix: [#17503] Parks with staff with an ID of 0 have all staff windows focus on that staff

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -47,8 +47,8 @@
     <TitleSequencesSha1>4ab0065e5a4d9f9c77d94718bbdfcfcd5a389da0</TitleSequencesSha1>
     <ObjectsUrl>https://github.com/OpenRCT2/objects/releases/download/v1.3.2/objects.zip</ObjectsUrl>
     <ObjectsSha1>040a99a8626ad7a7f43f8c8a17c3f4e1375b218f</ObjectsSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.67/replays.zip</ReplaysUrl>
-    <ReplaysSha1>0CA2DB3BEE021F0402D3E0F0E9EDB142CCEAFFC6</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.68/replays.zip</ReplaysUrl>
+    <ReplaysSha1>FC8EFE3FCA71F75D79728494ACC42DB49B18B529</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/actions/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.cpp
@@ -135,8 +135,8 @@ GameActions::Result SmallSceneryPlaceAction::Query() const
     }
     else
     {
-        loc2.x += SceneryQuadrantOffsets[quadrant & 3].x - 1;
-        loc2.y += SceneryQuadrantOffsets[quadrant & 3].y - 1;
+        loc2.x += SceneryQuadrantOffsets[quadrant & 3].x;
+        loc2.y += SceneryQuadrantOffsets[quadrant & 3].y;
     }
     landHeight = tile_element_height(loc2);
     waterHeight = tile_element_water_height(loc2);
@@ -329,8 +329,8 @@ GameActions::Result SmallSceneryPlaceAction::Execute() const
     }
     else
     {
-        x2 += SceneryQuadrantOffsets[quadrant & 3].x - 1;
-        y2 += SceneryQuadrantOffsets[quadrant & 3].y - 1;
+        x2 += SceneryQuadrantOffsets[quadrant & 3].x;
+        y2 += SceneryQuadrantOffsets[quadrant & 3].y;
     }
     landHeight = tile_element_height({ x2, y2 });
     waterHeight = tile_element_water_height({ x2, y2 });

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -626,10 +626,10 @@ int16_t tile_element_height(const CoordsXY& loc)
         switch (slope)
         {
             case TILE_ELEMENT_SLOPE_W_E_VALLEY:
-                quad = std::abs(xl + yl - TILE_SIZE);
+                quad = std::abs(xl - yl);
                 break;
             case TILE_ELEMENT_SLOPE_N_S_VALLEY:
-                quad = std::abs(xl - yl);
+                quad = std::abs(xl + yl - TILE_SIZE);
                 break;
         }
         height += quad / 2;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -527,7 +527,7 @@ int16_t tile_element_height(const CoordsXY& loc)
 
     uint8_t xl, yl; // coordinates across this tile
 
-    uint8_t TILE_SIZE = 31;
+    uint8_t TILE_SIZE = 32;
 
     xl = loc.x & 0x1f;
     yl = loc.y & 0x1f;
@@ -569,14 +569,13 @@ int16_t tile_element_height(const CoordsXY& loc)
     switch (slope)
     {
         case TILE_ELEMENT_SLOPE_NE_SIDE_UP:
-            height += xl / 2 + 1;
+            height += xl / 2;
             break;
         case TILE_ELEMENT_SLOPE_SE_SIDE_UP:
             height += (TILE_SIZE - yl) / 2;
             break;
         case TILE_ELEMENT_SLOPE_NW_SIDE_UP:
             height += yl / 2;
-            height++;
             break;
         case TILE_ELEMENT_SLOPE_SW_SIDE_UP:
             height += (TILE_SIZE - xl) / 2;
@@ -595,7 +594,7 @@ int16_t tile_element_height(const CoordsXY& loc)
                 break;
             case TILE_ELEMENT_SLOPE_S_CORNER_DN:
                 quad_extra = xl + yl;
-                quad = xl + yl - TILE_SIZE - 1;
+                quad = xl + yl - TILE_SIZE;
                 break;
             case TILE_ELEMENT_SLOPE_E_CORNER_DN:
                 quad_extra = TILE_SIZE - xl + yl;
@@ -603,14 +602,13 @@ int16_t tile_element_height(const CoordsXY& loc)
                 break;
             case TILE_ELEMENT_SLOPE_N_CORNER_DN:
                 quad_extra = (TILE_SIZE - xl) + (TILE_SIZE - yl);
-                quad = TILE_SIZE - yl - xl - 1;
+                quad = TILE_SIZE - yl - xl;
                 break;
         }
 
         if (extra_height)
         {
             height += quad_extra / 2;
-            height++;
             return height;
         }
         // This tile is essentially at the next height level
@@ -628,20 +626,13 @@ int16_t tile_element_height(const CoordsXY& loc)
         switch (slope)
         {
             case TILE_ELEMENT_SLOPE_W_E_VALLEY:
-                if (xl + yl <= TILE_SIZE + 1)
-                {
-                    return height;
-                }
-                quad = TILE_SIZE - xl - yl;
+                quad = std::abs(xl + yl - TILE_SIZE);
                 break;
             case TILE_ELEMENT_SLOPE_N_S_VALLEY:
-                quad = xl - yl;
+                quad = std::abs(xl - yl);
                 break;
         }
-        if (quad > 0)
-        {
-            height += quad / 2;
-        }
+        height += quad / 2;
     }
 
     return height;

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -59,10 +59,10 @@ static std::vector<ScenerySelection> _restrictedScenery;
 
 // rct2: 0x009A3E74
 const CoordsXY SceneryQuadrantOffsets[] = {
-    { 7, 7 },
-    { 7, 23 },
-    { 23, 23 },
-    { 23, 7 },
+    { 8, 8 },
+    { 8, 24 },
+    { 24, 24 },
+    { 24, 8 },
 };
 
 LargeSceneryText::LargeSceneryText(const rct_large_scenery_text& original)


### PR DESCRIPTION
#### Problem

Fix of https://github.com/OpenRCT2/OpenRCT2/issues/16392. Inspection of [Map.cpp](https://github.com/OpenRCT2/OpenRCT2/blob/develop/src/openrct2/world/Map.cpp) shows that the logic in `tile_element_height` seems to be wrong, which is explained in the following.

#### Bug

A lot of calls to `tile_element_height` hand over coordinates that represent the center of a tile, i.e. `x + 16, y + 16` for some tile coordinates `x, y`. (Note: This should be understood as the exact center of a tile of size 32 x 32, and not as the 16th cell in a 32 x 32 grid).
In the example of a surface element with two adjacent elevated corners (as seen in https://github.com/OpenRCT2/OpenRCT2/issues/16392), the center of the tile should be exactly `LAND_HEIGHT_STEP / 2 = 16 / 2 = 8` elevated. But, for e.g. South-East up, the height is calculated as `height + (TILE_SIZE - y) / 2 = height + (31 - 16) / 2 = height + 15 / 2 = 7`. Later, this is divided by `COORDS_Z_STEP = 8` and yields `0` instead of `1`.

Arguably, because of the aforementioned interpretation of the coordinates, `TILE_SIZE` should be `32` instead of `31`, and all `+1`'s and `-1`'s in the calculation should be removed.

Furthermore, the calculation for valleys is just plain wrong.

#### Effects

I looked through *all* occurences of `tile_element_height` and tried to find potential issues.
- `SmallSceneryPlaceAction` will now choose the correct height for scenery on slopes.
- Various `GameAction`s that return a result with a world position may be off by one, now reporting the correct value (the exact center of a tile).
- Swimming ducks may hit the shoreline 1 unit earlier.
- Various graphical effects may be offset by one, now using the correct value, e.g. the money animation, particle effects, viewport movements, height markers
- Three occurences in `Peep.cpp` that I did not track any further. After skimming the code, I guess it will make only a slight difference, but you are welcome to look deeper into it. One occurence for mowing staff.
- Tree placement in the map generation code probably suffered from the same problem as the `SmallSceneryPlaceAction`.
- Crashes of flying vehicles may now happen on land instead of water if the vehicle hits exactly the shore line which also is a slope.

Here, "off by one" refers to the effects of changing `TILE_SIZE` to `32`. The effects for fixing the valley calculations will be similiar, but bigger. Anyway, I consider all of the above effects to be 'bugfixing' and thus wanted.

#### Update

I changed SceneryQuadrantsOffset to use the coordinates `8` and `24` instead of `7` and `23`, following the same logic as explained throughout this PR. The call to `tile_element_height` for quarter tile scenery in `SmallSceneryPlaceAction` is now consistent with the call for full tile scenery, which uses coordinates `16`, `16`.