### PR TITLE
Remove any traces of WinNT5.1 as per #16911

### DIFF
--- a/src/openrct2-ui/UiContext.Win32.cpp
+++ b/src/openrct2-ui/UiContext.Win32.cpp
@@ -35,14 +35,9 @@
 
 static std::wstring SHGetPathFromIDListLongPath(LPCITEMIDLIST pidl)
 {
-#    if _WIN32_WINNT < 0x0600
-    std::wstring pszPath(MAX_PATH, 0);
-    auto result = SHGetPathFromIDListW(pidl, pszPath.data());
-#    else
     // Limit path length to 32K
     std::wstring pszPath(std::numeric_limits<int16_t>().max(), 0);
     auto result = SHGetPathFromIDListEx(pidl, pszPath.data(), static_cast<DWORD>(pszPath.size()), GPFIDL_DEFAULT);
-#    endif
     if (result)
     {
         // Truncate at first null terminator

--- a/src/openrct2/cmdline/RootCommands.cpp
+++ b/src/openrct2/cmdline/RootCommands.cpp
@@ -96,7 +96,7 @@ static exitcode_t HandleCommandJoin(CommandLineArgEnumerator * enumerator);
 static exitcode_t HandleCommandSetRCT2(CommandLineArgEnumerator * enumerator);
 static exitcode_t HandleCommandScanObjects(CommandLineArgEnumerator * enumerator);
 
-#if defined(_WIN32) && _WIN32_WINNT >= 0x0600
+#if defined(_WIN32)
 
 static bool _removeShell = false;
 
@@ -133,7 +133,7 @@ const CommandLineCommand CommandLine::RootCommands[]
     DefineCommand("scan-objects", "<path>",             StandardOptions, HandleCommandScanObjects),
     DefineCommand("handle-uri", "openrct2://.../",      StandardOptions, CommandLine::HandleCommandUri),
 
-#if defined(_WIN32) && _WIN32_WINNT >= 0x0600
+#if defined(_WIN32)
     DefineCommand("register-shell", "", RegisterShellOptions, HandleCommandRegisterShell),
 #endif
 
@@ -400,7 +400,7 @@ static exitcode_t HandleCommandScanObjects([[maybe_unused]] CommandLineArgEnumer
     return EXITCODE_OK;
 }
 
-#if defined(_WIN32) && _WIN32_WINNT >= 0x0600
+#if defined(_WIN32)
 static exitcode_t HandleCommandRegisterShell([[maybe_unused]] CommandLineArgEnumerator* enumerator)
 {
     exitcode_t result = CommandLine::HandleCommandDefault();
@@ -419,7 +419,7 @@ static exitcode_t HandleCommandRegisterShell([[maybe_unused]] CommandLineArgEnum
     }
     return EXITCODE_OK;
 }
-#endif // defined(_WIN32) && _WIN32_WINNT >= 0x0600
+#endif // defined(_WIN32)
 
 static void PrintAbout()
 {

--- a/src/openrct2/core/Crypt.CNG.cpp
+++ b/src/openrct2/core/Crypt.CNG.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#if !defined(DISABLE_NETWORK) && defined(_WIN32) && (!defined(_WIN32_WINNT) || _WIN32_WINNT >= 0x0600)
+#if !defined(DISABLE_NETWORK) && defined(_WIN32)
 
 #    include "Crypt.h"
 

--- a/src/openrct2/core/Crypt.OpenSSL.cpp
+++ b/src/openrct2/core/Crypt.OpenSSL.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#if !defined(DISABLE_NETWORK) && (!defined(_WIN32) || (defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600))
+#if !defined(DISABLE_NETWORK) && !defined(_WIN32)
 
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/src/openrct2/core/FileWatcher.cpp
+++ b/src/openrct2/core/FileWatcher.cpp
@@ -111,13 +111,7 @@ FileWatcher::FileWatcher(const std::string& directoryPath)
 FileWatcher::~FileWatcher()
 {
 #ifdef _WIN32
-#    if _WIN32_WINNT < 0x0600
-    // TODO CancelIo is documented as not working across a different thread but
-    //      CancelIoEx is not available.
-    CancelIo(_directoryHandle);
-#    else
     CancelIoEx(_directoryHandle, nullptr);
-#    endif
     CloseHandle(_directoryHandle);
 #elif defined(__linux__)
     _finished = true;

--- a/src/openrct2/core/Http.WinHttp.cpp
+++ b/src/openrct2/core/Http.WinHttp.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#if !defined(DISABLE_HTTP) && defined(_WIN32) && (!defined(_WIN32_WINNT) || _WIN32_WINNT >= 0x0600)
+#if !defined(DISABLE_HTTP) && defined(_WIN32)
 
 #    include "Http.h"
 

--- a/src/openrct2/core/Http.cURL.cpp
+++ b/src/openrct2/core/Http.cURL.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#if !defined(DISABLE_HTTP) && (!defined(_WIN32) || (defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600))
+#if !defined(DISABLE_HTTP) && !defined(_WIN32)
 
 #    include "Http.h"
 

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -704,7 +704,6 @@ namespace String
     std::string ToUpper(std::string_view src)
     {
 #ifdef _WIN32
-#    if _WIN32_WINNT >= 0x0600
         auto srcW = ToWideChar(src);
 
         // Measure how long the destination needs to be
@@ -728,11 +727,6 @@ namespace String
         }
 
         return String::ToUtf8(dstW);
-#    else
-        std::string dst = std::string(src);
-        std::transform(dst.begin(), dst.end(), dst.begin(), [](unsigned char c) { return std::toupper(c); });
-        return dst;
-#    endif
 #else
         icu::UnicodeString str = icu::UnicodeString::fromUTF8(std::string(src));
         str.toUpper();

--- a/src/openrct2/network/Socket.cpp
+++ b/src/openrct2/network/Socket.cpp
@@ -643,12 +643,6 @@ private:
     std::string GetIpAddressFromSocket(const sockaddr_in* addr) const
     {
         std::string result;
-#    if defined(_WIN32_WINNT) && _WIN32_WINNT < 0x0600
-        if (addr->sin_family == AF_INET)
-        {
-            result = inet_ntoa(addr->sin_addr);
-        }
-#    else
         if (addr->sin_family == AF_INET)
         {
             char str[INET_ADDRSTRLEN]{};
@@ -662,7 +656,6 @@ private:
             inet_ntop(AF_INET6, &addrv6->sin6_addr, str, sizeof(str));
             result = str;
         }
-#    endif
         return result;
     }
 };


### PR DESCRIPTION
With ReactOS/WinXP builds now removed from the CI via #16911, this PR removes any branching related to that support. Since apparently those builds haven't worked on XP/ReactOS for a while anyway (due to the third party dependencies breaking it), this should change nothing for the end users, but it untangles the code a little.