### PR TITLE
Add missing includes

### DIFF
--- a/src/openrct2-ui/Ui.cpp
+++ b/src/openrct2-ui/Ui.cpp
@@ -14,6 +14,7 @@
 #include "audio/AudioContext.h"
 #include "drawing/BitmapReader.h"
 
+#include <memory>
 #include <openrct2/Context.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/PlatformEnvironment.h>

--- a/src/openrct2-ui/audio/AudioMixer.h
+++ b/src/openrct2-ui/audio/AudioMixer.h
@@ -16,6 +16,7 @@
 #include <SDL.h>
 #include <cstdint>
 #include <list>
+#include <memory>
 #include <mutex>
 #include <openrct2/Context.h>
 #include <openrct2/audio/AudioChannel.h>

--- a/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/HardwareDisplayDrawingEngine.cpp
@@ -11,6 +11,7 @@
 
 #include <SDL.h>
 #include <cmath>
+#include <memory>
 #include <openrct2/Game.h>
 #include <openrct2/common.h>
 #include <openrct2/config/Config.h>

--- a/src/openrct2-ui/input/ShortcutManager.h
+++ b/src/openrct2-ui/input/ShortcutManager.h
@@ -13,6 +13,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <openrct2/core/FileSystem.hpp>
 #include <openrct2/localisation/StringIds.h>
 #include <optional>

--- a/src/openrct2-ui/scripting/CustomImages.h
+++ b/src/openrct2-ui/scripting/CustomImages.h
@@ -11,9 +11,11 @@
 
 #ifdef ENABLE_SCRIPTING
 
+#    include <memory>
 #    include <openrct2/drawing/Image.h>
 #    include <openrct2/drawing/ImageId.hpp>
 #    include <openrct2/scripting/Duktape.hpp>
+#    include <openrct2/scripting/Plugin.h>
 #    include <openrct2/scripting/ScriptEngine.h>
 
 namespace OpenRCT2::Scripting

--- a/src/openrct2-ui/scripting/CustomWindow.h
+++ b/src/openrct2-ui/scripting/CustomWindow.h
@@ -13,6 +13,7 @@
 
 #    include "../interface/Window.h"
 
+#    include <memory>
 #    include <optional>
 #    include <string_view>
 

--- a/src/openrct2-ui/scripting/ScTitleSequence.hpp
+++ b/src/openrct2-ui/scripting/ScTitleSequence.hpp
@@ -11,6 +11,7 @@
 
 #ifdef ENABLE_SCRIPTING
 
+#    include <memory>
 #    include <openrct2/Context.h>
 #    include <openrct2/Game.h>
 #    include <openrct2/OpenRCT2.h>

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -8,6 +8,7 @@
  *****************************************************************************/
 
 #include <algorithm>
+#include <memory>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <openrct2-ui/interface/Dropdown.h>
 #include <openrct2-ui/interface/Viewport.h>
 #include <openrct2-ui/interface/Widget.h>

--- a/src/openrct2/Intro.cpp
+++ b/src/openrct2/Intro.cpp
@@ -16,6 +16,8 @@
 #include "drawing/Drawing.h"
 #include "sprites.h"
 
+#include <memory>
+
 using namespace OpenRCT2::Audio;
 
 #define BACKROUND_COLOUR_DARK PALETTE_INDEX_10

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 #include <vector>
 
 namespace OpenRCT2::Audio

--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -14,6 +14,7 @@
 #include "../ride/RideTypes.h"
 #include "AudioMixer.h"
 
+#include <memory>
 #include <vector>
 
 class AudioObject;

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -13,6 +13,8 @@
 #include "IDrawingContext.h"
 #include "IDrawingEngine.h"
 
+#include <memory>
+
 namespace OpenRCT2
 {
     namespace Ui

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -59,6 +59,9 @@
 #include <algorithm>
 #include <iterator>
 #include <limits>
+#include <map>
+#include <memory>
+#include <optional>
 
 using namespace OpenRCT2::Audio;
 

--- a/src/openrct2/network/NetworkBase.h
+++ b/src/openrct2/network/NetworkBase.h
@@ -11,6 +11,7 @@
 #include "NetworkUser.h"
 
 #include <fstream>
+#include <memory>
 
 #ifndef DISABLE_NETWORK
 

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -42,6 +42,7 @@
 #include "WaterObject.h"
 
 #include <algorithm>
+#include <memory>
 #include <unordered_map>
 
 struct IFileDataRetriever

--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -12,6 +12,7 @@
 #include "../common.h"
 #include "../object/Object.h"
 
+#include <memory>
 #include <vector>
 
 struct IObjectRepository;

--- a/src/openrct2/peep/GuestPathfinding.h
+++ b/src/openrct2/peep/GuestPathfinding.h
@@ -13,6 +13,8 @@
 #include "../ride/RideTypes.h"
 #include "../world/Location.hpp"
 
+#include <memory>
+
 struct Peep;
 struct Guest;
 struct TileElement;

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -16,6 +16,7 @@
 
 #    include <SDL.h>
 #    include <jni.h>
+#    include <memory>
 
 AndroidClassLoader::~AndroidClassLoader()
 {

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -23,6 +23,7 @@
 
 #include <array>
 #include <limits>
+#include <memory>
 #include <string_view>
 
 struct IObjectManager;

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -16,6 +16,8 @@
 #include "../rct2/RCT2.h"
 #include "../world/Map.h"
 
+#include <memory>
+
 struct Ride;
 
 #define TRACK_PREVIEW_IMAGE_SIZE (370 * 217)

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -33,6 +33,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <string>
 #include <vector>
 
 using namespace OpenRCT2;

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -52,7 +52,9 @@
 #    include "bindings/world/ScTileElement.hpp"
 
 #    include <iostream>
+#    include <memory>
 #    include <stdexcept>
+#    include <string>
 
 using namespace OpenRCT2;
 using namespace OpenRCT2::Scripting;

--- a/src/openrct2/scripting/bindings/entity/ScStaff.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScStaff.hpp
@@ -13,6 +13,8 @@
 
 #    include "ScPeep.hpp"
 
+#    include <memory>
+
 namespace OpenRCT2::Scripting
 {
     class ScPatrolArea

--- a/src/openrct2/scripting/bindings/network/ScNetwork.hpp
+++ b/src/openrct2/scripting/bindings/network/ScNetwork.hpp
@@ -16,6 +16,8 @@
 #    include "ScPlayerGroup.hpp"
 #    include "ScSocket.hpp"
 
+#    include <memory>
+
 namespace OpenRCT2::Scripting
 {
     class ScNetwork

--- a/src/openrct2/scripting/bindings/network/ScSocket.hpp
+++ b/src/openrct2/scripting/bindings/network/ScSocket.hpp
@@ -19,6 +19,7 @@
 #        include "../../ScriptEngine.h"
 
 #        include <algorithm>
+#        include <memory>
 #        include <vector>
 
 namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/object/ScObject.hpp
+++ b/src/openrct2/scripting/bindings/object/ScObject.hpp
@@ -19,6 +19,7 @@
 #    include "../../Duktape.hpp"
 #    include "../../ScriptEngine.h"
 
+#    include <memory>
 #    include <optional>
 
 namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/ride/ScTrackIterator.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackIterator.h
@@ -16,6 +16,7 @@
 #    include "../../Duktape.hpp"
 
 #    include <cstdint>
+#    include <memory>
 
 namespace OpenRCT2::Scripting
 {

--- a/src/openrct2/scripting/bindings/world/ScTile.hpp
+++ b/src/openrct2/scripting/bindings/world/ScTile.hpp
@@ -17,6 +17,7 @@
 
 #    include <cstdio>
 #    include <cstring>
+#    include <memory>
 #    include <utility>
 #    include <vector>
 

--- a/src/openrct2/ui/WindowManager.h
+++ b/src/openrct2/ui/WindowManager.h
@@ -13,6 +13,7 @@
 #include "../interface/Window.h"
 #include "../windows/Intent.h"
 
+#include <memory>
 #include <string>
 #include <string_view>
 

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -26,10 +26,11 @@
 #include "../util/Util.h"
 #include "../windows/Intent.h"
 
-using namespace OpenRCT2::Audio;
-
 #include <algorithm>
 #include <iterator>
+#include <memory>
+
+using namespace OpenRCT2::Audio;
 
 constexpr int32_t MAX_THUNDER_INSTANCES = 2;
 

--- a/test/tests/FormattingTests.cpp
+++ b/test/tests/FormattingTests.cpp
@@ -10,6 +10,7 @@
 #include "openrct2/localisation/Formatting.h"
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <openrct2/Context.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/config/Config.h>

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -6,6 +6,7 @@
 #include "openrct2/scenario/Scenario.h"
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
 #include <openrct2/OpenRCT2.h>
@@ -13,6 +14,8 @@
 #include <openrct2/platform/Platform.h>
 #include <openrct2/world/Footpath.h>
 #include <openrct2/world/Map.h>
+#include <ostream>
+#include <string>
 
 using namespace OpenRCT2;
 

--- a/test/tests/PlayTests.cpp
+++ b/test/tests/PlayTests.cpp
@@ -10,6 +10,7 @@
 #include "TestData.h"
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
 #include <openrct2/GameState.h>

--- a/test/tests/TileElements.cpp
+++ b/test/tests/TileElements.cpp
@@ -10,6 +10,7 @@
 #include "TestData.h"
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
 #include <openrct2/OpenRCT2.h>

--- a/test/tests/TileElementsView.cpp
+++ b/test/tests/TileElementsView.cpp
@@ -10,6 +10,7 @@
 #include "TestData.h"
 
 #include <gtest/gtest.h>
+#include <memory>
 #include <openrct2/Context.h>
 #include <openrct2/Game.h>
 #include <openrct2/OpenRCT2.h>


### PR DESCRIPTION
While checking where `std::shared_ptr` and `std::unique_ptr` were being used, I found that many headers did not include the library header. Some source files where these classes are used (and not part of a definition that was declared in the header) now have it added as well.

A couple other missing library headers that I bumped into have also been added.