### PR TITLE
Fix: [#17346] Surface height markers are concealed by sprites of same surface.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -37,6 +37,7 @@
 - Fix: [#17310] Reversed reversible vehicles not imported properly when loading RCT1 parks.
 - Fix: [#17335] [Plugin] Documentation has an incorrect type for PixelData 'data' attribute.
 - Fix: [#17337] Air Powered Vertical Coaster trains not imported properly when loading RCT1 parks.
+- Fix: [#17346] Surface height markers are concealed by sprites of same surface.
 
 0.4.0 (2022-04-25)
 ------------------------------------------------------------------------

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1089,14 +1089,14 @@ void PaintSurface(paint_session& session, uint8_t direction, uint16_t height, co
         const int16_t x = session.MapPosition.x;
         const int16_t y = session.MapPosition.y;
 
-        int32_t dx = tile_element_height({ x + 16, y + 16 });
-        dx += 3;
+        int32_t surfaceHeight = tile_element_height({ x + 16, y + 16 });
+        int32_t dx = surfaceHeight + 3;
 
         int32_t image_id = (SPR_HEIGHT_MARKER_BASE + dx / 16) | 0x20780000;
         image_id += get_height_marker_offset();
         image_id -= gMapBaseZ;
 
-        PaintAddImageAsParent(session, image_id, { 16, 16, height }, { 1, 1, 0 });
+        PaintAddImageAsParent(session, image_id, { 16, 16, surfaceHeight }, { 1, 1, 0 });
     }
 
     bool has_surface = false;


### PR DESCRIPTION
Raised the label to the height of the center of the surface, instead of the base height of the surface.

Before:
![image](https://user-images.githubusercontent.com/15895532/172203631-e168b6c2-d4e6-4927-bdf8-2bd0f2791b6e.png)

After:
![image](https://user-images.githubusercontent.com/15895532/172203976-0bac7f08-0299-46e7-aba9-f8deaea59a6b.png)

