### PR TITLE
Lower default price for the Crooked House

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Improved: [#17575] You can now search for Authors in Object Selection.
 - Change: [#17319] Giant screenshots are now cropped to the horizontal view-clipping selection.
 - Change: [#17499] Update error text when using vehicle incompatible with TD6 and add error when using incompatible track elements.
+- Change: [#17655] Lower default price for the Crooked House.
 - Fix: [#7466] Coaster track not drawn at tunnel exit.
 - Fix: [#16392] Scenery on sloped surface is placed at wrong height.
 - Fix: [#16476] The game sometimes crashes when demolishing a maze.

--- a/src/openrct2/ride/gentle/meta/CrookedHouse.h
+++ b/src/openrct2/ride/gentle/meta/CrookedHouse.h
@@ -42,7 +42,7 @@ constexpr const RideTypeDescriptor CrookedHouseRTD =
     SET_FIELD(RatingsMultipliers, { 15, 8, 0 }),
     SET_FIELD(UpkeepCosts, { 30, 1, 0, 0, 0, 0 }),
     SET_FIELD(BuildCosts, { 32.50_GBP, 1.00_GBP, 1, }),
-    SET_FIELD(DefaultPrices, { 10, 0 }),
+    SET_FIELD(DefaultPrices, { 6, 0 }),
     SET_FIELD(DefaultMusic, MUSIC_OBJECT_GENTLE),
     SET_FIELD(PhotoItem, ShopItem::Photo),
     SET_FIELD(BonusValue, 22),


### PR DESCRIPTION
Guests don't want to pay the default price of 1.00 of the Crooked House, even if the ride is brand new. Guests will pay this new default price of 0.60 until the ride is 40 or more months old. This is similar to the Spiral Slide where the default price will also become to high at that ride age.