### PR TITLE
Remove unwanted condition in ride_ratings_update_state_5

### DIFF
--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -230,8 +230,7 @@ static void ride_ratings_update_state_2(RideRatingUpdateState& state)
                 continue;
         }
 
-        // TODO: Hack to be removed with new save format - trackType 0xFF should not be here.
-        if (trackType == 0xFF || trackType == TrackElemType::None
+        if (trackType == TrackElemType::None
             || (tileElement->AsTrack()->GetSequenceIndex() == 0 && trackType == tileElement->AsTrack()->GetTrackType()))
         {
             if (trackType == TrackElemType::EndStation)
@@ -337,8 +336,7 @@ static void ride_ratings_update_state_5(RideRatingUpdateState& state)
                 continue;
         }
 
-        // TODO: Hack to be removed with new save format - trackType 0xFF should not be here.
-        if (trackType == 0xFF || trackType == TrackElemType::None || trackType == tileElement->AsTrack()->GetTrackType())
+        if (trackType == TrackElemType::None || trackType == tileElement->AsTrack()->GetTrackType())
         {
             ride_ratings_score_close_proximity(state, tileElement);
 


### PR DESCRIPTION
Since there was a TODO comment this is probably a small oversight, the condition currently excludes the track type MultiDimInvertedUp90ToFlatQuarterLoop which is 0xFF, looking at the history the value 0xFF used to represent None.