### PR TITLE
Refactor struct TrackDesignFileRef

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -245,7 +245,7 @@ public:
             }
             case WC_MANAGE_TRACK_DESIGN:
                 return WindowTrackManageOpen(
-                    static_cast<track_design_file_ref*>(intent->GetPointerExtra(INTENT_EXTRA_TRACK_DESIGN)));
+                    static_cast<TrackDesignFileRef*>(intent->GetPointerExtra(INTENT_EXTRA_TRACK_DESIGN)));
             case WC_NETWORK_STATUS:
             {
                 std::string message = intent->GetStringExtra(INTENT_EXTRA_MESSAGE);
@@ -269,7 +269,7 @@ public:
             }
             case WC_TRACK_DESIGN_PLACE:
                 return WindowTrackPlaceOpen(
-                    static_cast<track_design_file_ref*>(intent->GetPointerExtra(INTENT_EXTRA_TRACK_DESIGN)));
+                    static_cast<TrackDesignFileRef*>(intent->GetPointerExtra(INTENT_EXTRA_TRACK_DESIGN)));
             case WC_TRACK_DESIGN_LIST:
             {
                 RideSelection rideItem;

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -22,6 +22,7 @@ static constexpr const int32_t WH = 44;
 static constexpr const int32_t WW = 250;
 static constexpr const int32_t WH_DELETE_PROMPT = 74;
 static constexpr const int32_t WW_DELETE_PROMPT = 250;
+static constexpr const int32_t TRACK_DESIGN_NAME_MAX_LENGTH = 127;
 
 #pragma region Widgets
 
@@ -139,7 +140,7 @@ static void WindowTrackManageMouseup(rct_window* w, rct_widgetindex widgetIndex)
         case WIDX_RENAME:
             WindowTextInputRawOpen(
                 w, widgetIndex, STR_TRACK_DESIGN_RENAME_TITLE, STR_TRACK_DESIGN_RENAME_DESC, {},
-                _trackDesignFileReference->name.c_str(), 127);
+                _trackDesignFileReference->name.c_str(), TRACK_DESIGN_NAME_MAX_LENGTH);
             break;
         case WIDX_DELETE:
             WindowTrackDeletePromptOpen();

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -22,7 +22,7 @@ static constexpr const int32_t WH = 44;
 static constexpr const int32_t WW = 250;
 static constexpr const int32_t WH_DELETE_PROMPT = 74;
 static constexpr const int32_t WW_DELETE_PROMPT = 250;
-static constexpr const int32_t TRACK_DESIGN_NAME_MAX_LENGTH = 127;
+static constexpr const int32_t TrackDesignNameMaxLength = 127;
 
 #pragma region Widgets
 
@@ -140,7 +140,7 @@ static void WindowTrackManageMouseup(rct_window* w, rct_widgetindex widgetIndex)
         case WIDX_RENAME:
             WindowTextInputRawOpen(
                 w, widgetIndex, STR_TRACK_DESIGN_RENAME_TITLE, STR_TRACK_DESIGN_RENAME_DESC, {},
-                _trackDesignFileReference->name.c_str(), TRACK_DESIGN_NAME_MAX_LENGTH);
+                _trackDesignFileReference->name.c_str(), TrackDesignNameMaxLength);
             break;
         case WIDX_DELETE:
             WindowTrackDeletePromptOpen();

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -82,7 +82,7 @@ static rct_window_event_list window_track_delete_prompt_events([](auto& events)
 
 #pragma endregion
 
-static track_design_file_ref* _trackDesignFileReference;
+static TrackDesignFileRef* _trackDesignFileReference;
 
 static void WindowTrackDeletePromptOpen();
 static void WindowTrackDesignListReloadTracks();
@@ -91,7 +91,7 @@ static void WindowTrackDesignListReloadTracks();
  *
  *  rct2: 0x006D348F
  */
-rct_window* WindowTrackManageOpen(track_design_file_ref* tdFileRef)
+rct_window* WindowTrackManageOpen(TrackDesignFileRef* tdFileRef)
 {
     window_close_by_class(WC_MANAGE_TRACK_DESIGN);
 
@@ -139,7 +139,7 @@ static void WindowTrackManageMouseup(rct_window* w, rct_widgetindex widgetIndex)
         case WIDX_RENAME:
             WindowTextInputRawOpen(
                 w, widgetIndex, STR_TRACK_DESIGN_RENAME_TITLE, STR_TRACK_DESIGN_RENAME_DESC, {},
-                _trackDesignFileReference->name, 127);
+                _trackDesignFileReference->name.c_str(), 127);
             break;
         case WIDX_DELETE:
             WindowTrackDeletePromptOpen();
@@ -188,7 +188,7 @@ static void WindowTrackManageTextinput(rct_window* w, rct_widgetindex widgetInde
  */
 static void WindowTrackManagePaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    Formatter::Common().Add<char*>(_trackDesignFileReference->name);
+    Formatter::Common().Add<const utf8*>(_trackDesignFileReference->name.c_str());
     WindowDrawWidgets(w, dpi);
 }
 
@@ -247,7 +247,7 @@ static void WindowTrackDeletePromptPaint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(w, dpi);
 
     auto ft = Formatter();
-    ft.Add<const char*>(_trackDesignFileReference->name);
+    ft.Add<const utf8*>(_trackDesignFileReference->name.c_str());
     DrawTextWrapped(
         dpi, { w->windowPos.x + (WW_DELETE_PROMPT / 2), w->windowPos.y + ((WH_DELETE_PROMPT / 2) - 9) }, (WW_DELETE_PROMPT - 4),
         STR_ARE_YOU_SURE_YOU_WANT_TO_PERMANENTLY_DELETE_TRACK, ft, { TextAlignment::CENTRE });

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -611,9 +611,9 @@ private:
     }
 };
 
-rct_window* WindowTrackPlaceOpen(const track_design_file_ref* tdFileRef)
+rct_window* WindowTrackPlaceOpen(const TrackDesignFileRef* tdFileRef)
 {
-    std::unique_ptr<TrackDesign> openTrackDesign = TrackDesignImport(tdFileRef->path);
+    std::unique_ptr<TrackDesign> openTrackDesign = TrackDesignImport(tdFileRef->path.c_str());
 
     if (openTrackDesign == nullptr)
     {

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -457,14 +457,14 @@ public:
         // Track preview
         auto& tdWidget = widgets[WIDX_TRACK_PREVIEW];
         int32_t colour = ColourMapA[colours[0]].darkest;
-        const utf8* path = _trackDesigns[trackIndex].path.c_str();
+        std::string path = _trackDesigns[trackIndex].path;
 
         // Show track file path (in debug mode)
         if (gConfigGeneral.debugging_tools)
         {
             utf8 pathBuffer[MAX_PATH];
             const utf8* pathPtr = pathBuffer;
-            shorten_path(pathBuffer, sizeof(pathBuffer), path, width, FontSpriteBase::MEDIUM);
+            shorten_path(pathBuffer, sizeof(pathBuffer), path.c_str(), width, FontSpriteBase::MEDIUM);
             auto ft = Formatter();
             ft.Add<utf8*>(pathPtr);
             DrawTextBasic(

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -71,7 +71,7 @@ RideSelection _window_track_list_item;
 class TrackListWindow final : public Window
 {
 private:
-    std::vector<track_design_file_ref> _trackDesigns;
+    std::vector<TrackDesignFileRef> _trackDesigns;
     utf8 _filterString[USER_STRING_MAX_LENGTH];
     std::vector<uint16_t> _filteredTrackIds;
     uint16_t _loadedTrackDesignIndex;
@@ -132,7 +132,7 @@ private:
         }
 
         uint16_t trackDesignIndex = _filteredTrackIds[listIndex];
-        track_design_file_ref* tdRef = &_trackDesigns[trackDesignIndex];
+        TrackDesignFileRef* tdRef = &_trackDesigns[trackDesignIndex];
         if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
         {
             auto intent = Intent(WC_MANAGE_TRACK_DESIGN);
@@ -186,9 +186,9 @@ private:
         FilterList();
     }
 
-    bool LoadDesignPreview(utf8* path)
+    bool LoadDesignPreview(const std::string& path)
     {
-        _loadedTrackDesign = TrackDesignImport(path);
+        _loadedTrackDesign = TrackDesignImport(path.c_str());
         if (_loadedTrackDesign != nullptr)
         {
             TrackDesignDrawPreview(_loadedTrackDesign.get(), _trackDesignPreviewPixels.data());
@@ -239,11 +239,6 @@ public:
         _trackDesignPreviewPixels.shrink_to_fit();
 
         // Dispose track list
-        for (auto& trackDesign : _trackDesigns)
-        {
-            delete trackDesign.name;
-            delete trackDesign.path;
-        }
         _trackDesigns.clear();
 
         // If gScreenAge is zero, we're already in the process
@@ -462,7 +457,7 @@ public:
         // Track preview
         auto& tdWidget = widgets[WIDX_TRACK_PREVIEW];
         int32_t colour = ColourMapA[colours[0]].darkest;
-        utf8* path = _trackDesigns[trackIndex].path;
+        const utf8* path = _trackDesigns[trackIndex].path.c_str();
 
         // Show track file path (in debug mode)
         if (gConfigGeneral.debugging_tools)
@@ -533,7 +528,7 @@ public:
 
         // Track design name
         auto ft = Formatter();
-        ft.Add<utf8*>(_trackDesigns[trackIndex].name);
+        ft.Add<const utf8*>(_trackDesigns[trackIndex].name.c_str());
         DrawTextEllipsised(&dpi, screenPos, 368, STR_TRACK_PREVIEW_NAME_FORMAT, ft, { TextAlignment::CENTRE });
 
         // Information
@@ -730,7 +725,7 @@ public:
                 // Draw track name
                 auto ft = Formatter();
                 ft.Add<rct_string_id>(STR_TRACK_LIST_NAME_FORMAT);
-                ft.Add<utf8*>(_trackDesigns[i].name);
+                ft.Add<const utf8*>(_trackDesigns[i].name.c_str());
                 DrawTextBasic(&dpi, screenCoords - ScreenCoordsXY{ 0, 1 }, stringId, ft);
             }
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -186,7 +186,7 @@ private:
         FilterList();
     }
 
-    bool LoadDesignPreview(const std::string& path)
+    bool LoadDesignPreview(const u8string& path)
     {
         _loadedTrackDesign = TrackDesignImport(path.c_str());
         if (_loadedTrackDesign != nullptr)
@@ -457,7 +457,7 @@ public:
         // Track preview
         auto& tdWidget = widgets[WIDX_TRACK_PREVIEW];
         int32_t colour = ColourMapA[colours[0]].darkest;
-        std::string path = _trackDesigns[trackIndex].path;
+        u8string path = _trackDesigns[trackIndex].path;
 
         // Show track file path (in debug mode)
         if (gConfigGeneral.debugging_tools)

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -108,8 +108,8 @@ struct TrackDesign;
 rct_window* WindowLoadsaveOpen(
     int32_t type, std::string_view defaultPath, std::function<void(int32_t result, std::string_view)> callback,
     TrackDesign* trackDesign);
-rct_window* WindowTrackPlaceOpen(const struct track_design_file_ref* tdFileRef);
-rct_window* WindowTrackManageOpen(struct track_design_file_ref* tdFileRef);
+rct_window* WindowTrackPlaceOpen(const struct TrackDesignFileRef* tdFileRef);
+rct_window* WindowTrackManageOpen(struct TrackDesignFileRef* tdFileRef);
 
 void TrackPlaceClearProvisionalTemporarily();
 void TrackPlaceRestoreProvisional();

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -26,7 +26,7 @@
 struct rct_drawpixelinfo;
 struct rct_window;
 union rct_window_event;
-struct track_design_file_ref;
+struct TrackDesignFileRef;
 struct TextInputSession;
 struct scenario_index_entry;
 

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -170,9 +170,9 @@ public:
      * @param entry The entry name to build a track list for. Leave empty to build track list for the non-separated types (e.g.
      * Hyper-Twister, Car Ride)
      */
-    std::vector<track_design_file_ref> GetItemsForObjectEntry(uint8_t rideType, const std::string& entry) const override
+    std::vector<TrackDesignFileRef> GetItemsForObjectEntry(uint8_t rideType, const std::string& entry) const override
     {
-        std::vector<track_design_file_ref> refs;
+        std::vector<TrackDesignFileRef> refs;
         const auto& repo = GetContext()->GetObjectRepository();
 
         for (const auto& item : _items)
@@ -193,9 +193,9 @@ public:
 
             if (entryIsNotSeparate || String::Equals(item.ObjectEntry, entry, true))
             {
-                track_design_file_ref ref;
-                ref.name = String::Duplicate(GetNameFromTrackPath(item.Path));
-                ref.path = String::Duplicate(item.Path);
+                TrackDesignFileRef ref;
+                ref.name = GetNameFromTrackPath(item.Path);
+                ref.path = item.Path;
                 refs.push_back(ref);
             }
         }
@@ -324,20 +324,20 @@ void track_repository_scan()
     repo->Scan(LocalisationService_GetCurrentLanguage());
 }
 
-bool track_repository_delete(const utf8* path)
+bool track_repository_delete(const std::string& path)
 {
     ITrackDesignRepository* repo = GetContext()->GetTrackDesignRepository();
     return repo->Delete(path);
 }
 
-bool track_repository_rename(const utf8* path, const utf8* newName)
+bool track_repository_rename(const std::string& path, const std::string& newName)
 {
     ITrackDesignRepository* repo = GetContext()->GetTrackDesignRepository();
     std::string newPath = repo->Rename(path, newName);
     return !newPath.empty();
 }
 
-bool track_repository_install(const utf8* srcPath, const utf8* name)
+bool track_repository_install(const std::string& srcPath, const std::string& name)
 {
     ITrackDesignRepository* repo = GetContext()->GetTrackDesignRepository();
     std::string newPath = repo->Install(srcPath, name);

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -324,20 +324,20 @@ void track_repository_scan()
     repo->Scan(LocalisationService_GetCurrentLanguage());
 }
 
-bool track_repository_delete(const std::string& path)
+bool track_repository_delete(const u8string& path)
 {
     ITrackDesignRepository* repo = GetContext()->GetTrackDesignRepository();
     return repo->Delete(path);
 }
 
-bool track_repository_rename(const std::string& path, const std::string& newName)
+bool track_repository_rename(const u8string& path, const u8string& newName)
 {
     ITrackDesignRepository* repo = GetContext()->GetTrackDesignRepository();
     std::string newPath = repo->Rename(path, newName);
     return !newPath.empty();
 }
 
-bool track_repository_install(const std::string& srcPath, const std::string& name)
+bool track_repository_install(const u8string& srcPath, const u8string& name)
 {
     ITrackDesignRepository* repo = GetContext()->GetTrackDesignRepository();
     std::string newPath = repo->Install(srcPath, name);

--- a/src/openrct2/ride/TrackDesignRepository.h
+++ b/src/openrct2/ride/TrackDesignRepository.h
@@ -13,15 +13,14 @@
 #include "../core/String.hpp"
 
 #include <memory>
-
-struct track_design_file_ref
-{
-    utf8* name;
-    utf8* path;
-};
-
 #include <string>
 #include <vector>
+
+struct TrackDesignFileRef
+{
+    std::string name;
+    std::string path;
+};
 
 namespace OpenRCT2
 {
@@ -34,7 +33,7 @@ struct ITrackDesignRepository
 
     [[nodiscard]] virtual size_t GetCount() const abstract;
     [[nodiscard]] virtual size_t GetCountForObjectEntry(uint8_t rideType, const std::string& entry) const abstract;
-    [[nodiscard]] virtual std::vector<track_design_file_ref> GetItemsForObjectEntry(
+    [[nodiscard]] virtual std::vector<TrackDesignFileRef> GetItemsForObjectEntry(
         uint8_t rideType, const std::string& entry) const abstract;
 
     virtual void Scan(int32_t language) abstract;
@@ -48,6 +47,6 @@ struct ITrackDesignRepository
 [[nodiscard]] std::string GetNameFromTrackPath(const std::string& path);
 
 void track_repository_scan();
-bool track_repository_delete(const utf8* path);
-bool track_repository_rename(const utf8* path, const utf8* newName);
-bool track_repository_install(const utf8* srcPath, const utf8* name);
+bool track_repository_delete(const std::string& path);
+bool track_repository_rename(const std::string& path, const std::string& newName);
+bool track_repository_install(const std::string& srcPath, const std::string& name);

--- a/src/openrct2/ride/TrackDesignRepository.h
+++ b/src/openrct2/ride/TrackDesignRepository.h
@@ -18,8 +18,8 @@
 
 struct TrackDesignFileRef
 {
-    std::string name;
-    std::string path;
+    u8string name;
+    u8string path;
 };
 
 namespace OpenRCT2
@@ -47,6 +47,6 @@ struct ITrackDesignRepository
 [[nodiscard]] std::string GetNameFromTrackPath(const std::string& path);
 
 void track_repository_scan();
-bool track_repository_delete(const std::string& path);
-bool track_repository_rename(const std::string& path, const std::string& newName);
-bool track_repository_install(const std::string& srcPath, const std::string& name);
+bool track_repository_delete(const u8string& path);
+bool track_repository_rename(const u8string& path, const u8string& newName);
+bool track_repository_install(const u8string& srcPath, const u8string& name);


### PR DESCRIPTION
Ref #11159

This PR
- Refactors `track_design_file_ref` to `TrackDesignFileRef` and replaces the `utf8*` fields of that struct with `std::string`
- Gets rid of some `String::Duplicate()` and `delete` calls
- Uses a bunch of `c_str()` calls to interface with older functions