### PR TITLE
Fix #17339. Reset Scaleing frame buffers on scale change

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Fix: [#16392] Scenery on sloped surface is placed at wrong height.
 - Fix: [#16476] The game sometimes crashes when demolishing a maze.
 - Fix: [#17312] (Flying) Inline Twist appearing under the surface when placed on ground level.
+- Fix: [#17339] Distorted visuals when changing scaling factor between integer numbers in OpenGL rendering mode.
 - Fix: [#17444] “Manta Ray” boats slowed down too much in “Ayers Rock” scenario (original bug).
 - Fix: [#17503] Parks with staff with an ID of 0 have all staff windows focus on that staff
 - Fix: [#17553] Crash when moving invention list items to empty list

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -444,6 +444,8 @@ private:
     {
         // Re-create screen framebuffer
         _screenFramebuffer = std::make_unique<OpenGLFramebuffer>(_window);
+        _smoothScaleFramebuffer.reset();
+        _scaleFramebuffer.reset();
         if (GetContext()->GetUiContext()->GetScaleQuality() != ScaleQuality::NearestNeighbour)
         {
             _scaleFramebuffer = std::make_unique<OpenGLFramebuffer>(_width, _height, false, false);


### PR DESCRIPTION
~~Issue is likely caused by small changes being compounded when adding/subtracting the floats.~~
~~This rounds any float that is near (within 0.1f) of an integer.~~

~~I was unable to reproduce the error so I can not confirm if this fixes it.~~

Issue caused by not freeing memory. Mistake made in https://github.com/OpenRCT2/OpenRCT2/pull/15512