### PR TITLE
Finance payment api hook

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -577,7 +577,7 @@ declare global {
     }
 
     /**
-     * A financial payment event, provided by the "park.financial.payment" hook
+     * A financial payment event, provided by the "park.finance.payment" hook
      */
     interface PaymentEventArgs {
         /** The type of the payment */

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -299,6 +299,7 @@ declare global {
         subscribe(hook: "vehicle.crash", callback: (e: VehicleCrashArgs) => void): IDisposable;
         subscribe(hook: "map.save", callback: () => void): IDisposable;
         subscribe(hook: "map.change", callback: () => void): IDisposable;
+        subscribe(hook: "park.finance.payment", callback: (e: PaymentEventArgs) => void): IDisposable;
 
         /**
          * Can only be used in intransient plugins.
@@ -412,7 +413,8 @@ declare global {
         "interval.tick" | "interval.day" |
         "network.chat" | "network.action" | "network.join" | "network.leave" |
         "ride.ratings.calculate" | "action.location" | "vehicle.crash" |
-        "map.change" | "map.changed" | "map.save";
+        "map.change" | "map.changed" | "map.save" |
+        "park.finance.payment";
 
     type ExpenditureType =
         "ride_construction" |
@@ -572,6 +574,19 @@ declare global {
     interface VehicleCrashArgs {
         readonly id: number;
         readonly crashIntoType: VehicleCrashIntoType;
+    }
+
+    /**
+     * A financial payment event, provided by the "park.financial.payment" hook
+     */
+    interface PaymentEventArgs {
+        /** The type of the payment */
+        readonly type: ExpenditureType
+        /**
+         * The amount of the payment, which is 10 times the amount display in-game e.g $3.50 is 35.
+         * Income i.e entrance tickets, ride tickets and food/drink sales, are negative
+         */
+        amount: number;
     }
 
     /**

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -96,8 +96,9 @@ void finance_payment(money32 amount, ExpenditureType type)
         auto e = scriptEngine.CreatePaymentEventArgDuk(amount, type);
         hookEngine.Call(HOOK_TYPE::PARK_FINANCE_PAYMENT, e, true);
 
-        // Allow remote scripts to modify amount
-        // TODO: Read back amount from args and reassign amount
+        // Allow scripts to modify amount
+        auto scriptAmount = AsOrDefault(e["amount"], static_cast<int32_t>(amount));
+        amount = std::clamp<int32_t>(scriptAmount, INT32_MIN, INT32_MAX);
     }
 #endif
 

--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -34,6 +34,7 @@ static const EnumMap<HOOK_TYPE> HooksLookupTable({
     { "map.change", HOOK_TYPE::MAP_CHANGE },
     { "map.changed", HOOK_TYPE::MAP_CHANGED },
     { "map.save", HOOK_TYPE::MAP_SAVE },
+    { "park.finance.payment", HOOK_TYPE::PARK_FINANCE_PAYMENT },
 });
 
 HOOK_TYPE OpenRCT2::Scripting::GetHookType(const std::string& name)

--- a/src/openrct2/scripting/HookEngine.h
+++ b/src/openrct2/scripting/HookEngine.h
@@ -43,6 +43,7 @@ namespace OpenRCT2::Scripting
         MAP_CHANGE,
         MAP_CHANGED,
         MAP_SAVE,
+        PARK_FINANCE_PAYMENT,
         COUNT,
         UNDEFINED = -1,
     };

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1464,6 +1464,28 @@ std::unique_ptr<GameAction> ScriptEngine::CreateGameAction(const std::string& ac
     return std::make_unique<CustomAction>(actionid, json);
 }
 
+/**
+ * Creates a DukObject for representing the `PaymentEventArg` object for the "park.finance.payment" API hook
+ * @param amount to deduct. Use negative values for income.
+ * @param type The ExpenditureType. This includes income.
+ */
+DukValue ScriptEngine::CreatePaymentEventArgDuk(money32 amount, ExpenditureType type)
+{
+    DukObject obj(_context);
+
+    if (amount != MONEY32_UNDEFINED)
+    {
+        obj.Set("amount", amount);
+    }
+
+    if (type != ExpenditureType::Count)
+    {
+        obj.Set("type", ExpenditureTypeToString(type));
+    }
+
+    return obj.Take();
+}
+
 void ScriptEngine::InitSharedStorage()
 {
     duk_push_object(_context);

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -241,6 +241,7 @@ namespace OpenRCT2::Scripting
             const std::shared_ptr<Plugin>& plugin, std::string_view action, const DukValue& query, const DukValue& execute);
         void RunGameActionHooks(const GameAction& action, GameActions::Result& result, bool isExecute);
         [[nodiscard]] std::unique_ptr<GameAction> CreateGameAction(const std::string& actionid, const DukValue& args);
+        DukValue CreatePaymentEventArgDuk(money32 amount, ExpenditureType type);
 
         void SaveSharedStorage();
 


### PR DESCRIPTION
As this is my first contribution to the project, I've created this as draft - I'd welcome some feedback.

I've implemented a new API hook named "park.financial.payment". It allows plugin authors to:

 1. Run code when a financial transaction occurs (both income and outgoings), see the amount and the expenditure type.
 2. Change the amount.

I discuss my design more here: https://github.com/OpenRCT2/OpenRCT2/discussions/17523