### PR TITLE
Refactor Twist rotations, fix truncating of operating value

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3320,24 +3320,21 @@ static void WindowRideOperatingTweakTextInput(rct_window* w, const Ride& ride)
         case RideMode::Dodgems:
             return;
         default:
-            if (ride.type == RIDE_TYPE_TWIST)
-            {
-                return;
-            }
             break;
     }
 
     const auto& operatingSettings = ride.GetRideTypeDescriptor().OperatingSettings;
-    uint8_t maxValue = gCheatsUnlockOperatingLimits ? OpenRCT2::Limits::CheatsMaxOperatingLimit : operatingSettings.MaxValue;
-    uint8_t minValue = gCheatsUnlockOperatingLimits ? 0 : operatingSettings.MinValue;
+    int16_t maxValue = gCheatsUnlockOperatingLimits ? OpenRCT2::Limits::CheatsMaxOperatingLimit : operatingSettings.MaxValue;
+    int16_t minValue = gCheatsUnlockOperatingLimits ? 0 : operatingSettings.MinValue;
 
     const auto& title = window_ride_operating_widgets[WIDX_MODE_TWEAK_LABEL].text;
     Formatter ft;
-    ft.Add<int16_t>(minValue);
-    ft.Add<int16_t>(maxValue);
+    ft.Add<int16_t>(minValue * operatingSettings.OperatingSettingMultiplier);
+    ft.Add<int16_t>(maxValue * operatingSettings.OperatingSettingMultiplier);
 
+    uint16_t currentValue = static_cast<uint16_t>(ride.operation_option) * operatingSettings.OperatingSettingMultiplier;
     char buffer[5]{};
-    snprintf(buffer, std::size(buffer), "%u", ride.operation_option);
+    snprintf(buffer, std::size(buffer), "%u", currentValue);
 
     WindowTextInputRawOpen(w, WIDX_MODE_TWEAK, title, STR_ENTER_VALUE, ft, buffer, 4);
 }
@@ -3416,14 +3413,15 @@ static void WindowRideOperatingTextinput(rct_window* w, rct_widgetindex widgetIn
     if (widgetIndex == WIDX_MODE_TWEAK)
     {
         const auto& operatingSettings = ride->GetRideTypeDescriptor().OperatingSettings;
-        uint8_t maxValue = gCheatsUnlockOperatingLimits ? OpenRCT2::Limits::CheatsMaxOperatingLimit
-                                                        : operatingSettings.MaxValue;
-        uint8_t minValue = gCheatsUnlockOperatingLimits ? 0 : operatingSettings.MinValue;
+        uint32_t maxValue = gCheatsUnlockOperatingLimits ? OpenRCT2::Limits::CheatsMaxOperatingLimit
+                                                         : operatingSettings.MaxValue;
+        uint32_t minValue = gCheatsUnlockOperatingLimits ? 0 : operatingSettings.MinValue;
+        auto multiplier = ride->GetRideTypeDescriptor().OperatingSettings.OperatingSettingMultiplier;
 
         try
         {
-            uint8_t size = std::stol(std::string(text));
-            size = std::clamp(size, minValue, maxValue);
+            uint32_t origSize = std::stol(std::string(text)) / multiplier;
+            uint8_t size = static_cast<uint8_t>(std::clamp(origSize, minValue, maxValue));
             set_operating_setting(ride->id, RideSetSetting::Operation, size);
         }
         catch (const std::logic_error&)
@@ -3613,9 +3611,10 @@ static void WindowRideOperatingInvalidate(rct_window* w)
         w->pressed_widgets |= (1ULL << WIDX_MAXIMUM_LENGTH_CHECKBOX);
 
     // Mode specific functionality
+    auto multiplier = ride->GetRideTypeDescriptor().OperatingSettings.OperatingSettingMultiplier;
     ft.Rewind();
     ft.Increment(18);
-    ft.Add<uint16_t>(ride->operation_option);
+    ft.Add<uint16_t>(static_cast<uint16_t>(ride->operation_option) * multiplier);
     switch (ride->mode)
     {
         case RideMode::PoweredLaunchPasstrough:
@@ -3673,13 +3672,6 @@ static void WindowRideOperatingInvalidate(rct_window* w)
 
     if (format != 0)
     {
-        if (ride->type == RIDE_TYPE_TWIST)
-        {
-            ft = Formatter::Common();
-            ft.Increment(18);
-            ft.Add<uint16_t>(ride->operation_option * 3);
-        }
-
         window_ride_operating_widgets[WIDX_MODE_TWEAK_LABEL].type = WindowWidgetType::Label;
         window_ride_operating_widgets[WIDX_MODE_TWEAK_LABEL].text = caption;
         window_ride_operating_widgets[WIDX_MODE_TWEAK_LABEL].tooltip = tooltip;

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -127,7 +127,8 @@ struct RideOperatingSettings
     uint8_t MaxBrakesSpeed;
     uint8_t PoweredLiftAcceleration;
     uint8_t BoosterAcceleration;
-    int8_t BoosterSpeedFactor; // The factor to shift the raw booster speed with
+    int8_t BoosterSpeedFactor;              // The factor to shift the raw booster speed with
+    uint8_t OperatingSettingMultiplier = 1; // Used for the Ride window, cosmetic only.
 };
 
 struct UpkeepCostsDescriptor

--- a/src/openrct2/ride/thrill/meta/Twist.h
+++ b/src/openrct2/ride/thrill/meta/Twist.h
@@ -29,7 +29,7 @@ constexpr const RideTypeDescriptor TwistRTD =
                      RIDE_TYPE_FLAG_SINGLE_SESSION | RIDE_TYPE_FLAG_INTERESTING_TO_LOOK_AT | RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY),
     SET_FIELD(RideModes, EnumsToFlags(RideMode::Rotation)),
     SET_FIELD(DefaultMode, RideMode::Rotation),
-    SET_FIELD(OperatingSettings, { 3, 6, 0, 0, 0, 0 }),
+    SET_FIELD(OperatingSettings, { 3, 6, 0, 0, 0, 0, 3 }),
     SET_FIELD(Naming, { STR_RIDE_NAME_TWIST, STR_RIDE_DESCRIPTION_TWIST }),
     SET_FIELD(NameConvention, { RideComponentType::Structure, RideComponentType::Structure, RideComponentType::Station }),
     SET_FIELD(EnumName, nameof(RIDE_TYPE_TWIST)),


### PR DESCRIPTION
- Removes another direct ride type check
- Fixes a bug/limitation from https://github.com/OpenRCT2/OpenRCT2/pull/17107 , so that typing `300` will no longer overflow to `44`, but will instead be nicely clamped to `255` or whatever the limit is.
- Enables setting Twist rotations via text input