### PR TITLE
Fix #17532: Object Selection window allows unselecting all station types

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3607,6 +3607,9 @@ STR_6499    :Vehicle type not supported by track design format
 STR_6500    :Track elements not supported by track design format
 STR_6501    :Random colour
 STR_6502    :Enter value between {COMMA16} and {COMMA16}
+STR_6503    :At least one station object must be selected
+STR_6504    :At least one terrain surface must be selected
+STR_6505    :At least one terrain edge must be selected
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Fix: [#17444] “Manta Ray” boats slowed down too much in “Ayers Rock” scenario (original bug).
 - Fix: [#17503] Parks with staff with an ID of 0 have all staff windows focus on that staff.
 - Fix: [#17508] Grid doesn’t disable after setting patrol area.
+- Fix: [#17532] Object Selection window allows unselecting all station types.
 - Fix: [#17533] Missing audio when specifying ‘--rct2-data-path’.
 - Fix: [#17541] Station style not correctly saved to TD6.
 - Fix: [#17542] Stalls will autorotate towards paths outside the park.

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -493,6 +493,19 @@ namespace Editor
         {
             return { ObjectType::Ride, STR_AT_LEAST_ONE_RIDE_OBJECT_MUST_BE_SELECTED };
         }
+        if (!editor_check_object_group_at_least_one_selected(ObjectType::Station))
+        {
+            return { ObjectType::Station, STR_AT_LEAST_ONE_STATION_OBJECT_MUST_BE_SELECTED };
+        }
+
+        if (!editor_check_object_group_at_least_one_selected(ObjectType::TerrainSurface))
+        {
+            return { ObjectType::TerrainSurface, STR_AT_LEAST_ONE_TERRAIN_SURFACE_OBJECT_MUST_BE_SELECTED };
+        }
+        if (!editor_check_object_group_at_least_one_selected(ObjectType::TerrainEdge))
+        {
+            return { ObjectType::TerrainEdge, STR_AT_LEAST_ONE_TERRAIN_EDGE_OBJECT_MUST_BE_SELECTED };
+        }
 
         if (!isTrackDesignerManager)
         {

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3884,6 +3884,10 @@ enum : uint16_t
 
     STR_ENTER_VALUE = 6502,
 
+    STR_AT_LEAST_ONE_STATION_OBJECT_MUST_BE_SELECTED = 6503,
+    STR_AT_LEAST_ONE_TERRAIN_SURFACE_OBJECT_MUST_BE_SELECTED = 6504,
+    STR_AT_LEAST_ONE_TERRAIN_EDGE_OBJECT_MUST_BE_SELECTED = 6505,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
While it shouldn’t be possible to unselect them under normal circumstances,
I added checks for terrain surfaces and edges as well for good measure.