### PR TITLE
Fix #17399: Guest not having being watched thoughts

### DIFF
--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -7,7 +7,6 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include <random>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>
@@ -33,6 +32,7 @@
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
+#include <random>
 
 static constexpr const rct_string_id WINDOW_TITLE = STR_STRINGID;
 static constexpr const int32_t WH = 157;
@@ -1055,15 +1055,15 @@ void WindowGuestOverviewUpdate(rct_window* w)
     if (network_get_mode() == NETWORK_MODE_NONE)
     {
         // Create the "I have the strangest feeling I am being watched thought"
-        if ((w->highlighted_item & 0xFFFF) >= 24)
+        if ((w->highlighted_item & 0xFFFF) >= 3840)
         {
-            std::random_device rd;                         // obtain a random number from hardware
-            std::mt19937 gen(rd());                        // seed the generator
-            std::uniform_int_distribution<> distr(0, 11000); // define the range
-            int32_t random = distr(gen);
-            if (random >= 0x2AAA)
+            if (!(w->highlighted_item & 0x3FF))
             {
-                peep->InsertNewThought(PeepThoughtType::Watched);
+                int32_t random = util_rand() & 0xFFFF;
+                if (random <= 0x2AAA)
+                {
+                    peep->InsertNewThought(PeepThoughtType::Watched);
+                }
             }
         }
     }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -32,7 +32,6 @@
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Park.h>
-#include <random>
 
 static constexpr const rct_string_id WINDOW_TITLE = STR_STRINGID;
 static constexpr const int32_t WH = 157;

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include <random>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>
@@ -1054,15 +1055,15 @@ void WindowGuestOverviewUpdate(rct_window* w)
     if (network_get_mode() == NETWORK_MODE_NONE)
     {
         // Create the "I have the strangest feeling I am being watched thought"
-        if ((w->highlighted_item & 0xFFFF) >= 3840)
+        if ((w->highlighted_item & 0xFFFF) >= 24)
         {
-            if (!(w->highlighted_item & 0x3FF))
+            std::random_device rd;                         // obtain a random number from hardware
+            std::mt19937 gen(rd());                        // seed the generator
+            std::uniform_int_distribution<> distr(0, 11000); // define the range
+            int32_t random = distr(gen);
+            if (random >= 0x2AAA)
             {
-                int32_t random = util_rand() & 0xFFFF;
-                if (random <= 0x2AAA)
-                {
-                    peep->InsertNewThought(PeepThoughtType::Watched);
-                }
+                peep->InsertNewThought(PeepThoughtType::Watched);
             }
         }
     }

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -83,9 +83,9 @@ struct rct_window
         int16_t picked_peep_frame; // Animation frame of picked peep in staff window and guest window
         int16_t var_492;
     };
+    uint32_t highlighted_item;
     union
     {
-        uint32_t highlighted_item;
         uint16_t ride_colour;
         ResearchItem* research_item;
         const scenario_index_entry* highlighted_scenario;


### PR DESCRIPTION
Fix #17399 

Issue: Guests never have the thought of being watched, even though vanilla behavior has this happen after a while.

Fix: Decoupled w->highlighted_item from w->var_496, as w->var_496 is linked to the newAnimationFrame cycle. This would inadvertently cause the highlighted_item value to only reach a maximum of 24, as this cycle resets at 24, which is lower than the threshold required to even get past the first check to insert the thought.

