### PR TITLE
Ported all fixes from fix-16688

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3419,19 +3419,20 @@ void ride_construction_toolupdate_entrance_exit(const ScreenCoordsXY& screenCoor
  *
  *  rct2: 0x006CCA73
  */
+
 void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
 {
     const CursorState* state = context_get_cursor_state();
-    RideId rideIndex;
-    int32_t trackType, trackDirection, liftHillAndAlternativeState, z, properties, highestZ;
+
     rct_window* w;
 
     map_invalidate_map_selection_tiles();
     ride_construction_invalidate_current_track();
 
     CoordsXYZ mapCoords{};
-    if (window_ride_construction_update_state(
-            &trackType, &trackDirection, &rideIndex, &liftHillAndAlternativeState, &mapCoords, &properties))
+    int32_t trackType, z, highestZ;
+
+    if (window_ride_construction_update_state(&trackType, nullptr, nullptr, nullptr, nullptr, nullptr))
         return;
 
     z = mapCoords.z;


### PR DESCRIPTION
Ported all fixes from #17453 due to that branch having unusable commit titles

Fix #16688

Issue: Unused Properties Variable in refactor-ride_construction_tooldown_construct under openrct2-ui/windows/RideConstruction.cpp

Solution: Removed unused properties variable. Plugged in nullptr instead of a reference to the variable.

Not quite sure if this should work though, even if it passes tests and compiles perfectly fine.