### PR TITLE
Fix deadlock in AudioChannel and loop ride music

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#16825] Add Alpine Coaster track type.
 - Feature: [#17011] Option to show ride vehicles as separate entries when selecting a ride to construct.
+- Feature: [#17217] Add FLAC and OGG/vorbis as supported audio formats for ride music objects.
 - Improved: [#7983] The red colour in the ride stat screen and the ride graphs now corresponds better to negative effects on a ride’s stats.
 - Improved: [#13966] Music Style dropdown is now sorted by name.
 - Improved: [#16978] Tree placement is more natural during map generation.

--- a/src/openrct2-ui/audio/AudioChannel.cpp
+++ b/src/openrct2-ui/audio/AudioChannel.cpp
@@ -254,7 +254,7 @@ namespace OpenRCT2::Audio
                     bytesRead += readLen;
                     _offset += readLen;
                 }
-                if (_offset >= _source->GetLength())
+                if (readLen == 0 || _offset >= _source->GetLength())
                 {
                     if (_loop == 0)
                     {

--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -226,7 +226,8 @@ namespace OpenRCT2::RideAudio
                         auto source = audioContext->CreateStreamFromWAV(std::move(stream));
                         if (source != nullptr)
                         {
-                            auto channel = Mixer_Play_Music(source, MIXER_LOOP_NONE, true);
+                            auto shouldLoop = musicObj->GetTrackCount() == 1;
+                            auto channel = Mixer_Play_Music(source, shouldLoop ? MIXER_LOOP_INFINITE : MIXER_LOOP_NONE, true);
                             if (channel != nullptr)
                             {
                                 _musicChannels.emplace_back(instance, channel, source);


### PR DESCRIPTION
* Fixes a deadlock that occurs due to an ogg stream ending before all the expected bytes have been read. Discovered by @karst.
* Changes ride music (with only 1 song) to loop so that it doesn't reload the object which can take a second or so thus causing a gap in the music.