### PR TITLE
Fix #17553: Crash when moving invention list items to empty list

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -194,6 +194,7 @@ The following people are not part of the development team, but have been contrib
 * Erik Wouters (EWouters)
 * Hoby R. (hobyr)
 * Huu Kim Nguyen (CoderUndefined)
+* Henry Cheng (jazzysoggy)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Change: [#17499] Update error text when using vehicle incompatible with TD6 and add error when using incompatible track elements.
 - Fix: [#16476] The game sometimes crashes when demolishing a maze.
 - Fix: [#17444] “Manta Ray” boats slowed down too much in “Ayers Rock” scenario (original bug).
+- Fix: [#17553] Crash when moving invention list items to empty list
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -618,7 +618,7 @@ public:
         {
             res = inventionListWindow->GetResearchItemAt(newScreenCoords);
             newScreenCoords.y += LIST_ROW_HEIGHT;
-        } while (res.has_value() && res->research->IsAlwaysResearched());
+        } while (res->research != nullptr && res->research->IsAlwaysResearched());
 
         if (res.has_value())
         {

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -618,7 +618,7 @@ public:
         {
             res = inventionListWindow->GetResearchItemAt(newScreenCoords);
             newScreenCoords.y += LIST_ROW_HEIGHT;
-        } while (res->research != nullptr && res->research->IsAlwaysResearched());
+        } while (res.has_value() && res->research != nullptr && res->research->IsAlwaysResearched());
 
         if (res.has_value())
         {


### PR DESCRIPTION
Fix #17553 

The original implementation was only checking whether the optional variable had at least one of the sub variables are defined. 

This leads to an error where if one of the Researched/non-researched list is a nullptr and the other variable exists, then the if condition will try to access a item on a nullptr array, leading to a crash.

The fix for this is to specifically check whether the list is a nullptr or not.