### PR TITLE
Reset gClipSelection to default values when new map is loaded.

### DIFF
--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -69,7 +69,7 @@ class ViewClippingWindow final : public Window
 private:
     CoordsXY _selectionStart;
     CoordsXY _previousClipSelectionA = { 0, 0 };
-    CoordsXY _previousClipSelectionB = { gMapSize.x * 32, gMapSize.y * 32 };
+    CoordsXY _previousClipSelectionB = gMapSize.ToCoordsXY();
     bool _toolActive{ false };
     bool _dragging{ false };
     bool _firstStart = true;

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -68,8 +68,8 @@ class ViewClippingWindow final : public Window
 {
 private:
     CoordsXY _selectionStart;
-    CoordsXY _previousClipSelectionA = { 0, 0 };
-    CoordsXY _previousClipSelectionB = gMapSize.ToCoordsXY();
+    CoordsXY _previousClipSelectionA;
+    CoordsXY _previousClipSelectionB;
     bool _toolActive{ false };
     bool _dragging{ false };
     static inline DisplayType _clipHeightDisplayType;
@@ -122,7 +122,7 @@ public:
                 _previousClipSelectionA = gClipSelectionA;
                 _previousClipSelectionB = gClipSelectionB;
                 gClipSelectionA = { 0, 0 };
-                gClipSelectionB = gMapSize.ToCoordsXY();
+                gClipSelectionB = { MAXIMUM_MAP_SIZE_BIG - 1, MAXIMUM_MAP_SIZE_BIG - 1 };
                 gfx_invalidate_screen();
                 break;
             case WIDX_CLIP_CLEAR:
@@ -342,7 +342,11 @@ public:
     }
 
     void OnOpen() override
-    {
+    {   
+        if(_previousClipSelectionA == NULL || _previousClipSelectionB == NULL) {
+            _previousClipSelectionA = { 0, 0 };
+            _previousClipSelectionB = gMapSize.ToCoordsXY();
+        }
         this->widgets = window_view_clipping_widgets;
         this->hold_down_widgets = (1ULL << WIDX_CLIP_HEIGHT_INCREASE) | (1UL << WIDX_CLIP_HEIGHT_DECREASE);
         WindowInitScrollWidgets(this);

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -69,7 +69,7 @@ class ViewClippingWindow final : public Window
 private:
     CoordsXY _selectionStart;
     CoordsXY _previousClipSelectionA = { 0, 0 };
-    CoordsXY _previousClipSelectionB = { MAXIMUM_TILE_START_XY, MAXIMUM_TILE_START_XY };
+    CoordsXY _previousClipSelectionB = { gMapSize.x * 32, gMapSize.y * 32 };
     bool _toolActive{ false };
     bool _dragging{ false };
     bool _firstStart = true;
@@ -123,7 +123,7 @@ public:
                 _previousClipSelectionA = gClipSelectionA;
                 _previousClipSelectionB = gClipSelectionB;
                 gClipSelectionA = { 0, 0 };
-                gClipSelectionB = { MAXIMUM_TILE_START_XY, MAXIMUM_TILE_START_XY };
+                gClipSelectionB = { gMapSize.x * 32, gMapSize.y * 32 };
                 gfx_invalidate_screen();
                 break;
             case WIDX_CLIP_CLEAR:
@@ -133,7 +133,7 @@ public:
                     tool_cancel();
                 }
                 gClipSelectionA = { 0, 0 };
-                gClipSelectionB = { MAXIMUM_TILE_START_XY, MAXIMUM_TILE_START_XY };
+                gClipSelectionB = { gMapSize.x * 32, gMapSize.y * 32 };
                 gfx_invalidate_screen();
                 break;
         }
@@ -348,7 +348,7 @@ public:
         {
             _firstStart = false;
             gClipSelectionA = { 0, 0 };
-            gClipSelectionB = { MAXIMUM_TILE_START_XY, MAXIMUM_TILE_START_XY };
+            gClipSelectionB = { gMapSize.x * 32, gMapSize.y * 32 };
         }
 
         this->widgets = window_view_clipping_widgets;

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -343,7 +343,8 @@ public:
 
     void OnOpen() override
     {   
-        if(_previousClipSelectionA == NULL || _previousClipSelectionB == NULL) {
+        if(_previousClipSelectionA == NULL || _previousClipSelectionB == NULL) 
+        {
             _previousClipSelectionA = { 0, 0 };
             _previousClipSelectionB = gMapSize.ToCoordsXY();
         }

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -342,13 +342,13 @@ public:
     }
 
     void OnOpen() override
-    {   
+    {
         if (_previousClipSelectionA == NULL || _previousClipSelectionB == NULL) 
         {
             _previousClipSelectionA = { 0, 0 };
             _previousClipSelectionB = gMapSize.ToCoordsXY();
         }
-        
+
         this->widgets = window_view_clipping_widgets;
         this->hold_down_widgets = (1ULL << WIDX_CLIP_HEIGHT_INCREASE) | (1UL << WIDX_CLIP_HEIGHT_DECREASE);
         WindowInitScrollWidgets(this);

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -72,7 +72,6 @@ private:
     CoordsXY _previousClipSelectionB = gMapSize.ToCoordsXY();
     bool _toolActive{ false };
     bool _dragging{ false };
-    bool _firstStart = true;
     static inline DisplayType _clipHeightDisplayType;
 
 public:
@@ -344,13 +343,6 @@ public:
 
     void OnOpen() override
     {
-        if (_firstStart)
-        {
-            _firstStart = false;
-            gClipSelectionA = { 0, 0 };
-            gClipSelectionB = gMapSize.ToCoordsXY();
-        }
-
         this->widgets = window_view_clipping_widgets;
         this->hold_down_widgets = (1ULL << WIDX_CLIP_HEIGHT_INCREASE) | (1UL << WIDX_CLIP_HEIGHT_DECREASE);
         WindowInitScrollWidgets(this);

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -123,7 +123,7 @@ public:
                 _previousClipSelectionA = gClipSelectionA;
                 _previousClipSelectionB = gClipSelectionB;
                 gClipSelectionA = { 0, 0 };
-                gClipSelectionB = { gMapSize.x * 32, gMapSize.y * 32 };
+                gClipSelectionB = gMapSize.ToCoordsXY();
                 gfx_invalidate_screen();
                 break;
             case WIDX_CLIP_CLEAR:
@@ -133,7 +133,7 @@ public:
                     tool_cancel();
                 }
                 gClipSelectionA = { 0, 0 };
-                gClipSelectionB = { gMapSize.x * 32, gMapSize.y * 32 };
+                gClipSelectionB = gMapSize.ToCoordsXY();
                 gfx_invalidate_screen();
                 break;
         }
@@ -348,7 +348,7 @@ public:
         {
             _firstStart = false;
             gClipSelectionA = { 0, 0 };
-            gClipSelectionB = { gMapSize.x * 32, gMapSize.y * 32 };
+            gClipSelectionB = gMapSize.ToCoordsXY();
         }
 
         this->widgets = window_view_clipping_widgets;

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -343,12 +343,6 @@ public:
 
     void OnOpen() override
     {
-        if (_previousClipSelectionA == NULL || _previousClipSelectionB == NULL) 
-        {
-            _previousClipSelectionA = { 0, 0 };
-            _previousClipSelectionB = gMapSize.ToCoordsXY();
-        }
-
         this->widgets = window_view_clipping_widgets;
         this->hold_down_widgets = (1ULL << WIDX_CLIP_HEIGHT_INCREASE) | (1UL << WIDX_CLIP_HEIGHT_DECREASE);
         WindowInitScrollWidgets(this);

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -348,6 +348,7 @@ public:
             _previousClipSelectionA = { 0, 0 };
             _previousClipSelectionB = gMapSize.ToCoordsXY();
         }
+        
         this->widgets = window_view_clipping_widgets;
         this->hold_down_widgets = (1ULL << WIDX_CLIP_HEIGHT_INCREASE) | (1UL << WIDX_CLIP_HEIGHT_DECREASE);
         WindowInitScrollWidgets(this);

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -132,7 +132,7 @@ public:
                     tool_cancel();
                 }
                 gClipSelectionA = { 0, 0 };
-                gClipSelectionB = gMapSize.ToCoordsXY();
+                gClipSelectionB = { MAXIMUM_MAP_SIZE_BIG - 1, MAXIMUM_MAP_SIZE_BIG - 1 };
                 gfx_invalidate_screen();
                 break;
         }

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -68,10 +68,11 @@ class ViewClippingWindow final : public Window
 {
 private:
     CoordsXY _selectionStart;
-    CoordsXY _previousClipSelectionA;
-    CoordsXY _previousClipSelectionB;
+    CoordsXY _previousClipSelectionA = { 0, 0 };
+    CoordsXY _previousClipSelectionB = { MAXIMUM_TILE_START_XY, MAXIMUM_TILE_START_XY };
     bool _toolActive{ false };
     bool _dragging{ false };
+    bool _firstStart = true;
     static inline DisplayType _clipHeightDisplayType;
 
 public:
@@ -122,7 +123,7 @@ public:
                 _previousClipSelectionA = gClipSelectionA;
                 _previousClipSelectionB = gClipSelectionB;
                 gClipSelectionA = { 0, 0 };
-                gClipSelectionB = { MAXIMUM_MAP_SIZE_BIG - 1, MAXIMUM_MAP_SIZE_BIG - 1 };
+                gClipSelectionB = { MAXIMUM_TILE_START_XY, MAXIMUM_TILE_START_XY };
                 gfx_invalidate_screen();
                 break;
             case WIDX_CLIP_CLEAR:
@@ -132,7 +133,7 @@ public:
                     tool_cancel();
                 }
                 gClipSelectionA = { 0, 0 };
-                gClipSelectionB = { MAXIMUM_MAP_SIZE_BIG - 1, MAXIMUM_MAP_SIZE_BIG - 1 };
+                gClipSelectionB = { MAXIMUM_TILE_START_XY, MAXIMUM_TILE_START_XY };
                 gfx_invalidate_screen();
                 break;
         }
@@ -343,6 +344,13 @@ public:
 
     void OnOpen() override
     {
+        if (_firstStart)
+        {
+            _firstStart = false;
+            gClipSelectionA = { 0, 0 };
+            gClipSelectionB = { MAXIMUM_TILE_START_XY, MAXIMUM_TILE_START_XY };
+        }
+
         this->widgets = window_view_clipping_widgets;
         this->hold_down_widgets = (1ULL << WIDX_CLIP_HEIGHT_INCREASE) | (1UL << WIDX_CLIP_HEIGHT_DECREASE);
         WindowInitScrollWidgets(this);

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -343,7 +343,7 @@ public:
 
     void OnOpen() override
     {   
-        if(_previousClipSelectionA == NULL || _previousClipSelectionB == NULL) 
+        if (_previousClipSelectionA == NULL || _previousClipSelectionB == NULL) 
         {
             _previousClipSelectionA = { 0, 0 };
             _previousClipSelectionB = gMapSize.ToCoordsXY();

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -504,7 +504,6 @@ void game_load_init()
     gGameSpeed = 1;
     gClipSelectionA = { 0, 0 };
     gClipSelectionB = gMapSize.ToCoordsXY();
-    printf("a\n");
 }
 
 void game_load_scripts()

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -432,7 +432,7 @@ void game_fix_save_vars()
             // At this point, we can be sure that surfaceElement is not NULL.
             if (x == 0 || x == gMapSize.x - 1 || y == 0 || y == gMapSize.y - 1)
             {
-             gMapSize.toCoords   surfaceElement->SetBaseZ(MINIMUM_LAND_HEIGHT_BIG);
+                surfaceElement->SetBaseZ(MINIMUM_LAND_HEIGHT_BIG);
                 surfaceElement->SetClearanceZ(MINIMUM_LAND_HEIGHT_BIG);
                 surfaceElement->SetSlope(0);
                 surfaceElement->SetWaterHeight(0);

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -502,7 +502,7 @@ void game_load_init()
 
     OpenRCT2::Audio::StopTitleMusic();
     gGameSpeed = 1;
-    gClipSelectionA = { 0,0 };
+    gClipSelectionA = { 0, 0 };
     gClipSelectionB = gMapSize.ToCoordsXY();
     printf("a\n");
 }

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -432,7 +432,7 @@ void game_fix_save_vars()
             // At this point, we can be sure that surfaceElement is not NULL.
             if (x == 0 || x == gMapSize.x - 1 || y == 0 || y == gMapSize.y - 1)
             {
-                surfaceElement->SetBaseZ(MINIMUM_LAND_HEIGHT_BIG);
+             gMapSize.toCoords   surfaceElement->SetBaseZ(MINIMUM_LAND_HEIGHT_BIG);
                 surfaceElement->SetClearanceZ(MINIMUM_LAND_HEIGHT_BIG);
                 surfaceElement->SetSlope(0);
                 surfaceElement->SetWaterHeight(0);
@@ -503,7 +503,7 @@ void game_load_init()
     OpenRCT2::Audio::StopTitleMusic();
     gGameSpeed = 1;
     gClipSelectionA = { 0, 0 };
-    gClipSelectionB = gMapSize.ToCoordsXY();
+    gClipSelectionB = { MAXIMUM_MAP_SIZE_BIG - 1, MAXIMUM_MAP_SIZE_BIG - 1 };
 }
 
 void game_load_scripts()

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -41,6 +41,7 @@
 #include "network/network.h"
 #include "object/Object.h"
 #include "object/ObjectList.h"
+#include "paint/Paint.h"
 #include "platform/Platform.h"
 #include "ride/Ride.h"
 #include "ride/RideRatings.h"
@@ -501,6 +502,9 @@ void game_load_init()
 
     OpenRCT2::Audio::StopTitleMusic();
     gGameSpeed = 1;
+    gClipSelectionA = { 0,0 };
+    gClipSelectionB = gMapSize.ToCoordsXY();
+    printf("a\n");
 }
 
 void game_load_scripts()


### PR DESCRIPTION
A separate pull request that should be handled separately from the original pull request #17319 

This is to fix a separate issue which has become more noticeable with that pull request but already existed beforehand.
To reproduce, here are the steps.

1. Open any map, preferably a very large one.
2. Open Cut-Away View
3. Select a small area in the center of the very large map. This should work fine. Technically any area works which is out of bounds on the very small map.
4. Close this map and start a new map which has to be a very small one (ex. Micro Park)
5. Open Cut-Away View again on the small map
6. The result should be a black screen plus the UI elements until a new selection is made, because the currently saved selection from the very large map is kept here, even though it is out of bounds.

This current implementation is less than ideal. Basically right now it relies on a bool which is always set to true when a new map is loaded. As soon as the cut-away view window is opened, it checks for that bool. If that bool is true, then set gClipSelection to its original default values. Then set the bool to false so it never occurs again, until a new map is loaded which sets that bool to true.

I should probably avoid using that bool _firstStart or at the very least rename it  but I have no idea what to use instead.

Note that the pull request #17319 should be applied first. This is not strictly required but recommended. That has a separate check that ensures that the giant screenshot is never larger than the map size.