### PR TITLE
Created function Format_VA_String and Format_String, then switched ot…

### DIFF
--- a/src/openrct2/core/String.hpp
+++ b/src/openrct2/core/String.hpp
@@ -82,6 +82,8 @@ namespace String
     utf8* Format(utf8* buffer, size_t bufferSize, const utf8* format, ...);
     utf8* Format(const utf8* format, ...);
     utf8* Format_VA(const utf8* format, va_list args);
+    std::string Format_String(const utf8* format, ...);
+    std::string Format_VA_String(const utf8* format, va_list args);
     utf8* AppendFormat(utf8* buffer, size_t bufferSize, const utf8* format, ...);
     utf8* Duplicate(const std::string& src);
     utf8* Duplicate(const utf8* src);


### PR DESCRIPTION
…her functions in String.cpp to use these alternatives.

Created two new functions, Format_VA_String and Format_String, which take in the same input as Format_VA and Format, while outputting to std::string instead of utf8*. Also switched StdFormat_VA and StdFormat to use these newly created function.