### PR TITLE
Provide enough space in temp buffer

### DIFF
--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -3334,7 +3334,7 @@ static void WindowRideOperatingTweakTextInput(rct_window* w, const Ride& ride)
     ft.Add<int16_t>(maxValue * operatingSettings.OperatingSettingMultiplier);
 
     uint16_t currentValue = static_cast<uint16_t>(ride.operation_option) * operatingSettings.OperatingSettingMultiplier;
-    char buffer[5]{};
+    char buffer[6]{};
     snprintf(buffer, std::size(buffer), "%u", currentValue);
 
     WindowTextInputRawOpen(w, WIDX_MODE_TWEAK, title, STR_ENTER_VALUE, ft, buffer, 4);


### PR DESCRIPTION
```
src/openrct2-ui/windows/Ride.cpp:3338:44: error: ‘__builtin___snprintf_chk’ output may be truncated before the last format character [-Werror=format-truncation=]
 3338 |     snprintf(buffer, std::size(buffer), "%u", currentValue);
      |

(...)

/usr/include/x86_64-linux-gnu/bits/stdio2.h:71:35: note: ‘__builtin___snprintf_chk’ output between 2 and 6 bytes into a destination of size 5
```