### PR TITLE
Remove some calls to free

### DIFF
--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -13,6 +13,7 @@
 #include <openrct2/Game.h>
 #include <openrct2/actions/NetworkModifyGroupAction.h>
 #include <openrct2/config/Config.h>
+#include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/network/network.h>
@@ -347,9 +348,9 @@ static ScreenCoordsXY WindowMultiplayerInformationGetSize()
 
     // Server name is displayed word-wrapped, so figure out how high it will be.
     {
-        utf8* buffer = _strdup(network_get_server_name());
+        utf8* buffer = String::Duplicate(network_get_server_name());
         gfx_wrap_string(buffer, width, FontSpriteBase::MEDIUM, &numLines);
-        free(buffer);
+        delete buffer;
         height += ++numLines * lineHeight + (LIST_ROW_HEIGHT / 2);
     }
 
@@ -357,9 +358,9 @@ static ScreenCoordsXY WindowMultiplayerInformationGetSize()
     const utf8* descString = network_get_server_description();
     if (!str_is_null_or_empty(descString))
     {
-        utf8* buffer = _strdup(descString);
+        utf8* buffer = String::Duplicate(descString);
         gfx_wrap_string(buffer, width, FontSpriteBase::MEDIUM, &numLines);
-        free(buffer);
+        delete buffer;
         height += ++numLines * lineHeight + (LIST_ROW_HEIGHT / 2);
     }
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -241,8 +241,8 @@ public:
         // Dispose track list
         for (auto& trackDesign : _trackDesigns)
         {
-            free(trackDesign.name);
-            free(trackDesign.path);
+            delete trackDesign.name;
+            delete trackDesign.path;
         }
         _trackDesigns.clear();
 


### PR DESCRIPTION
Ref #11159

## Summary

This PR removes calls to `free()` within `openrct2-ui`. Remaining occurrences of `free(` within that folder:

```
grep 'free(' -r openrct2-ui
openrct2-ui/TextComposition.cpp:                        SDL_free(text);
openrct2-ui/windows/EditorObjectSelection.cpp:        editor_object_flags_free();
openrct2-ui/scripting/ScImageManager.hpp:        void free(const DukValue& dukRange)
```

## Testing
I'm not sure how to test these changes, but I have verified that they compile. I also did the following:
- Opened the server list, hovered up and down over the names to view the descriptions
- Opened the track designer and track designs manager and looked through some lists, though wasn't very familiar with the interface for either