### PR TITLE
Add Authors to the list of things you can search for in the Object Selection menu

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Feature: [#13634] Add ability to sell merchandise in random colours.
 - Feature: [#16662] Show a warning message when g2.dat is mismatched.
+- Improvement: [#17575] You can now search for Authors in Object Selection.
 - Change: [#17319] Giant screenshots are now cropped to the horizontal view-clipping selection.
 - Change: [#17499] Update error text when using vehicle incompatible with TD6 and add error when using incompatible track elements.
 - Fix: [#16392] Scenery on sloped surface is placed at wrong height.

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1355,11 +1355,10 @@ private:
             inAuthor = String::ToUpper(author).find(filterUpper) != std::string::npos;
             if (inAuthor)
             {
-                break;
+                return true;
             }
         }
-
-        return inAuthor;
+        return false;
     }
 
     bool SourcesMatch(ObjectSourceGame source)

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1319,6 +1319,19 @@ private:
         return false;
     }
 
+    static bool IsFilterInAuthor(const std::vector<std::string>& authors, const std::string& filterUpper)
+    {
+        for (auto& author : authors)
+        {
+            bool inAuthor = String::ToUpper(author).find(filterUpper) != std::string::npos;
+            if (inAuthor)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     bool FilterString(const ObjectRepositoryItem* item)
     {
         // Nothing to search for
@@ -1338,27 +1351,13 @@ private:
         const auto pathUpper = String::ToUpper(item->Path);
         const auto filterUpper = String::ToUpper(_filter_string);
 
-        // Check if the searched string exists in the name, ride type, or filename
+        // Check if the searched string exists in the name, ride type, filename, or authors field
         bool inName = nameUpper.find(filterUpper) != std::string::npos;
         bool inRideType = (item->Type == ObjectType::Ride) && typeUpper.find(filterUpper) != std::string::npos;
         bool inPath = pathUpper.find(filterUpper) != std::string::npos;
+        bool inAuthor = IsFilterInAuthor(item->Authors, filterUpper);
 
-        if (inName || inRideType || inPath)
-        {
-            return true;
-        }
-
-        // Check in the searched string exists in the authors field
-        bool inAuthor = false;
-        for (auto author : item->Authors)
-        {
-            inAuthor = String::ToUpper(author).find(filterUpper) != std::string::npos;
-            if (inAuthor)
-            {
-                return true;
-            }
-        }
-        return false;
+        return inName || inRideType || inPath || inAuthor;
     }
 
     bool SourcesMatch(ObjectSourceGame source)

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1343,7 +1343,23 @@ private:
         bool inRideType = (item->Type == ObjectType::Ride) && typeUpper.find(filterUpper) != std::string::npos;
         bool inPath = pathUpper.find(filterUpper) != std::string::npos;
 
-        return inName || inRideType || inPath;
+        if (inName || inRideType || inPath)
+        {
+            return true;
+        }
+
+        // Check in the searched string exists in the authors field
+        bool inAuthor = false;
+        for (auto author : item->Authors)
+        {
+            inAuthor = String::ToUpper(author).find(filterUpper) != std::string::npos;
+            if (inAuthor)
+            {
+                break;
+            }
+        }
+
+        return inAuthor;
     }
 
     bool SourcesMatch(ObjectSourceGame source)


### PR DESCRIPTION
Thanks SpaceK for providing their code. My own way of doing it was pretty similar but i kept running into one issue which is fixed here.

This feature/improvement will definitely help with the object creation community. I really hope it prompts people to stop putting their names in the object names.

I am gonna see if I can add this author trivia to some other windows so people get credit where it's due.