### PR TITLE
Fix #17508: Grid Doesn't Disable After Setting Patrol Area

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,6 +13,7 @@
 - Fix: [#17444] “Manta Ray” boats slowed down too much in “Ayers Rock” scenario (original bug).
 - Fix: [#17503] Parks with staff with an ID of 0 have all staff windows focus on that staff
 - Fix: [#17553] Crash when moving invention list items to empty list
+- Fix: [#17508] Grid Doesn't Disable After Setting Patrol Area.
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -12,8 +12,8 @@
 - Fix: [#17339] Distorted visuals when changing scaling factor between integer numbers in OpenGL rendering mode.
 - Fix: [#17444] “Manta Ray” boats slowed down too much in “Ayers Rock” scenario (original bug).
 - Fix: [#17503] Parks with staff with an ID of 0 have all staff windows focus on that staff
-- Fix: [#17553] Crash when moving invention list items to empty list
 - Fix: [#17508] Grid doesn’t disable after setting patrol area.
+- Fix: [#17553] Crash when moving invention list items to empty list
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,7 +13,7 @@
 - Fix: [#17444] “Manta Ray” boats slowed down too much in “Ayers Rock” scenario (original bug).
 - Fix: [#17503] Parks with staff with an ID of 0 have all staff windows focus on that staff
 - Fix: [#17553] Crash when moving invention list items to empty list
-- Fix: [#17508] Grid Doesn't Disable After Setting Patrol Area.
+- Fix: [#17508] Grid doesn’t disable after setting patrol area.
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -190,8 +190,6 @@ public:
     void OnToolAbort(rct_widgetindex widgetIndex) override
     {
         hide_gridlines();
-        if (!tool_set(this, 0, Tool::WalkDown))
-            hide_gridlines();
         ClearPatrolAreaToRender();
         gfx_invalidate_screen();
     }
@@ -250,7 +248,6 @@ private:
             if (!tool_set(this, 0, Tool::WalkDown))
             {
                 input_set_flag(INPUT_FLAG_6, true);
-                show_gridlines();
                 SetPatrolAreaToRender(_staffId);
                 gfx_invalidate_screen();
             }

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -244,9 +244,9 @@ private:
         }
         else
         {
-            show_gridlines();
             if (!tool_set(this, 0, Tool::WalkDown))
             {
+                show_gridlines();
                 input_set_flag(INPUT_FLAG_6, true);
                 SetPatrolAreaToRender(_staffId);
                 gfx_invalidate_screen();

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -190,6 +190,8 @@ public:
     void OnToolAbort(rct_widgetindex widgetIndex) override
     {
         hide_gridlines();
+        if (!tool_set(this, 0, Tool::WalkDown))
+            hide_gridlines();
         ClearPatrolAreaToRender();
         gfx_invalidate_screen();
     }
@@ -248,6 +250,7 @@ private:
             if (!tool_set(this, 0, Tool::WalkDown))
             {
                 input_set_flag(INPUT_FLAG_6, true);
+                show_gridlines();
                 SetPatrolAreaToRender(_staffId);
                 gfx_invalidate_screen();
             }

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -248,7 +248,6 @@ private:
             if (!tool_set(this, 0, Tool::WalkDown))
             {
                 input_set_flag(INPUT_FLAG_6, true);
-                show_gridlines();
                 SetPatrolAreaToRender(_staffId);
                 gfx_invalidate_screen();
             }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1160,8 +1160,6 @@ private:
             viewport_flags = 0;
             if (gConfigGeneral.always_show_gridlines)
                 viewport_flags |= VIEWPORT_FLAG_GRIDLINES;
-            else
-                viewport_flags &= ~VIEWPORT_FLAG_GRIDLINES;
         }
 
         window_event_invalidate_call(this);

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1160,6 +1160,8 @@ private:
             viewport_flags = 0;
             if (gConfigGeneral.always_show_gridlines)
                 viewport_flags |= VIEWPORT_FLAG_GRIDLINES;
+            else
+                viewport_flags &= ~VIEWPORT_FLAG_GRIDLINES;
         }
 
         window_event_invalidate_call(this);


### PR DESCRIPTION
Fix #17508

Issue: When display gridlines option is disabled in the options menu, setting a staff's patrol area will display gridlines even after closing the patrol area window.

Fix: Added an additional hide_gridlines() function call if tool_set(this, 0, Tool::WalkDown) returns not true, as show_gridlines() is called twice if that returns not true, while hide_gridlines() originally would only be called once.