### PR TITLE
Fix #17605. Prevent crash when parks include missing objects

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Fix: [#17508] Grid doesn’t disable after setting patrol area.
 - Fix: [#17533] Missing audio when specifying ‘--rct2-data-path’.
 - Fix: [#17553] Crash when moving invention list items to empty list.
+- Fix: [#17605] Crash when opening parks which have had objects removed externally.
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -113,7 +113,12 @@ void SceneryGroupObject::UpdateEntryIndexes()
             continue;
 
         auto entryIndex = objectManager.GetLoadedObjectEntryIndex(ori->LoadedObject.get());
-        Guard::Assert(entryIndex != OBJECT_ENTRY_INDEX_NULL, GUARD_LINE);
+        if (entryIndex == OBJECT_ENTRY_INDEX_NULL)
+        {
+            // Some parks have manually deleted objects from the save so they might not be loaded
+            // silently remove the object from the SceneryGroupObject
+            continue;
+        }
 
         auto sceneryType = GetSceneryType(ori->Type);
         if (sceneryType.has_value())


### PR DESCRIPTION
Specifically the park needs to have had removed an object that is referenced within a scenery group object.