### PR TITLE
Fix #17639: Upside Down Special Element list doubles up on names

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#17542] Stalls will autorotate towards paths outside the park.
 - Fix: [#17553] Crash when moving invention list items to empty list.
 - Fix: [#17605] Crash when opening parks which have had objects removed externally.
+- Fix: [#17639] When building upside down, the special elements list contains many items twice (original bug).
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2108,7 +2108,8 @@ public:
                 }
             }
 
-            if (bank == TRACK_BANK_UPSIDE_DOWN && bank != _previousTrackBankEnd)
+            if ((bank == TRACK_BANK_UPSIDE_DOWN || ted.Definition.bank_end == TRACK_BANK_UPSIDE_DOWN)
+                && bank != _previousTrackBankEnd)
                 continue;
 
             _currentPossibleRideConfigurations[currentPossibleRideConfigurationIndex] = trackType;


### PR DESCRIPTION
Fix #17639

Issue: Upside down special elements are listed twice in the drop-down menu if the previous track ends with an upside-down bank.

Fix: Add condition for bank check to be checked for track elements that end with an upside-down bank.