### PR TITLE
Improve placeholder text for steps to reproduce

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -47,11 +47,11 @@ body:
   attributes:
     label: Steps to reproduce
     description: We highly suggest including a screenshot and a bug report log (System tray->Report bug).
-    placeholder: Tell us the steps required to trigger your bug.
-    value: |
-      1. 
-      2. 
-      3. 
+    placeholder: |
+      Tell us the steps required to trigger your bug. Example:
+      1. Open the attached park file
+      2. Click on the park entrance
+      3. The game crashes
   validations:
     required: true
 


### PR DESCRIPTION
Move value to placeholder, so the field is empty and the user has to write something in this field themselves.
Provide simple example steps to make it more clear what we expect.

This will prevent players from leaving the default "1. 2. 3." text in this field and pressing the report button, without actually providing steps to reproduce the bug.