### PR TITLE
Refactor a couple internal Window member variables

### DIFF
--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -136,6 +136,8 @@ static constexpr const ScreenCoordsXY MiniMapOffsets[] = {
 
 class MapWindow final : public Window
 {
+    uint8_t rotation;
+
 public:
     MapWindow()
     {
@@ -152,7 +154,7 @@ public:
 
         InitScrollWidgets();
 
-        map.rotation = get_current_rotation();
+        rotation = get_current_rotation();
 
         InitMap();
         gWindowSceneryRotation = 0;
@@ -318,9 +320,9 @@ public:
 
     void OnUpdate() override
     {
-        if (get_current_rotation() != map.rotation)
+        if (get_current_rotation() != rotation)
         {
-            map.rotation = get_current_rotation();
+            rotation = get_current_rotation();
             InitMap();
             CentreMapOnViewPoint();
         }

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -136,7 +136,7 @@ static constexpr const ScreenCoordsXY MiniMapOffsets[] = {
 
 class MapWindow final : public Window
 {
-    uint8_t rotation;
+    uint8_t _rotation;
 
 public:
     MapWindow()
@@ -154,7 +154,7 @@ public:
 
         InitScrollWidgets();
 
-        rotation = get_current_rotation();
+        _rotation = get_current_rotation();
 
         InitMap();
         gWindowSceneryRotation = 0;
@@ -320,9 +320,9 @@ public:
 
     void OnUpdate() override
     {
-        if (get_current_rotation() != rotation)
+        if (get_current_rotation() != _rotation)
         {
-            rotation = get_current_rotation();
+            _rotation = get_current_rotation();
             InitMap();
             CentreMapOnViewPoint();
         }

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -58,6 +58,9 @@ class SignWindow final : public Window
 {
 private:
     bool _isSmall = false;
+    ObjectEntryIndex _sceneryEntry = OBJECT_ENTRY_INDEX_NULL;
+    colour_t _mainColour = {};
+    colour_t _textColour = {};
 
     BannerIndex GetBannerIndex() const
     {
@@ -110,9 +113,9 @@ public:
             {
                 return false;
             }
-            list_information_type = wallElement->GetPrimaryColour();
-            var_492 = wallElement->GetSecondaryColour();
-            SceneryEntry = wallElement->GetEntryIndex();
+            _mainColour = wallElement->GetPrimaryColour();
+            _textColour = wallElement->GetSecondaryColour();
+            _sceneryEntry = wallElement->GetEntryIndex();
         }
         else
         {
@@ -121,9 +124,9 @@ public:
             {
                 return false;
             }
-            list_information_type = sceneryElement->GetPrimaryColour();
-            var_492 = sceneryElement->GetSecondaryColour();
-            SceneryEntry = sceneryElement->GetEntryIndex();
+            _mainColour = sceneryElement->GetPrimaryColour();
+            _textColour = sceneryElement->GetSecondaryColour();
+            _sceneryEntry = sceneryElement->GetEntryIndex();
         }
 
         // Create viewport
@@ -188,10 +191,10 @@ public:
         switch (widgetIndex)
         {
             case WIDX_MAIN_COLOUR:
-                WindowDropdownShowColour(this, widget, TRANSLUCENT(colours[1]), static_cast<uint8_t>(list_information_type));
+                WindowDropdownShowColour(this, widget, TRANSLUCENT(colours[1]), static_cast<uint8_t>(_mainColour));
                 break;
             case WIDX_TEXT_COLOUR:
-                WindowDropdownShowColour(this, widget, TRANSLUCENT(colours[1]), static_cast<uint8_t>(var_492));
+                WindowDropdownShowColour(this, widget, TRANSLUCENT(colours[1]), static_cast<uint8_t>(_textColour));
                 break;
         }
     }
@@ -204,8 +207,8 @@ public:
             {
                 if (dropdownIndex == -1)
                     return;
-                list_information_type = dropdownIndex;
-                auto signSetStyleAction = SignSetStyleAction(GetBannerIndex(), dropdownIndex, var_492, !_isSmall);
+                _mainColour = dropdownIndex;
+                auto signSetStyleAction = SignSetStyleAction(GetBannerIndex(), dropdownIndex, _textColour, !_isSmall);
                 GameActions::Execute(&signSetStyleAction);
                 break;
             }
@@ -213,8 +216,8 @@ public:
             {
                 if (dropdownIndex == -1)
                     return;
-                var_492 = dropdownIndex;
-                auto signSetStyleAction = SignSetStyleAction(GetBannerIndex(), list_information_type, dropdownIndex, !_isSmall);
+                _textColour = dropdownIndex;
+                auto signSetStyleAction = SignSetStyleAction(GetBannerIndex(), _mainColour, dropdownIndex, !_isSmall);
                 GameActions::Execute(&signSetStyleAction);
                 break;
             }
@@ -241,7 +244,7 @@ public:
 
         if (_isSmall)
         {
-            auto* wallEntry = get_wall_entry(SceneryEntry);
+            auto* wallEntry = get_wall_entry(_sceneryEntry);
 
             main_colour_btn->type = WindowWidgetType::Empty;
             text_colour_btn->type = WindowWidgetType::Empty;
@@ -257,7 +260,7 @@ public:
         }
         else
         {
-            auto* sceneryEntry = get_large_scenery_entry(SceneryEntry);
+            auto* sceneryEntry = get_large_scenery_entry(_sceneryEntry);
 
             main_colour_btn->type = WindowWidgetType::Empty;
             text_colour_btn->type = WindowWidgetType::Empty;
@@ -272,8 +275,8 @@ public:
             }
         }
 
-        main_colour_btn->image = SPRITE_ID_PALETTE_COLOUR_1(list_information_type) | IMAGE_TYPE_TRANSPARENT | SPR_PALETTE_BTN;
-        text_colour_btn->image = SPRITE_ID_PALETTE_COLOUR_1(var_492) | IMAGE_TYPE_TRANSPARENT | SPR_PALETTE_BTN;
+        main_colour_btn->image = SPRITE_ID_PALETTE_COLOUR_1(_mainColour) | IMAGE_TYPE_TRANSPARENT | SPR_PALETTE_BTN;
+        text_colour_btn->image = SPRITE_ID_PALETTE_COLOUR_1(_textColour) | IMAGE_TYPE_TRANSPARENT | SPR_PALETTE_BTN;
     }
 
     void OnDraw(rct_drawpixelinfo& dpi) override

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -293,15 +293,6 @@ struct news_variables
     uint16_t var_488;
 };
 
-struct map_variables
-{
-    int16_t rotation;
-    int16_t var_482;
-    uint16_t var_484;
-    uint16_t var_486;
-    uint16_t var_488;
-};
-
 struct ride_variables
 {
     int16_t view;

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -284,15 +284,6 @@ struct new_ride_variables
     uint16_t selected_ride_countdown; // 488
 };
 
-struct news_variables
-{
-    int16_t var_480;
-    int16_t var_482;
-    uint16_t var_484;
-    uint16_t var_486;
-    uint16_t var_488;
-};
-
 struct ride_variables
 {
     int16_t view;

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -74,7 +74,6 @@ struct rct_window
         int16_t picked_peep_old_x; // staff/guest window: peep x gets set to 0x8000 on pickup, this is the old value
         int16_t vehicleIndex;      // Ride window: selected car when setting vehicle colours
         int16_t numberOfStaff;     // Used in park window.
-        int16_t SceneryEntry;      // Used in sign window.
         int16_t var_48C;
     };
     uint16_t frame_no{};              // updated every tic for motion in windows sprites

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -60,7 +60,6 @@ struct rct_window
         campaign_variables campaign;
         new_ride_variables new_ride;
         news_variables news;
-        map_variables map;
         ride_variables ride;
         track_list_variables track_list;
         error_variables error;

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -59,7 +59,6 @@ struct rct_window
     {
         campaign_variables campaign;
         new_ride_variables new_ride;
-        news_variables news;
         ride_variables ride;
         track_list_variables track_list;
         error_variables error;


### PR DESCRIPTION
These variables are not common across Window's so should be part of their specific class instances. This should help remove the unions after all the Window class refactors are completed.