### PR TITLE
Fix #16989: Re-focusing maximised window triggers a restore and maximise

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#16799] Browing “Up” in the Load Save window shows no files, only folders.
 - Fix: [#16934] Park size displayed incorrectly in Park window.
 - Fix: [#16974] Small scenery ghosts can be deleted.
+- Fix: [#16989] Re-focusing maximized window triggers a restore and maximize.
 - Fix: [#17005] Unable to set patrol area for first staff member in park.
 - Fix: [#17017] [Plugin] Crash when using tile element properties that require a valid ride to be linked.
 - Fix: [#17073] Corrupt ride window and random crashes when trains have more than 144 cars.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,7 +21,7 @@
 - Fix: [#16799] Browing “Up” in the Load Save window shows no files, only folders.
 - Fix: [#16934] Park size displayed incorrectly in Park window.
 - Fix: [#16974] Small scenery ghosts can be deleted.
-- Fix: [#16989] Re-focusing maximized window triggers a restore and maximize.
+- Fix: [#16989] Re-focusing maximised window triggers a restore and maximise.
 - Fix: [#17005] Unable to set patrol area for first staff member in park.
 - Fix: [#17017] [Plugin] Crash when using tile element properties that require a valid ride to be linked.
 - Fix: [#17073] Corrupt ride window and random crashes when trains have more than 144 cars.

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -338,23 +338,6 @@ public:
                     context_quit();
                     break;
                 case SDL_WINDOWEVENT:
-                    // HACK: Fix #2158, OpenRCT2 does not draw if it does not think that the window is
-                    //                  visible - due a bug in SDL 2.0.3 this hack is required if the
-                    //                  window is maximised, minimised and then restored again.
-                    if (e.window.event == SDL_WINDOWEVENT_FOCUS_GAINED)
-                    {
-                        if (SDL_GetWindowFlags(_window) & SDL_WINDOW_MAXIMIZED)
-                        {
-                            SDL_RestoreWindow(_window);
-                            SDL_MaximizeWindow(_window);
-                        }
-                        if ((SDL_GetWindowFlags(_window) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP)
-                        {
-                            SDL_RestoreWindow(_window);
-                            SDL_SetWindowFullscreen(_window, SDL_WINDOW_FULLSCREEN_DESKTOP);
-                        }
-                    }
-
                     if (e.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
                     {
                         OnResize(e.window.data1, e.window.data2);


### PR DESCRIPTION
Fixes #16989 by removing an SDL hack. Originally added to address issue #2158, I can't reproduce this issue with the hack removed. Only tested on Linux though.