### PR TITLE
Fix #17229: Rename G1_FLAG_BMP to G1_FLAG_HAS_TRANSPARENCY

### DIFF
--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -155,7 +155,7 @@ namespace OpenRCT2::Scripting
         obj.Set("width", g1->width);
         obj.Set("height", g1->height);
 
-        obj.Set("isBMP", (g1->flags & G1_FLAG_BMP) != 0);
+        obj.Set("isBMP", (g1->flags & G1_FLAG_HAS_TRANSPARENCY) != 0);
         obj.Set("isRLE", (g1->flags & G1_FLAG_RLE_COMPRESSION) != 0);
         obj.Set("isPalette", (g1->flags & G1_FLAG_PALETTE) != 0);
         obj.Set("noZoom", (g1->flags & G1_FLAG_NO_ZOOM_DRAW) != 0);

--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -155,7 +155,7 @@ namespace OpenRCT2::Scripting
         obj.Set("width", g1->width);
         obj.Set("height", g1->height);
 
-        obj.Set("isBMP", (g1->flags & G1_FLAG_HAS_TRANSPARENCY) != 0);
+        obj.Set("hasTransparent", (g1->flags & G1_FLAG_HAS_TRANSPARENCY) != 0);
         obj.Set("isRLE", (g1->flags & G1_FLAG_RLE_COMPRESSION) != 0);
         obj.Set("isPalette", (g1->flags & G1_FLAG_PALETTE) != 0);
         obj.Set("noZoom", (g1->flags & G1_FLAG_NO_ZOOM_DRAW) != 0);

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -208,7 +208,7 @@ static void WindowInstallTrackPaint(rct_window* w, rct_drawpixelinfo* dpi)
     g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * TRACK_PREVIEW_IMAGE_SIZE);
     g1temp.width = 370;
     g1temp.height = 217;
-    g1temp.flags = G1_FLAG_BMP;
+    g1temp.flags = G1_FLAG_HAS_TRANSPARENCY;
     gfx_set_g1_element(SPR_TEMP, &g1temp);
     drawing_engine_invalidate_image(SPR_TEMP);
     gfx_draw_sprite(dpi, ImageId(SPR_TEMP), screenPos);

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -504,7 +504,7 @@ public:
         g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * TRACK_PREVIEW_IMAGE_SIZE);
         g1temp.width = 370;
         g1temp.height = 217;
-        g1temp.flags = G1_FLAG_BMP;
+        g1temp.flags = G1_FLAG_HAS_TRANSPARENCY;
         gfx_set_g1_element(SPR_TEMP, &g1temp);
         drawing_engine_invalidate_image(SPR_TEMP);
         gfx_draw_sprite(&dpi, ImageId(SPR_TEMP), trackPreview);

--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -102,7 +102,7 @@ void FASTCALL gfx_bmp_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteA
         // Used for glass.
         DrawBMPSprite<BLEND_TRANSPARENT | BLEND_DST>(dpi, args);
     }
-    else if (!(args.SourceImage.flags & G1_FLAG_BMP))
+    else if (!(args.SourceImage.flags & G1_FLAG_HAS_TRANSPARENCY))
     {
         // Copy raw bitmap data to target
         DrawBMPSprite<BLEND_NONE>(dpi, args);

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -633,7 +633,7 @@ void FASTCALL gfx_draw_sprite_raw_masked_software(
         return;
     }
 
-    // Only BMP format is supported for masking
+    // Must have transparency in order to pass check
     if (!(imgMask->flags & G1_FLAG_HAS_TRANSPARENCY) || !(imgColour->flags & G1_FLAG_HAS_TRANSPARENCY))
     {
         gfx_draw_sprite_software(dpi, colourImage, scrCoords);

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -634,7 +634,7 @@ void FASTCALL gfx_draw_sprite_raw_masked_software(
     }
 
     // Only BMP format is supported for masking
-    if (!(imgMask->flags & G1_FLAG_BMP) || !(imgColour->flags & G1_FLAG_BMP))
+    if (!(imgMask->flags & G1_FLAG_HAS_TRANSPARENCY) || !(imgColour->flags & G1_FLAG_HAS_TRANSPARENCY))
     {
         gfx_draw_sprite_software(dpi, colourImage, scrCoords);
         return;

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -146,7 +146,7 @@ assert_struct_size(rct_g1_element_32bit, 0x10);
 
 enum
 {
-    G1_FLAG_HAS_TRANSPARENCY = (1 << 0), // Image data is encoded as raw pixels (no transparency)
+    G1_FLAG_HAS_TRANSPARENCY = (1 << 0), // Image data contains transparent pixels (0XFF) which will not be rendered
     G1_FLAG_1 = (1 << 1),
     G1_FLAG_RLE_COMPRESSION = (1 << 2), // Image data is encoded using RCT2's form of run length encoding
     G1_FLAG_PALETTE = (1 << 3),         // Image data is a sequence of palette entries R8G8B8

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -146,7 +146,7 @@ assert_struct_size(rct_g1_element_32bit, 0x10);
 
 enum
 {
-    G1_FLAG_BMP = (1 << 0), // Image data is encoded as raw pixels (no transparency)
+    G1_FLAG_HAS_TRANSPARENCY = (1 << 0), // Image data is encoded as raw pixels (no transparency)
     G1_FLAG_1 = (1 << 1),
     G1_FLAG_RLE_COMPRESSION = (1 << 2), // Image data is encoded using RCT2's form of run length encoding
     G1_FLAG_PALETTE = (1 << 3),         // Image data is a sequence of palette entries R8G8B8

--- a/src/openrct2/drawing/ImageImporter.cpp
+++ b/src/openrct2/drawing/ImageImporter.cpp
@@ -46,7 +46,7 @@ ImportResult ImageImporter::Import(
     rct_g1_element outElement;
     outElement.width = width;
     outElement.height = height;
-    outElement.flags = (flags & ImportFlags::RLE ? G1_FLAG_RLE_COMPRESSION : G1_FLAG_BMP);
+    outElement.flags = (flags & ImportFlags::RLE ? G1_FLAG_RLE_COMPRESSION : G1_FLAG_HAS_TRANSPARENCY);
     outElement.x_offset = offsetX;
     outElement.y_offset = offsetY;
     outElement.zoomed_offset = 0;

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -108,7 +108,7 @@ void scrolling_text_initialise_bitmaps()
         g1.offset = _drawScrollTextList[i].bitmap;
         g1.x_offset = -32;
         g1.y_offset = 0;
-        g1.flags = G1_FLAG_BMP;
+        g1.flags = G1_FLAG_HAS_TRANSPARENCY;
         g1.width = 64;
         g1.height = 40;
         g1.offset[0] = 0xFF;

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1509,7 +1509,7 @@ static bool is_pixel_present_bmp(
     PROFILED_FUNCTION();
 
     // Probably used to check for corruption
-    if (!(g1->flags & G1_FLAG_BMP))
+    if (!(g1->flags & G1_FLAG_HAS_TRANSPARENCY))
     {
         return false;
     }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1508,7 +1508,7 @@ static bool is_pixel_present_bmp(
 {
     PROFILED_FUNCTION();
 
-    // Probably used to check for corruption
+    // Needs investigation as it has no consideration for pure BMP maps.
     if (!(g1->flags & G1_FLAG_HAS_TRANSPARENCY))
     {
         return false;


### PR DESCRIPTION
Fix for #17229 

Renamed all instances of G1_FLAG_BMP to GA_FLAG_HAS_TRANSPARENCY in order to have more consistency with the actual meaning of the flag on a sprite.