### PR TITLE
[Plugin] Fix Car.travelBy() moving other cars as well

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -44,6 +44,7 @@
 - Fix: [#17335] [Plugin] Documentation has an incorrect type for PixelData ‘data’ attribute.
 - Fix: [#17337] Air Powered Vertical Coaster trains not imported properly when loading RCT1 parks.
 - Fix: [#17346] Surface height markers are concealed by sprites of same surface.
+- Fix: [#17369] [Plugin] ‘Car.travelBy()’ moves other cars as well.
 - Fix: [#17381] Air Powered Vertical Coaster stat penalty is wrong.
 - Fix: [#17433] Wrong T-shirt colours for guests on a Twist ride.
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -8891,7 +8891,7 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
     UpdateVelocity();
 
     Vehicle* vehicle = this;
-    if (_vehicleVelocityF64E08 < 0)
+    if (_vehicleVelocityF64E08 < 0 && !vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION))
     {
         vehicle = vehicle->TrainTail();
     }


### PR DESCRIPTION
Hey all,

Ever since the plugin api's `trackProgress` and `travelBy()` were implemented for use in my ride vehicle editor plugin, they've been such a great feature. It shipped with one little bug though, where in some situations it would move other cars as well despite that it should be a single vehicle update. See the following video:

https://user-images.githubusercontent.com/20048660/172928892-6c51bb8d-b94f-403d-8922-4016f966dbeb.mp4

In the last few days I tried to track down what the issue is here. It turns out that when the gravity caused by the track angle is too strong compared the vehicles current velocity in a single tick, it will push all vehicles in the other direction by switching to another car first (the tail vehicle). This fix prevents that from happening if the `UpdateTrackMotion()` is called with the `VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION` flag, which is only used for the plugin api. For all other cases (regular game situations) there should be no difference. The tests (like BPB 1000 ticks) should hopefully prove this. :)

The final result:

https://user-images.githubusercontent.com/20048660/172934375-aade8383-3f55-4eef-98fd-6744a856cf93.mp4

Thank you for your time!

