### PR TITLE
Improve CMake handling of g2.dat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,7 +393,7 @@ endif ()
 if (NOT (MACOS_BUNDLE AND (NOT CMAKE_OSX_ARCHITECTURES MATCHES "${SYSTEM_MACOS_ARCH}")))
     add_custom_command(
         OUTPUT g2.dat
-        COMMAND ./openrct2-cli sprite build \"${CMAKE_BINARY_DIR}/g2.dat\" \"${ROOT_DIR}/resources/g2/sprites.json\"
+        COMMAND ./openrct2-cli sprite build ${CMAKE_BINARY_DIR}/g2.dat ${ROOT_DIR}/resources/g2/sprites.json
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     )
     add_custom_target(g2 DEPENDS ${PROJECT_NAME} g2.dat)


### PR DESCRIPTION
CMake variables already escape characters. Fixes #17534

I was able to reproduce issue reported in #17534 and fix it. I have also tested with build dir named `build 🎠`