### PR TITLE
Close #16867: Refactor window_editor_object_selection_select_object to return a message

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -594,7 +594,8 @@ public:
 
         if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
         {
-            if (window_editor_object_selection_select_object(0, INPUT_FLAG_EDITOR_OBJECT_SELECT, listItem->repositoryItem).Error != GameActions::Status::Ok)
+            if (window_editor_object_selection_select_object(0, INPUT_FLAG_EDITOR_OBJECT_SELECT, listItem->repositoryItem).Error
+                != GameActions::Status::Ok)
                 return;
 
             // Close any other open windows such as options/colour schemes to prevent a crash.

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -594,7 +594,7 @@ public:
 
         if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
         {
-            if (!window_editor_object_selection_select_object(0, INPUT_FLAG_EDITOR_OBJECT_SELECT, listItem->repositoryItem))
+            if (window_editor_object_selection_select_object(0, INPUT_FLAG_EDITOR_OBJECT_SELECT, listItem->repositoryItem).Error != GameActions::Status::Ok)
                 return;
 
             // Close any other open windows such as options/colour schemes to prevent a crash.
@@ -612,7 +612,8 @@ public:
             inputFlags |= INPUT_FLAG_EDITOR_OBJECT_SELECT;
 
         _gSceneryGroupPartialSelectError = false;
-        if (!window_editor_object_selection_select_object(0, inputFlags, listItem->repositoryItem))
+        if (window_editor_object_selection_select_object(0, inputFlags, listItem->repositoryItem).Error
+            != GameActions::Status::Ok)
         {
             rct_string_id error_title = (inputFlags & INPUT_FLAG_EDITOR_OBJECT_SELECT) ? STR_UNABLE_TO_SELECT_THIS_OBJECT
                                                                                        : STR_UNABLE_TO_DE_SELECT_THIS_OBJECT;

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -490,9 +490,8 @@ void finish_object_selection()
  * optional / required dependants of an
  * object.
  */
-static void set_object_selection_error(uint8_t is_master_object, rct_string_id error_msg)
+static void set_object_selection_error(uint8_t is_master_object)
 {
-    gGameCommandErrorText = error_msg;
     if (!is_master_object)
     {
         reset_selected_object_count_and_size();
@@ -508,6 +507,7 @@ GameActions::Result window_editor_object_selection_select_object(
 {
     if (item == nullptr)
     {
+        set_object_selection_error(isMasterObject);
         return GameActions::Result(GameActions::Status::Unknown, STR_OBJECT_SELECTION_ERR_OBJECT_DATA_NOT_FOUND, STR_NONE);
     }
 
@@ -533,12 +533,14 @@ GameActions::Result window_editor_object_selection_select_object(
 
         if (*selectionFlags & ObjectSelectionFlags::InUse)
         {
+            set_object_selection_error(isMasterObject);
             return GameActions::Result(
                 GameActions::Status::Unknown, STR_OBJECT_SELECTION_ERR_CURRENTLY_IN_USE, STR_NONE);
         }
 
         if (*selectionFlags & ObjectSelectionFlags::AlwaysRequired)
         {
+            set_object_selection_error(isMasterObject);
             return GameActions::Result(GameActions::Status::Unknown, STR_OBJECT_SELECTION_ERR_ALWAYS_REQUIRED, STR_NONE);
         }
 
@@ -574,7 +576,7 @@ GameActions::Result window_editor_object_selection_select_object(
 
     if (maxObjects <= _numSelectedObjectsForType[EnumValue(objectType)])
     {
-        set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_TOO_MANY_OF_TYPE_SELECTED);
+        set_object_selection_error(isMasterObject);
         return GameActions::Result(GameActions::Status::Unknown, STR_OBJECT_SELECTION_ERR_TOO_MANY_OF_TYPE_SELECTED, STR_NONE);
     }
 
@@ -600,13 +602,13 @@ GameActions::Result window_editor_object_selection_select_object(
         object_create_identifier_name(objectName, 64, &item->ObjectEntry);
         auto ft = Formatter::Common();
         ft.Add<const char*>(objectName);
-        set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_SHOULD_SELECT_X_FIRST);
+        set_object_selection_error(isMasterObject);
         return GameActions::Result(GameActions::Status::Unknown, STR_OBJECT_SELECTION_ERR_SHOULD_SELECT_X_FIRST, STR_NONE);
     }
 
     if (maxObjects <= _numSelectedObjectsForType[EnumValue(objectType)])
     {
-        set_object_selection_error(isMasterObject, STR_OBJECT_SELECTION_ERR_TOO_MANY_OF_TYPE_SELECTED);
+        set_object_selection_error(isMasterObject);
         return GameActions::Result(GameActions::Status::Unknown, STR_OBJECT_SELECTION_ERR_TOO_MANY_OF_TYPE_SELECTED, STR_NONE);
     }
 

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -30,7 +30,6 @@
 #include "world/LargeScenery.h"
 #include "world/Scenery.h"
 
-
 #include <iterator>
 #include <vector>
 
@@ -534,8 +533,7 @@ GameActions::Result window_editor_object_selection_select_object(
         if (*selectionFlags & ObjectSelectionFlags::InUse)
         {
             set_object_selection_error(isMasterObject);
-            return GameActions::Result(
-                GameActions::Status::Unknown, STR_OBJECT_SELECTION_ERR_CURRENTLY_IN_USE, STR_NONE);
+            return GameActions::Result(GameActions::Status::Unknown, STR_OBJECT_SELECTION_ERR_CURRENTLY_IN_USE, STR_NONE);
         }
 
         if (*selectionFlags & ObjectSelectionFlags::AlwaysRequired)

--- a/src/openrct2/EditorObjectSelectionSession.h
+++ b/src/openrct2/EditorObjectSelectionSession.h
@@ -9,10 +9,11 @@
 
 #pragma once
 
+#include "actions/GameAction.h"
 #include "common.h"
 #include "object/Object.h"
 #include "util/Util.h"
-#include "actions/GameAction.h"
+
 #include <vector>
 
 enum EDITOR_INPUT_FLAGS

--- a/src/openrct2/EditorObjectSelectionSession.h
+++ b/src/openrct2/EditorObjectSelectionSession.h
@@ -12,7 +12,7 @@
 #include "common.h"
 #include "object/Object.h"
 #include "util/Util.h"
-
+#include "actions/GameAction.h"
 #include <vector>
 
 enum EDITOR_INPUT_FLAGS
@@ -34,8 +34,10 @@ void unload_unselected_objects();
 void sub_6AB211();
 void reset_selected_object_count_and_size();
 void finish_object_selection();
-bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_t flags, const ObjectRepositoryItem* item);
-bool window_editor_object_selection_select_object(uint8_t isMasterObject, int32_t flags, const ObjectEntryDescriptor& entry);
+GameActions::Result window_editor_object_selection_select_object(
+    uint8_t isMasterObject, int32_t flags, const ObjectRepositoryItem* item);
+GameActions::Result window_editor_object_selection_select_object(
+    uint8_t isMasterObject, int32_t flags, const ObjectEntryDescriptor& entry);
 
 /**
  * Removes all unused objects from the object selection.

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -255,7 +255,6 @@ namespace OpenRCT2
                 });
             }
         }
-
         void ReadWriteObjectsChunk(OrcaStream& os)
         {
             static constexpr uint8_t DESCRIPTOR_NONE = 0;


### PR DESCRIPTION
Close #16867

Issue: window_editor_object_selection_select_object currently returns its success through a bool and also the global gGameCommandErrorText. It should be refactored to return a GameAction::Result to remove the use of the global.

Change: Change the output the GameActions::Result, with function handling window_editor_object_selection_select_object's output being changed to accommodate this change.

Remove all internal instances of gGameCommandErrorText change.