### PR TITLE
Fix primary color picker for canvas tent

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4798,8 +4798,7 @@ static void WindowRideColourPaint(rct_window* w, rct_drawpixelinfo* dpi)
             auto stationObj = ride->GetStationObject();
             if (stationObj != nullptr && stationObj->BaseImageId != ImageIndexUndefined)
             {
-                auto imageTemplate = ImageId(trackColour.main, trackColour.additional);
-                auto imageId = imageTemplate.WithIndex(stationObj->BaseImageId);
+                auto imageId = ImageId(stationObj->BaseImageId, trackColour.main, trackColour.additional);
 
                 // Back
                 gfx_draw_sprite(&clippedDpi, imageId, { 34, 20 });


### PR DESCRIPTION
Tiny fix for the issue #17383 

The problem:
Main color `trackColour.main` was provided as first argument to `ImageId` where `index` was expected.
On the next line index was "reset" to the correct value (`stationObj->BaseImageId`), but main color information was lost at this point.
```cpp
auto imageTemplate = ImageId(trackColour.main, trackColour.additional);
```

Fix:
Provide `stationObj->BaseImageId` as a first argument.
```cpp
auto imageId = ImageId(stationObj->BaseImageId, trackColour.main, trackColour.additional);
```