### PR TITLE
Fix #17620. Missing setting ride id for construction window

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -200,6 +200,7 @@ public:
         }
 
         widgets = window_ride_construction_widgets;
+        number = _currentRideIndex.ToUnderlying();
 
         InitScrollWidgets();
 


### PR DESCRIPTION
This would eventually cause a crash when trying to reset the window on last track piece deletion. Mistake made in refactor #17578