### PR TITLE
Add missing includes to VehicleEntry.h

### DIFF
--- a/src/openrct2/ride/VehicleEntry.h
+++ b/src/openrct2/ride/VehicleEntry.h
@@ -12,8 +12,11 @@
 #include "../audio/AudioMixer.h"
 #include "../common.h"
 #include "../entity/Yaw.hpp"
+#include "../util/Util.h"
+#include "../world/Location.hpp"
 
 #include <array>
+#include <string>
 #include <vector>
 
 enum : uint32_t


### PR DESCRIPTION
`std::string`, `EnumValue` and `CoordsXY` are used within this header.