### PR TITLE
Fix #17462: Crash when zooming or moving around the park

### DIFF
--- a/src/openrct2-ui/audio/SDLAudioSource.h
+++ b/src/openrct2-ui/audio/SDLAudioSource.h
@@ -18,6 +18,8 @@
 
 namespace OpenRCT2::Audio
 {
+    struct IAudioMixer;
+
 #ifdef __WARN_SUGGEST_FINAL_METHODS__
 #    pragma GCC diagnostic push
 #    pragma GCC diagnostic ignored "-Wsuggest-final-methods"
@@ -38,6 +40,9 @@ namespace OpenRCT2::Audio
 
     protected:
         virtual void Unload() = 0;
+
+    private:
+        IAudioMixer* GetMixer();
     };
 #ifdef __WARN_SUGGEST_FINAL_METHODS__
 #    pragma GCC diagnostic pop

--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -202,7 +202,7 @@ namespace OpenRCT2::RideAudio
                 auto source = audioObj->GetSample(0);
                 if (source != nullptr)
                 {
-                    auto channel = CreateAudioChannel(source, MixerGroup::Sound, false);
+                    auto channel = CreateAudioChannel(source, MixerGroup::Sound, false, 0);
                     if (channel != nullptr)
                     {
                         _musicChannels.emplace_back(instance, channel, nullptr);
@@ -226,7 +226,7 @@ namespace OpenRCT2::RideAudio
                         if (source != nullptr)
                         {
                             auto shouldLoop = musicObj->GetTrackCount() == 1;
-                            auto channel = CreateAudioChannel(source, MixerGroup::RideMusic, shouldLoop);
+                            auto channel = CreateAudioChannel(source, MixerGroup::RideMusic, shouldLoop, 0);
                             if (channel != nullptr)
                             {
                                 _musicChannels.emplace_back(instance, channel, source);


### PR DESCRIPTION
* Lock the mixer to make sure we aren't mixing the source as we dispose it.
* Also fixes ride music channels starting at a loud volume before being updated to the correct volume for the current view.