### PR TITLE
Update changelog to mention a pre-NT6 removal

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Change: [#17002] Weather no longer resets when converting a save to scenario.
 - Change: [#17294] New ride window remembers scroll position per tab instead of highlighted ride.
 - Removed: [#16864] Title sequence editor (replaced by plug-in).
+- Removed: [#16911, #17411] Support for pre-Vista Windows systems.
 - Fix: [#13997] Placing a track design interferes with other players building a ride.
 - Fix: [#16799] Browing “Up” in the Load Save window shows no files, only folders.
 - Fix: [#16934] Park size displayed incorrectly in Park window.


### PR DESCRIPTION
https://github.com/OpenRCT2/OpenRCT2/pull/17411#issuecomment-1161371295 for a discussion.