### PR TITLE
Fix: Wrong T-shirt colors when riding Twist

### DIFF
--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -67,7 +67,7 @@ static void paint_twist_structure(
         {
             imageTemplate = ImageId(0, vehicle->peep_tshirt_colours[i], vehicle->peep_tshirt_colours[i + 1]);
             auto peepFrameNum = (frameNum + i * 12) % 216;
-            imageId = imageId.WithIndex(baseImageId + 24 + peepFrameNum);
+            imageId = imageTemplate.WithIndex(baseImageId + 24 + peepFrameNum);
             PaintAddImageAsChild(
                 session, imageId, { xOffset, yOffset, height }, { 24, 24, 48 }, { xOffset + 16, yOffset + 16, height });
         }


### PR DESCRIPTION
A one-word typo in Twist.cpp (from a8505dc6890881ca86a0b797cdcbe3c4ca290fca) had caused the wrong ImageId object to be used when painting the peeps, resulting in their T-shirts being set to the ride colors. This PR fixes the typo, so that peeps are now painted with the correct T-shirt colors.

Before (peep T-shirts are colored according to the ride colorscheme):
![twist_peeps_01](https://user-images.githubusercontent.com/96934073/175202759-79cc7b1c-1a4f-4898-b337-8d29917f9583.png)

After:
![twist_peeps_02](https://user-images.githubusercontent.com/96934073/175202827-e1335944-007c-4b3f-92bc-38c73e257281.png)

