### PR TITLE
Fix #17464: Green Tarmac Footpath no longer showing up in the Track Designer

### DIFF
--- a/src/openrct2/object/DefaultObjects.cpp
+++ b/src/openrct2/object/DefaultObjects.cpp
@@ -152,6 +152,7 @@ const std::string_view DesignerSelectedObjects[] = {
     "rct2.footpath_surface.tarmac",
     "rct2.footpath_surface.tarmac_brown",
     "rct2.footpath_surface.tarmac_red",
+    "rct2.footpath_surface.tarmac_green",
     "rct2.footpath_surface.dirt",
     "rct2.footpath_surface.crazy_paving",
     "rct2.footpath_surface.ash",

--- a/src/openrct2/object/DefaultObjects.h
+++ b/src/openrct2/object/DefaultObjects.h
@@ -13,4 +13,4 @@
 
 extern const std::string_view MinimumRequiredObjects[2];
 extern const std::string_view DefaultSelectedObjects[103];
-extern const std::string_view DesignerSelectedObjects[38];
+extern const std::string_view DesignerSelectedObjects[39];


### PR DESCRIPTION
Fix #17464

Issue: Green Tarmac isn't showing up as an option in the track designer
Solution: Added Green Tarmac to DefaultObjects DesignerSelectedObjects string array, as well as increasing the defined size for the array