### PR TITLE
Fix #17472: Possible fix for improper reticle behavior on save

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -585,7 +585,6 @@ static void WindowTopToolbarDropdown(rct_window* w, rct_widgetindex widgetIndex,
                     break;
                 }
                 case DDIDX_SAVE_GAME:
-                    tool_cancel();
                     save_game();
                     break;
                 case DDIDX_SAVE_GAME_AS:
@@ -598,7 +597,6 @@ static void WindowTopToolbarDropdown(rct_window* w, rct_widgetindex widgetIndex,
                     }
                     else
                     {
-                        tool_cancel();
                         save_game_as();
                     }
                     break;

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -745,7 +745,6 @@ void game_load_or_quit_no_save_prompt()
         {
             auto loadOrQuitAction = LoadOrQuitAction(LoadOrQuitModes::CloseSavePrompt);
             GameActions::Execute(&loadOrQuitAction);
-            tool_cancel();
             if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
             {
                 load_landscape();
@@ -763,7 +762,6 @@ void game_load_or_quit_no_save_prompt()
         {
             auto loadOrQuitAction = LoadOrQuitAction(LoadOrQuitModes::CloseSavePrompt);
             GameActions::Execute(&loadOrQuitAction);
-            tool_cancel();
             if (input_test_flag(INPUT_FLAG_5))
             {
                 input_set_flag(INPUT_FLAG_5, false);


### PR DESCRIPTION
Fix #17472 
Issue: While the original issue points out that upon saving, the tile inspector would experience improper reticle behavior where the reticle would just disappear and the tool would no longer work, I found through more testing that this behavior applied to loading saves, as well as with the footpath window and ride constructor window.

The workaround would be simply closing the bugged window and re-opening it in the current version

The fix for this issue is removing the tool_cancel function call inside of Game.cpp's game_load_or_quit_no_save_prompt()  as well as the TopToolbar.cpp tool_cancel function.