### PR TITLE
#17493: Title sequence defaults to RCT1

### DIFF
--- a/src/openrct2-ui/scripting/ScTitleSequence.hpp
+++ b/src/openrct2-ui/scripting/ScTitleSequence.hpp
@@ -360,7 +360,7 @@ namespace OpenRCT2::Scripting
             const auto* item = GetItem();
             if (item != nullptr)
             {
-                return item->PredefinedIndex != std::numeric_limits<size_t>::max();
+                return item->PredefinedIndex != PREDEFINED_INDEX_CUSTOM;
             }
             return {};
         }

--- a/src/openrct2-ui/title/TitleSequencePlayer.cpp
+++ b/src/openrct2-ui/title/TitleSequencePlayer.cpp
@@ -161,22 +161,32 @@ namespace OpenRCT2::Title
 
                         if (!loadSuccess)
                         {
-                            auto message = std::string("Failed to load: \"") + scenarioName + " for the title sequence.";
+                            auto message = std::string("Failed to load: \"") + scenarioName + "\" for the title sequence.";
                             throw std::domain_error(message);
                         }
 
                         game_notify_map_changed();
                     }
+
+                    IncrementPosition();
                 }
                 catch (std::exception& e)
                 {
                     const char* commandName = std::visit(
                         [](auto&& command) { return std::decay_t<decltype(command)>::Name; }, currentCommand);
                     Console::Error::WriteLine("%s (command %i) failed with error: %s", commandName, _position, e.what());
-                    Console::Error::WriteLine("  Skipping to the next command.");
-                }
 
-                IncrementPosition();
+                    if (TitleSequenceIsLoadCommand(currentCommand))
+                    {
+                        Console::Error::WriteLine("  Skipping to the next load command.");
+                        SkipToNextLoadCommand();
+                    }
+                    else
+                    {
+                        Console::Error::WriteLine("  Skipping to the next command.");
+                        IncrementPosition();
+                    }
+                }
 
                 if (_position == entryPosition)
                 {

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -274,8 +274,7 @@ namespace TitleSequenceManager
     {
         for (const auto& pseq : TitleSequenceManager::PredefinedSequences)
         {
-            auto predefinedName = Path::GetFileNameWithoutExtension(pseq.Filename);
-            if (String::Equals(name, predefinedName, true))
+            if (String::Equals(name, pseq.ConfigId, true))
             {
                 return true;
             }
@@ -317,7 +316,7 @@ const utf8* title_sequence_manager_get_config_id(size_t index)
         return nullptr;
     }
     const auto& name = item->Name;
-    auto filename = Path::GetFileName(name);
+    const auto filename = Path::GetFileName(item->Path);
     for (const auto& pseq : TitleSequenceManager::PredefinedSequences)
     {
         if (String::Equals(filename, pseq.Filename, true))

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -182,13 +182,9 @@ namespace TitleSequenceManager
         // Sort sequences by predefined index and then name
         std::sort(
             _items.begin(), _items.end(), [](const TitleSequenceManagerItem& a, const TitleSequenceManagerItem& b) -> bool {
-                if (a.PredefinedIndex < b.PredefinedIndex)
+                if (a.PredefinedIndex != b.PredefinedIndex)
                 {
-                    return true;
-                }
-                if (a.PredefinedIndex > b.PredefinedIndex)
-                {
-                    return false;
+                    return a.PredefinedIndex < b.PredefinedIndex;
                 }
                 return _strcmpi(a.Name.c_str(), b.Name.c_str()) < 0;
             });
@@ -364,11 +360,6 @@ size_t title_sequence_manager_get_index_for_name(const utf8* name)
         }
     }
     return SIZE_MAX;
-}
-
-bool title_sequence_manager_is_name_reserved(const utf8* name)
-{
-    return TitleSequenceManager::IsNameReserved(name);
 }
 
 void title_sequence_manager_scan()

--- a/src/openrct2/title/TitleSequenceManager.h
+++ b/src/openrct2/title/TitleSequenceManager.h
@@ -11,6 +11,7 @@
 #include "../common.h"
 #include "../core/String.hpp"
 
+#include <limits>
 #include <string>
 
 struct TitleSequenceManagerItem
@@ -32,7 +33,7 @@ namespace TitleSequenceManager
     void Scan();
 } // namespace TitleSequenceManager
 
-constexpr const size_t PREDEFINED_INDEX_CUSTOM = SIZE_MAX;
+constexpr const size_t PREDEFINED_INDEX_CUSTOM = std::numeric_limits<size_t>::max();
 
 size_t title_sequence_manager_get_count();
 const utf8* title_sequence_manager_get_name(size_t index);
@@ -41,7 +42,6 @@ const utf8* title_sequence_manager_get_config_id(size_t index);
 size_t title_sequence_manager_get_predefined_index(size_t index);
 size_t title_sequence_manager_get_index_for_config_id(const utf8* configId);
 size_t title_sequence_manager_get_index_for_name(const utf8* name);
-bool title_sequence_manager_is_name_reserved(const utf8* name);
 void title_sequence_manager_scan();
 void title_sequence_manager_delete(size_t i);
 size_t title_sequence_manager_rename(size_t i, const utf8* name);


### PR DESCRIPTION
Even while the default config value is "*OPENRCT2", the game failed to find this predefined config ID and fell back to the first sequence in the list instead.

The second contains some changes I made while looking into this issue.