### PR TITLE
Fix #17481: Roto-drop cars try going up to the wrong top pieces

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -50,6 +50,7 @@
 - Fix: [#17450] Ducks can swim on three-corners-up land tile.
 - Fix: [#17461] Footpath Railing tooltip showing incorrect tooltip.
 - Fix: [#17466] New object types not packed in save files.
+- Fix: [#17481] Roto-drop cars try going up to top pieces that are ghosts or belong to other rides.
 
 0.4.0 (2022-04-25)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3011,7 +3011,7 @@ void Vehicle::TestReset()
     test_reset(*curRide, current_station);
 }
 
-bool Vehicle::CurrentTowerElementIsTop()
+bool Vehicle::CurrentTowerElementIsTop(RideId currentRideId)
 {
     TileElement* tileElement = map_get_track_element_at_of_type(TrackLocation, GetTrackType());
     if (tileElement != nullptr)
@@ -3019,10 +3019,14 @@ bool Vehicle::CurrentTowerElementIsTop()
         while (!tileElement->IsLastForTile())
         {
             tileElement++;
-            if (tileElement->GetType() == TileElementType::Track
-                && tileElement->AsTrack()->GetTrackType() == TrackElemType::TowerSection)
+            if (tileElement->GetType() == TileElementType::Track && !tileElement->IsGhost())
             {
-                return false;
+                const auto* trackElement = tileElement->AsTrack();
+                if (trackElement->GetRideIndex() == currentRideId
+                    && trackElement->GetTrackType() == TrackElemType::TowerSection)
+                {
+                    return false;
+                }
             }
         }
     }
@@ -3302,7 +3306,7 @@ void Vehicle::UpdateDeparting()
         }
     }
 
-    if (!CurrentTowerElementIsTop())
+    if (!CurrentTowerElementIsTop(ride))
     {
         if (curRide->mode == RideMode::FreefallDrop)
             Invalidate();
@@ -3693,7 +3697,7 @@ void Vehicle::UpdateTravelling()
         }
         else
         {
-            if (CurrentTowerElementIsTop())
+            if (CurrentTowerElementIsTop(ride))
             {
                 velocity = 0;
                 sub_state = 2;

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -329,7 +329,7 @@ private:
     void UpdateAnimationAnimalFlying();
     void UpdateAdditionalAnimation();
     void CheckIfMissing();
-    bool CurrentTowerElementIsTop();
+    bool CurrentTowerElementIsTop(RideId currentRideId);
     bool UpdateTrackMotionForwards(CarEntry* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry);
     bool UpdateTrackMotionBackwards(CarEntry* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry);
     int32_t UpdateTrackMotionPoweredRideAcceleration(CarEntry* vehicleEntry, uint32_t totalMass, const int32_t curAcceleration);

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -329,7 +329,7 @@ private:
     void UpdateAnimationAnimalFlying();
     void UpdateAdditionalAnimation();
     void CheckIfMissing();
-    bool CurrentTowerElementIsTop(RideId currentRideId);
+    bool CurrentTowerElementIsTop();
     bool UpdateTrackMotionForwards(CarEntry* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry);
     bool UpdateTrackMotionBackwards(CarEntry* vehicleEntry, Ride* curRide, rct_ride_entry* rideEntry);
     int32_t UpdateTrackMotionPoweredRideAcceleration(CarEntry* vehicleEntry, uint32_t totalMass, const int32_t curAcceleration);


### PR DESCRIPTION
This adds two checks:
- For the ride id, so that it won’t go up to top pieces that belong to other rides
- For ghosts, which fixes a very similar bug when you use ghost train simulation mode on tower rides.