### PR TITLE
Fix upper_case_banners option

### DIFF
--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -959,6 +959,7 @@ private:
                 gConfigGeneral.upper_case_banners ^= 1;
                 config_save_default();
                 Invalidate();
+                scrolling_text_invalidate();
                 break;
             case WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX:
                 gConfigGeneral.disable_lightning_effect ^= 1;


### PR DESCRIPTION
One liner for #17380
Option `upper_case_banners` used in a couple of places to calculate new width for scrolling text:

- https://github.com/OpenRCT2/OpenRCT2/blob/269673e3aa40923337f2cde1d7744a5cf5fc0615/src/openrct2/paint/tile_element/Paint.Banner.cpp#L55
- https://github.com/OpenRCT2/OpenRCT2/blob/37c0fffb9902d12814b51e3166191bdd2a5267e0/src/openrct2/paint/tile_element/Paint.Entrance.cpp#L64
- https://github.com/OpenRCT2/OpenRCT2/blob/e78c29ea5c5b2f301ae8d7d1518c11d01174b516/src/openrct2/paint/tile_element/Paint.Wall.cpp#L198
- https://github.com/OpenRCT2/OpenRCT2/blob/fc2ed95641eca0ce60e0a0ae596983f120edea1c/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp#L319

Method `scrolling_text_invalidate()` is invoked in multiple actions to re-create string for sprite:
- [ParkSetNameAction.cpp](https://github.com/OpenRCT2/OpenRCT2/blob/83b911b193b1f461832a8024dea83cebe93d52ed/src/openrct2/actions/ParkSetNameAction.cpp)
- [BannerSetNameAction.cpp](https://github.com/OpenRCT2/OpenRCT2/blob/83b911b193b1f461832a8024dea83cebe93d52ed/src/openrct2/actions/BannerSetNameAction.cpp)
- [SignSetNameAction.cpp](https://github.com/OpenRCT2/OpenRCT2/blob/c0474d2d276c15243c6a4cd0d902c26f54385fbc/src/openrct2/actions/SignSetNameAction.cpp)
- [RideSetNameAction.cpp](https://github.com/OpenRCT2/OpenRCT2/blob/c0474d2d276c15243c6a4cd0d902c26f54385fbc/src/openrct2/actions/RideSetNameAction.cpp)

But scrolling text is not invalidated on `upper_case_banners` option change.
This fix should add this behavior to checkbox click.
