### PR TITLE
New API hook "ride.upkeep.calculate"

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -301,6 +301,12 @@ declare global {
         subscribe(hook: "map.change", callback: () => void): IDisposable;
 
         /**
+         * Subscribe to hook that raised when the game calculates the upkeep for an individual ride.
+         * The game does this every 2 weeks simulation time.
+         */
+        subscribe(hook: "ride.upkeep.calculate", callback: (e: RideUpkeepCalculateArgs) => void): IDisposable;
+
+        /**
          * Can only be used in intransient plugins.
          */
         subscribe(hook: "map.changed", callback: () => void): IDisposable;
@@ -411,7 +417,8 @@ declare global {
     type HookType =
         "interval.tick" | "interval.day" |
         "network.chat" | "network.action" | "network.join" | "network.leave" |
-        "ride.ratings.calculate" | "action.location" | "vehicle.crash" |
+        "ride.ratings.calculate" | "ride.upkeep.calculate" | "vehicle.crash" |
+        "action.location" |
         "map.change" | "map.changed" | "map.save";
 
     type ExpenditureType =
@@ -572,6 +579,16 @@ declare global {
     interface VehicleCrashArgs {
         readonly id: number;
         readonly crashIntoType: VehicleCrashIntoType;
+    }
+
+    /**
+     * Arguments for the calculation of ride upkeep (runnning cost), provided by the "ride.upkeep.calculate" hook
+     */
+    interface RideUpkeepCalculateArgs {
+        /** The ID of the ride upkeep is being calculated for */
+        readonly ride: number
+        /** The currency value that was calculated by the game, which can be adjusted/overrided by plugins */
+        upkeep: number;
     }
 
     /**

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -968,7 +968,7 @@ static void InvokeUpkeepCalculateHook(Ride* ride, uint16_t& upkeep)
 
     if (hookEngine.HasSubscriptions(HOOK_TYPE::RIDE_UPKEEP_CALCULATE))
     {
-        auto e = scriptEngine.RideUpkeepCalculateArgsDuk(ride->id, upkeep);
+        auto e = scriptEngine.CreateRideUpkeepCalculateArgsDuk(ride->id, upkeep);
         hookEngine.Call(HOOK_TYPE::RIDE_UPKEEP_CALCULATE, e, true);
 
         // Allow scripts to modify upkeep

--- a/src/openrct2/scripting/HookEngine.cpp
+++ b/src/openrct2/scripting/HookEngine.cpp
@@ -28,6 +28,7 @@ static const EnumMap<HOOK_TYPE> HooksLookupTable({
     { "network.join", HOOK_TYPE::NETWORK_JOIN },
     { "network.leave", HOOK_TYPE::NETWORK_LEAVE },
     { "ride.ratings.calculate", HOOK_TYPE::RIDE_RATINGS_CALCULATE },
+    { "ride.upkeep.calculate", HOOK_TYPE::RIDE_UPKEEP_CALCULATE },
     { "action.location", HOOK_TYPE::ACTION_LOCATION },
     { "guest.generation", HOOK_TYPE::GUEST_GENERATION },
     { "vehicle.crash", HOOK_TYPE::VEHICLE_CRASH },

--- a/src/openrct2/scripting/HookEngine.h
+++ b/src/openrct2/scripting/HookEngine.h
@@ -43,6 +43,7 @@ namespace OpenRCT2::Scripting
         MAP_CHANGE,
         MAP_CHANGED,
         MAP_SAVE,
+        RIDE_UPKEEP_CALCULATE,
         COUNT,
         UNDEFINED = -1,
     };

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1464,6 +1464,24 @@ std::unique_ptr<GameAction> ScriptEngine::CreateGameAction(const std::string& ac
     return std::make_unique<CustomAction>(actionid, json);
 }
 
+/**
+ * Creates a DukObject for representing the `RideUpkeepCalculateArgs` object for the "ride.upkeep.calculate" API hook
+ * @param amount to deduct. Use negative values for income.
+ * @param type The ExpenditureType. This includes income.
+ */
+DukValue ScriptEngine::RideUpkeepCalculateArgsDuk(RideId ride, uint32_t upkeep)
+{
+    DukObject obj(_context);
+
+    if (!ride.IsNull())
+    {
+        obj.Set("ride", ride.ToUnderlying());
+    }
+
+    obj.Set("upkeep", upkeep);
+    return obj.Take();
+}
+
 void ScriptEngine::InitSharedStorage()
 {
     duk_push_object(_context);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1469,7 +1469,7 @@ std::unique_ptr<GameAction> ScriptEngine::CreateGameAction(const std::string& ac
  * @param amount to deduct. Use negative values for income.
  * @param type The ExpenditureType. This includes income.
  */
-DukValue ScriptEngine::RideUpkeepCalculateArgsDuk(RideId ride, uint32_t upkeep)
+DukValue ScriptEngine::CreateRideUpkeepCalculateArgsDuk(RideId ride, uint32_t upkeep)
 {
     DukObject obj(_context);
 

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -241,7 +241,7 @@ namespace OpenRCT2::Scripting
             const std::shared_ptr<Plugin>& plugin, std::string_view action, const DukValue& query, const DukValue& execute);
         void RunGameActionHooks(const GameAction& action, GameActions::Result& result, bool isExecute);
         [[nodiscard]] std::unique_ptr<GameAction> CreateGameAction(const std::string& actionid, const DukValue& args);
-        DukValue RideUpkeepCalculateArgsDuk(RideId ride, uint32_t upkeep);
+        DukValue CreateRideUpkeepCalculateArgsDuk(RideId ride, uint32_t upkeep);
 
         void SaveSharedStorage();
 

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -241,6 +241,7 @@ namespace OpenRCT2::Scripting
             const std::shared_ptr<Plugin>& plugin, std::string_view action, const DukValue& query, const DukValue& execute);
         void RunGameActionHooks(const GameAction& action, GameActions::Result& result, bool isExecute);
         [[nodiscard]] std::unique_ptr<GameAction> CreateGameAction(const std::string& actionid, const DukValue& args);
+        DukValue RideUpkeepCalculateArgsDuk(RideId ride, uint32_t upkeep);
 
         void SaveSharedStorage();
 


### PR DESCRIPTION
The hook is invoked whenever the game recalculates the running cost of a ride every 2 weeks. Plugins receive the ride ID and the currency value that was calculated. Plugins can also change the upkeep value.

I created this new hook as I want to create a plugin that allows the user to increase or decrease the value of various costs. I original [wrote a hook for every financial transaction](https://github.com/OpenRCT2/OpenRCT2/pull/17526), however there were some issue with this approach. If the plugin uses this hook to change the ride running cost, it has the advantage that its new value is reflected in the UI and in the `GameMap.rides` API property.

An enhancement I might like to make is to include in the hook arguments the parameters that the game uses in calculating ride running costs, which is encapsulated in the `RideRatingUpdateState` struct. This could allow plugin authors to define their own algorithms for calculating ride costs. For now I'm submitting my current progress for feedback.