### PR TITLE
Close #16688: Remove unused variables on RideConstruction

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3419,19 +3419,20 @@ void ride_construction_toolupdate_entrance_exit(const ScreenCoordsXY& screenCoor
  *
  *  rct2: 0x006CCA73
  */
+
 void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
 {
     const CursorState* state = context_get_cursor_state();
-    RideId rideIndex;
-    int32_t trackType, trackDirection, liftHillAndAlternativeState, z, properties, highestZ;
+
     rct_window* w;
 
     map_invalidate_map_selection_tiles();
     ride_construction_invalidate_current_track();
 
     CoordsXYZ mapCoords{};
-    if (window_ride_construction_update_state(
-            &trackType, &trackDirection, &rideIndex, &liftHillAndAlternativeState, &mapCoords, &properties))
+    int32_t trackType, z, highestZ;
+
+    if (window_ride_construction_update_state(&trackType, nullptr, nullptr, nullptr, nullptr, nullptr))
         return;
 
     z = mapCoords.z;

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3419,7 +3419,6 @@ void ride_construction_toolupdate_entrance_exit(const ScreenCoordsXY& screenCoor
  *
  *  rct2: 0x006CCA73
  */
-
 void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
 {
     const CursorState* state = context_get_cursor_state();

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2020 OpenRCT2 developers
+ * Copyright (c) 2014-2022 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * Copyright (c) 2014-2022 OpenRCT2 developers
+ * Copyright (c) 2014-2020 OpenRCT2 developers
  *
  * For a complete list of all authors, please refer to contributors.md
  * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2


### PR DESCRIPTION
Fix #16688

Issue: Unused Properties Variable in refactor-ride_construction_tooldown_construct under openrct2-ui/windows/RideConstruction.cpp

Solution: Removed unused properties variable. Plugged in nullptr instead of a reference to the variable.

Not quite sure if this should work though, even if it passes tests and compiles perfectly fine. 