### PR TITLE
Refactor window functions to take references

### DIFF
--- a/src/openrct2-ui/input/InputManager.cpp
+++ b/src/openrct2-ui/input/InputManager.cpp
@@ -115,7 +115,7 @@ void InputManager::HandleViewScrolling()
     auto mainWindow = window_get_main();
     if (mainWindow != nullptr && (_viewScroll.x != 0 || _viewScroll.y != 0))
     {
-        window_unfollow_sprite(mainWindow);
+        window_unfollow_sprite(*mainWindow);
     }
     InputScrollViewport(_viewScroll);
 

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -297,7 +297,7 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
 
                     if (w != nullptr)
                     {
-                        w = window_bring_to_front(w);
+                        w = window_bring_to_front(*w);
                     }
 
                     if (widgetIndex != -1)
@@ -530,7 +530,7 @@ static void InputViewportDragBegin(rct_window& w)
     gInputDragLast = cursorPosition;
     context_hide_cursor();
 
-    window_unfollow_sprite(&w);
+    window_unfollow_sprite(w);
     // gInputFlags |= INPUT_FLAG_5;
 }
 
@@ -1012,7 +1012,7 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, r
     if (w == nullptr)
         return;
 
-    w = window_bring_to_front(w);
+    w = window_bring_to_front(*w);
     if (widgetIndex == -1)
         return;
 

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -459,12 +459,12 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
 
 #pragma region Window positioning / resizing
 
-void InputWindowPositionBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
+void InputWindowPositionBegin(rct_window& w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
     _inputState = InputState::PositioningWindow;
-    gInputDragLast = screenCoords - w->windowPos;
-    _dragWidget.window_classification = w->classification;
-    _dragWidget.window_number = w->number;
+    gInputDragLast = screenCoords - w.windowPos;
+    _dragWidget.window_classification = w.classification;
+    _dragWidget.window_number = w.number;
     _dragWidget.widget_index = widgetIndex;
 }
 
@@ -1048,7 +1048,7 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, r
             }
             break;
         case WindowWidgetType::Caption:
-            InputWindowPositionBegin(w, widgetIndex, screenCoords);
+            InputWindowPositionBegin(*w, widgetIndex, screenCoords);
             break;
         case WindowWidgetType::Scroll:
             InputScrollBegin(*w, widgetIndex, screenCoords);

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1061,7 +1061,7 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, r
             InputScrollBegin(w, widgetIndex, screenCoords);
             break;
         default:
-            if (!WidgetIsDisabled(w, widgetIndex))
+            if (!WidgetIsDisabled(*w, widgetIndex))
             {
                 OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::Click1, 0, w->windowPos.x + widget.midX());
 
@@ -1207,7 +1207,7 @@ void InputStateWidgetPressed(
                 || widgetIndex != cursor_widgetIndex)
                 break;
 
-            if (WidgetIsDisabled(w, widgetIndex))
+            if (WidgetIsDisabled(*w, widgetIndex))
                 break;
 
             if (_clickRepeatTicks != 0)
@@ -1217,7 +1217,7 @@ void InputStateWidgetPressed(
                 // Handle click repeat
                 if (_clickRepeatTicks >= 16 && (_clickRepeatTicks & 3) == 0)
                 {
-                    if (WidgetIsHoldable(w, widgetIndex))
+                    if (WidgetIsHoldable(*w, widgetIndex))
                     {
                         window_event_mouse_down_call(w, widgetIndex);
                     }
@@ -1334,7 +1334,7 @@ void InputStateWidgetPressed(
             if (cursor_w_class != w->classification || cursor_w_number != w->number || widgetIndex != cursor_widgetIndex)
                 break;
 
-            if (WidgetIsDisabled(w, widgetIndex))
+            if (WidgetIsDisabled(*w, widgetIndex))
                 break;
 
             widget_invalidate_by_number(cursor_w_class, cursor_w_number, widgetIndex);
@@ -1441,7 +1441,7 @@ static void InputUpdateTooltip(rct_window* w, rct_widgetindex widgetIndex, const
         if (gTooltipCursor == screenCoords)
         {
             _tooltipNotShownTicks++;
-            if (_tooltipNotShownTicks > 50 && w != nullptr && WidgetIsVisible(w, widgetIndex))
+            if (_tooltipNotShownTicks > 50 && w != nullptr && WidgetIsVisible(*w, widgetIndex))
             {
                 gTooltipTimeout = 0;
                 WindowTooltipOpen(w, widgetIndex, screenCoords);
@@ -1457,7 +1457,7 @@ static void InputUpdateTooltip(rct_window* w, rct_widgetindex widgetIndex, const
 
         if (w == nullptr || gTooltipWidget.window_classification != w->classification
             || gTooltipWidget.window_number != w->number || gTooltipWidget.widget_index != widgetIndex
-            || !WidgetIsVisible(w, widgetIndex))
+            || !WidgetIsVisible(*w, widgetIndex))
         {
             WindowTooltipClose();
         }

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -182,7 +182,7 @@ static void InputScrollDragBegin(const ScreenCoordsXY& screenCoords, rct_window*
     _dragWidget.widget_index = widgetIndex;
     _ticksSinceDragStart = 0;
 
-    _dragScrollIndex = window_get_scroll_data_index(w, widgetIndex);
+    _dragScrollIndex = window_get_scroll_data_index(*w, widgetIndex);
     context_hide_cursor();
 }
 
@@ -275,7 +275,7 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
 
     // Get window and widget under cursor position
     w = window_find_from_point(screenCoords);
-    widgetIndex = w == nullptr ? -1 : window_find_widget_from_point(w, screenCoords);
+    widgetIndex = w == nullptr ? -1 : window_find_widget_from_point(*w, screenCoords);
     widget = widgetIndex == -1 ? nullptr : &w->widgets[widgetIndex];
 
     switch (_inputState)
@@ -474,7 +474,7 @@ static void InputWindowPositionContinue(
     int32_t snapProximity;
 
     snapProximity = (w->flags & WF_NO_SNAPPING) ? 0 : gConfigGeneral.window_snap_proximity;
-    window_move_and_snap(w, newScreenCoords - lastScreenCoords, snapProximity);
+    window_move_and_snap(*w, newScreenCoords - lastScreenCoords, snapProximity);
 }
 
 static void InputWindowPositionEnd(rct_window* w, const ScreenCoordsXY& screenCoords)
@@ -504,7 +504,7 @@ static void InputWindowResizeContinue(rct_window* w, const ScreenCoordsXY& scree
         int32_t targetWidth = _originalWindowWidth + differentialCoords.x - w->width;
         int32_t targetHeight = _originalWindowHeight + differentialCoords.y - w->height;
 
-        window_resize(w, targetWidth, targetHeight);
+        window_resize(*w, targetWidth, targetHeight);
     }
 }
 
@@ -1035,7 +1035,7 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, r
     {
         case WindowWidgetType::Frame:
         case WindowWidgetType::Resize:
-            if (window_can_resize(w)
+            if (window_can_resize(*w)
                 && (screenCoords.x >= w->windowPos.x + w->width - 19 && screenCoords.y >= w->windowPos.y + w->height - 19))
                 InputWindowResizeBegin(w, widgetIndex, screenCoords);
             break;
@@ -1098,7 +1098,7 @@ void ProcessMouseOver(const ScreenCoordsXY& screenCoords)
 
     if (window != nullptr)
     {
-        rct_widgetindex widgetId = window_find_widget_from_point(window, screenCoords);
+        rct_widgetindex widgetId = window_find_widget_from_point(*window, screenCoords);
         if (widgetId != -1)
         {
             switch (window->widgets[widgetId].type)

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -76,23 +76,23 @@ void InputStateWidgetPressed(
     const ScreenCoordsXY& screenCoords, MouseState state, rct_widgetindex widgetIndex, rct_window* w, rct_widget* widget);
 void SetCursor(CursorID cursor_id);
 static void InputWindowPositionContinue(
-    rct_window* w, const ScreenCoordsXY& lastScreenCoords, const ScreenCoordsXY& newScreenCoords);
-static void InputWindowPositionEnd(rct_window* w, const ScreenCoordsXY& screenCoords);
-static void InputWindowResizeBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
-static void InputWindowResizeContinue(rct_window* w, const ScreenCoordsXY& screenCoords);
+    rct_window& w, const ScreenCoordsXY& lastScreenCoords, const ScreenCoordsXY& newScreenCoords);
+static void InputWindowPositionEnd(rct_window& w, const ScreenCoordsXY& screenCoords);
+static void InputWindowResizeBegin(rct_window& w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
+static void InputWindowResizeContinue(rct_window& w, const ScreenCoordsXY& screenCoords);
 static void InputWindowResizeEnd();
-static void InputViewportDragBegin(rct_window* w);
+static void InputViewportDragBegin(rct_window& w);
 static void InputViewportDragContinue();
 static void InputViewportDragEnd();
-static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
-static void InputScrollContinue(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
+static void InputScrollBegin(rct_window& w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
+static void InputScrollContinue(rct_window& w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
 static void InputScrollEnd();
-static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t x, int32_t scroll_id);
-static void InputScrollPartUpdateHLeft(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
-static void InputScrollPartUpdateHRight(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
-static void InputScrollPartUpdateVThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t y, int32_t scroll_id);
-static void InputScrollPartUpdateVTop(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
-static void InputScrollPartUpdateVBottom(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id);
+static void InputScrollPartUpdateHThumb(rct_window& w, rct_widgetindex widgetIndex, int32_t x, int32_t scroll_id);
+static void InputScrollPartUpdateHLeft(rct_window& w, rct_widgetindex widgetIndex, int32_t scroll_id);
+static void InputScrollPartUpdateHRight(rct_window& w, rct_widgetindex widgetIndex, int32_t scroll_id);
+static void InputScrollPartUpdateVThumb(rct_window& w, rct_widgetindex widgetIndex, int32_t y, int32_t scroll_id);
+static void InputScrollPartUpdateVTop(rct_window& w, rct_widgetindex widgetIndex, int32_t scroll_id);
+static void InputScrollPartUpdateVBottom(rct_window& w, rct_widgetindex widgetIndex, int32_t scroll_id);
 static void InputUpdateTooltip(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
 
 #pragma region Mouse input
@@ -307,7 +307,7 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                             case WindowWidgetType::Viewport:
                                 if (!(gScreenFlags & (SCREEN_FLAGS_TRACK_MANAGER | SCREEN_FLAGS_TITLE_DEMO)))
                                 {
-                                    InputViewportDragBegin(w);
+                                    InputViewportDragBegin(*w);
                                 }
                                 break;
                             case WindowWidgetType::Scroll:
@@ -335,10 +335,10 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
             }
             else
             {
-                InputWindowPositionContinue(w, gInputDragLast, screenCoords);
+                InputWindowPositionContinue(*w, gInputDragLast, screenCoords);
                 if (state == MouseState::LeftRelease)
                 {
-                    InputWindowPositionEnd(w, screenCoords);
+                    InputWindowPositionEnd(*w, screenCoords);
                 }
             }
             break;
@@ -421,7 +421,7 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
             switch (state)
             {
                 case MouseState::Released:
-                    InputScrollContinue(w, widgetIndex, screenCoords);
+                    InputScrollContinue(*w, widgetIndex, screenCoords);
                     break;
                 case MouseState::LeftRelease:
                     InputScrollEnd();
@@ -447,7 +447,7 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                 }
                 if (state == MouseState::Released || state == MouseState::LeftRelease)
                 {
-                    InputWindowResizeContinue(w, screenCoords);
+                    InputWindowResizeContinue(*w, screenCoords);
                 }
             }
             break;
@@ -469,42 +469,42 @@ void InputWindowPositionBegin(rct_window* w, rct_widgetindex widgetIndex, const 
 }
 
 static void InputWindowPositionContinue(
-    rct_window* w, const ScreenCoordsXY& lastScreenCoords, const ScreenCoordsXY& newScreenCoords)
+    rct_window& w, const ScreenCoordsXY& lastScreenCoords, const ScreenCoordsXY& newScreenCoords)
 {
     int32_t snapProximity;
 
-    snapProximity = (w->flags & WF_NO_SNAPPING) ? 0 : gConfigGeneral.window_snap_proximity;
-    window_move_and_snap(*w, newScreenCoords - lastScreenCoords, snapProximity);
+    snapProximity = (w.flags & WF_NO_SNAPPING) ? 0 : gConfigGeneral.window_snap_proximity;
+    window_move_and_snap(w, newScreenCoords - lastScreenCoords, snapProximity);
 }
 
-static void InputWindowPositionEnd(rct_window* w, const ScreenCoordsXY& screenCoords)
+static void InputWindowPositionEnd(rct_window& w, const ScreenCoordsXY& screenCoords)
 {
     _inputState = InputState::Normal;
     gTooltipTimeout = 0;
     gTooltipWidget = _dragWidget;
-    window_event_moved_call(w, screenCoords);
+    window_event_moved_call(&w, screenCoords);
 }
 
-static void InputWindowResizeBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
+static void InputWindowResizeBegin(rct_window& w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
     _inputState = InputState::Resizing;
     gInputDragLast = screenCoords;
-    _dragWidget.window_classification = w->classification;
-    _dragWidget.window_number = w->number;
+    _dragWidget.window_classification = w.classification;
+    _dragWidget.window_number = w.number;
     _dragWidget.widget_index = widgetIndex;
-    _originalWindowWidth = w->width;
-    _originalWindowHeight = w->height;
+    _originalWindowWidth = w.width;
+    _originalWindowHeight = w.height;
 }
 
-static void InputWindowResizeContinue(rct_window* w, const ScreenCoordsXY& screenCoords)
+static void InputWindowResizeContinue(rct_window& w, const ScreenCoordsXY& screenCoords)
 {
     if (screenCoords.y < static_cast<int32_t>(context_get_height()) - 2)
     {
         auto differentialCoords = screenCoords - gInputDragLast;
-        int32_t targetWidth = _originalWindowWidth + differentialCoords.x - w->width;
-        int32_t targetHeight = _originalWindowHeight + differentialCoords.y - w->height;
+        int32_t targetWidth = _originalWindowWidth + differentialCoords.x - w.width;
+        int32_t targetHeight = _originalWindowHeight + differentialCoords.y - w.height;
 
-        window_resize(*w, targetWidth, targetHeight);
+        window_resize(w, targetWidth, targetHeight);
     }
 }
 
@@ -519,18 +519,18 @@ static void InputWindowResizeEnd()
 
 #pragma region Viewport dragging
 
-static void InputViewportDragBegin(rct_window* w)
+static void InputViewportDragBegin(rct_window& w)
 {
-    w->flags &= ~WF_SCROLLING_TO_LOCATION;
+    w.flags &= ~WF_SCROLLING_TO_LOCATION;
     _inputState = InputState::ViewportRight;
-    _dragWidget.window_classification = w->classification;
-    _dragWidget.window_number = w->number;
+    _dragWidget.window_classification = w.classification;
+    _dragWidget.window_number = w.number;
     _ticksSinceDragStart = 0;
     auto cursorPosition = context_get_cursor_position();
     gInputDragLast = cursorPosition;
     context_hide_cursor();
 
-    window_unfollow_sprite(w);
+    window_unfollow_sprite(&w);
     // gInputFlags |= INPUT_FLAG_5;
 }
 
@@ -603,32 +603,32 @@ static void InputViewportDragEnd()
 
 #pragma region Scroll bars
 
-static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
+static void InputScrollBegin(rct_window& w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     _inputState = InputState::ScrollLeft;
-    gPressedWidget.window_classification = w->classification;
-    gPressedWidget.window_number = w->number;
+    gPressedWidget.window_classification = w.classification;
+    gPressedWidget.window_number = w.number;
     gPressedWidget.widget_index = widgetIndex;
     gTooltipCursor = screenCoords;
 
     int32_t scroll_area, scroll_id;
     ScreenCoordsXY scrollCoords;
     scroll_id = 0; // safety
-    WidgetScrollGetPart(*w, &widget, screenCoords, scrollCoords, &scroll_area, &scroll_id);
+    WidgetScrollGetPart(w, &widget, screenCoords, scrollCoords, &scroll_area, &scroll_id);
 
     _currentScrollArea = scroll_area;
     _currentScrollIndex = scroll_id;
-    window_event_unknown_15_call(w, scroll_id, scroll_area);
+    window_event_unknown_15_call(&w, scroll_id, scroll_area);
     if (scroll_area == SCROLL_PART_VIEW)
     {
-        window_event_scroll_mousedown_call(w, scroll_id, scrollCoords);
+        window_event_scroll_mousedown_call(&w, scroll_id, scrollCoords);
         return;
     }
 
-    const auto& widg = w->widgets[widgetIndex];
-    auto& scroll = w->scrolls[scroll_id];
+    const auto& widg = w.widgets[widgetIndex];
+    auto& scroll = w.scrolls[scroll_id];
 
     int32_t widget_width = widg.width() - 1;
     if (scroll.flags & VSCROLLBAR_VISIBLE)
@@ -669,18 +669,16 @@ static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const S
         default:
             break;
     }
-    WidgetScrollUpdateThumbs(*w, widgetIndex);
-    window_invalidate_by_number(widgetIndex, w->classification);
+    WidgetScrollUpdateThumbs(w, widgetIndex);
+    window_invalidate_by_number(widgetIndex, w.classification);
 }
 
-static void InputScrollContinue(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
+static void InputScrollContinue(rct_window& w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords)
 {
     int32_t scroll_part, scroll_id;
 
-    assert(w != nullptr);
-
-    const auto& widget = w->widgets[widgetIndex];
-    if (w->classification != gPressedWidget.window_classification || w->number != gPressedWidget.window_number
+    const auto& widget = w.widgets[widgetIndex];
+    if (w.classification != gPressedWidget.window_classification || w.number != gPressedWidget.window_number
         || widgetIndex != gPressedWidget.widget_index)
     {
         InvalidateScroll();
@@ -688,7 +686,7 @@ static void InputScrollContinue(rct_window* w, rct_widgetindex widgetIndex, cons
     }
 
     ScreenCoordsXY newScreenCoords;
-    WidgetScrollGetPart(*w, &widget, screenCoords, newScreenCoords, &scroll_part, &scroll_id);
+    WidgetScrollGetPart(w, &widget, screenCoords, newScreenCoords, &scroll_part, &scroll_id);
 
     if (_currentScrollArea == SCROLL_PART_HSCROLLBAR_THUMB)
     {
@@ -715,7 +713,7 @@ static void InputScrollContinue(rct_window* w, rct_widgetindex widgetIndex, cons
     switch (scroll_part)
     {
         case SCROLL_PART_VIEW:
-            window_event_scroll_mousedrag_call(w, scroll_id, newScreenCoords);
+            window_event_scroll_mousedrag_call(&w, scroll_id, newScreenCoords);
             break;
         case SCROLL_PART_HSCROLLBAR_LEFT:
             InputScrollPartUpdateHLeft(w, widgetIndex, scroll_id);
@@ -742,12 +740,12 @@ static void InputScrollEnd()
  *
  *  rct2: 0x006E98F2
  */
-static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t x, int32_t scroll_id)
+static void InputScrollPartUpdateHThumb(rct_window& w, rct_widgetindex widgetIndex, int32_t x, int32_t scroll_id)
 {
-    const auto& widget = w->widgets[widgetIndex];
-    auto& scroll = w->scrolls[scroll_id];
+    const auto& widget = w.widgets[widgetIndex];
+    auto& scroll = w.scrolls[scroll_id];
 
-    if (window_find_by_number(w->classification, w->number) != nullptr)
+    if (window_find_by_number(w.classification, w.number) != nullptr)
     {
         int32_t newLeft;
         newLeft = scroll.h_right;
@@ -772,8 +770,8 @@ static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetInd
         if (newLeft > x)
             newLeft = x;
         scroll.h_left = newLeft;
-        WidgetScrollUpdateThumbs(*w, widgetIndex);
-        widget_invalidate_by_number(w->classification, w->number, widgetIndex);
+        WidgetScrollUpdateThumbs(w, widgetIndex);
+        widget_invalidate_by_number(w.classification, w.number, widgetIndex);
     }
 }
 
@@ -781,13 +779,12 @@ static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetInd
  *
  *  rct2: 0x006E99A9
  */
-static void InputScrollPartUpdateVThumb(rct_window* w, rct_widgetindex widgetIndex, int32_t y, int32_t scroll_id)
+static void InputScrollPartUpdateVThumb(rct_window& w, rct_widgetindex widgetIndex, int32_t y, int32_t scroll_id)
 {
-    assert(w != nullptr);
-    const auto& widget = w->widgets[widgetIndex];
-    auto& scroll = w->scrolls[scroll_id];
+    const auto& widget = w.widgets[widgetIndex];
+    auto& scroll = w.scrolls[scroll_id];
 
-    if (window_find_by_number(w->classification, w->number) != nullptr)
+    if (window_find_by_number(w.classification, w.number) != nullptr)
     {
         int32_t newTop;
         newTop = scroll.v_bottom;
@@ -812,8 +809,8 @@ static void InputScrollPartUpdateVThumb(rct_window* w, rct_widgetindex widgetInd
         if (newTop > y)
             newTop = y;
         scroll.v_top = newTop;
-        WidgetScrollUpdateThumbs(*w, widgetIndex);
-        widget_invalidate_by_number(w->classification, w->number, widgetIndex);
+        WidgetScrollUpdateThumbs(w, widgetIndex);
+        widget_invalidate_by_number(w.classification, w.number, widgetIndex);
     }
 }
 
@@ -821,17 +818,16 @@ static void InputScrollPartUpdateVThumb(rct_window* w, rct_widgetindex widgetInd
  *
  *  rct2: 0x006E9A60
  */
-static void InputScrollPartUpdateHLeft(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
+static void InputScrollPartUpdateHLeft(rct_window& w, rct_widgetindex widgetIndex, int32_t scroll_id)
 {
-    assert(w != nullptr);
-    if (window_find_by_number(w->classification, w->number) != nullptr)
+    if (window_find_by_number(w.classification, w.number) != nullptr)
     {
-        auto& scroll = w->scrolls[scroll_id];
+        auto& scroll = w.scrolls[scroll_id];
         scroll.flags |= HSCROLLBAR_LEFT_PRESSED;
         if (scroll.h_left >= 3)
             scroll.h_left -= 3;
-        WidgetScrollUpdateThumbs(*w, widgetIndex);
-        widget_invalidate_by_number(w->classification, w->number, widgetIndex);
+        WidgetScrollUpdateThumbs(w, widgetIndex);
+        widget_invalidate_by_number(w.classification, w.number, widgetIndex);
     }
 }
 
@@ -839,13 +835,12 @@ static void InputScrollPartUpdateHLeft(rct_window* w, rct_widgetindex widgetInde
  *
  *  rct2: 0x006E9ABF
  */
-static void InputScrollPartUpdateHRight(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
+static void InputScrollPartUpdateHRight(rct_window& w, rct_widgetindex widgetIndex, int32_t scroll_id)
 {
-    assert(w != nullptr);
-    const auto& widget = w->widgets[widgetIndex];
-    if (window_find_by_number(w->classification, w->number) != nullptr)
+    const auto& widget = w.widgets[widgetIndex];
+    if (window_find_by_number(w.classification, w.number) != nullptr)
     {
-        auto& scroll = w->scrolls[scroll_id];
+        auto& scroll = w.scrolls[scroll_id];
         scroll.flags |= HSCROLLBAR_RIGHT_PRESSED;
         scroll.h_left += 3;
         int32_t newLeft = widget.width() - 1;
@@ -857,8 +852,8 @@ static void InputScrollPartUpdateHRight(rct_window* w, rct_widgetindex widgetInd
             newLeft = 0;
         if (scroll.h_left > newLeft)
             scroll.h_left = newLeft;
-        WidgetScrollUpdateThumbs(*w, widgetIndex);
-        widget_invalidate_by_number(w->classification, w->number, widgetIndex);
+        WidgetScrollUpdateThumbs(w, widgetIndex);
+        widget_invalidate_by_number(w.classification, w.number, widgetIndex);
     }
 }
 
@@ -866,17 +861,16 @@ static void InputScrollPartUpdateHRight(rct_window* w, rct_widgetindex widgetInd
  *
  *  rct2: 0x006E9C37
  */
-static void InputScrollPartUpdateVTop(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
+static void InputScrollPartUpdateVTop(rct_window& w, rct_widgetindex widgetIndex, int32_t scroll_id)
 {
-    assert(w != nullptr);
-    if (window_find_by_number(w->classification, w->number) != nullptr)
+    if (window_find_by_number(w.classification, w.number) != nullptr)
     {
-        auto& scroll = w->scrolls[scroll_id];
+        auto& scroll = w.scrolls[scroll_id];
         scroll.flags |= VSCROLLBAR_UP_PRESSED;
         if (scroll.v_top >= 3)
             scroll.v_top -= 3;
-        WidgetScrollUpdateThumbs(*w, widgetIndex);
-        widget_invalidate_by_number(w->classification, w->number, widgetIndex);
+        WidgetScrollUpdateThumbs(w, widgetIndex);
+        widget_invalidate_by_number(w.classification, w.number, widgetIndex);
     }
 }
 
@@ -884,13 +878,12 @@ static void InputScrollPartUpdateVTop(rct_window* w, rct_widgetindex widgetIndex
  *
  *  rct2: 0x006E9C96
  */
-static void InputScrollPartUpdateVBottom(rct_window* w, rct_widgetindex widgetIndex, int32_t scroll_id)
+static void InputScrollPartUpdateVBottom(rct_window& w, rct_widgetindex widgetIndex, int32_t scroll_id)
 {
-    assert(w != nullptr);
-    const auto& widget = w->widgets[widgetIndex];
-    if (window_find_by_number(w->classification, w->number) != nullptr)
+    const auto& widget = w.widgets[widgetIndex];
+    if (window_find_by_number(w.classification, w.number) != nullptr)
     {
-        auto& scroll = w->scrolls[scroll_id];
+        auto& scroll = w.scrolls[scroll_id];
         scroll.flags |= VSCROLLBAR_DOWN_PRESSED;
         scroll.v_top += 3;
         int32_t newTop = widget.height() - 1;
@@ -902,8 +895,8 @@ static void InputScrollPartUpdateVBottom(rct_window* w, rct_widgetindex widgetIn
             newTop = 0;
         if (scroll.v_top > newTop)
             scroll.v_top = newTop;
-        WidgetScrollUpdateThumbs(*w, widgetIndex);
-        widget_invalidate_by_number(w->classification, w->number, widgetIndex);
+        WidgetScrollUpdateThumbs(w, widgetIndex);
+        widget_invalidate_by_number(w.classification, w.number, widgetIndex);
     }
 }
 
@@ -1037,7 +1030,7 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, r
         case WindowWidgetType::Resize:
             if (window_can_resize(*w)
                 && (screenCoords.x >= w->windowPos.x + w->width - 19 && screenCoords.y >= w->windowPos.y + w->height - 19))
-                InputWindowResizeBegin(w, widgetIndex, screenCoords);
+                InputWindowResizeBegin(*w, widgetIndex, screenCoords);
             break;
         case WindowWidgetType::Viewport:
             _inputState = InputState::ViewportLeft;
@@ -1058,7 +1051,7 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, r
             InputWindowPositionBegin(w, widgetIndex, screenCoords);
             break;
         case WindowWidgetType::Scroll:
-            InputScrollBegin(w, widgetIndex, screenCoords);
+            InputScrollBegin(*w, widgetIndex, screenCoords);
             break;
         default:
             if (!WidgetIsDisabled(*w, widgetIndex))

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -218,7 +218,7 @@ static void InputScrollDragContinue(const ScreenCoordsXY& screenCoords, rct_wind
         scroll.v_top = std::min<uint16_t>(std::max(0, scroll.v_top + differentialCoords.y), size);
     }
 
-    WidgetScrollUpdateThumbs(w, widgetIndex);
+    WidgetScrollUpdateThumbs(*w, widgetIndex);
     window_invalidate_by_number(w->classification, w->number);
 
     ScreenCoordsXY fixedCursorPosition = { static_cast<int32_t>(std::ceil(gInputDragLast.x * gConfigGeneral.window_scale)),
@@ -616,7 +616,7 @@ static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const S
     int32_t scroll_area, scroll_id;
     ScreenCoordsXY scrollCoords;
     scroll_id = 0; // safety
-    WidgetScrollGetPart(w, &widget, screenCoords, scrollCoords, &scroll_area, &scroll_id);
+    WidgetScrollGetPart(*w, &widget, screenCoords, scrollCoords, &scroll_area, &scroll_id);
 
     _currentScrollArea = scroll_area;
     _currentScrollIndex = scroll_id;
@@ -669,7 +669,7 @@ static void InputScrollBegin(rct_window* w, rct_widgetindex widgetIndex, const S
         default:
             break;
     }
-    WidgetScrollUpdateThumbs(w, widgetIndex);
+    WidgetScrollUpdateThumbs(*w, widgetIndex);
     window_invalidate_by_number(widgetIndex, w->classification);
 }
 
@@ -688,7 +688,7 @@ static void InputScrollContinue(rct_window* w, rct_widgetindex widgetIndex, cons
     }
 
     ScreenCoordsXY newScreenCoords;
-    WidgetScrollGetPart(w, &widget, screenCoords, newScreenCoords, &scroll_part, &scroll_id);
+    WidgetScrollGetPart(*w, &widget, screenCoords, newScreenCoords, &scroll_part, &scroll_id);
 
     if (_currentScrollArea == SCROLL_PART_HSCROLLBAR_THUMB)
     {
@@ -772,7 +772,7 @@ static void InputScrollPartUpdateHThumb(rct_window* w, rct_widgetindex widgetInd
         if (newLeft > x)
             newLeft = x;
         scroll.h_left = newLeft;
-        WidgetScrollUpdateThumbs(w, widgetIndex);
+        WidgetScrollUpdateThumbs(*w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
 }
@@ -812,7 +812,7 @@ static void InputScrollPartUpdateVThumb(rct_window* w, rct_widgetindex widgetInd
         if (newTop > y)
             newTop = y;
         scroll.v_top = newTop;
-        WidgetScrollUpdateThumbs(w, widgetIndex);
+        WidgetScrollUpdateThumbs(*w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
 }
@@ -830,7 +830,7 @@ static void InputScrollPartUpdateHLeft(rct_window* w, rct_widgetindex widgetInde
         scroll.flags |= HSCROLLBAR_LEFT_PRESSED;
         if (scroll.h_left >= 3)
             scroll.h_left -= 3;
-        WidgetScrollUpdateThumbs(w, widgetIndex);
+        WidgetScrollUpdateThumbs(*w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
 }
@@ -857,7 +857,7 @@ static void InputScrollPartUpdateHRight(rct_window* w, rct_widgetindex widgetInd
             newLeft = 0;
         if (scroll.h_left > newLeft)
             scroll.h_left = newLeft;
-        WidgetScrollUpdateThumbs(w, widgetIndex);
+        WidgetScrollUpdateThumbs(*w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
 }
@@ -875,7 +875,7 @@ static void InputScrollPartUpdateVTop(rct_window* w, rct_widgetindex widgetIndex
         scroll.flags |= VSCROLLBAR_UP_PRESSED;
         if (scroll.v_top >= 3)
             scroll.v_top -= 3;
-        WidgetScrollUpdateThumbs(w, widgetIndex);
+        WidgetScrollUpdateThumbs(*w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
 }
@@ -902,7 +902,7 @@ static void InputScrollPartUpdateVBottom(rct_window* w, rct_widgetindex widgetIn
             newTop = 0;
         if (scroll.v_top > newTop)
             scroll.v_top = newTop;
-        WidgetScrollUpdateThumbs(w, widgetIndex);
+        WidgetScrollUpdateThumbs(*w, widgetIndex);
         widget_invalidate_by_number(w->classification, w->number, widgetIndex);
     }
 }
@@ -934,7 +934,7 @@ static void InputWidgetOver(const ScreenCoordsXY& screenCoords, rct_window* w, r
     {
         int32_t scroll_part, scrollId;
         ScreenCoordsXY newScreenCoords;
-        WidgetScrollGetPart(w, widget, screenCoords, newScreenCoords, &scroll_part, &scrollId);
+        WidgetScrollGetPart(*w, widget, screenCoords, newScreenCoords, &scroll_part, &scrollId);
 
         if (scroll_part != SCROLL_PART_VIEW)
             WindowTooltipClose();
@@ -1138,7 +1138,7 @@ void ProcessMouseOver(const ScreenCoordsXY& screenCoords)
                     int32_t output_scroll_area, scroll_id;
                     ScreenCoordsXY scrollCoords;
                     WidgetScrollGetPart(
-                        window, &window->widgets[widgetId], screenCoords, scrollCoords, &output_scroll_area, &scroll_id);
+                        *window, &window->widgets[widgetId], screenCoords, scrollCoords, &output_scroll_area, &scroll_id);
                     if (output_scroll_area != SCROLL_PART_VIEW)
                     {
                         cursorId = CursorID::Arrow;

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -60,7 +60,7 @@ static void RotateCamera(int32_t direction)
         auto window = window_get_main();
         if (window != nullptr)
         {
-            window_rotate_camera(window, direction);
+            window_rotate_camera(*window, direction);
         }
     }
 }
@@ -148,10 +148,10 @@ static void ShortcutRemoveTopBottomToolbarToggle()
     {
         if (window_find_by_class(WC_TITLE_LOGO) != nullptr)
         {
-            window_close(window_find_by_class(WC_TITLE_LOGO));
-            window_close(window_find_by_class(WC_TITLE_OPTIONS));
-            window_close(window_find_by_class(WC_TITLE_MENU));
-            window_close(window_find_by_class(WC_TITLE_EXIT));
+            window_close(*window_find_by_class(WC_TITLE_LOGO));
+            window_close(*window_find_by_class(WC_TITLE_OPTIONS));
+            window_close(*window_find_by_class(WC_TITLE_MENU));
+            window_close(*window_find_by_class(WC_TITLE_EXIT));
             title_set_hide_version_info(true);
         }
         else
@@ -163,9 +163,9 @@ static void ShortcutRemoveTopBottomToolbarToggle()
     {
         if (window_find_by_class(WC_TOP_TOOLBAR) != nullptr)
         {
-            window_close(window_find_by_class(WC_DROPDOWN));
-            window_close(window_find_by_class(WC_TOP_TOOLBAR));
-            window_close(window_find_by_class(WC_BOTTOM_TOOLBAR));
+            window_close(*window_find_by_class(WC_DROPDOWN));
+            window_close(*window_find_by_class(WC_TOP_TOOLBAR));
+            window_close(*window_find_by_class(WC_BOTTOM_TOOLBAR));
         }
         else
         {
@@ -385,7 +385,7 @@ static void ShortcutOpenCheatWindow()
     rct_window* window = window_find_by_class(WC_CHEATS);
     if (window != nullptr)
     {
-        window_close(window);
+        window_close(*window);
         return;
     }
     context_open_window(WC_CHEATS);
@@ -762,7 +762,7 @@ void ShortcutManager::RegisterDefaultShortcuts()
             auto window = window_find_by_class(WC_ERROR);
             if (window != nullptr)
             {
-                window_close(window);
+                window_close(*window);
             }
             else if (input_test_flag(INPUT_FLAG_TOOL_ACTIVE))
             {
@@ -909,7 +909,7 @@ void ShortcutManager::RegisterDefaultShortcuts()
             auto window = window_find_by_class(WC_DEBUG_PAINT);
             if (window != nullptr)
             {
-                window_close(window);
+                window_close(*window);
             }
             else
             {

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -85,7 +85,7 @@ static void ShortcutRotateConstructionObject()
 
     // Rotate scenery
     rct_window* w = window_find_by_class(WC_SCENERY);
-    if (w != nullptr && !WidgetIsDisabled(w, WC_SCENERY__WIDX_SCENERY_ROTATE_OBJECTS_BUTTON)
+    if (w != nullptr && !WidgetIsDisabled(*w, WC_SCENERY__WIDX_SCENERY_ROTATE_OBJECTS_BUTTON)
         && w->widgets[WC_SCENERY__WIDX_SCENERY_ROTATE_OBJECTS_BUTTON].type != WindowWidgetType::Empty)
     {
         window_event_mouse_up_call(w, WC_SCENERY__WIDX_SCENERY_ROTATE_OBJECTS_BUTTON);
@@ -94,7 +94,7 @@ static void ShortcutRotateConstructionObject()
 
     // Rotate construction track piece
     w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w != nullptr && !WidgetIsDisabled(w, WC_RIDE_CONSTRUCTION__WIDX_ROTATE)
+    if (w != nullptr && !WidgetIsDisabled(*w, WC_RIDE_CONSTRUCTION__WIDX_ROTATE)
         && w->widgets[WC_RIDE_CONSTRUCTION__WIDX_ROTATE].type != WindowWidgetType::Empty)
     {
         // Check if building a maze...
@@ -107,7 +107,7 @@ static void ShortcutRotateConstructionObject()
 
     // Rotate track design preview
     w = window_find_by_class(WC_TRACK_DESIGN_LIST);
-    if (w != nullptr && !WidgetIsDisabled(w, WC_TRACK_DESIGN_LIST__WIDX_ROTATE)
+    if (w != nullptr && !WidgetIsDisabled(*w, WC_TRACK_DESIGN_LIST__WIDX_ROTATE)
         && w->widgets[WC_TRACK_DESIGN_LIST__WIDX_ROTATE].type != WindowWidgetType::Empty)
     {
         window_event_mouse_up_call(w, WC_TRACK_DESIGN_LIST__WIDX_ROTATE);
@@ -116,7 +116,7 @@ static void ShortcutRotateConstructionObject()
 
     // Rotate track design placement
     w = window_find_by_class(WC_TRACK_DESIGN_PLACE);
-    if (w != nullptr && !WidgetIsDisabled(w, WC_TRACK_DESIGN_PLACE__WIDX_ROTATE)
+    if (w != nullptr && !WidgetIsDisabled(*w, WC_TRACK_DESIGN_PLACE__WIDX_ROTATE)
         && w->widgets[WC_TRACK_DESIGN_PLACE__WIDX_ROTATE].type != WindowWidgetType::Empty)
     {
         window_event_mouse_up_call(w, WC_TRACK_DESIGN_PLACE__WIDX_ROTATE);
@@ -125,7 +125,7 @@ static void ShortcutRotateConstructionObject()
 
     // Rotate park entrance
     w = window_find_by_class(WC_MAP);
-    if (w != nullptr && !WidgetIsDisabled(w, WC_MAP__WIDX_ROTATE_90)
+    if (w != nullptr && !WidgetIsDisabled(*w, WC_MAP__WIDX_ROTATE_90)
         && w->widgets[WC_MAP__WIDX_ROTATE_90].type != WindowWidgetType::Empty)
     {
         window_event_mouse_up_call(w, WC_MAP__WIDX_ROTATE_90);
@@ -134,7 +134,7 @@ static void ShortcutRotateConstructionObject()
 
     // Rotate selected element in tile inspector
     w = window_find_by_class(WC_TILE_INSPECTOR);
-    if (w != nullptr && !WidgetIsDisabled(w, WC_TILE_INSPECTOR__WIDX_BUTTON_ROTATE)
+    if (w != nullptr && !WidgetIsDisabled(*w, WC_TILE_INSPECTOR__WIDX_BUTTON_ROTATE)
         && w->widgets[WC_TILE_INSPECTOR__WIDX_BUTTON_ROTATE].type != WindowWidgetType::Empty)
     {
         window_event_mouse_up_call(w, WC_TILE_INSPECTOR__WIDX_BUTTON_ROTATE);
@@ -462,7 +462,7 @@ static void ShortcutOpenSceneryPicker()
     }
 
     window_scenery = window_find_by_class(WC_SCENERY);
-    if (window_scenery != nullptr && !WidgetIsDisabled(window_scenery, WC_SCENERY__WIDX_SCENERY_EYEDROPPER_BUTTON)
+    if (window_scenery != nullptr && !WidgetIsDisabled(*window_scenery, WC_SCENERY__WIDX_SCENERY_EYEDROPPER_BUTTON)
         && window_scenery->widgets[WC_SCENERY__WIDX_SCENERY_EYEDROPPER_BUTTON].type != WindowWidgetType::Empty
         && !gWindowSceneryEyedropperEnabled)
     {
@@ -494,7 +494,7 @@ static void ShortcutScaleDown()
 static void TileInspectorMouseUp(rct_widgetindex widgetIndex)
 {
     auto w = window_find_by_class(WC_TILE_INSPECTOR);
-    if (w != nullptr && !WidgetIsDisabled(w, widgetIndex) && w->widgets[widgetIndex].type != WindowWidgetType::Empty)
+    if (w != nullptr && !WidgetIsDisabled(*w, widgetIndex) && w->widgets[widgetIndex].type != WindowWidgetType::Empty)
     {
         window_event_mouse_up_call(w, widgetIndex);
     }
@@ -503,7 +503,7 @@ static void TileInspectorMouseUp(rct_widgetindex widgetIndex)
 static void TileInspectorMouseDown(rct_widgetindex widgetIndex)
 {
     auto w = window_find_by_class(WC_TILE_INSPECTOR);
-    if (w != nullptr && !WidgetIsDisabled(w, widgetIndex) && w->widgets[widgetIndex].type != WindowWidgetType::Empty)
+    if (w != nullptr && !WidgetIsDisabled(*w, widgetIndex) && w->widgets[widgetIndex].type != WindowWidgetType::Empty)
     {
         window_event_mouse_down_call(w, widgetIndex);
     }
@@ -563,7 +563,7 @@ static void ShortcutIncreaseElementHeight()
             case TileInspectorPage::Default:
                 break;
         }
-        if (action != -1 && !WidgetIsDisabled(w, action) && w->widgets[action].type != WindowWidgetType::Empty)
+        if (action != -1 && !WidgetIsDisabled(*w, action) && w->widgets[action].type != WindowWidgetType::Empty)
             window_event_mouse_down_call(w, action);
         return;
     }
@@ -604,7 +604,7 @@ static void ShortcutDecreaseElementHeight()
             case TileInspectorPage::Default:
                 break;
         }
-        if (action != -1 && !WidgetIsDisabled(w, action) && w->widgets[action].type != WindowWidgetType::Empty)
+        if (action != -1 && !WidgetIsDisabled(*w, action) && w->widgets[action].type != WindowWidgetType::Empty)
             window_event_mouse_down_call(w, action);
         return;
     }

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -191,7 +191,7 @@ static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
                      w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Check if the button is pressed down
-    uint8_t press = WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
+    uint8_t press = WidgetIsPressed(*w, widgetIndex) || WidgetIsActiveTool(*w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
     // Get the colour
     uint8_t colour = w->colours[widget.colour];
@@ -223,7 +223,7 @@ static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex
 
     if (widget.type == WindowWidgetType::Tab)
     {
-        if (WidgetIsDisabled(w, widgetIndex))
+        if (WidgetIsDisabled(*w, widgetIndex))
             return;
 
         if (widget.image == static_cast<uint32_t>(SPR_NONE))
@@ -234,7 +234,7 @@ static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex
     }
 
     // Draw widgets that aren't explicitly disabled.
-    if (!WidgetIsDisabled(w, widgetIndex))
+    if (!WidgetIsDisabled(*w, widgetIndex))
     {
         WidgetDrawImage(dpi, w, widgetIndex);
         return;
@@ -263,7 +263,7 @@ static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex
  */
 static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
 {
-    if (!WidgetIsDisabled(w, widgetIndex) && WidgetIsHighlighted(w, widgetIndex))
+    if (!WidgetIsDisabled(*w, widgetIndex) && WidgetIsHighlighted(*w, widgetIndex))
     {
         WidgetButtonDraw(dpi, w, widgetIndex);
         return;
@@ -280,7 +280,7 @@ static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
     uint8_t colour = w->colours[widget.colour];
 
     // Check if the button is pressed down
-    if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
+    if (WidgetIsPressed(*w, widgetIndex) || WidgetIsActiveTool(*w, widgetIndex))
     {
         if (static_cast<int32_t>(widget.image) == -2)
         {
@@ -314,7 +314,7 @@ static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
     uint8_t colour = w->colours[widget.colour];
 
     // Border
-    uint8_t press = WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
+    uint8_t press = WidgetIsPressed(*w, widgetIndex) || WidgetIsActiveTool(*w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
     gfx_fill_rect_inset(dpi, rect, colour, press);
 
     // Button caption
@@ -343,7 +343,7 @@ static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     // Get the colour
     colour_t colour = w->colours[widget.colour];
     colour &= ~(COLOUR_FLAG_TRANSLUCENT);
-    if (WidgetIsDisabled(w, widgetIndex))
+    if (WidgetIsDisabled(*w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
     // Resolve the absolute ltrb
@@ -388,7 +388,7 @@ static void WidgetText(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex wi
 
     // Get the colour
     uint8_t colour = w->colours[widget.colour];
-    if (WidgetIsDisabled(w, widgetIndex))
+    if (WidgetIsDisabled(*w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
     // Resolve the absolute ltrb
@@ -482,7 +482,7 @@ static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     if (stringId != STR_NONE)
     {
         uint8_t colour = w->colours[widget.colour] & 0x7F;
-        if (WidgetIsDisabled(w, widgetIndex))
+        if (WidgetIsDisabled(*w, widgetIndex))
             colour |= COLOUR_FLAG_INSET;
 
         utf8 buffer[512] = { 0 };
@@ -589,7 +589,7 @@ static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     uint8_t press = 0;
     if (w->flags & WF_10)
         press |= INSET_RECT_FLAG_FILL_MID_LIGHT;
-    if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
+    if (WidgetIsPressed(*w, widgetIndex) || WidgetIsActiveTool(*w, widgetIndex))
         press |= INSET_RECT_FLAG_BORDER_INSET;
 
     // Get the colour
@@ -603,7 +603,7 @@ static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
 
     topLeft = w->windowPos + ScreenCoordsXY{ widget.midX() - 1, std::max<int32_t>(widget.top, widget.midY() - 5) };
 
-    if (WidgetIsDisabled(w, widgetIndex))
+    if (WidgetIsDisabled(*w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
     DrawTextEllipsised(dpi, topLeft, widget.width() - 2, widget.text, Formatter::Common(), { colour, TextAlignment::CENTRE });
@@ -629,13 +629,13 @@ static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     // checkbox
     gfx_fill_rect_inset(dpi, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, INSET_RECT_F_60);
 
-    if (WidgetIsDisabled(w, widgetIndex))
+    if (WidgetIsDisabled(*w, widgetIndex))
     {
         colour |= COLOUR_FLAG_INSET;
     }
 
     // fill it when checkbox is pressed
-    if (WidgetIsPressed(w, widgetIndex))
+    if (WidgetIsPressed(*w, widgetIndex))
     {
         gfx_draw_string(
             dpi, { midLeft - ScreenCoordsXY{ 0, 5 } }, static_cast<const char*>(CheckBoxMarkString),
@@ -814,10 +814,10 @@ static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetind
 
     if (widget.type == WindowWidgetType::ColourBtn || widget.type == WindowWidgetType::TrnBtn
         || widget.type == WindowWidgetType::Tab)
-        if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
+        if (WidgetIsPressed(*w, widgetIndex) || WidgetIsActiveTool(*w, widgetIndex))
             image++;
 
-    if (WidgetIsDisabled(w, widgetIndex))
+    if (WidgetIsDisabled(*w, widgetIndex))
     {
         // Draw greyed out (light border bottom right shadow)
         colour = w->colours[widget.colour];
@@ -845,37 +845,37 @@ static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetind
     }
 }
 
-bool WidgetIsDisabled(const rct_window* w, rct_widgetindex widgetIndex)
+bool WidgetIsDisabled(const rct_window& w, rct_widgetindex widgetIndex)
 {
-    if (w->classification == WC_CUSTOM)
-        return w->widgets[widgetIndex].flags & WIDGET_FLAGS::IS_DISABLED;
-    return (w->disabled_widgets & (1LL << widgetIndex)) != 0;
+    if (w.classification == WC_CUSTOM)
+        return w.widgets[widgetIndex].flags & WIDGET_FLAGS::IS_DISABLED;
+    return (w.disabled_widgets & (1LL << widgetIndex)) != 0;
 }
 
-bool WidgetIsHoldable(const rct_window* w, rct_widgetindex widgetIndex)
+bool WidgetIsHoldable(const rct_window& w, rct_widgetindex widgetIndex)
 {
-    if (w->classification == WC_CUSTOM)
-        return w->widgets[widgetIndex].flags & WIDGET_FLAGS::IS_HOLDABLE;
-    return (w->hold_down_widgets & (1LL << widgetIndex)) != 0;
+    if (w.classification == WC_CUSTOM)
+        return w.widgets[widgetIndex].flags & WIDGET_FLAGS::IS_HOLDABLE;
+    return (w.hold_down_widgets & (1LL << widgetIndex)) != 0;
 }
 
-bool WidgetIsVisible(const rct_window* w, rct_widgetindex widgetIndex)
+bool WidgetIsVisible(const rct_window& w, rct_widgetindex widgetIndex)
 {
-    return w->widgets[widgetIndex].IsVisible();
+    return w.widgets[widgetIndex].IsVisible();
 }
 
-bool WidgetIsPressed(const rct_window* w, rct_widgetindex widgetIndex)
+bool WidgetIsPressed(const rct_window& w, rct_widgetindex widgetIndex)
 {
-    if (w->classification == WC_CUSTOM)
+    if (w.classification == WC_CUSTOM)
     {
-        if (w->widgets[widgetIndex].flags & WIDGET_FLAGS::IS_PRESSED)
+        if (w.widgets[widgetIndex].flags & WIDGET_FLAGS::IS_PRESSED)
         {
             return true;
         }
     }
     else
     {
-        if (w->pressed_widgets & (1LL << widgetIndex))
+        if (w.pressed_widgets & (1LL << widgetIndex))
         {
             return true;
         }
@@ -885,9 +885,9 @@ bool WidgetIsPressed(const rct_window* w, rct_widgetindex widgetIndex)
     {
         if (!(input_test_flag(INPUT_FLAG_WIDGET_PRESSED)))
             return false;
-        if (gPressedWidget.window_classification != w->classification)
+        if (gPressedWidget.window_classification != w.classification)
             return false;
-        if (gPressedWidget.window_number != w->number)
+        if (gPressedWidget.window_number != w.number)
             return false;
         if (gPressedWidget.widget_index != widgetIndex)
             return false;
@@ -896,24 +896,24 @@ bool WidgetIsPressed(const rct_window* w, rct_widgetindex widgetIndex)
     return false;
 }
 
-bool WidgetIsHighlighted(const rct_window* w, rct_widgetindex widgetIndex)
+bool WidgetIsHighlighted(const rct_window& w, rct_widgetindex widgetIndex)
 {
-    if (gHoverWidget.window_classification != w->classification)
+    if (gHoverWidget.window_classification != w.classification)
         return false;
-    if (gHoverWidget.window_number != w->number)
+    if (gHoverWidget.window_number != w.number)
         return false;
     if (gHoverWidget.widget_index != widgetIndex)
         return false;
     return true;
 }
 
-bool WidgetIsActiveTool(const rct_window* w, rct_widgetindex widgetIndex)
+bool WidgetIsActiveTool(const rct_window& w, rct_widgetindex widgetIndex)
 {
     if (!(input_test_flag(INPUT_FLAG_TOOL_ACTIVE)))
         return false;
-    if (gCurrentToolWidget.window_classification != w->classification)
+    if (gCurrentToolWidget.window_classification != w.classification)
         return false;
-    if (gCurrentToolWidget.window_number != w->number)
+    if (gCurrentToolWidget.window_number != w.number)
         return false;
     if (gCurrentToolWidget.widget_index != widgetIndex)
         return false;
@@ -1054,9 +1054,9 @@ rct_widget* GetWidgetByIndex(const rct_window& w, rct_widgetindex widgetIndex)
     return nullptr;
 }
 
-static void SafeSetWidgetFlag(rct_window* w, rct_widgetindex widgetIndex, WidgetFlags mask, bool value)
+static void SafeSetWidgetFlag(rct_window& w, rct_widgetindex widgetIndex, WidgetFlags mask, bool value)
 {
-    rct_widget* widget = GetWidgetByIndex(*w, widgetIndex);
+    rct_widget* widget = GetWidgetByIndex(w, widgetIndex);
     if (widget == nullptr)
     {
         return;
@@ -1068,52 +1068,52 @@ static void SafeSetWidgetFlag(rct_window* w, rct_widgetindex widgetIndex, Widget
         widget->flags &= ~mask;
 }
 
-void WidgetSetEnabled(rct_window* w, rct_widgetindex widgetIndex, bool enabled)
+void WidgetSetEnabled(rct_window& w, rct_widgetindex widgetIndex, bool enabled)
 {
     WidgetSetDisabled(w, widgetIndex, !enabled);
 }
 
-void WidgetSetDisabled(rct_window* w, rct_widgetindex widgetIndex, bool value)
+void WidgetSetDisabled(rct_window& w, rct_widgetindex widgetIndex, bool value)
 {
     SafeSetWidgetFlag(w, widgetIndex, WIDGET_FLAGS::IS_DISABLED, value);
     if (value)
     {
-        w->disabled_widgets |= (1ULL << widgetIndex);
+        w.disabled_widgets |= (1ULL << widgetIndex);
     }
     else
     {
-        w->disabled_widgets &= ~(1ULL << widgetIndex);
+        w.disabled_widgets &= ~(1ULL << widgetIndex);
     }
 }
 
-void WidgetSetHoldable(rct_window* w, rct_widgetindex widgetIndex, bool value)
+void WidgetSetHoldable(rct_window& w, rct_widgetindex widgetIndex, bool value)
 {
     SafeSetWidgetFlag(w, widgetIndex, WIDGET_FLAGS::IS_HOLDABLE, value);
     if (value)
     {
-        w->hold_down_widgets |= (1ULL << widgetIndex);
+        w.hold_down_widgets |= (1ULL << widgetIndex);
     }
     else
     {
-        w->hold_down_widgets &= ~(1ULL << widgetIndex);
+        w.hold_down_widgets &= ~(1ULL << widgetIndex);
     }
 }
 
-void WidgetSetVisible(rct_window* w, rct_widgetindex widgetIndex, bool value)
+void WidgetSetVisible(rct_window& w, rct_widgetindex widgetIndex, bool value)
 {
     SafeSetWidgetFlag(w, widgetIndex, WIDGET_FLAGS::IS_HIDDEN, !value);
 }
 
-void WidgetSetPressed(rct_window* w, rct_widgetindex widgetIndex, bool value)
+void WidgetSetPressed(rct_window& w, rct_widgetindex widgetIndex, bool value)
 {
     SafeSetWidgetFlag(w, widgetIndex, WIDGET_FLAGS::IS_PRESSED, value);
     if (value)
-        w->pressed_widgets |= (1ULL << widgetIndex);
+        w.pressed_widgets |= (1ULL << widgetIndex);
     else
-        w->pressed_widgets &= ~(1ULL << widgetIndex);
+        w.pressed_widgets &= ~(1ULL << widgetIndex);
 }
 
-void WidgetSetCheckboxValue(rct_window* w, rct_widgetindex widgetIndex, bool value)
+void WidgetSetCheckboxValue(rct_window& w, rct_widgetindex widgetIndex, bool value)
 {
     WidgetSetPressed(w, widgetIndex, value);
 }

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -21,34 +21,34 @@
 #include <openrct2/sprites.h>
 #include <openrct2/util/Util.h>
 
-static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetText(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetTextInset(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
-static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
+static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetText(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetTextInset(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
+static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
 static void WidgetHScrollbarDraw(
     rct_drawpixelinfo* dpi, const rct_scroll& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour);
 static void WidgetVScrollbarDraw(
     rct_drawpixelinfo* dpi, const rct_scroll& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour);
-static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
+static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
 
 /**
  *
  *  rct2: 0x006EB2A8
  */
-void WidgetDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+void WidgetDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
-    const auto* widget = GetWidgetByIndex(*w, widgetIndex);
+    const auto* widget = GetWidgetByIndex(w, widgetIndex);
     if (widget == nullptr)
     {
         log_error("Tried drawing an out-of-bounds widget index!");
@@ -116,33 +116,33 @@ void WidgetDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetInd
  *
  *  rct2: 0x006EB6CE
  */
-static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    auto leftTop = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
-    int32_t r = w->windowPos.x + widget.right;
-    int32_t b = w->windowPos.y + widget.bottom;
+    auto leftTop = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    int32_t r = w.windowPos.x + widget.right;
+    int32_t b = w.windowPos.y + widget.bottom;
 
     //
-    uint8_t press = ((w->flags & WF_10) ? INSET_RECT_FLAG_FILL_MID_LIGHT : 0);
+    uint8_t press = ((w.flags & WF_10) ? INSET_RECT_FLAG_FILL_MID_LIGHT : 0);
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour];
+    uint8_t colour = w.colours[widget.colour];
 
     // Draw the frame
     gfx_fill_rect_inset(dpi, { leftTop, { r, b } }, colour, press);
 
     // Check if the window can be resized
-    if (!(w->flags & WF_RESIZABLE))
+    if (!(w.flags & WF_RESIZABLE))
         return;
-    if (w->min_width == w->max_width && w->min_height == w->max_height)
+    if (w.min_width == w.max_width && w.min_height == w.max_height)
         return;
 
     // Draw the resize sprite at the bottom right corner
-    leftTop = w->windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
+    leftTop = w.windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
     gfx_draw_sprite(dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
 }
 
@@ -150,30 +150,30 @@ static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetind
  *
  *  rct2: 0x006EB765
  */
-static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    auto leftTop = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
-    int32_t r = w->windowPos.x + widget.right;
-    int32_t b = w->windowPos.y + widget.bottom;
+    auto leftTop = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    int32_t r = w.windowPos.x + widget.right;
+    int32_t b = w.windowPos.y + widget.bottom;
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour];
+    uint8_t colour = w.colours[widget.colour];
 
     // Draw the panel
     gfx_fill_rect_inset(dpi, { leftTop, { r, b } }, colour, 0);
 
     // Check if the window can be resized
-    if (!(w->flags & WF_RESIZABLE))
+    if (!(w.flags & WF_RESIZABLE))
         return;
-    if (w->min_width == w->max_width && w->min_height == w->max_height)
+    if (w.min_width == w.max_width && w.min_height == w.max_height)
         return;
 
     // Draw the resize sprite at the bottom right corner
-    leftTop = w->windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
+    leftTop = w.windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
     gfx_draw_sprite(dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
 }
 
@@ -181,20 +181,20 @@ static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
  *
  *  rct2: 0x006EB8E5
  */
-static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget.left, widget.top },
-                     w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
+    ScreenRect rect{ w.windowPos + ScreenCoordsXY{ widget.left, widget.top },
+                     w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Check if the button is pressed down
-    uint8_t press = WidgetIsPressed(*w, widgetIndex) || WidgetIsActiveTool(*w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
+    uint8_t press = WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour];
+    uint8_t colour = w.colours[widget.colour];
 
     if (static_cast<int32_t>(widget.image) == -2)
     {
@@ -213,17 +213,17 @@ static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
  *
  *  rct2: 0x006EB806
  */
-static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    auto& widget = w->widgets[widgetIndex];
+    auto& widget = w.widgets[widgetIndex];
 
     if (widget.type != WindowWidgetType::Tab && static_cast<int32_t>(widget.image) == -1)
         return;
 
     if (widget.type == WindowWidgetType::Tab)
     {
-        if (WidgetIsDisabled(*w, widgetIndex))
+        if (WidgetIsDisabled(w, widgetIndex))
             return;
 
         if (widget.image == static_cast<uint32_t>(SPR_NONE))
@@ -234,7 +234,7 @@ static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex
     }
 
     // Draw widgets that aren't explicitly disabled.
-    if (!WidgetIsDisabled(*w, widgetIndex))
+    if (!WidgetIsDisabled(w, widgetIndex))
     {
         WidgetDrawImage(dpi, w, widgetIndex);
         return;
@@ -247,10 +247,10 @@ static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex
     }
 
     // Resolve the absolute ltrb
-    auto leftTop = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    auto leftTop = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
     // Get the colour and disabled image
-    auto colour = w->colours[widget.colour] & 0x7F;
+    auto colour = w.colours[widget.colour] & 0x7F;
     auto image = ImageId::FromUInt32(widget.image + 2).WithPrimary(colour);
 
     // Draw disabled image
@@ -261,26 +261,26 @@ static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex
  *
  *  rct2: 0x006EB861
  */
-static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
-    if (!WidgetIsDisabled(*w, widgetIndex) && WidgetIsHighlighted(*w, widgetIndex))
+    if (!WidgetIsDisabled(w, widgetIndex) && WidgetIsHighlighted(w, widgetIndex))
     {
         WidgetButtonDraw(dpi, w, widgetIndex);
         return;
     }
 
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget.left, widget.top },
-                     w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
+    ScreenRect rect{ w.windowPos + ScreenCoordsXY{ widget.left, widget.top },
+                     w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour];
+    uint8_t colour = w.colours[widget.colour];
 
     // Check if the button is pressed down
-    if (WidgetIsPressed(*w, widgetIndex) || WidgetIsActiveTool(*w, widgetIndex))
+    if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
     {
         if (static_cast<int32_t>(widget.image) == -2)
         {
@@ -301,20 +301,20 @@ static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widg
  *
  *  rct2: 0x006EBBEB
  */
-static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget.left, widget.top },
-                     w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
+    ScreenRect rect{ w.windowPos + ScreenCoordsXY{ widget.left, widget.top },
+                     w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour];
+    uint8_t colour = w.colours[widget.colour];
 
     // Border
-    uint8_t press = WidgetIsPressed(*w, widgetIndex) || WidgetIsActiveTool(*w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
+    uint8_t press = WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
     gfx_fill_rect_inset(dpi, rect, colour, press);
 
     // Button caption
@@ -332,23 +332,23 @@ static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
  *
  *  rct2: 0x006EBC41
  */
-static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     if (widget.text == STR_NONE)
         return;
 
     // Get the colour
-    colour_t colour = w->colours[widget.colour];
+    colour_t colour = w.colours[widget.colour];
     colour &= ~(COLOUR_FLAG_TRANSLUCENT);
-    if (WidgetIsDisabled(*w, widgetIndex))
+    if (WidgetIsDisabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
     // Resolve the absolute ltrb
-    auto topLeft = w->windowPos + ScreenCoordsXY{ widget.left, 0 };
-    int32_t r = w->windowPos.x + widget.right;
+    auto topLeft = w.windowPos + ScreenCoordsXY{ widget.left, 0 };
+    int32_t r = w.windowPos.x + widget.right;
 
     if (widget.type == WindowWidgetType::Button || widget.type == WindowWidgetType::TableHeader)
         topLeft.y += widget.textTop();
@@ -378,31 +378,31 @@ static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
  *
  *  rct2: 0x006EBD52
  */
-static void WidgetText(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetText(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     if (widget.text == STR_NONE || widget.text == STR_VIEWPORT)
         return;
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour];
-    if (WidgetIsDisabled(*w, widgetIndex))
+    uint8_t colour = w.colours[widget.colour];
+    if (WidgetIsDisabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
     // Resolve the absolute ltrb
-    int32_t l = w->windowPos.x + widget.left;
-    int32_t r = w->windowPos.x + widget.right;
+    int32_t l = w.windowPos.x + widget.left;
+    int32_t r = w.windowPos.x + widget.right;
     int32_t t;
 
     if (widget.type == WindowWidgetType::Button || widget.type == WindowWidgetType::DropdownMenu
         || widget.type == WindowWidgetType::Spinner || widget.type == WindowWidgetType::TableHeader)
     {
-        t = w->windowPos.y + widget.textTop();
+        t = w.windowPos.y + widget.textTop();
     }
     else
-        t = w->windowPos.y + widget.top;
+        t = w.windowPos.y + widget.top;
 
     auto stringId = widget.text;
     auto ft = Formatter::Common();
@@ -427,17 +427,17 @@ static void WidgetText(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex wi
  *
  *  rct2: 0x006EBD1F
  */
-static void WidgetTextInset(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetTextInset(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    ScreenRect rect{ w->windowPos + ScreenCoordsXY{ widget.left, widget.top },
-                     w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
+    ScreenRect rect{ w.windowPos + ScreenCoordsXY{ widget.left, widget.top },
+                     w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour];
+    uint8_t colour = w.colours[widget.colour];
 
     gfx_fill_rect_inset(dpi, rect, colour, INSET_RECT_F_60);
     WidgetText(dpi, w, widgetIndex);
@@ -467,22 +467,22 @@ static std::pair<rct_string_id, void*> WidgetGetStringidAndArgs(const rct_widget
  *
  *  rct2: 0x006EB535
  */
-static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    auto l = w->windowPos.x + widget.left + 5;
-    auto t = w->windowPos.y + widget.top;
+    auto l = w.windowPos.x + widget.left + 5;
+    auto t = w.windowPos.y + widget.top;
     auto textRight = l;
 
     // Text
     auto [stringId, formatArgs] = WidgetGetStringidAndArgs(widget);
     if (stringId != STR_NONE)
     {
-        uint8_t colour = w->colours[widget.colour] & 0x7F;
-        if (WidgetIsDisabled(*w, widgetIndex))
+        uint8_t colour = w.colours[widget.colour] & 0x7F;
+        if (WidgetIsDisabled(w, widgetIndex))
             colour |= COLOUR_FLAG_INSET;
 
         utf8 buffer[512] = { 0 };
@@ -495,13 +495,13 @@ static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
 
     // Border
     // Resolve the absolute ltrb
-    l = w->windowPos.x + widget.left;
-    t = w->windowPos.y + widget.top + 4;
-    const auto r = w->windowPos.x + widget.right;
-    const auto b = w->windowPos.y + widget.bottom;
+    l = w.windowPos.x + widget.left;
+    t = w.windowPos.y + widget.top + 4;
+    const auto r = w.windowPos.x + widget.right;
+    const auto b = w.windowPos.y + widget.bottom;
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour] & 0x7F;
+    uint8_t colour = w.colours[widget.colour] & 0x7F;
 
     // Border left of text
     gfx_fill_rect(dpi, { { l, t }, { l + 4, t } }, ColourMapA[colour].mid_dark);
@@ -528,20 +528,20 @@ static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
  *
  *  rct2: 0x006EB2F9
  */
-static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto* widget = &w->widgets[widgetIndex];
+    const auto* widget = &w.widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    auto topLeft = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
-    auto bottomRight = w->windowPos + ScreenCoordsXY{ widget->right, widget->bottom };
+    auto topLeft = w.windowPos + ScreenCoordsXY{ widget->left, widget->top };
+    auto bottomRight = w.windowPos + ScreenCoordsXY{ widget->right, widget->bottom };
 
     // Get the colour
-    uint8_t colour = w->colours[widget->colour];
+    uint8_t colour = w.colours[widget->colour];
 
     uint8_t press = INSET_RECT_F_60;
-    if (w->flags & WF_10)
+    if (w.flags & WF_10)
         press |= INSET_RECT_FLAG_FILL_MID_LIGHT;
 
     gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, colour, press);
@@ -559,7 +559,7 @@ static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     if (widget->text == STR_NONE)
         return;
 
-    topLeft = w->windowPos + ScreenCoordsXY{ widget->left + 2, widget->top + 1 };
+    topLeft = w.windowPos + ScreenCoordsXY{ widget->left + 2, widget->top + 1 };
     int32_t width = widget->width() - 4;
     if ((widget + 1)->type == WindowWidgetType::CloseBox)
     {
@@ -576,24 +576,24 @@ static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
  *
  *  rct2: 0x006EBB85
  */
-static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    auto topLeft = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
-    auto bottomRight = w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
+    auto topLeft = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    auto bottomRight = w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
 
     // Check if the button is pressed down
     uint8_t press = 0;
-    if (w->flags & WF_10)
+    if (w.flags & WF_10)
         press |= INSET_RECT_FLAG_FILL_MID_LIGHT;
-    if (WidgetIsPressed(*w, widgetIndex) || WidgetIsActiveTool(*w, widgetIndex))
+    if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
         press |= INSET_RECT_FLAG_BORDER_INSET;
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour];
+    uint8_t colour = w.colours[widget.colour];
 
     // Draw the button
     gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, colour, press);
@@ -601,9 +601,9 @@ static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
     if (widget.text == STR_NONE)
         return;
 
-    topLeft = w->windowPos + ScreenCoordsXY{ widget.midX() - 1, std::max<int32_t>(widget.top, widget.midY() - 5) };
+    topLeft = w.windowPos + ScreenCoordsXY{ widget.midX() - 1, std::max<int32_t>(widget.top, widget.midY() - 5) };
 
-    if (WidgetIsDisabled(*w, widgetIndex))
+    if (WidgetIsDisabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
     DrawTextEllipsised(dpi, topLeft, widget.width() - 2, widget.text, Formatter::Common(), { colour, TextAlignment::CENTRE });
@@ -613,29 +613,29 @@ static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
  *
  *  rct2: 0x006EBAD9
  */
-static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Resolve the absolute ltb
-    ScreenCoordsXY topLeft = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
-    ScreenCoordsXY bottomRight = w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
+    ScreenCoordsXY topLeft = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    ScreenCoordsXY bottomRight = w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
     ScreenCoordsXY midLeft = { topLeft.x, (topLeft.y + bottomRight.y) / 2 };
 
     // Get the colour
-    colour_t colour = w->colours[widget.colour];
+    colour_t colour = w.colours[widget.colour];
 
     // checkbox
     gfx_fill_rect_inset(dpi, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, INSET_RECT_F_60);
 
-    if (WidgetIsDisabled(*w, widgetIndex))
+    if (WidgetIsDisabled(w, widgetIndex))
     {
         colour |= COLOUR_FLAG_INSET;
     }
 
     // fill it when checkbox is pressed
-    if (WidgetIsPressed(*w, widgetIndex))
+    if (WidgetIsPressed(w, widgetIndex))
     {
         gfx_draw_string(
             dpi, { midLeft - ScreenCoordsXY{ 0, 5 } }, static_cast<const char*>(CheckBoxMarkString),
@@ -654,19 +654,19 @@ static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widget
  *
  *  rct2: 0x006EBD96
  */
-static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    int32_t scrollIndex = window_get_scroll_data_index(w, widgetIndex);
-    const auto& widget = w->widgets[widgetIndex];
-    const auto& scroll = w->scrolls[scrollIndex];
+    int32_t scrollIndex = window_get_scroll_data_index(&w, widgetIndex);
+    const auto& widget = w.widgets[widgetIndex];
+    const auto& scroll = w.scrolls[scrollIndex];
 
     // Resolve the absolute ltrb
-    ScreenCoordsXY topLeft = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
-    ScreenCoordsXY bottomRight = w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
+    ScreenCoordsXY topLeft = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    ScreenCoordsXY bottomRight = w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom };
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour];
+    uint8_t colour = w.colours[widget.colour];
 
     // Draw the border
     gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
@@ -719,7 +719,7 @@ static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetin
 
     // Draw the scroll contents
     if (scroll_dpi.width > 0 && scroll_dpi.height > 0)
-        window_event_scroll_paint_call(w, &scroll_dpi, scrollIndex);
+        window_event_scroll_paint_call(&w, &scroll_dpi, scrollIndex);
 }
 
 static void WidgetHScrollbarDraw(
@@ -796,10 +796,10 @@ static void WidgetVScrollbarDraw(
  *
  *  rct2: 0x006EB951
  */
-static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Get the image
     int32_t image = widget.image;
@@ -807,25 +807,25 @@ static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetind
         return;
 
     // Resolve the absolute ltrb
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ widget.left, widget.top };
+    auto screenCoords = w.windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
     // Get the colour
-    uint8_t colour = NOT_TRANSLUCENT(w->colours[widget.colour]);
+    uint8_t colour = NOT_TRANSLUCENT(w.colours[widget.colour]);
 
     if (widget.type == WindowWidgetType::ColourBtn || widget.type == WindowWidgetType::TrnBtn
         || widget.type == WindowWidgetType::Tab)
-        if (WidgetIsPressed(*w, widgetIndex) || WidgetIsActiveTool(*w, widgetIndex))
+        if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
             image++;
 
-    if (WidgetIsDisabled(*w, widgetIndex))
+    if (WidgetIsDisabled(w, widgetIndex))
     {
         // Draw greyed out (light border bottom right shadow)
-        colour = w->colours[widget.colour];
+        colour = w.colours[widget.colour];
         colour = ColourMapA[NOT_TRANSLUCENT(colour)].lighter;
         gfx_draw_sprite_solid(dpi, image, screenCoords + ScreenCoordsXY{ 1, 1 }, colour);
 
         // Draw greyed out (dark)
-        colour = w->colours[widget.colour];
+        colour = w.colours[widget.colour];
         colour = ColourMapA[NOT_TRANSLUCENT(colour)].mid_light;
         gfx_draw_sprite_solid(dpi, image, screenCoords, colour);
     }
@@ -932,11 +932,11 @@ bool WidgetIsActiveTool(const rct_window& w, rct_widgetindex widgetIndex)
  *  edi: widget
  */
 void WidgetScrollGetPart(
-    rct_window* w, const rct_widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
+    rct_window& w, const rct_widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
     int32_t* output_scroll_area, int32_t* scroll_id)
 {
     *scroll_id = 0;
-    for (rct_widget* iterator = w->widgets; iterator != widget; iterator++)
+    for (rct_widget* iterator = w.widgets; iterator != widget; iterator++)
     {
         if (iterator->type == WindowWidgetType::Scroll)
         {
@@ -944,13 +944,13 @@ void WidgetScrollGetPart(
         }
     }
 
-    const auto& scroll = w->scrolls[*scroll_id];
-    if ((scroll.flags & HSCROLLBAR_VISIBLE) && screenCoords.y >= (w->windowPos.y + widget->bottom - (SCROLLBAR_WIDTH + 1)))
+    const auto& scroll = w.scrolls[*scroll_id];
+    if ((scroll.flags & HSCROLLBAR_VISIBLE) && screenCoords.y >= (w.windowPos.y + widget->bottom - (SCROLLBAR_WIDTH + 1)))
     {
         // horizontal scrollbar
         int32_t rightOffset = 0;
-        int32_t iteratorLeft = widget->left + w->windowPos.x + SCROLLBAR_WIDTH;
-        int32_t iteratorRight = widget->right + w->windowPos.x - SCROLLBAR_WIDTH;
+        int32_t iteratorLeft = widget->left + w.windowPos.x + SCROLLBAR_WIDTH;
+        int32_t iteratorRight = widget->right + w.windowPos.x - SCROLLBAR_WIDTH;
         if (!(scroll.flags & VSCROLLBAR_VISIBLE))
         {
             rightOffset = SCROLLBAR_WIDTH + 1;
@@ -968,11 +968,11 @@ void WidgetScrollGetPart(
         {
             *output_scroll_area = SCROLL_PART_HSCROLLBAR_RIGHT;
         }
-        else if (screenCoords.x < (widget->left + w->windowPos.x + scroll.h_thumb_left))
+        else if (screenCoords.x < (widget->left + w.windowPos.x + scroll.h_thumb_left))
         {
             *output_scroll_area = SCROLL_PART_HSCROLLBAR_LEFT_TROUGH;
         }
-        else if (screenCoords.x > (widget->left + w->windowPos.x + scroll.h_thumb_right))
+        else if (screenCoords.x > (widget->left + w.windowPos.x + scroll.h_thumb_right))
         {
             *output_scroll_area = SCROLL_PART_HSCROLLBAR_RIGHT_TROUGH;
         }
@@ -981,12 +981,12 @@ void WidgetScrollGetPart(
             *output_scroll_area = SCROLL_PART_HSCROLLBAR_THUMB;
         }
     }
-    else if ((scroll.flags & VSCROLLBAR_VISIBLE) && (screenCoords.x >= w->windowPos.x + widget->right - (SCROLLBAR_WIDTH + 1)))
+    else if ((scroll.flags & VSCROLLBAR_VISIBLE) && (screenCoords.x >= w.windowPos.x + widget->right - (SCROLLBAR_WIDTH + 1)))
     {
         // vertical scrollbar
         int32_t bottomOffset = 0;
-        int32_t iteratorTop = widget->top + w->windowPos.y + SCROLLBAR_WIDTH;
-        int32_t iteratorBottom = widget->bottom + w->windowPos.y;
+        int32_t iteratorTop = widget->top + w.windowPos.y + SCROLLBAR_WIDTH;
+        int32_t iteratorBottom = widget->bottom + w.windowPos.y;
         if (scroll.flags & HSCROLLBAR_VISIBLE)
         {
             bottomOffset = (SCROLLBAR_WIDTH + 1);
@@ -1004,11 +1004,11 @@ void WidgetScrollGetPart(
         {
             *output_scroll_area = SCROLL_PART_VSCROLLBAR_BOTTOM;
         }
-        else if (screenCoords.y < (widget->top + w->windowPos.y + scroll.v_thumb_top))
+        else if (screenCoords.y < (widget->top + w.windowPos.y + scroll.v_thumb_top))
         {
             *output_scroll_area = SCROLL_PART_VSCROLLBAR_TOP_TROUGH;
         }
-        else if (screenCoords.y > (widget->top + w->windowPos.y + scroll.v_thumb_bottom))
+        else if (screenCoords.y > (widget->top + w.windowPos.y + scroll.v_thumb_bottom))
         {
             *output_scroll_area = SCROLL_PART_VSCROLLBAR_BOTTOM_TROUGH;
         }
@@ -1023,7 +1023,7 @@ void WidgetScrollGetPart(
         *output_scroll_area = SCROLL_PART_VIEW;
         retScreenCoords.x = screenCoords.x - widget->left;
         retScreenCoords.y = screenCoords.y - widget->top;
-        retScreenCoords -= w->windowPos;
+        retScreenCoords -= w.windowPos;
         if (retScreenCoords.x <= 0 || retScreenCoords.y <= 0)
         {
             *output_scroll_area = SCROLL_PART_NONE;
@@ -1118,29 +1118,29 @@ void WidgetSetCheckboxValue(rct_window& w, rct_widgetindex widgetIndex, bool val
     WidgetSetPressed(w, widgetIndex, value);
 }
 
-static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex)
+static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     int32_t no_lines = 0;
     char wrapped_string[TEXT_INPUT_SIZE];
 
     // Get the widget
-    const auto& widget = w->widgets[widgetIndex];
+    const auto& widget = w.widgets[widgetIndex];
 
     // Resolve the absolute ltrb
-    ScreenCoordsXY topLeft{ w->windowPos + ScreenCoordsXY{ widget.left, widget.top } };
-    ScreenCoordsXY bottomRight{ w->windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
+    ScreenCoordsXY topLeft{ w.windowPos + ScreenCoordsXY{ widget.left, widget.top } };
+    ScreenCoordsXY bottomRight{ w.windowPos + ScreenCoordsXY{ widget.right, widget.bottom } };
 
     // Get the colour
-    uint8_t colour = w->colours[widget.colour];
+    uint8_t colour = w.colours[widget.colour];
 
-    bool active = w->classification == gCurrentTextBox.window.classification && w->number == gCurrentTextBox.window.number
+    bool active = w.classification == gCurrentTextBox.window.classification && w.number == gCurrentTextBox.window.number
         && widgetIndex == gCurrentTextBox.widget_index;
 
     // gfx_fill_rect_inset(dpi, l, t, r, b, colour, 0x20 | (!active ? 0x40 : 0x00));
     gfx_fill_rect_inset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
 
     // Figure out where the text should be positioned vertically.
-    topLeft.y = w->windowPos.y + widget.textTop();
+    topLeft.y = w.windowPos.y + widget.textTop();
 
     if (!active || gTextInput == nullptr)
     {
@@ -1149,7 +1149,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
             safe_strcpy(wrapped_string, widget.string, 512);
             gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5, FontSpriteBase::MEDIUM, &no_lines);
             gfx_draw_string_no_formatting(
-                dpi, { topLeft.x + 2, topLeft.y }, wrapped_string, { w->colours[1], FontSpriteBase::MEDIUM });
+                dpi, { topLeft.x + 2, topLeft.y }, wrapped_string, { w.colours[1], FontSpriteBase::MEDIUM });
         }
         return;
     }
@@ -1160,7 +1160,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
     // +13 for cursor when max length.
     gfx_wrap_string(wrapped_string, bottomRight.x - topLeft.x - 5 - 6, FontSpriteBase::MEDIUM, &no_lines);
 
-    gfx_draw_string_no_formatting(dpi, { topLeft.x + 2, topLeft.y }, wrapped_string, { w->colours[1], FontSpriteBase::MEDIUM });
+    gfx_draw_string_no_formatting(dpi, { topLeft.x + 2, topLeft.y }, wrapped_string, { w.colours[1], FontSpriteBase::MEDIUM });
 
     size_t string_length = get_string_size(wrapped_string) - 1;
 
@@ -1181,7 +1181,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgeti
 
     if (gTextBoxFrameNo <= 15)
     {
-        colour = ColourMapA[w->colours[1]].mid_light;
+        colour = ColourMapA[w.colours[1]].mid_light;
         auto y = topLeft.y + (widget.height() - 1);
         gfx_fill_rect(dpi, { { cur_x, y }, { cur_x + width, y } }, colour + 5);
     }

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -657,7 +657,7 @@ static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widget
 static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex)
 {
     // Get the widget
-    int32_t scrollIndex = window_get_scroll_data_index(&w, widgetIndex);
+    int32_t scrollIndex = window_get_scroll_data_index(w, widgetIndex);
     const auto& widget = w.widgets[widgetIndex];
     const auto& scroll = w.scrolls[scrollIndex];
 

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -224,7 +224,7 @@ rct_window* WindowCreate(
         {
             if (!(w->flags & (WF_STICK_TO_BACK | WF_STICK_TO_FRONT | WF_NO_AUTO_CLOSE)))
             {
-                window_close(w.get());
+                window_close(*w.get());
                 break;
             }
         }
@@ -380,7 +380,7 @@ static void WindowScrollWheelInput(rct_window& w, int32_t scrollIndex, int32_t w
     }
 
     WidgetScrollUpdateThumbs(w, widgetIndex);
-    widget_invalidate(&w, widgetIndex);
+    widget_invalidate(w, widgetIndex);
 }
 
 /**
@@ -418,9 +418,9 @@ static void WindowViewportWheelInput(rct_window& w, int32_t wheel)
         return;
 
     if (wheel < 0)
-        window_zoom_in(&w, true);
+        window_zoom_in(w, true);
     else if (wheel > 0)
-        window_zoom_out(&w, true);
+        window_zoom_out(w, true);
 }
 
 static bool WindowOtherWheelInput(rct_window& w, rct_widgetindex widgetIndex, int32_t wheel)
@@ -537,7 +537,7 @@ void WindowAllWheelInput()
             }
 
             // Check scroll view, cursor is over
-            rct_widgetindex widgetIndex = window_find_widget_from_point(w, cursorState->position);
+            rct_widgetindex widgetIndex = window_find_widget_from_point(*w, cursorState->position);
             if (widgetIndex != -1)
             {
                 const auto& widget = w->widgets[widgetIndex];
@@ -686,7 +686,7 @@ static void WindowInvalidatePressedImageButton(const rct_window& w)
 void InvalidateAllWindowsAfterInput()
 {
     window_visit_each([](rct_window* w) {
-        window_update_scroll_widgets(w);
+        window_update_scroll_widgets(*w);
         WindowInvalidatePressedImageButton(*w);
         window_event_resize_call(w);
     });
@@ -714,7 +714,7 @@ void Window::InitScrollWidgets()
 
 void Window::InvalidateWidget(rct_widgetindex widgetIndex)
 {
-    widget_invalidate(this, widgetIndex);
+    widget_invalidate(*this, widgetIndex);
 }
 
 bool Window::IsWidgetDisabled(rct_widgetindex widgetIndex) const
@@ -749,7 +749,7 @@ void Window::DrawWidgets(rct_drawpixelinfo& dpi)
 
 void Window::Close()
 {
-    window_close(this);
+    window_close(*this);
 }
 
 void Window::TextInputOpen(

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -488,7 +488,7 @@ static bool WindowOtherWheelInput(rct_window& w, rct_widgetindex widgetIndex, in
             return false;
     }
 
-    if (WidgetIsDisabled(&w, buttonWidgetIndex))
+    if (WidgetIsDisabled(w, buttonWidgetIndex))
     {
         return false;
     }
@@ -674,7 +674,7 @@ static void WindowInvalidatePressedImageButton(const rct_window& w)
         if (widget->type != WindowWidgetType::ImgBtn)
             continue;
 
-        if (WidgetIsPressed(&w, widgetIndex) || WidgetIsActiveTool(&w, widgetIndex))
+        if (WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex))
             gfx_set_dirty_blocks({ w.windowPos, w.windowPos + ScreenCoordsXY{ w.width, w.height } });
     }
 }
@@ -719,22 +719,22 @@ void Window::InvalidateWidget(rct_widgetindex widgetIndex)
 
 bool Window::IsWidgetDisabled(rct_widgetindex widgetIndex) const
 {
-    return WidgetIsDisabled(this, widgetIndex);
+    return WidgetIsDisabled(*this, widgetIndex);
 }
 
 bool Window::IsWidgetPressed(rct_widgetindex widgetIndex) const
 {
-    return WidgetIsPressed(this, widgetIndex);
+    return WidgetIsPressed(*this, widgetIndex);
 }
 
 void Window::SetWidgetDisabled(rct_widgetindex widgetIndex, bool value)
 {
-    WidgetSetDisabled(this, widgetIndex, value);
+    WidgetSetDisabled(*this, widgetIndex, value);
 }
 
 void Window::SetWidgetPressed(rct_widgetindex widgetIndex, bool value)
 {
-    WidgetSetPressed(this, widgetIndex, value);
+    WidgetSetPressed(*this, widgetIndex, value);
 }
 
 void Window::SetCheckboxValue(rct_widgetindex widgetIndex, bool value)
@@ -766,7 +766,7 @@ void window_align_tabs(rct_window* w, rct_widgetindex start_tab_id, rct_widgetin
 
     for (i = start_tab_id; i <= end_tab_id; i++)
     {
-        if (!WidgetIsDisabled(w, i))
+        if (!WidgetIsDisabled(*w, i))
         {
             auto& widget = w->widgets[i];
             widget.left = x;

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -379,7 +379,7 @@ static void WindowScrollWheelInput(rct_window& w, int32_t scrollIndex, int32_t w
         scroll.h_left = std::min(std::max(0, scroll.h_left + wheel), size);
     }
 
-    WidgetScrollUpdateThumbs(&w, widgetIndex);
+    WidgetScrollUpdateThumbs(w, widgetIndex);
     widget_invalidate(&w, widgetIndex);
 }
 
@@ -607,7 +607,7 @@ void WindowInitScrollWidgets(rct_window& w)
         if (widget->content & SCROLL_VERTICAL)
             scroll.flags |= VSCROLLBAR_VISIBLE;
 
-        WidgetScrollUpdateThumbs(&w, widget_index);
+        WidgetScrollUpdateThumbs(w, widget_index);
 
         widget_index++;
         scroll_index++;
@@ -640,7 +640,7 @@ void WindowDrawWidgets(rct_window& w, rct_drawpixelinfo* dpi)
                 if (w.windowPos.y + widget->top < dpi->y + dpi->height && w.windowPos.y + widget->bottom >= dpi->y)
                 {
                     if (w.IsLegacy())
-                        WidgetDraw(dpi, &w, widgetIndex);
+                        WidgetDraw(dpi, w, widgetIndex);
                     else
                         w.OnDrawWidget(widgetIndex, *dpi);
                 }
@@ -704,7 +704,7 @@ void Window::OnDraw(rct_drawpixelinfo& dpi)
 
 void Window::OnDrawWidget(rct_widgetindex widgetIndex, rct_drawpixelinfo& dpi)
 {
-    WidgetDraw(&dpi, this, widgetIndex);
+    WidgetDraw(&dpi, *this, widgetIndex);
 }
 
 void Window::InitScrollWidgets()

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -255,7 +255,7 @@ void CustomListView::SetColumns(const std::vector<ListViewColumn>& columns, bool
     SortItems(0, ColumnSortOrder::None);
     if (!initialising)
     {
-        window_update_scroll_widgets(ParentWindow);
+        window_update_scroll_widgets(*ParentWindow);
         Invalidate();
     }
 }
@@ -272,7 +272,7 @@ void CustomListView::SetItems(const std::vector<ListViewItem>& items, bool initi
     SortItems(0, ColumnSortOrder::None);
     if (!initialising)
     {
-        window_update_scroll_widgets(ParentWindow);
+        window_update_scroll_widgets(*ParentWindow);
         Invalidate();
     }
 }
@@ -283,7 +283,7 @@ void CustomListView::SetItems(std::vector<ListViewItem>&& items, bool initialisi
     SortItems(0, ColumnSortOrder::None);
     if (!initialising)
     {
-        window_update_scroll_widgets(ParentWindow);
+        window_update_scroll_widgets(*ParentWindow);
         Invalidate();
     }
 }

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -237,7 +237,7 @@ void CustomListView::SetScrollbars(ScrollbarType value, bool initialising)
             else
                 widget->content = 0;
         }
-        WindowInitScrollWidgets(ParentWindow);
+        WindowInitScrollWidgets(*ParentWindow);
         Invalidate();
     }
 }

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -469,7 +469,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 if (widget->type == WindowWidgetType::Scroll)
                 {
-                    WidgetScrollUpdateThumbs(this, widgetIndex);
+                    WidgetScrollUpdateThumbs(*this, widgetIndex);
                 }
                 widgetIndex++;
             }

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -666,7 +666,7 @@ namespace OpenRCT2::Ui::Windows
                 else if (widgetDesc->Type == "textbox")
                 {
                     auto* text = const_cast<char*>(widgetDesc->Text.c_str());
-                    window_start_textbox(this, widgetIndex, STR_STRING, text, widgetDesc->MaxLength + 1);
+                    window_start_textbox(*this, widgetIndex, STR_STRING, text, widgetDesc->MaxLength + 1);
                 }
             }
         }

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -536,7 +536,7 @@ namespace OpenRCT2::Ui::Windows
             if (viewport != nullptr)
             {
                 auto widgetIndex = GetViewportWidgetIndex();
-                if (WidgetIsVisible(this, widgetIndex.value_or(false)))
+                if (WidgetIsVisible(*this, widgetIndex.value_or(false)))
                 {
                     window_draw_viewport(&dpi, this);
                 }
@@ -602,7 +602,7 @@ namespace OpenRCT2::Ui::Windows
                             widget.flags ^= WIDGET_FLAGS::IS_PRESSED;
                             bool isChecked = widget.flags & WIDGET_FLAGS::IS_PRESSED;
 
-                            WidgetSetCheckboxValue(this, widgetIndex, isChecked);
+                            WidgetSetCheckboxValue(*this, widgetIndex, isChecked);
 
                             std::vector<DukValue> args;
                             auto ctx = widgetDesc->OnChange.context();
@@ -858,7 +858,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 auto widgetIndex = static_cast<rct_widgetindex>(WIDX_TAB_0 + tabIndex);
                 auto widget = &widgets[widgetIndex];
-                if (WidgetIsVisible(this, widgetIndex))
+                if (WidgetIsVisible(*this, widgetIndex))
                 {
                     auto leftTop = windowPos + tab.offset + ScreenCoordsXY{ widget->left, widget->top };
                     auto image = tab.imageFrameBase;

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -456,7 +456,7 @@ namespace OpenRCT2::Ui::Windows
                     {
                         frame_no = 0;
                     }
-                    widget_invalidate(this, WIDX_TAB_0 + this->page);
+                    widget_invalidate(*this, WIDX_TAB_0 + this->page);
                 }
             }
 
@@ -538,7 +538,7 @@ namespace OpenRCT2::Ui::Windows
                 auto widgetIndex = GetViewportWidgetIndex();
                 if (WidgetIsVisible(*this, widgetIndex.value_or(false)))
                 {
-                    window_draw_viewport(&dpi, this);
+                    window_draw_viewport(&dpi, *this);
                 }
             }
         }
@@ -577,7 +577,7 @@ namespace OpenRCT2::Ui::Windows
             switch (widgetIndex)
             {
                 case WIDX_CLOSE:
-                    window_close(this);
+                    window_close(*this);
                     break;
                 default:
                 {
@@ -1196,7 +1196,7 @@ namespace OpenRCT2::Ui::Windows
             {
                 customWidgetInfo->Text = value;
                 w->widgets[widgetIndex].string = customWidgetInfo->Text.data();
-                widget_invalidate(w, widgetIndex);
+                widget_invalidate(*w, widgetIndex);
             }
         }
     }
@@ -1230,7 +1230,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     customWidgetInfo->Colour = colour;
                     widget.image = GetColourButtonImage(colour);
-                    widget_invalidate(w, widgetIndex);
+                    widget_invalidate(*w, widgetIndex);
 
                     std::vector<DukValue> args;
                     auto ctx = customWidgetInfo->OnChange.context();
@@ -1275,7 +1275,7 @@ namespace OpenRCT2::Ui::Windows
                 }
                 customWidgetInfo->SelectedIndex = selectedIndex;
 
-                widget_invalidate(w, widgetIndex);
+                widget_invalidate(*w, widgetIndex);
 
                 if (lastSelectedIndex != selectedIndex)
                 {
@@ -1399,7 +1399,7 @@ namespace OpenRCT2::Ui::Windows
         if (w->custom_info != nullptr)
         {
             auto& info = GetInfo(w);
-            auto scrollIndex = window_get_scroll_data_index(w, widgetIndex);
+            auto scrollIndex = window_get_scroll_data_index(*w, widgetIndex);
             if (scrollIndex < static_cast<int32_t>(info.ListViews.size()))
             {
                 return &info.ListViews[scrollIndex];
@@ -1454,7 +1454,7 @@ namespace OpenRCT2::Ui::Windows
 
         for (auto& window : customWindows)
         {
-            window_close(window.get());
+            window_close(*window.get());
         }
     }
 

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -531,7 +531,7 @@ namespace OpenRCT2::Ui::Windows
 
         void OnDraw(rct_drawpixelinfo& dpi) override
         {
-            WindowDrawWidgets(this, &dpi);
+            WindowDrawWidgets(*this, &dpi);
             DrawTabImages(dpi);
             if (viewport != nullptr)
             {
@@ -829,7 +829,7 @@ namespace OpenRCT2::Ui::Windows
             Invalidate();
             window_event_resize_call(this);
             window_event_invalidate_call(this);
-            WindowInitScrollWidgets(this);
+            WindowInitScrollWidgets(*this);
             Invalidate();
 
             InvokeEventHandler(info.Owner, info.Desc.OnTabChange);
@@ -950,7 +950,7 @@ namespace OpenRCT2::Ui::Windows
             widgetList.push_back(WIDGETS_END);
             widgets = widgetList.data();
 
-            WindowInitScrollWidgets(this);
+            WindowInitScrollWidgets(*this);
             UpdateViewport();
         }
 

--- a/src/openrct2-ui/scripting/ScViewport.hpp
+++ b/src/openrct2-ui/scripting/ScViewport.hpp
@@ -122,7 +122,7 @@ namespace OpenRCT2::Scripting
                 {
                     while (get_current_rotation() != value)
                     {
-                        window_rotate_camera(w, 1);
+                        window_rotate_camera(*w, 1);
                     }
                 }
             }
@@ -143,7 +143,7 @@ namespace OpenRCT2::Scripting
             if (w != nullptr)
             {
                 auto i8Value = static_cast<int8_t>(value);
-                window_zoom_set(w, ZoomLevel{ i8Value }, false);
+                window_zoom_set(*w, ZoomLevel{ i8Value }, false);
             }
         }
 
@@ -220,7 +220,7 @@ namespace OpenRCT2::Scripting
                 auto coords = GetCoordsFromObject(position);
                 if (coords)
                 {
-                    window_scroll_to_location(w, *coords);
+                    window_scroll_to_location(*w, *coords);
                 }
             }
         }

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -296,7 +296,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                return WidgetIsDisabled(w, _widgetIndex);
+                return WidgetIsDisabled(*w, _widgetIndex);
             }
             return false;
         }
@@ -305,19 +305,19 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                WidgetSetDisabled(w, _widgetIndex, value);
+                WidgetSetDisabled(*w, _widgetIndex, value);
 
                 auto widget = GetWidget();
                 if (widget != nullptr)
                 {
                     if (widget->type == WindowWidgetType::DropdownMenu)
                     {
-                        WidgetSetDisabled(w, _widgetIndex + 1, value);
+                        WidgetSetDisabled(*w, _widgetIndex + 1, value);
                     }
                     else if (widget->type == WindowWidgetType::Spinner)
                     {
-                        WidgetSetDisabled(w, _widgetIndex + 1, value);
-                        WidgetSetDisabled(w, _widgetIndex + 2, value);
+                        WidgetSetDisabled(*w, _widgetIndex + 1, value);
+                        WidgetSetDisabled(*w, _widgetIndex + 2, value);
                     }
                 }
             }
@@ -328,7 +328,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                return WidgetIsVisible(w, _widgetIndex);
+                return WidgetIsVisible(*w, _widgetIndex);
             }
             return false;
         }
@@ -337,19 +337,19 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                WidgetSetVisible(w, _widgetIndex, value);
+                WidgetSetVisible(*w, _widgetIndex, value);
 
                 auto widget = GetWidget();
                 if (widget != nullptr)
                 {
                     if (widget->type == WindowWidgetType::DropdownMenu)
                     {
-                        WidgetSetVisible(w, _widgetIndex + 1, value);
+                        WidgetSetVisible(*w, _widgetIndex + 1, value);
                     }
                     else if (widget->type == WindowWidgetType::Spinner)
                     {
-                        WidgetSetVisible(w, _widgetIndex + 1, value);
-                        WidgetSetVisible(w, _widgetIndex + 2, value);
+                        WidgetSetVisible(*w, _widgetIndex + 1, value);
+                        WidgetSetVisible(*w, _widgetIndex + 2, value);
                     }
                 }
             }
@@ -460,7 +460,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                return WidgetIsPressed(w, _widgetIndex);
+                return WidgetIsPressed(*w, _widgetIndex);
             }
             return false;
         }
@@ -469,7 +469,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                WidgetSetCheckboxValue(w, _widgetIndex, value ? 1 : 0);
+                WidgetSetCheckboxValue(*w, _widgetIndex, value ? 1 : 0);
                 Invalidate();
             }
         }
@@ -514,7 +514,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                return WidgetIsPressed(w, _widgetIndex);
+                return WidgetIsPressed(*w, _widgetIndex);
             }
             return false;
         }
@@ -523,7 +523,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                WidgetSetCheckboxValue(w, _widgetIndex, value ? 1 : 0);
+                WidgetSetCheckboxValue(*w, _widgetIndex, value ? 1 : 0);
                 Invalidate();
             }
         }

--- a/src/openrct2-ui/scripting/ScWindow.hpp
+++ b/src/openrct2-ui/scripting/ScWindow.hpp
@@ -307,7 +307,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                window_bring_to_front(w);
+                window_bring_to_front(*w);
                 w->flags |= WF_WHITE_BORDER_MASK;
             }
         }

--- a/src/openrct2-ui/scripting/ScWindow.hpp
+++ b/src/openrct2-ui/scripting/ScWindow.hpp
@@ -65,7 +65,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                window_set_position(w, { value, w->windowPos.y });
+                window_set_position(*w, { value, w->windowPos.y });
             }
         }
         int32_t y_get() const
@@ -82,7 +82,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                window_set_position(w, { w->windowPos.x, value });
+                window_set_position(*w, { w->windowPos.x, value });
             }
         }
         int32_t width_get() const
@@ -99,7 +99,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                window_resize(w, value - w->width, 0);
+                window_resize(*w, value - w->width, 0);
             }
         }
         int32_t height_get() const
@@ -116,7 +116,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                window_resize(w, 0, value - w->height);
+                window_resize(*w, 0, value - w->height);
             }
         }
         int32_t minWidth_get() const
@@ -133,7 +133,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                window_set_resize(w, value, w->min_height, w->max_width, w->max_height);
+                window_set_resize(*w, value, w->min_height, w->max_width, w->max_height);
             }
         }
         int32_t maxWidth_get() const
@@ -150,7 +150,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                window_set_resize(w, w->min_width, w->min_height, value, w->max_height);
+                window_set_resize(*w, w->min_width, w->min_height, value, w->max_height);
             }
         }
         int32_t minHeight_get() const
@@ -167,7 +167,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                window_set_resize(w, w->min_width, value, w->max_width, w->max_height);
+                window_set_resize(*w, w->min_width, value, w->max_width, w->max_height);
             }
         }
         int32_t maxHeight_get() const
@@ -184,7 +184,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                window_set_resize(w, w->min_width, w->min_height, w->max_width, value);
+                window_set_resize(*w, w->min_width, w->min_height, w->max_width, value);
             }
         }
         bool isSticky_get() const
@@ -283,7 +283,7 @@ namespace OpenRCT2::Scripting
             auto w = GetWindow();
             if (w != nullptr)
             {
-                window_close(w);
+                window_close(*w);
             }
         }
 

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -94,7 +94,7 @@ public:
     {
         widgets = _windowAboutOpenRCT2Widgets;
 
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         SetPage(WINDOW_ABOUT_PAGE_OPENRCT2);
     }
 
@@ -171,7 +171,7 @@ private:
         widgets = _windowAboutPageWidgets[p];
 
         pressed_widgets |= (p == WINDOW_ABOUT_PAGE_RCT2) ? (1ULL << WIDX_TAB_ABOUT_RCT2) : (1ULL << WIDX_TAB_ABOUT_OPENRCT2);
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         Invalidate();
     }
 

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -126,7 +126,7 @@ public:
     void OnOpen() override
     {
         widgets = window_banner_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
     }
 
     void Initialise(rct_windownumber _number)

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -260,7 +260,7 @@ public:
 
         if (viewport != nullptr)
         {
-            window_draw_viewport(&dpi, this);
+            window_draw_viewport(&dpi, *this);
         }
     }
 

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -111,7 +111,7 @@ public:
     {
         widgets = _windowChangelogWidgets;
 
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         min_width = MIN_WW;
         min_height = MIN_WH;
         max_width = MIN_WW;

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -430,7 +430,7 @@ public:
         if (widgets != targetWidgets)
         {
             widgets = targetWidgets;
-            WindowInitScrollWidgets(this);
+            WindowInitScrollWidgets(*this);
         }
 
         pressed_widgets = 0;

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -66,7 +66,7 @@ public:
         widgets = window_clear_scenery_widgets;
         hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
         WindowInitScrollWidgets(*this);
-        window_push_others_below(this);
+        window_push_others_below(*this);
 
         gLandToolSize = 2;
         gClearSceneryCost = MONEY64_UNDEFINED;

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -65,7 +65,7 @@ public:
     {
         widgets = window_clear_scenery_widgets;
         hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         window_push_others_below(this);
 
         gLandToolSize = 2;

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -53,7 +53,7 @@ public:
     {
         widgets = window_custom_currency_widgets;
         hold_down_widgets = (1ULL << WIDX_RATE_UP) | (1ULL << WIDX_RATE_DOWN);
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         colours[0] = COLOUR_LIGHT_BROWN;
         colours[1] = COLOUR_LIGHT_BROWN;
         colours[2] = COLOUR_LIGHT_BROWN;

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -55,7 +55,7 @@ public:
         widgets = window_debug_paint_widgets;
 
         InitScrollWidgets();
-        window_push_others_below(this);
+        window_push_others_below(*this);
 
         colours[0] = TRANSLUCENT(COLOUR_BLACK);
         colours[1] = COLOUR_GREY;

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -130,11 +130,11 @@ public:
             Invalidate();
         }
 
-        WidgetSetCheckboxValue(this, WIDX_TOGGLE_SHOW_WIDE_PATHS, gPaintWidePathsAsGhost);
-        WidgetSetCheckboxValue(this, WIDX_TOGGLE_SHOW_BLOCKED_TILES, gPaintBlockedTiles);
-        WidgetSetCheckboxValue(this, WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS, gShowSupportSegmentHeights);
-        WidgetSetCheckboxValue(this, WIDX_TOGGLE_SHOW_BOUND_BOXES, gPaintBoundingBoxes);
-        WidgetSetCheckboxValue(this, WIDX_TOGGLE_SHOW_DIRTY_VISUALS, gShowDirtyVisuals);
+        WidgetSetCheckboxValue(*this, WIDX_TOGGLE_SHOW_WIDE_PATHS, gPaintWidePathsAsGhost);
+        WidgetSetCheckboxValue(*this, WIDX_TOGGLE_SHOW_BLOCKED_TILES, gPaintBlockedTiles);
+        WidgetSetCheckboxValue(*this, WIDX_TOGGLE_SHOW_SEGMENT_HEIGHTS, gShowSupportSegmentHeights);
+        WidgetSetCheckboxValue(*this, WIDX_TOGGLE_SHOW_BOUND_BOXES, gPaintBoundingBoxes);
+        WidgetSetCheckboxValue(*this, WIDX_TOGGLE_SHOW_DIRTY_VISUALS, gShowDirtyVisuals);
     }
 
     void OnDraw(rct_drawpixelinfo& dpi) override

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -53,7 +53,7 @@ public:
     void OnOpen() override
     {
         widgets = window_ride_demolish_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
     }
 
     void OnMouseUp(rct_widgetindex widgetIndex) override
@@ -75,7 +75,7 @@ public:
 
     void OnDraw(rct_drawpixelinfo& dpi) override
     {
-        WindowDrawWidgets(this, &dpi);
+        WindowDrawWidgets(*this, &dpi);
 
         auto currentRide = get_ride(rideId);
         if (currentRide != nullptr)

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -100,7 +100,7 @@ rct_window* WindowRideDemolishPromptOpen(Ride* ride)
     if (w != nullptr)
     {
         auto windowPos = w->windowPos;
-        window_close(w);
+        window_close(*w);
         newWindow = WindowCreate<DemolishRidePromptWindow>(WC_DEMOLISH_RIDE_PROMPT, windowPos, WW, WH, WF_TRANSPARENT);
     }
     else

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -665,7 +665,7 @@ public:
         width = stringWidth;
         Invalidate();
 
-        InputWindowPositionBegin(this, 0, gTooltipCursor);
+        InputWindowPositionBegin(*this, 0, gTooltipCursor);
     }
 
     const ResearchItem& GetItem() const

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -199,7 +199,7 @@ public:
     {
         frame_no++;
         OnPrepareDraw();
-        widget_invalidate(this, WIDX_TAB_1);
+        widget_invalidate(*this, WIDX_TAB_1);
 
         if (WindowEditorInventionsListDragGetItem() != nullptr)
             return;
@@ -483,7 +483,7 @@ public:
         if (windowPos.x <= screenCoords.x && windowPos.y < screenCoords.y && windowPos.x + width > screenCoords.x
             && windowPos.y + height > screenCoords.y)
         {
-            rct_widgetindex widgetIndex = window_find_widget_from_point(this, screenCoords);
+            rct_widgetindex widgetIndex = window_find_widget_from_point(*this, screenCoords);
             auto& widget = widgets[widgetIndex];
             if (widgetIndex == WIDX_PRE_RESEARCHED_SCROLL || widgetIndex == WIDX_RESEARCH_ORDER_SCROLL)
             {

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -491,7 +491,7 @@ public:
                 int32_t outScrollArea{};
                 ScreenCoordsXY outScrollCoords{};
                 int32_t outScrollId{};
-                WidgetScrollGetPart(this, &widget, screenCoords, outScrollCoords, &outScrollArea, &outScrollId);
+                WidgetScrollGetPart(*this, &widget, screenCoords, outScrollCoords, &outScrollArea, &outScrollId);
                 if (outScrollArea == SCROLL_PART_VIEW)
                 {
                     const auto isInvented = outScrollId == 0;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -272,7 +272,7 @@ public:
         _filter_flags = gConfigInterface.object_selection_filter_flags;
         std::fill_n(_filter_string, sizeof(_filter_string), 0x00);
 
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
 
         selected_tab = 0;
         selected_list_item = -1;

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -327,7 +327,7 @@ public:
         if (gCurrentTextBox.window.classification == classification && gCurrentTextBox.window.number == number)
         {
             window_update_textbox_caret();
-            widget_invalidate(this, WIDX_FILTER_TEXT_BOX);
+            widget_invalidate(*this, WIDX_FILTER_TEXT_BOX);
         }
 
         for (rct_widgetindex i = WIDX_FILTER_RIDE_TAB_TRANSPORT; i <= WIDX_FILTER_RIDE_TAB_STALL; i++)
@@ -339,7 +339,7 @@ public:
             if (frame_no >= window_editor_object_selection_animation_loops[i - WIDX_FILTER_RIDE_TAB_TRANSPORT])
                 frame_no = 0;
 
-            widget_invalidate(this, i);
+            widget_invalidate(*this, i);
             break;
         }
     }
@@ -353,7 +353,7 @@ public:
         switch (widgetIndex)
         {
             case WIDX_CLOSE:
-                window_close(this);
+                window_close(*this);
                 if (gScreenFlags & SCREEN_FLAGS_EDITOR)
                 {
                     finish_object_selection();
@@ -461,7 +461,7 @@ public:
 
     void OnResize() override
     {
-        window_set_resize(this, WW, WH, 1200, 1000);
+        window_set_resize(*this, WW, WH, 1200, 1000);
     }
 
     void OnMouseDown(rct_widgetindex widgetIndex) override
@@ -601,7 +601,7 @@ public:
 
             // Close any other open windows such as options/colour schemes to prevent a crash.
             window_close_all();
-            // window_close(w);
+            // window_close(*w);
 
             // This function calls window_track_list_open
             ManageTracks();

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -416,7 +416,7 @@ public:
                 break;
             }
             case WIDX_FILTER_TEXT_BOX:
-                window_start_textbox(this, widgetIndex, STR_STRING, _filter_string, sizeof(_filter_string));
+                window_start_textbox(*this, widgetIndex, STR_STRING, _filter_string, sizeof(_filter_string));
                 break;
             case WIDX_FILTER_CLEAR_BUTTON:
                 std::fill_n(_filter_string, sizeof(_filter_string), 0x00);

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -206,7 +206,7 @@ rct_window* WindowEditorObjectiveOptionsOpen()
     w->widgets = window_editor_objective_options_main_widgets;
     w->pressed_widgets = 0;
     w->hold_down_widgets = window_editor_objective_options_page_hold_down_widgets[WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN];
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->selected_tab = WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN;
     w->no_list_items = 0;
     w->selected_list_item = -1;
@@ -281,7 +281,7 @@ static void WindowEditorObjectiveOptionsSetPage(rct_window* w, int32_t page)
     WindowEditorObjectiveOptionsUpdateDisabledWidgets(w);
     window_event_resize_call(w);
     window_event_invalidate_call(w);
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->Invalidate();
 }
 
@@ -717,7 +717,7 @@ static void WindowEditorObjectiveOptionsMainInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowEditorObjectiveOptionsSetPressedTab(w);
@@ -772,7 +772,7 @@ static void WindowEditorObjectiveOptionsMainPaint(rct_window* w, rct_drawpixelin
     int32_t width;
     rct_string_id stringId;
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowEditorObjectiveOptionsDrawTabImages(w, dpi);
 
     // Objective label
@@ -1026,7 +1026,7 @@ static void WindowEditorObjectiveOptionsRidesInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowEditorObjectiveOptionsSetPressedTab(w);
@@ -1044,7 +1044,7 @@ static void WindowEditorObjectiveOptionsRidesInvalidate(rct_window* w)
  */
 static void WindowEditorObjectiveOptionsRidesPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowEditorObjectiveOptionsDrawTabImages(w, dpi);
 
     DrawTextBasic(

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -340,7 +340,7 @@ static void WindowEditorObjectiveOptionsMainMouseup(rct_window* w, rct_widgetind
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -372,7 +372,7 @@ static void WindowEditorObjectiveOptionsMainMouseup(rct_window* w, rct_widgetind
  */
 static void WindowEditorObjectiveOptionsMainResize(rct_window* w)
 {
-    window_set_resize(w, 450, 229, 450, 229);
+    window_set_resize(*w, 450, 229, 450, 229);
 }
 
 static void WindowEditorObjectiveOptionsShowObjectiveDropdown(rct_window* w)
@@ -656,7 +656,7 @@ static void WindowEditorObjectiveOptionsMainUpdate(rct_window* w)
 
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_1);
+    widget_invalidate(*w, WIDX_TAB_1);
 
     parkFlags = gParkFlags;
     objectiveType = gScenarioObjective.Type;
@@ -918,7 +918,7 @@ static void WindowEditorObjectiveOptionsRidesMouseup(rct_window* w, rct_widgetin
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -933,7 +933,7 @@ static void WindowEditorObjectiveOptionsRidesMouseup(rct_window* w, rct_widgetin
  */
 static void WindowEditorObjectiveOptionsRidesResize(rct_window* w)
 {
-    window_set_resize(w, 380, 224, 380, 224);
+    window_set_resize(*w, 380, 224, 380, 224);
 }
 
 /**
@@ -945,7 +945,7 @@ static void WindowEditorObjectiveOptionsRidesUpdate(rct_window* w)
     w->frame_no++;
     window_event_invalidate_call(w);
     window_event_resize_call(w);
-    widget_invalidate(w, WIDX_TAB_2);
+    widget_invalidate(*w, WIDX_TAB_2);
 
     auto numItems = 0;
     for (auto& ride : GetRideManager())

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -249,7 +249,7 @@ static void WindowEditorObjectiveOptionsDrawTabImages(rct_window* w, rct_drawpix
     gfx_draw_sprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget->left, widget->top });
 
     // Tab 2
-    if (!WidgetIsDisabled(w, WIDX_TAB_2))
+    if (!WidgetIsDisabled(*w, WIDX_TAB_2))
     {
         widget = &w->widgets[WIDX_TAB_2];
         spriteIndex = SPR_TAB_RIDE_0;

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -289,7 +289,7 @@ rct_window* WindowEditorScenarioOptionsOpen()
         280, 148, window_editor_scenario_options_page_events[0], WC_EDITOR_SCENARIO_OPTIONS, WF_NO_SCROLLING);
     w->widgets = window_editor_scenario_options_widgets[0];
     w->hold_down_widgets = window_editor_scenario_options_page_hold_down_widgets[0];
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->page = 0;
 
     return w;
@@ -363,7 +363,7 @@ static void WindowEditorScenarioOptionsSetPage(rct_window* w, int32_t page)
     w->Invalidate();
     window_event_resize_call(w);
     window_event_invalidate_call(w);
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->Invalidate();
 }
 
@@ -568,7 +568,7 @@ static void WindowEditorScenarioOptionsFinancialInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowEditorScenarioOptionsSetPressedTab(w);
@@ -616,7 +616,7 @@ static void WindowEditorScenarioOptionsFinancialPaint(rct_window* w, rct_drawpix
 {
     ScreenCoordsXY screenCoords{};
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowEditorScenarioOptionsDrawTabImages(w, dpi);
 
     const auto& initialCashWidget = w->widgets[WIDX_INITIAL_CASH];
@@ -855,7 +855,7 @@ static void WindowEditorScenarioOptionsGuestsInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowEditorScenarioOptionsSetPressedTab(w);
@@ -899,7 +899,7 @@ static void WindowEditorScenarioOptionsGuestsPaint(rct_window* w, rct_drawpixeli
 {
     ScreenCoordsXY screenCoords{};
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowEditorScenarioOptionsDrawTabImages(w, dpi);
 
     const auto& cashPerGuestWidget = w->widgets[WIDX_CASH_PER_GUEST];
@@ -1190,7 +1190,7 @@ static void WindowEditorScenarioOptionsParkInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowEditorScenarioOptionsSetPressedTab(w);
@@ -1260,7 +1260,7 @@ static void WindowEditorScenarioOptionsParkPaint(rct_window* w, rct_drawpixelinf
 {
     ScreenCoordsXY screenCoords{};
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowEditorScenarioOptionsDrawTabImages(w, dpi);
 
     const auto& landCostWidget = w->widgets[WIDX_LAND_COST];

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -378,7 +378,7 @@ static void WindowEditorScenarioOptionsFinancialMouseup(rct_window* w, rct_widge
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -410,7 +410,7 @@ static void WindowEditorScenarioOptionsFinancialMouseup(rct_window* w, rct_widge
  */
 static void WindowEditorScenarioOptionsFinancialResize(rct_window* w)
 {
-    window_set_resize(w, 280, 149, 280, 149);
+    window_set_resize(*w, 280, 149, 280, 149);
 }
 
 static void WindowEditorScenarioOptionsShowClimateDropdown(rct_window* w)
@@ -555,7 +555,7 @@ static void WindowEditorScenarioOptionsFinancialUpdate(rct_window* w)
 {
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_1);
+    widget_invalidate(*w, WIDX_TAB_1);
 }
 
 /**
@@ -682,7 +682,7 @@ static void WindowEditorScenarioOptionsGuestsMouseup(rct_window* w, rct_widgetin
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -714,7 +714,7 @@ static void WindowEditorScenarioOptionsGuestsMouseup(rct_window* w, rct_widgetin
  */
 static void WindowEditorScenarioOptionsGuestsResize(rct_window* w)
 {
-    window_set_resize(w, 380, 149, 380, 149);
+    window_set_resize(*w, 380, 149, 380, 149);
 }
 
 /**
@@ -840,7 +840,7 @@ static void WindowEditorScenarioOptionsGuestsUpdate(rct_window* w)
 {
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_2);
+    widget_invalidate(*w, WIDX_TAB_2);
 }
 
 /**
@@ -963,7 +963,7 @@ static void WindowEditorScenarioOptionsParkMouseup(rct_window* w, rct_widgetinde
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -1020,7 +1020,7 @@ static void WindowEditorScenarioOptionsParkMouseup(rct_window* w, rct_widgetinde
  */
 static void WindowEditorScenarioOptionsParkResize(rct_window* w)
 {
-    window_set_resize(w, 400, 200, 400, 200);
+    window_set_resize(*w, 400, 200, 400, 200);
 }
 
 /**
@@ -1175,7 +1175,7 @@ static void WindowEditorScenarioOptionsParkUpdate(rct_window* w)
 {
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_3);
+    widget_invalidate(*w, WIDX_TAB_3);
 }
 
 /**

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -128,7 +128,7 @@ static void WindowErrorUnknown5(rct_window* w)
 {
     w->error.var_480++;
     if (w->error.var_480 >= 8)
-        window_close(w);
+        window_close(*w);
 }
 
 /**

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -983,7 +983,7 @@ public:
         const auto& widget = this->widgets[widgetIndex];
         scrolls[scrollId].h_left = std::max(0, scrolls[scrollId].h_right - (widget.width() - 2));
 
-        WidgetScrollUpdateThumbs(this, widgetIndex);
+        WidgetScrollUpdateThumbs(*this, widgetIndex);
     }
 
     void DrawTabImage(rct_drawpixelinfo& dpi, int32_t tabPage, int32_t spriteIndex)

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -296,7 +296,7 @@ public:
         if (widgets != targetWidgets)
         {
             widgets = targetWidgets;
-            WindowInitScrollWidgets(this);
+            WindowInitScrollWidgets(*this);
         }
 
         for (auto i = 0; i < WINDOW_FINANCES_PAGE_COUNT; i++)
@@ -464,7 +464,7 @@ public:
         window_event_resize_call(this);
         window_event_invalidate_call(this);
 
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
 
         // Scroll summary all the way to the right, initially.
         if (p == WINDOW_FINANCES_PAGE_SUMMARY)

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -639,7 +639,7 @@ static void WindowFootpathPaint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowDrawWidgets(*w, dpi);
     WindowFootpathDrawDropdownButtons(w, dpi);
 
-    if (!WidgetIsDisabled(w, WIDX_CONSTRUCT))
+    if (!WidgetIsDisabled(*w, WIDX_CONSTRUCT))
     {
         // Get construction image
         uint8_t direction = (_footpathConstructDirection + get_current_rotation()) % 4;
@@ -1380,8 +1380,8 @@ static PathConstructFlags FootpathCreateConstructFlags(ObjectEntryIndex& type)
 void window_footpath_keyboard_shortcut_turn_left()
 {
     rct_window* w = window_find_by_class(WC_FOOTPATH);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_DIRECTION_NW) || WidgetIsDisabled(w, WIDX_DIRECTION_NE)
-        || WidgetIsDisabled(w, WIDX_DIRECTION_SW) || WidgetIsDisabled(w, WIDX_DIRECTION_SE) || _footpathConstructionMode != 2)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_DIRECTION_NW) || WidgetIsDisabled(*w, WIDX_DIRECTION_NE)
+        || WidgetIsDisabled(*w, WIDX_DIRECTION_SW) || WidgetIsDisabled(*w, WIDX_DIRECTION_SE) || _footpathConstructionMode != 2)
     {
         return;
     }
@@ -1393,8 +1393,8 @@ void window_footpath_keyboard_shortcut_turn_left()
 void window_footpath_keyboard_shortcut_turn_right()
 {
     rct_window* w = window_find_by_class(WC_FOOTPATH);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_DIRECTION_NW) || WidgetIsDisabled(w, WIDX_DIRECTION_NE)
-        || WidgetIsDisabled(w, WIDX_DIRECTION_SW) || WidgetIsDisabled(w, WIDX_DIRECTION_SE) || _footpathConstructionMode != 2)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_DIRECTION_NW) || WidgetIsDisabled(*w, WIDX_DIRECTION_NE)
+        || WidgetIsDisabled(*w, WIDX_DIRECTION_SW) || WidgetIsDisabled(*w, WIDX_DIRECTION_SE) || _footpathConstructionMode != 2)
     {
         return;
     }
@@ -1406,8 +1406,8 @@ void window_footpath_keyboard_shortcut_turn_right()
 void window_footpath_keyboard_shortcut_slope_down()
 {
     rct_window* w = window_find_by_class(WC_FOOTPATH);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_SLOPEDOWN) || WidgetIsDisabled(w, WIDX_LEVEL)
-        || WidgetIsDisabled(w, WIDX_SLOPEUP) || w->widgets[WIDX_LEVEL].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_SLOPEDOWN) || WidgetIsDisabled(*w, WIDX_LEVEL)
+        || WidgetIsDisabled(*w, WIDX_SLOPEUP) || w->widgets[WIDX_LEVEL].type == WindowWidgetType::Empty)
     {
         return;
     }
@@ -1429,8 +1429,8 @@ void window_footpath_keyboard_shortcut_slope_down()
 void window_footpath_keyboard_shortcut_slope_up()
 {
     rct_window* w = window_find_by_class(WC_FOOTPATH);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_SLOPEDOWN) || WidgetIsDisabled(w, WIDX_LEVEL)
-        || WidgetIsDisabled(w, WIDX_SLOPEUP) || w->widgets[WIDX_LEVEL].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_SLOPEDOWN) || WidgetIsDisabled(*w, WIDX_LEVEL)
+        || WidgetIsDisabled(*w, WIDX_SLOPEUP) || w->widgets[WIDX_LEVEL].type == WindowWidgetType::Empty)
     {
         return;
     }
@@ -1452,7 +1452,7 @@ void window_footpath_keyboard_shortcut_slope_up()
 void window_footpath_keyboard_shortcut_demolish_current()
 {
     rct_window* w = window_find_by_class(WC_FOOTPATH);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_REMOVE) || w->widgets[WIDX_REMOVE].type == WindowWidgetType::Empty
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_REMOVE) || w->widgets[WIDX_REMOVE].type == WindowWidgetType::Empty
         || (!gCheatsBuildInPauseMode && game_is_paused()))
     {
         return;
@@ -1464,7 +1464,7 @@ void window_footpath_keyboard_shortcut_demolish_current()
 void window_footpath_keyboard_shortcut_build_current()
 {
     rct_window* w = window_find_by_class(WC_FOOTPATH);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_CONSTRUCT) || w->widgets[WIDX_CONSTRUCT].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_CONSTRUCT) || w->widgets[WIDX_CONSTRUCT].type == WindowWidgetType::Empty)
     {
         return;
     }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -208,7 +208,7 @@ rct_window* WindowFootpathOpen()
     window->widgets = window_footpath_widgets;
 
     WindowInitScrollWidgets(*window);
-    window_push_others_right(window);
+    window_push_others_right(*window);
     show_gridlines();
 
     tool_cancel();
@@ -244,7 +244,7 @@ static void WindowFootpathMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_CONSTRUCT:
             WindowFootpathConstruct();
@@ -466,7 +466,7 @@ static void WindowFootpathUpdateProvisionalPathForBridgeMode(rct_window* w)
         auto pathConstructFlags = FootpathCreateConstructFlags(type);
 
         _window_footpath_cost = footpath_provisional_set(type, railings, footpathLoc, slope, pathConstructFlags);
-        widget_invalidate(w, WIDX_CONSTRUCT);
+        widget_invalidate(*w, WIDX_CONSTRUCT);
     }
 
     auto curTime = Platform::GetTicks();
@@ -500,7 +500,7 @@ static void WindowFootpathUpdateProvisionalPathForBridgeMode(rct_window* w)
  */
 static void WindowFootpathUpdate(rct_window* w)
 {
-    widget_invalidate(w, WIDX_CONSTRUCT);
+    widget_invalidate(*w, WIDX_CONSTRUCT);
     WindowFootpathUpdateProvisionalPathForBridgeMode(w);
 
     // #2502: The camera might have changed rotation, so we need to update which directional buttons are pressed
@@ -516,30 +516,30 @@ static void WindowFootpathUpdate(rct_window* w)
     {
         if (!(input_test_flag(INPUT_FLAG_TOOL_ACTIVE)))
         {
-            window_close(w);
+            window_close(*w);
         }
         else if (gCurrentToolWidget.window_classification != WC_FOOTPATH)
         {
-            window_close(w);
+            window_close(*w);
         }
         else if (gCurrentToolWidget.widget_index != WIDX_CONSTRUCT_ON_LAND)
         {
-            window_close(w);
+            window_close(*w);
         }
     }
     else if (_footpathConstructionMode == PATH_CONSTRUCTION_MODE_BRIDGE_OR_TUNNEL_TOOL)
     {
         if (!(input_test_flag(INPUT_FLAG_TOOL_ACTIVE)))
         {
-            window_close(w);
+            window_close(*w);
         }
         else if (gCurrentToolWidget.window_classification != WC_FOOTPATH)
         {
-            window_close(w);
+            window_close(*w);
         }
         else if (gCurrentToolWidget.widget_index != WIDX_CONSTRUCT_BRIDGE_OR_TUNNEL)
         {
-            window_close(w);
+            window_close(*w);
         }
     }
 }

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -207,7 +207,7 @@ rct_window* WindowFootpathOpen()
     window = WindowCreate(ScreenCoordsXY(0, 29), WW, WH, &window_footpath_events, WC_FOOTPATH, 0);
     window->widgets = window_footpath_widgets;
 
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
     window_push_others_right(window);
     show_gridlines();
 
@@ -636,7 +636,7 @@ static void WindowFootpathDrawDropdownButtons(rct_window* w, rct_drawpixelinfo* 
 static void WindowFootpathPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     ScreenCoordsXY screenCoords;
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowFootpathDrawDropdownButtons(w, dpi);
 
     if (!WidgetIsDisabled(w, WIDX_CONSTRUCT))

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -178,7 +178,7 @@ static void WindowGameBottomToolbarMouseup(rct_window* w, rct_widgetindex widget
 
                 rct_window* mainWindow = window_get_main();
                 if (mainWindow != nullptr)
-                    window_scroll_to_location(mainWindow, subjectLoc.value());
+                    window_scroll_to_location(*mainWindow, subjectLoc.value());
             }
             break;
         case WIDX_RIGHT_OUTSET:
@@ -734,30 +734,30 @@ static void WindowGameBottomToolbarInvalidateDirtyWidgets(rct_window* w)
     if (gToolbarDirtyFlags & BTM_TB_DIRTY_FLAG_MONEY)
     {
         gToolbarDirtyFlags &= ~BTM_TB_DIRTY_FLAG_MONEY;
-        widget_invalidate(w, WIDX_LEFT_INSET);
+        widget_invalidate(*w, WIDX_LEFT_INSET);
     }
 
     if (gToolbarDirtyFlags & BTM_TB_DIRTY_FLAG_DATE)
     {
         gToolbarDirtyFlags &= ~BTM_TB_DIRTY_FLAG_DATE;
-        widget_invalidate(w, WIDX_RIGHT_INSET);
+        widget_invalidate(*w, WIDX_RIGHT_INSET);
     }
 
     if (gToolbarDirtyFlags & BTM_TB_DIRTY_FLAG_PEEP_COUNT)
     {
         gToolbarDirtyFlags &= ~BTM_TB_DIRTY_FLAG_PEEP_COUNT;
-        widget_invalidate(w, WIDX_LEFT_INSET);
+        widget_invalidate(*w, WIDX_LEFT_INSET);
     }
 
     if (gToolbarDirtyFlags & BTM_TB_DIRTY_FLAG_CLIMATE)
     {
         gToolbarDirtyFlags &= ~BTM_TB_DIRTY_FLAG_CLIMATE;
-        widget_invalidate(w, WIDX_RIGHT_INSET);
+        widget_invalidate(*w, WIDX_RIGHT_INSET);
     }
 
     if (gToolbarDirtyFlags & BTM_TB_DIRTY_FLAG_PARK_RATING)
     {
         gToolbarDirtyFlags &= ~BTM_TB_DIRTY_FLAG_PARK_RATING;
-        widget_invalidate(w, WIDX_LEFT_INSET);
+        widget_invalidate(*w, WIDX_LEFT_INSET);
     }
 }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -120,7 +120,7 @@ rct_window* WindowGameBottomToolbarOpen()
     window->widgets = window_game_bottom_toolbar_widgets;
 
     window->frame_no = 0;
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
 
     // Reset the middle widget to not show by default.
     // If it is required to be shown news_update will reshow it.
@@ -370,7 +370,7 @@ static void WindowGameBottomToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
         gfx_filter_rect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
     }
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     WindowGameBottomToolbarDrawLeftPanel(dpi, w);
     WindowGameBottomToolbarDrawRightPanel(dpi, w);

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -418,7 +418,7 @@ private:
         }
         maxWidth = std::max(minWidth, maxWidth);
 
-        window_set_resize(this, minWidth, minHeight, maxWidth, maxHeight);
+        window_set_resize(*this, minWidth, minHeight, maxWidth, maxHeight);
     }
 
     void OnPrepareDrawCommon()
@@ -586,7 +586,7 @@ private:
         DisableWidgets();
         OnPrepareDraw();
 
-        widget_invalidate(this, WIDX_MARQUEE);
+        widget_invalidate(*this, WIDX_MARQUEE);
 
         OnResizeCommon();
 
@@ -756,7 +756,7 @@ private:
         // Draw the viewport no sound sprite
         if (viewport != nullptr)
         {
-            window_draw_viewport(&dpi, this);
+            window_draw_viewport(&dpi, *this);
             if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
             {
                 gfx_draw_sprite(&dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
@@ -859,8 +859,8 @@ private:
         newAnimationFrame %= 24;
         _guestAnimationFrame = newAnimationFrame;
 
-        widget_invalidate(this, WIDX_TAB_1);
-        widget_invalidate(this, WIDX_TAB_2);
+        widget_invalidate(*this, WIDX_TAB_1);
+        widget_invalidate(*this, WIDX_TAB_2);
 
         const auto peep = GetGuest();
         if (peep == nullptr)
@@ -870,7 +870,7 @@ private:
         if (peep->WindowInvalidateFlags & PEEP_INVALIDATE_PEEP_ACTION)
         {
             peep->WindowInvalidateFlags &= ~PEEP_INVALIDATE_PEEP_ACTION;
-            widget_invalidate(this, WIDX_ACTION_LBL);
+            widget_invalidate(*this, WIDX_ACTION_LBL);
         }
 
         _marqueePosition += 2;
@@ -1229,8 +1229,8 @@ private:
     {
         frame_no++;
 
-        widget_invalidate(this, WIDX_TAB_2);
-        widget_invalidate(this, WIDX_TAB_3);
+        widget_invalidate(*this, WIDX_TAB_2);
+        widget_invalidate(*this, WIDX_TAB_3);
 
         const auto guest = GetGuest();
         if (guest == nullptr)
@@ -1404,8 +1404,8 @@ private:
     {
         frame_no++;
 
-        widget_invalidate(this, WIDX_TAB_2);
-        widget_invalidate(this, WIDX_TAB_4);
+        widget_invalidate(*this, WIDX_TAB_2);
+        widget_invalidate(*this, WIDX_TAB_4);
     }
 
     void OnDrawFinance(rct_drawpixelinfo& dpi)
@@ -1542,8 +1542,8 @@ private:
     {
         frame_no++;
 
-        widget_invalidate(this, WIDX_TAB_2);
-        widget_invalidate(this, WIDX_TAB_5);
+        widget_invalidate(*this, WIDX_TAB_2);
+        widget_invalidate(*this, WIDX_TAB_5);
 
         auto peep = GetGuest();
         if (peep == nullptr)
@@ -1617,8 +1617,8 @@ private:
     {
         frame_no++;
 
-        widget_invalidate(this, WIDX_TAB_2);
-        widget_invalidate(this, WIDX_TAB_6);
+        widget_invalidate(*this, WIDX_TAB_2);
+        widget_invalidate(*this, WIDX_TAB_6);
 
         auto peep = GetGuest();
         if (peep == nullptr)

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -697,7 +697,7 @@ private:
     void GuestFollow()
     {
         rct_window* main = window_get_main();
-        window_follow_sprite(main, EntityId::FromUnderlying(number));
+        window_follow_sprite(*main, EntityId::FromUnderlying(number));
     }
 
     void OnViewportRotateOverview()

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -411,7 +411,7 @@ private:
         // Ensure min size is large enough for all tabs to fit
         for (int32_t i = WIDX_TAB_1; i <= WIDX_TAB_7; i++)
         {
-            if (!WidgetIsDisabled(this, i))
+            if (!WidgetIsDisabled(*this, i))
             {
                 minWidth = std::max(minWidth, widgets[i].right + 3);
             }
@@ -461,13 +461,13 @@ private:
 
         if (peep->CanBePickedUp())
         {
-            if (WidgetIsDisabled(this, WIDX_PICKUP))
+            if (WidgetIsDisabled(*this, WIDX_PICKUP))
                 Invalidate();
         }
         else
         {
             newDisabledWidgets = (1ULL << WIDX_PICKUP);
-            if (!WidgetIsDisabled(this, WIDX_PICKUP))
+            if (!WidgetIsDisabled(*this, WIDX_PICKUP))
                 Invalidate();
         }
         if (gParkFlags & PARK_FLAGS_NO_MONEY)
@@ -520,7 +520,7 @@ private:
 
     void OverviewTabDraw(rct_drawpixelinfo& dpi)
     {
-        if (WidgetIsDisabled(this, WIDX_TAB_1))
+        if (WidgetIsDisabled(*this, WIDX_TAB_1))
             return;
 
         const auto& widget = widgets[WIDX_TAB_1];
@@ -990,7 +990,7 @@ private:
 #pragma region Stats
     void StatsTabDraw(rct_drawpixelinfo& dpi)
     {
-        if (WidgetIsDisabled(this, WIDX_TAB_2))
+        if (WidgetIsDisabled(*this, WIDX_TAB_2))
             return;
 
         const auto& widget = widgets[WIDX_TAB_2];
@@ -1209,7 +1209,7 @@ private:
 #pragma region Rides
     void RidesTabDraw(rct_drawpixelinfo& dpi)
     {
-        if (WidgetIsDisabled(this, WIDX_TAB_3))
+        if (WidgetIsDisabled(*this, WIDX_TAB_3))
             return;
 
         const auto& widget = widgets[WIDX_TAB_3];
@@ -1384,7 +1384,7 @@ private:
 #pragma region Finance
     void FinanceTabDraw(rct_drawpixelinfo& dpi)
     {
-        if (WidgetIsDisabled(this, WIDX_TAB_4))
+        if (WidgetIsDisabled(*this, WIDX_TAB_4))
             return;
 
         const auto& widget = widgets[WIDX_TAB_4];
@@ -1522,7 +1522,7 @@ private:
 #pragma region Thoughts
     void ThoughtsTabDraw(rct_drawpixelinfo& dpi)
     {
-        if (WidgetIsDisabled(this, WIDX_TAB_5))
+        if (WidgetIsDisabled(*this, WIDX_TAB_5))
             return;
 
         const auto& widget = widgets[WIDX_TAB_5];
@@ -1604,7 +1604,7 @@ private:
 #pragma region Inventory
     void InventoryTabDraw(rct_drawpixelinfo& dpi)
     {
-        if (WidgetIsDisabled(this, WIDX_TAB_6))
+        if (WidgetIsDisabled(*this, WIDX_TAB_6))
             return;
 
         const auto& widget = widgets[WIDX_TAB_6];
@@ -1793,7 +1793,7 @@ private:
 #pragma region Debug
     void DebugTabDraw(rct_drawpixelinfo& dpi)
     {
-        if (WidgetIsDisabled(this, WIDX_TAB_7))
+        if (WidgetIsDisabled(*this, WIDX_TAB_7))
             return;
 
         const auto& widget = widgets[WIDX_TAB_7];

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -154,7 +154,7 @@ public:
     void OnOpen() override
     {
         widgets = window_guest_list_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
 
         _selectedTab = TabId::Summarised;
         _selectedView = GuestViewType::Thoughts;

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -119,7 +119,7 @@ rct_window* WindowInstallTrackOpen(const utf8* path)
 
     rct_window* w = WindowCreate(ScreenCoordsXY(x, y), WW, WH, &window_install_track_events, WC_INSTALL_TRACK, 0);
     w->widgets = window_install_track_widgets;
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->track_list.track_list_being_updated = false;
     window_push_others_right(w);
 
@@ -197,7 +197,7 @@ static void WindowInstallTrackInvalidate(rct_window* w)
  */
 static void WindowInstallTrackPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     // Track preview
     rct_widget* widget = &window_install_track_widgets[WIDX_TRACK_PREVIEW];

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -121,7 +121,7 @@ rct_window* WindowInstallTrackOpen(const utf8* path)
     w->widgets = window_install_track_widgets;
     WindowInitScrollWidgets(*w);
     w->track_list.track_list_being_updated = false;
-    window_push_others_right(w);
+    window_push_others_right(*w);
 
     _trackPath = path;
     _trackName = GetNameFromTrackPath(path);
@@ -156,7 +156,7 @@ static void WindowInstallTrackMouseup(rct_window* w, rct_widgetindex widgetIndex
     {
         case WIDX_CLOSE:
         case WIDX_CANCEL:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_ROTATE:
             _currentTrackPieceDirection++;
@@ -454,7 +454,7 @@ static void WindowInstallTrackDesign(rct_window* w)
     {
         if (track_repository_install(_trackPath.c_str(), _trackName.c_str()))
         {
-            window_close(w);
+            window_close(*w);
         }
         else
         {

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -253,8 +253,8 @@ public:
             screenCoords = { windowPos.x + previewWidget->left, windowPos.y + previewWidget->top };
             auto sprite = ImageId(gLandToolSize % 2 == 0 ? SPR_G2_MOUNTAIN_TOOL_EVEN : SPR_G2_MOUNTAIN_TOOL_ODD);
             gfx_draw_sprite(&dpi, sprite, screenCoords);
-            WidgetDraw(&dpi, this, WIDX_DECREMENT);
-            WidgetDraw(&dpi, this, WIDX_INCREMENT);
+            WidgetDraw(&dpi, *this, WIDX_DECREMENT);
+            WidgetDraw(&dpi, *this, WIDX_INCREMENT);
         }
 
         screenCoords = { windowPos.x + previewWidget->midX(), windowPos.y + previewWidget->bottom + 5 };

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -72,7 +72,7 @@ public:
         widgets = window_land_widgets;
         hold_down_widgets = (1ULL << WIDX_DECREMENT) | (1ULL << WIDX_INCREMENT);
         WindowInitScrollWidgets(*this);
-        window_push_others_below(this);
+        window_push_others_below(*this);
 
         gLandToolSize = 1;
         gLandToolTerrainSurface = OBJECT_ENTRY_INDEX_NULL;

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -71,7 +71,7 @@ public:
     {
         widgets = window_land_widgets;
         hold_down_widgets = (1ULL << WIDX_DECREMENT) | (1ULL << WIDX_INCREMENT);
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         window_push_others_below(this);
 
         gLandToolSize = 1;

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -59,7 +59,7 @@ public:
     {
         widgets = window_land_rights_widgets;
         hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         window_push_others_below(this);
         _landRightsMode = LAND_RIGHTS_MODE_BUY_LAND;
         pressed_widgets = (1ULL << WIDX_BUY_LAND_RIGHTS);

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -60,7 +60,7 @@ public:
         widgets = window_land_rights_widgets;
         hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
         WindowInitScrollWidgets(*this);
-        window_push_others_below(this);
+        window_push_others_below(*this);
         _landRightsMode = LAND_RIGHTS_MODE_BUY_LAND;
         pressed_widgets = (1ULL << WIDX_BUY_LAND_RIGHTS);
 

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -325,7 +325,7 @@ rct_window* WindowLoadsaveOpen(
             openrct2_assert(true, "Unsupported load/save type: %d", type & 0x0F);
     }
 
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     WindowLoadsaveComputeMaxDateWidth();
 
     return w;
@@ -447,7 +447,7 @@ static void WindowLoadsaveMouseup(rct_window* w, rct_widgetindex widgetIndex)
 
         case WIDX_UP:
             WindowLoadsavePopulateList(w, isSave, _parentDirectory, _extensionPattern);
-            WindowInitScrollWidgets(w);
+            WindowInitScrollWidgets(*w);
             w->no_list_items = static_cast<uint16_t>(_listItems.size());
             break;
 
@@ -472,7 +472,7 @@ static void WindowLoadsaveMouseup(rct_window* w, rct_widgetindex widgetIndex)
             {
                 // If user cancels file dialog, refresh list
                 WindowLoadsavePopulateList(w, isSave, _directory, _extensionPattern);
-                WindowInitScrollWidgets(w);
+                WindowInitScrollWidgets(*w);
                 w->no_list_items = static_cast<uint16_t>(_listItems.size());
             }
         }
@@ -508,7 +508,7 @@ static void WindowLoadsaveMouseup(rct_window* w, rct_widgetindex widgetIndex)
 
         case WIDX_DEFAULT:
             WindowLoadsavePopulateList(w, isSave, GetInitialDirectoryByType(_type).c_str(), _extensionPattern);
-            WindowInitScrollWidgets(w);
+            WindowInitScrollWidgets(*w);
             w->no_list_items = static_cast<uint16_t>(_listItems.size());
             break;
     }
@@ -540,7 +540,7 @@ static void WindowLoadsaveScrollmousedown(rct_window* w, int32_t scrollIndex, co
         safe_strcpy(directory, _listItems[selectedItem].path.c_str(), sizeof(directory));
 
         WindowLoadsavePopulateList(w, includeNewItem, directory, _extensionPattern);
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
 
         w->no_list_items = static_cast<uint16_t>(_listItems.size());
     }
@@ -596,7 +596,7 @@ static void WindowLoadsaveTextinput(rct_window* w, rct_widgetindex widgetIndex, 
             w->selected_list_item = -1;
 
             WindowLoadsavePopulateList(w, (_type & 1) == LOADSAVETYPE_SAVE, path, _extensionPattern);
-            WindowInitScrollWidgets(w);
+            WindowInitScrollWidgets(*w);
 
             w->no_list_items = static_cast<uint16_t>(_listItems.size());
             w->Invalidate();
@@ -692,7 +692,7 @@ static void WindowLoadsaveInvalidate(rct_window* w)
 
 static void WindowLoadsavePaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     if (_shortenedDirectory[0] == '\0')
     {
@@ -1158,7 +1158,7 @@ static rct_window* WindowOverwritePromptOpen(const char* name, const char* path)
         OVERWRITE_WW, OVERWRITE_WH, &window_overwrite_prompt_events, WC_LOADSAVE_OVERWRITE_PROMPT, WF_STICK_TO_FRONT);
     w->widgets = window_overwrite_prompt_widgets;
 
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
 
     w->flags |= WF_TRANSPARENT;
     w->colours[0] = TRANSLUCENT(COLOUR_BORDEAUX_RED);
@@ -1193,7 +1193,7 @@ static void WindowOverwritePromptMouseup(rct_window* w, rct_widgetindex widgetIn
 
 static void WindowOverwritePromptPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     auto ft = Formatter();
     ft.Add<rct_string_id>(STR_STRING);

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -442,7 +442,7 @@ static void WindowLoadsaveMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
 
         case WIDX_UP:
@@ -1186,7 +1186,7 @@ static void WindowOverwritePromptMouseup(rct_window* w, rct_widgetindex widgetIn
 
         case WIDX_OVERWRITE_CANCEL:
         case WIDX_OVERWRITE_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
     }
 }

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -665,7 +665,7 @@ public:
                 gLandToolTerrainSurface, gLandToolTerrainEdge);
             GameActions::Execute(&surfaceSetStyleAction);
         }
-        else if (WidgetIsActiveTool(this, WIDX_SET_LAND_RIGHTS))
+        else if (WidgetIsActiveTool(*this, WIDX_SET_LAND_RIGHTS))
         {
             // Set land rights
             int32_t landRightsToolSize = std::max<int32_t>(1, _landRightsToolSize);
@@ -856,7 +856,7 @@ public:
             + ScreenCoordsXY{ window_map_widgets[WIDX_LAND_TOOL].midX(), window_map_widgets[WIDX_LAND_TOOL].midY() };
 
         // Draw land tool size
-        if (WidgetIsActiveTool(this, WIDX_SET_LAND_RIGHTS) && _landRightsToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
+        if (WidgetIsActiveTool(*this, WIDX_SET_LAND_RIGHTS) && _landRightsToolSize > MAX_TOOL_SIZE_WITH_SPRITE)
         {
             auto ft = Formatter();
             ft.Add<uint16_t>(_landRightsToolSize);
@@ -900,7 +900,7 @@ public:
                 }
             }
         }
-        else if (!WidgetIsActiveTool(this, WIDX_SET_LAND_RIGHTS))
+        else if (!WidgetIsActiveTool(*this, WIDX_SET_LAND_RIGHTS))
         {
             DrawTextBasic(
                 &dpi, windowPos + ScreenCoordsXY{ 4, widgets[WIDX_MAP_SIZE_SPINNER_Y].top + 1 }, STR_MAP_SIZE, {},

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -642,7 +642,7 @@ public:
         rct_window* mainWindow = window_get_main();
         if (mainWindow != nullptr)
         {
-            window_scroll_to_location(mainWindow, { mapCoords, mapZ });
+            window_scroll_to_location(*mainWindow, { mapCoords, mapZ });
         }
 
         if (LandToolIsActive())

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -962,7 +962,7 @@ private:
 
         scrolls[0].h_left = cx;
         scrolls[0].v_top = dx;
-        WidgetScrollUpdateThumbs(this, WIDX_MAP);
+        WidgetScrollUpdateThumbs(*this, WIDX_MAP);
     }
 
     void IncreaseMapSize()

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -438,7 +438,7 @@ rct_window* WindowMapgenOpen()
     w->event_handlers = PageEvents[WINDOW_MAPGEN_PAGE_BASE];
     w->pressed_widgets = PressedWidgets[WINDOW_MAPGEN_PAGE_BASE];
     w->disabled_widgets = PageDisabledWidgets[WINDOW_MAPGEN_PAGE_BASE];
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
 
     _heightmapLoaded = false;
 
@@ -667,7 +667,7 @@ static void WindowMapgenBaseInvalidate(rct_window* w)
     if (w->widgets != PageWidgets[WINDOW_MAPGEN_PAGE_BASE])
     {
         w->widgets = PageWidgets[WINDOW_MAPGEN_PAGE_BASE];
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     // Only allow linking the map size when X and Y are the same
@@ -733,7 +733,7 @@ static void WindowMapgenDrawDropdownButtons(
 
 static void WindowMapgenBasePaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowMapgenDrawTabImages(dpi, w);
     WindowMapgenDrawDropdownButtons(w, dpi, WIDX_FLOOR_TEXTURE, WIDX_WALL_TEXTURE);
 
@@ -817,7 +817,7 @@ static void WindowMapgenRandomInvalidate(rct_window* w)
     if (w->widgets != PageWidgets[WINDOW_MAPGEN_PAGE_RANDOM])
     {
         w->widgets = PageWidgets[WINDOW_MAPGEN_PAGE_RANDOM];
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     w->pressed_widgets = 0;
@@ -831,7 +831,7 @@ static void WindowMapgenRandomInvalidate(rct_window* w)
 
 static void WindowMapgenRandomPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowMapgenDrawTabImages(dpi, w);
 }
 
@@ -1015,7 +1015,7 @@ static void WindowMapgenSimplexInvalidate(rct_window* w)
     if (w->widgets != PageWidgets[WINDOW_MAPGEN_PAGE_SIMPLEX])
     {
         w->widgets = PageWidgets[WINDOW_MAPGEN_PAGE_SIMPLEX];
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     // Only allow linking the map size when X and Y are the same
@@ -1047,7 +1047,7 @@ static void WindowMapgenSimplexInvalidate(rct_window* w)
 
 static void WindowMapgenSimplexPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowMapgenDrawTabImages(dpi, w);
     WindowMapgenDrawDropdownButtons(w, dpi, WIDX_SIMPLEX_FLOOR_TEXTURE, WIDX_SIMPLEX_WALL_TEXTURE);
 
@@ -1240,7 +1240,7 @@ static void WindowMapgenHeightmapInvalidate(rct_window* w)
     if (w->widgets != PageWidgets[WINDOW_MAPGEN_PAGE_HEIGHTMAP])
     {
         w->widgets = PageWidgets[WINDOW_MAPGEN_PAGE_HEIGHTMAP];
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WidgetSetCheckboxValue(w, WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP, _heightmapSmoothMap);
@@ -1252,7 +1252,7 @@ static void WindowMapgenHeightmapInvalidate(rct_window* w)
 
 static void WindowMapgenHeightmapPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowMapgenDrawTabImages(dpi, w);
 
     const colour_t enabledColour = w->colours[1];
@@ -1345,7 +1345,7 @@ static void WindowMapgenSetPage(rct_window* w, int32_t page)
         WidgetSetEnabled(w, WIDX_HEIGHTMAP_WATER_LEVEL_DOWN, true);
     }
 
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->Invalidate();
 }
 

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -455,7 +455,7 @@ static void WindowMapgenSharedMouseup(rct_window* w, rct_widgetindex widgetIndex
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -620,7 +620,7 @@ static void WindowMapgenBaseUpdate(rct_window* w)
     // Tab animation
     if (++w->frame_no >= TabAnimationLoops[w->page])
         w->frame_no = 0;
-    widget_invalidate(w, WIDX_TAB_1);
+    widget_invalidate(*w, WIDX_TAB_1);
 }
 
 static void WindowMapgenTextinput(rct_window* w, rct_widgetindex widgetIndex, char* text)
@@ -809,7 +809,7 @@ static void WindowMapgenRandomUpdate(rct_window* w)
     // Tab animation
     if (++w->frame_no >= TabAnimationLoops[w->page])
         w->frame_no = 0;
-    widget_invalidate(w, WIDX_TAB_2);
+    widget_invalidate(*w, WIDX_TAB_2);
 }
 
 static void WindowMapgenRandomInvalidate(rct_window* w)
@@ -1007,7 +1007,7 @@ static void WindowMapgenSimplexUpdate(rct_window* w)
     // Tab animation
     if (++w->frame_no >= TabAnimationLoops[w->page])
         w->frame_no = 0;
-    widget_invalidate(w, WIDX_TAB_3);
+    widget_invalidate(*w, WIDX_TAB_3);
 }
 
 static void WindowMapgenSimplexInvalidate(rct_window* w)
@@ -1120,37 +1120,37 @@ static void WindowMapgenHeightmapMousedown(rct_window* w, rct_widgetindex widget
     {
         case WIDX_HEIGHTMAP_STRENGTH_UP:
             _heightmapSmoothStrength = std::min(_heightmapSmoothStrength + 1, MAX_SMOOTH_ITERATIONS);
-            widget_invalidate(w, WIDX_HEIGHTMAP_STRENGTH);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_STRENGTH);
             break;
         case WIDX_HEIGHTMAP_STRENGTH_DOWN:
             _heightmapSmoothStrength = std::max(_heightmapSmoothStrength - 1, 1);
-            widget_invalidate(w, WIDX_HEIGHTMAP_STRENGTH);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_STRENGTH);
             break;
         case WIDX_HEIGHTMAP_LOW_UP:
             _heightmapLow = std::min(_heightmapLow + 1, 142 - 1);
             _heightmapHigh = std::max(_heightmapHigh, _heightmapLow + 1);
-            widget_invalidate(w, WIDX_HEIGHTMAP_LOW);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_LOW);
             break;
         case WIDX_HEIGHTMAP_LOW_DOWN:
             _heightmapLow = std::max(_heightmapLow - 1, 2);
-            widget_invalidate(w, WIDX_HEIGHTMAP_LOW);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_LOW);
             break;
         case WIDX_HEIGHTMAP_HIGH_UP:
             _heightmapHigh = std::min(_heightmapHigh + 1, 142);
-            widget_invalidate(w, WIDX_HEIGHTMAP_HIGH);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_HIGH);
             break;
         case WIDX_HEIGHTMAP_HIGH_DOWN:
             _heightmapHigh = std::max(_heightmapHigh - 1, 2 + 1);
             _heightmapLow = std::min(_heightmapLow, _heightmapHigh - 1);
-            widget_invalidate(w, WIDX_HEIGHTMAP_HIGH);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_HIGH);
             break;
         case WIDX_HEIGHTMAP_WATER_LEVEL_UP:
             _waterLevel = std::min(_waterLevel + MINIMUM_WATER_HEIGHT, MINIMUM_WATER_HEIGHT + MAXIMUM_WATER_HEIGHT);
-            widget_invalidate(w, WIDX_HEIGHTMAP_WATER_LEVEL);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_WATER_LEVEL);
             break;
         case WIDX_HEIGHTMAP_WATER_LEVEL_DOWN:
             _waterLevel = std::max(_waterLevel - MINIMUM_WATER_HEIGHT, 0);
-            widget_invalidate(w, WIDX_HEIGHTMAP_WATER_LEVEL);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_WATER_LEVEL);
             break;
     }
 }
@@ -1216,18 +1216,18 @@ static void WindowMapgenHeightmapMouseup(rct_window* w, rct_widgetindex widgetIn
             WidgetSetEnabled(*w, WIDX_HEIGHTMAP_STRENGTH, _heightmapSmoothMap);
             WidgetSetEnabled(*w, WIDX_HEIGHTMAP_STRENGTH_UP, _heightmapSmoothMap);
             WidgetSetEnabled(*w, WIDX_HEIGHTMAP_STRENGTH_DOWN, _heightmapSmoothMap);
-            widget_invalidate(w, WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP);
-            widget_invalidate(w, WIDX_HEIGHTMAP_STRENGTH);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_STRENGTH);
             break;
         case WIDX_HEIGHTMAP_NORMALIZE:
             _heightmapNormalize = !_heightmapNormalize;
             WidgetSetCheckboxValue(*w, WIDX_HEIGHTMAP_NORMALIZE, _heightmapNormalize);
-            widget_invalidate(w, WIDX_HEIGHTMAP_NORMALIZE);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_NORMALIZE);
             break;
         case WIDX_HEIGHTMAP_SMOOTH_TILES:
             _heightmapSmoothTiles = !_heightmapSmoothTiles;
             WidgetSetCheckboxValue(*w, WIDX_HEIGHTMAP_SMOOTH_TILES, _heightmapSmoothTiles);
-            widget_invalidate(w, WIDX_HEIGHTMAP_SMOOTH_TILES);
+            widget_invalidate(*w, WIDX_HEIGHTMAP_SMOOTH_TILES);
             break;
     }
 

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -671,8 +671,8 @@ static void WindowMapgenBaseInvalidate(rct_window* w)
     }
 
     // Only allow linking the map size when X and Y are the same
-    WidgetSetPressed(w, WIDX_MAP_SIZE_LINK, _mapWidthAndHeightLinked);
-    WidgetSetDisabled(w, WIDX_MAP_SIZE_LINK, _mapSize.x != _mapSize.y);
+    WidgetSetPressed(*w, WIDX_MAP_SIZE_LINK, _mapWidthAndHeightLinked);
+    WidgetSetDisabled(*w, WIDX_MAP_SIZE_LINK, _mapSize.x != _mapSize.y);
 
     WindowMapgenSetPressedTab(w);
 
@@ -686,7 +686,7 @@ static void WindowMapgenDrawDropdownButton(rct_window* w, rct_drawpixelinfo* dpi
 {
     const auto& widget = w->widgets[widgetIndex];
     ScreenCoordsXY pos = { w->windowPos.x + widget.left, w->windowPos.y + widget.top };
-    if (WidgetIsDisabled(w, widgetIndex))
+    if (WidgetIsDisabled(*w, widgetIndex))
     {
         // Draw greyed out (light border bottom right shadow)
         auto colour = w->colours[widget.colour];
@@ -1019,22 +1019,22 @@ static void WindowMapgenSimplexInvalidate(rct_window* w)
     }
 
     // Only allow linking the map size when X and Y are the same
-    WidgetSetPressed(w, WIDX_SIMPLEX_MAP_SIZE_LINK, _mapWidthAndHeightLinked);
-    WidgetSetDisabled(w, WIDX_SIMPLEX_MAP_SIZE_LINK, _mapSize.x != _mapSize.y);
+    WidgetSetPressed(*w, WIDX_SIMPLEX_MAP_SIZE_LINK, _mapWidthAndHeightLinked);
+    WidgetSetDisabled(*w, WIDX_SIMPLEX_MAP_SIZE_LINK, _mapSize.x != _mapSize.y);
 
-    WidgetSetCheckboxValue(w, WIDX_SIMPLEX_RANDOM_TERRAIN_CHECKBOX, _randomTerrain != 0);
-    WidgetSetCheckboxValue(w, WIDX_SIMPLEX_PLACE_TREES_CHECKBOX, _placeTrees != 0);
+    WidgetSetCheckboxValue(*w, WIDX_SIMPLEX_RANDOM_TERRAIN_CHECKBOX, _randomTerrain != 0);
+    WidgetSetCheckboxValue(*w, WIDX_SIMPLEX_PLACE_TREES_CHECKBOX, _placeTrees != 0);
 
     // Only allow floor and wall texture options if random terrain is disabled
     if (!_randomTerrain)
     {
-        WidgetSetEnabled(w, WIDX_SIMPLEX_FLOOR_TEXTURE, true);
-        WidgetSetEnabled(w, WIDX_SIMPLEX_WALL_TEXTURE, true);
+        WidgetSetEnabled(*w, WIDX_SIMPLEX_FLOOR_TEXTURE, true);
+        WidgetSetEnabled(*w, WIDX_SIMPLEX_WALL_TEXTURE, true);
     }
     else
     {
-        WidgetSetEnabled(w, WIDX_SIMPLEX_FLOOR_TEXTURE, false);
-        WidgetSetEnabled(w, WIDX_SIMPLEX_WALL_TEXTURE, false);
+        WidgetSetEnabled(*w, WIDX_SIMPLEX_FLOOR_TEXTURE, false);
+        WidgetSetEnabled(*w, WIDX_SIMPLEX_WALL_TEXTURE, false);
     }
 
     WindowMapgenSetPressedTab(w);
@@ -1212,21 +1212,21 @@ static void WindowMapgenHeightmapMouseup(rct_window* w, rct_widgetindex widgetIn
         }
         case WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP:
             _heightmapSmoothMap = !_heightmapSmoothMap;
-            WidgetSetCheckboxValue(w, WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP, _heightmapSmoothMap);
-            WidgetSetEnabled(w, WIDX_HEIGHTMAP_STRENGTH, _heightmapSmoothMap);
-            WidgetSetEnabled(w, WIDX_HEIGHTMAP_STRENGTH_UP, _heightmapSmoothMap);
-            WidgetSetEnabled(w, WIDX_HEIGHTMAP_STRENGTH_DOWN, _heightmapSmoothMap);
+            WidgetSetCheckboxValue(*w, WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP, _heightmapSmoothMap);
+            WidgetSetEnabled(*w, WIDX_HEIGHTMAP_STRENGTH, _heightmapSmoothMap);
+            WidgetSetEnabled(*w, WIDX_HEIGHTMAP_STRENGTH_UP, _heightmapSmoothMap);
+            WidgetSetEnabled(*w, WIDX_HEIGHTMAP_STRENGTH_DOWN, _heightmapSmoothMap);
             widget_invalidate(w, WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP);
             widget_invalidate(w, WIDX_HEIGHTMAP_STRENGTH);
             break;
         case WIDX_HEIGHTMAP_NORMALIZE:
             _heightmapNormalize = !_heightmapNormalize;
-            WidgetSetCheckboxValue(w, WIDX_HEIGHTMAP_NORMALIZE, _heightmapNormalize);
+            WidgetSetCheckboxValue(*w, WIDX_HEIGHTMAP_NORMALIZE, _heightmapNormalize);
             widget_invalidate(w, WIDX_HEIGHTMAP_NORMALIZE);
             break;
         case WIDX_HEIGHTMAP_SMOOTH_TILES:
             _heightmapSmoothTiles = !_heightmapSmoothTiles;
-            WidgetSetCheckboxValue(w, WIDX_HEIGHTMAP_SMOOTH_TILES, _heightmapSmoothTiles);
+            WidgetSetCheckboxValue(*w, WIDX_HEIGHTMAP_SMOOTH_TILES, _heightmapSmoothTiles);
             widget_invalidate(w, WIDX_HEIGHTMAP_SMOOTH_TILES);
             break;
     }
@@ -1243,9 +1243,9 @@ static void WindowMapgenHeightmapInvalidate(rct_window* w)
         WindowInitScrollWidgets(*w);
     }
 
-    WidgetSetCheckboxValue(w, WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP, _heightmapSmoothMap);
-    WidgetSetCheckboxValue(w, WIDX_HEIGHTMAP_NORMALIZE, _heightmapNormalize);
-    WidgetSetCheckboxValue(w, WIDX_HEIGHTMAP_SMOOTH_TILES, _heightmapSmoothTiles);
+    WidgetSetCheckboxValue(*w, WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP, _heightmapSmoothMap);
+    WidgetSetCheckboxValue(*w, WIDX_HEIGHTMAP_NORMALIZE, _heightmapNormalize);
+    WidgetSetCheckboxValue(*w, WIDX_HEIGHTMAP_SMOOTH_TILES, _heightmapSmoothTiles);
 
     WindowMapgenSetPressedTab(w);
 }
@@ -1328,21 +1328,21 @@ static void WindowMapgenSetPage(rct_window* w, int32_t page)
     // Enable heightmap widgets if one is loaded
     if (page == WINDOW_MAPGEN_PAGE_HEIGHTMAP && _heightmapLoaded)
     {
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_STRENGTH, _heightmapSmoothMap);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_STRENGTH_UP, _heightmapSmoothMap);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_STRENGTH_DOWN, _heightmapSmoothMap);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_NORMALIZE, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_SMOOTH_TILES, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_HIGH, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_HIGH_UP, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_HIGH_DOWN, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_LOW, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_LOW_UP, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_LOW_DOWN, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_WATER_LEVEL, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_WATER_LEVEL_UP, true);
-        WidgetSetEnabled(w, WIDX_HEIGHTMAP_WATER_LEVEL_DOWN, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_SMOOTH_HEIGHTMAP, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_STRENGTH, _heightmapSmoothMap);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_STRENGTH_UP, _heightmapSmoothMap);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_STRENGTH_DOWN, _heightmapSmoothMap);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_NORMALIZE, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_SMOOTH_TILES, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_HIGH, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_HIGH_UP, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_HIGH_DOWN, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_LOW, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_LOW_UP, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_LOW_DOWN, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_WATER_LEVEL, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_WATER_LEVEL_UP, true);
+        WidgetSetEnabled(*w, WIDX_HEIGHTMAP_WATER_LEVEL_DOWN, true);
     }
 
     WindowInitScrollWidgets(*w);
@@ -1361,7 +1361,7 @@ static void WindowMapgenDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int3
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + page;
 
-    if (!WidgetIsDisabled(w, widgetIndex))
+    if (!WidgetIsDisabled(*w, widgetIndex))
     {
         if (w->page == page)
         {

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -179,7 +179,7 @@ public:
         {
             if ((disabledWidgets & (1ULL << i)) != (currentDisabledWidgets & (1ULL << i)))
             {
-                widget_invalidate(this, i);
+                widget_invalidate(*this, i);
             }
         }
         disabled_widgets = disabledWidgets;

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -94,7 +94,7 @@ public:
     void OnOpen() override
     {
         widgets = window_maze_construction_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         rideId = _currentRideIndex;
         show_gridlines();
     }

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -213,14 +213,14 @@ public:
         switch (_rideConstructionState)
         {
             case RideConstructionState::Place:
-                if (!WidgetIsActiveTool(this, WIDX_MAZE_DIRECTION_GROUPBOX))
+                if (!WidgetIsActiveTool(*this, WIDX_MAZE_DIRECTION_GROUPBOX))
                 {
                     Close();
                     return;
                 }
                 break;
             case RideConstructionState::EntranceExit:
-                if (!WidgetIsActiveTool(this, WIDX_MAZE_ENTRANCE) && !WidgetIsActiveTool(this, WIDX_MAZE_EXIT))
+                if (!WidgetIsActiveTool(*this, WIDX_MAZE_ENTRANCE) && !WidgetIsActiveTool(*this, WIDX_MAZE_EXIT))
                 {
                     _rideConstructionState = gRideEntranceExitPlacePreviousRideConstructionState;
                     WindowMazeConstructionUpdatePressedWidgets();

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -259,7 +259,7 @@ static void WindowMultiplayerSetPage(rct_window* w, int32_t page)
 
     window_event_resize_call(w);
     window_event_invalidate_call(w);
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->Invalidate();
 }
 
@@ -403,7 +403,7 @@ static void WindowMultiplayerInformationInvalidate(rct_window* w)
 
 static void WindowMultiplayerInformationPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowMultiplayerDrawTabImages(w, dpi);
 
     rct_drawpixelinfo clippedDPI;
@@ -561,7 +561,7 @@ static void WindowMultiplayerPlayersPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     rct_string_id stringId;
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowMultiplayerDrawTabImages(w, dpi);
 
     // Number of players
@@ -841,7 +841,7 @@ static void WindowMultiplayerGroupsPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     thread_local std::string _buffer;
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowMultiplayerDrawTabImages(w, dpi);
 
     rct_widget* widget = &window_multiplayer_groups_widgets[WIDX_DEFAULT_GROUP];
@@ -989,7 +989,7 @@ static void WindowMultiplayerOptionsInvalidate(rct_window* w)
 
 static void WindowMultiplayerOptionsPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowMultiplayerDrawTabImages(w, dpi);
 }
 

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -318,7 +318,7 @@ static void WindowMultiplayerInformationMouseup(rct_window* w, rct_widgetindex w
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB1:
         case WIDX_TAB2:
@@ -385,13 +385,13 @@ static ScreenCoordsXY WindowMultiplayerInformationGetSize()
 static void WindowMultiplayerInformationResize(rct_window* w)
 {
     auto size = WindowMultiplayerInformationGetSize();
-    window_set_resize(w, size.x, size.y, size.x, size.y);
+    window_set_resize(*w, size.x, size.y, size.x, size.y);
 }
 
 static void WindowMultiplayerInformationUpdate(rct_window* w)
 {
     w->frame_no++;
-    widget_invalidate(w, WIDX_TAB1 + w->page);
+    widget_invalidate(*w, WIDX_TAB1 + w->page);
 }
 
 static void WindowMultiplayerInformationInvalidate(rct_window* w)
@@ -468,7 +468,7 @@ static void WindowMultiplayerPlayersMouseup(rct_window* w, rct_widgetindex widge
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB1:
         case WIDX_TAB2:
@@ -484,7 +484,7 @@ static void WindowMultiplayerPlayersMouseup(rct_window* w, rct_widgetindex widge
 
 static void WindowMultiplayerPlayersResize(rct_window* w)
 {
-    window_set_resize(w, 420, 124, 500, 450);
+    window_set_resize(*w, 420, 124, 500, 450);
 
     w->no_list_items = network_get_num_players();
     w->list_item_positions[0] = 0;
@@ -498,7 +498,7 @@ static void WindowMultiplayerPlayersResize(rct_window* w)
 static void WindowMultiplayerPlayersUpdate(rct_window* w)
 {
     w->frame_no++;
-    widget_invalidate(w, WIDX_TAB1 + w->page);
+    widget_invalidate(*w, WIDX_TAB1 + w->page);
 }
 
 static void WindowMultiplayerPlayersScrollgetsize(rct_window* w, int32_t scrollIndex, int32_t* width, int32_t* height)
@@ -676,7 +676,7 @@ static void WindowMultiplayerGroupsMouseup(rct_window* w, rct_widgetindex widget
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB1:
         case WIDX_TAB2:
@@ -709,7 +709,7 @@ static void WindowMultiplayerGroupsMouseup(rct_window* w, rct_widgetindex widget
 
 static void WindowMultiplayerGroupsResize(rct_window* w)
 {
-    window_set_resize(w, 320, 200, 320, 500);
+    window_set_resize(*w, 320, 200, 320, 500);
 
     w->no_list_items = network_get_num_actions();
     w->list_item_positions[0] = 0;
@@ -758,7 +758,7 @@ static void WindowMultiplayerGroupsDropdown(rct_window* w, rct_widgetindex widge
 static void WindowMultiplayerGroupsUpdate(rct_window* w)
 {
     w->frame_no++;
-    widget_invalidate(w, WIDX_TAB1 + w->page);
+    widget_invalidate(*w, WIDX_TAB1 + w->page);
 }
 
 static void WindowMultiplayerGroupsScrollgetsize(rct_window* w, int32_t scrollIndex, int32_t* width, int32_t* height)
@@ -934,7 +934,7 @@ static void WindowMultiplayerOptionsMouseup(rct_window* w, rct_widgetindex widge
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB1:
         case WIDX_TAB2:
@@ -962,13 +962,13 @@ static void WindowMultiplayerOptionsMouseup(rct_window* w, rct_widgetindex widge
 
 static void WindowMultiplayerOptionsResize(rct_window* w)
 {
-    window_set_resize(w, 300, 100, 300, 100);
+    window_set_resize(*w, 300, 100, 300, 100);
 }
 
 static void WindowMultiplayerOptionsUpdate(rct_window* w)
 {
     w->frame_no++;
-    widget_invalidate(w, WIDX_TAB1 + w->page);
+    widget_invalidate(*w, WIDX_TAB1 + w->page);
 }
 
 static void WindowMultiplayerOptionsInvalidate(rct_window* w)

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -982,9 +982,9 @@ static void WindowMultiplayerOptionsInvalidate(rct_window* w)
         w->widgets[WIDX_KNOWN_KEYS_ONLY_CHECKBOX].type = WindowWidgetType::Empty;
     }
 
-    WidgetSetCheckboxValue(w, WIDX_LOG_CHAT_CHECKBOX, gConfigNetwork.log_chat);
-    WidgetSetCheckboxValue(w, WIDX_LOG_SERVER_ACTIONS_CHECKBOX, gConfigNetwork.log_server_actions);
-    WidgetSetCheckboxValue(w, WIDX_KNOWN_KEYS_ONLY_CHECKBOX, gConfigNetwork.known_keys_only);
+    WidgetSetCheckboxValue(*w, WIDX_LOG_CHAT_CHECKBOX, gConfigNetwork.log_chat);
+    WidgetSetCheckboxValue(*w, WIDX_LOG_SERVER_ACTIONS_CHECKBOX, gConfigNetwork.log_server_actions);
+    WidgetSetCheckboxValue(*w, WIDX_KNOWN_KEYS_ONLY_CHECKBOX, gConfigNetwork.known_keys_only);
 }
 
 static void WindowMultiplayerOptionsPaint(rct_window* w, rct_drawpixelinfo* dpi)
@@ -999,7 +999,7 @@ static void WindowMultiplayerDrawTabImage(rct_window* w, rct_drawpixelinfo* dpi,
 {
     rct_widgetindex widgetIndex = WIDX_TAB1 + page;
 
-    if (!WidgetIsDisabled(w, widgetIndex))
+    if (!WidgetIsDisabled(*w, widgetIndex))
     {
         if (w->page == page)
         {

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -112,14 +112,14 @@ static void WindowNetworkStatusMouseup(rct_window* w, rct_widgetindex widgetInde
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
     }
 }
 
 static void WindowNetworkStatusUpdate(rct_window* w)
 {
-    widget_invalidate(w, WIDX_BACKGROUND);
+    widget_invalidate(*w, WIDX_BACKGROUND);
 }
 
 static void WindowNetworkStatusTextinput(rct_window* w, rct_widgetindex widgetIndex, char* text)

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -66,7 +66,7 @@ rct_window* WindowNetworkStatusOpen(const char* text, close_callback onClose)
     window = WindowCreateCentred(420, 90, &window_network_status_events, WC_NETWORK_STATUS, WF_10 | WF_TRANSPARENT);
 
     window->widgets = window_network_status_widgets;
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
     window->no_list_items = 0;
     window->selected_list_item = -1;
     window->frame_no = 0;
@@ -153,7 +153,7 @@ static void WindowNetworkStatusInvalidate(rct_window* w)
 
 static void WindowNetworkStatusPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     thread_local std::string _buffer;
     _buffer.assign("{BLACK}");

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -337,9 +337,9 @@ public:
         widgets[WIDX_WEEKS_SPINNER].text = STR_NONE;
 
         // Enable / disable start button based on ride dropdown
-        WidgetSetDisabled(this, WIDX_START_BUTTON, false);
+        WidgetSetDisabled(*this, WIDX_START_BUTTON, false);
         if (widgets[WIDX_RIDE_DROPDOWN].type == WindowWidgetType::DropdownMenu && campaign.RideId == RideId::GetNull())
-            WidgetSetDisabled(this, WIDX_START_BUTTON, true);
+            WidgetSetDisabled(*this, WIDX_START_BUTTON, true);
     }
 
     void OnDraw(rct_drawpixelinfo& dpi) override

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -156,7 +156,7 @@ public:
     {
         widgets = window_new_campaign_widgets;
         hold_down_widgets = (1ULL << WIDX_WEEKS_INCREASE_BUTTON) | (1ULL << WIDX_WEEKS_DECREASE_BUTTON);
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
     }
 
     void SetCampaign(int16_t campaignType)

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -379,7 +379,7 @@ rct_window* WindowNewCampaignOpen(int16_t campaignType)
         if (w->campaign.campaign_type == campaignType)
             return w;
 
-        window_close(w);
+        window_close(*w);
     }
 
     w = WindowCreate<NewCampaignWindow>(WC_NEW_CAMPAIGN, WW, WH, 0);

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -642,7 +642,7 @@ static void WindowNewRideMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_LAST_DEVELOPMENT_BUTTON:
             News::OpenSubject(News::ItemType::Research, gResearchLastItem->rawValue);
@@ -678,7 +678,7 @@ static void WindowNewRideUpdate(rct_window* w)
     if (w->frame_no >= window_new_ride_tab_animation_loops[_windowNewRideCurrentTab])
         w->frame_no = 0;
 
-    widget_invalidate(w, WIDX_TAB_1 + _windowNewRideCurrentTab);
+    widget_invalidate(*w, WIDX_TAB_1 + _windowNewRideCurrentTab);
 
     if (w->new_ride.SelectedRide.Type != RIDE_TYPE_NULL && w->new_ride.selected_ride_countdown-- == 0)
         WindowNewRideSelect(w);
@@ -693,7 +693,7 @@ static void WindowNewRideUpdate(rct_window* w)
         if (!WidgetIsHighlighted(*w, WIDX_RIDE_LIST))
         {
             w->new_ride.HighlightedRide = { RIDE_TYPE_NULL, OBJECT_ENTRY_INDEX_NULL };
-            widget_invalidate(w, WIDX_RIDE_LIST);
+            widget_invalidate(*w, WIDX_RIDE_LIST);
         }
     }
 }
@@ -992,7 +992,7 @@ static void WindowNewRideSelect(rct_window* w)
     if (item.Type == RIDE_TYPE_NULL)
         return;
 
-    window_close(w);
+    window_close(*w);
     window_close_construction_windows();
 
     if (_lastTrackDesignCount > 0)

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -456,7 +456,7 @@ rct_window* WindowNewRideOpen()
     w = WindowCreateAutoPos(WW, WH, &window_new_ride_events, WC_CONSTRUCT_RIDE, WF_10);
     w->widgets = window_new_ride_widgets;
     WindowNewRidePopulateList();
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
 
     w->frame_no = 0;
     w->new_ride.SelectedRide = { RIDE_TYPE_NULL, OBJECT_ENTRY_INDEX_NULL };
@@ -589,7 +589,7 @@ static void WindowNewRideRefreshWidgetSizing(rct_window* w)
         w->Invalidate();
     }
 
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
 }
 
 static void WindowNewRideSetPressedTab(rct_window* w)
@@ -791,7 +791,7 @@ static void WindowNewRideInvalidate(rct_window* w)
  */
 static void WindowNewRidePaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowNewRideDrawTabImages(dpi, w);
 
     if (_windowNewRideCurrentTab != WINDOW_NEW_RIDE_PAGE_RESEARCH)

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -608,7 +608,7 @@ static void WindowNewRideDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + page;
 
-    if (w->widgets[widgetIndex].type != WindowWidgetType::Empty && !WidgetIsDisabled(w, widgetIndex))
+    if (w->widgets[widgetIndex].type != WindowWidgetType::Empty && !WidgetIsDisabled(*w, widgetIndex))
     {
         int32_t frame = 0;
         if (_windowNewRideCurrentTab == page)
@@ -690,7 +690,7 @@ static void WindowNewRideUpdate(rct_window* w)
         _windowNewRideTabScroll[_windowNewRideCurrentTab] = w->scrolls[0].v_top;
 
         // Remove highlight when mouse leaves rides list
-        if (!WidgetIsHighlighted(w, WIDX_RIDE_LIST))
+        if (!WidgetIsHighlighted(*w, WIDX_RIDE_LIST))
         {
             w->new_ride.HighlightedRide = { RIDE_TYPE_NULL, OBJECT_ENTRY_INDEX_NULL };
             widget_invalidate(w, WIDX_RIDE_LIST);

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -434,7 +434,7 @@ static void WindowNewRideRestoreScrollPositionForCurrentTab(rct_window* w)
     currentTabScroll = std::min<uint16_t>(currentTabScroll, std::max(0, scrollHeight - listWidgetHeight));
 
     w->scrolls[0].v_top = currentTabScroll;
-    WidgetScrollUpdateThumbs(w, WIDX_RIDE_LIST);
+    WidgetScrollUpdateThumbs(*w, WIDX_RIDE_LIST);
 }
 
 /**

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -64,7 +64,7 @@ public:
         rct_widget* widget = &widgets[WIDX_SCROLL];
         window_get_scroll_size(this, 0, &w, &h);
         scrolls[0].v_top = std::max(0, h - (widget->height() - 1));
-        WidgetScrollUpdateThumbs(this, WIDX_SCROLL);
+        WidgetScrollUpdateThumbs(*this, WIDX_SCROLL);
     }
 
     void OnMouseUp(rct_widgetindex widgetIndex) override

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -114,7 +114,7 @@ public:
             auto subjectLoc = News::GetSubjectLocation(newsItem.Type, newsItem.Assoc);
             if (subjectLoc.has_value() && (_mainWindow = window_get_main()) != nullptr)
             {
-                window_scroll_to_location(_mainWindow, subjectLoc.value());
+                window_scroll_to_location(*_mainWindow, subjectLoc.value());
             }
         }
     }

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -57,7 +57,7 @@ public:
     void OnOpen() override
     {
         widgets = window_news_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         _pressedNewsItemIndex = -1;
 
         int32_t w = 0, h = 0;

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -229,7 +229,7 @@ private:
     {
         rct_widgetindex widgetIndex = WIDX_FIRST_TAB + p;
 
-        if (!WidgetIsDisabled(this, widgetIndex))
+        if (!WidgetIsDisabled(*this, widgetIndex))
         {
             if (page == p)
             {

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -384,7 +384,7 @@ private:
         {
             selected_list_item = index;
         }
-        widget_invalidate(this, WIDX_SCROLL);
+        widget_invalidate(*this, WIDX_SCROLL);
     }
 
 public:
@@ -409,7 +409,7 @@ public:
         switch (widgetIndex)
         {
             case WIDX_CLOSE:
-                window_close(this);
+                window_close(*this);
                 return;
             case WIDX_COPY_CURRENT:
                 if (selected_list_item > -1 && selected_list_item < no_list_items)
@@ -437,7 +437,7 @@ public:
         if (!WidgetIsHighlighted(*this, WIDX_SCROLL))
         {
             _highlightedIndex = -1;
-            widget_invalidate(this, WIDX_SCROLL);
+            widget_invalidate(*this, WIDX_SCROLL);
         }
 
 #ifndef DISABLE_HTTP
@@ -480,7 +480,7 @@ public:
         else
             _highlightedIndex = selectedItem;
 
-        widget_invalidate(this, WIDX_SCROLL);
+        widget_invalidate(*this, WIDX_SCROLL);
     }
 
     void OnDraw(rct_drawpixelinfo& dpi) override

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -392,7 +392,7 @@ public:
     {
         widgets = window_object_load_error_widgets;
 
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         colours[0] = COLOUR_LIGHT_BLUE;
         colours[1] = COLOUR_LIGHT_BLUE;
         colours[2] = COLOUR_LIGHT_BLUE;
@@ -485,7 +485,7 @@ public:
 
     void OnDraw(rct_drawpixelinfo& dpi) override
     {
-        WindowDrawWidgets(this, &dpi);
+        WindowDrawWidgets(*this, &dpi);
 
         // Draw explanatory message
         auto ft = Formatter();

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -434,7 +434,7 @@ public:
         frame_no++;
 
         // Check if the mouse is hovering over the list
-        if (!WidgetIsHighlighted(this, WIDX_SCROLL))
+        if (!WidgetIsHighlighted(*this, WIDX_SCROLL))
         {
             _highlightedIndex = -1;
             widget_invalidate(this, WIDX_SCROLL);

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2137,7 +2137,7 @@ private:
         int32_t widgetSize = scroll.h_right - (widget.width() - 1);
         scroll.h_left = ceil(volume / 100.0f * widgetSize);
 
-        WidgetScrollUpdateThumbs(this, widgetIndex);
+        WidgetScrollUpdateThumbs(*this, widgetIndex);
     }
 
     static bool IsRCT1TitleMusicAvailable()

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1063,7 +1063,7 @@ private:
         }
 
         WidgetSetCheckboxValue(
-            this, WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX,
+            *this, WIDX_RENDER_WEATHER_EFFECTS_CHECKBOX,
             gConfigGeneral.render_weather_effects || gConfigGeneral.render_weather_gloom);
         SetCheckboxValue(WIDX_DISABLE_LIGHTNING_EFFECT_CHECKBOX, gConfigGeneral.disable_lightning_effect);
         if (!gConfigGeneral.render_weather_effects && !gConfigGeneral.render_weather_gloom)
@@ -1511,8 +1511,8 @@ private:
         SetCheckboxValue(WIDX_MASTER_SOUND_CHECKBOX, gConfigSound.master_sound_enabled);
         SetCheckboxValue(WIDX_MUSIC_CHECKBOX, gConfigSound.ride_music_enabled);
         SetCheckboxValue(WIDX_AUDIO_FOCUS_CHECKBOX, gConfigSound.audio_focus);
-        WidgetSetEnabled(this, WIDX_SOUND_CHECKBOX, gConfigSound.master_sound_enabled);
-        WidgetSetEnabled(this, WIDX_MUSIC_CHECKBOX, gConfigSound.master_sound_enabled);
+        WidgetSetEnabled(*this, WIDX_SOUND_CHECKBOX, gConfigSound.master_sound_enabled);
+        WidgetSetEnabled(*this, WIDX_MUSIC_CHECKBOX, gConfigSound.master_sound_enabled);
 
         // Initialize only on first frame, otherwise the scrollbars won't be able to be modified
         if (frame_no == 0)
@@ -1997,7 +1997,7 @@ private:
     {
         SetCheckboxValue(WIDX_DEBUGGING_TOOLS, gConfigGeneral.debugging_tools);
         WidgetSetCheckboxValue(
-            this, WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM, gConfigGeneral.allow_loading_with_incorrect_checksum);
+            *this, WIDX_ALLOW_LOADING_WITH_INCORRECT_CHECKSUM, gConfigGeneral.allow_loading_with_incorrect_checksum);
         SetCheckboxValue(WIDX_SAVE_PLUGIN_DATA_CHECKBOX, gConfigGeneral.save_plugin_data);
         SetCheckboxValue(WIDX_STAY_CONNECTED_AFTER_DESYNC, gConfigNetwork.stay_connected);
         SetCheckboxValue(WIDX_ALWAYS_NATIVE_LOADSAVE, gConfigGeneral.use_native_browse_dialog);
@@ -2093,7 +2093,7 @@ private:
 
         auto screenCoords = windowPos + ScreenCoordsXY{ widget->left, widget->top };
 
-        if (!WidgetIsDisabled(this, widgetIndex))
+        if (!WidgetIsDisabled(*this, widgetIndex))
         {
             if (page == p)
             {

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -622,7 +622,7 @@ private:
         switch (widgetIndex)
         {
             case WIDX_CLOSE:
-                window_close(this);
+                window_close(*this);
                 break;
             case WIDX_TAB_DISPLAY:
             case WIDX_TAB_RENDERING:

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -516,9 +516,9 @@ private:
         }
         widgets[WIDX_OPEN_OR_CLOSE].image = park_is_open() ? SPR_OPEN : SPR_CLOSED;
         widgets[WIDX_CLOSE_LIGHT].image = SPR_G2_RCT1_CLOSE_BUTTON_0 + !park_is_open() * 2
-            + WidgetIsPressed(this, WIDX_CLOSE_LIGHT);
+            + WidgetIsPressed(*this, WIDX_CLOSE_LIGHT);
         widgets[WIDX_OPEN_LIGHT].image = SPR_G2_RCT1_OPEN_BUTTON_0 + park_is_open() * 2
-            + WidgetIsPressed(this, WIDX_OPEN_LIGHT);
+            + WidgetIsPressed(*this, WIDX_OPEN_LIGHT);
 
         // Only allow closing of park for guest / rating objective
         if (gScenarioObjective.Type == OBJECTIVE_GUESTS_AND_RATING)
@@ -1219,7 +1219,7 @@ private:
     void DrawTabImages(rct_drawpixelinfo& dpi)
     {
         // Entrance tab
-        if (!WidgetIsDisabled(this, WIDX_TAB_1))
+        if (!WidgetIsDisabled(*this, WIDX_TAB_1))
         {
             gfx_draw_sprite(
                 &dpi, ImageId(SPR_TAB_PARK_ENTRANCE),
@@ -1227,7 +1227,7 @@ private:
         }
 
         // Rating tab
-        if (!WidgetIsDisabled(this, WIDX_TAB_2))
+        if (!WidgetIsDisabled(*this, WIDX_TAB_2))
         {
             ImageId spriteIdx(SPR_TAB_GRAPH_0);
             if (page == WINDOW_PARK_PAGE_RATING)
@@ -1242,7 +1242,7 @@ private:
         }
 
         // Guests tab
-        if (!WidgetIsDisabled(this, WIDX_TAB_3))
+        if (!WidgetIsDisabled(*this, WIDX_TAB_3))
         {
             ImageId spriteIdx(SPR_TAB_GRAPH_0);
             if (page == WINDOW_PARK_PAGE_GUESTS)
@@ -1258,7 +1258,7 @@ private:
         }
 
         // Price tab
-        if (!WidgetIsDisabled(this, WIDX_TAB_4))
+        if (!WidgetIsDisabled(*this, WIDX_TAB_4))
         {
             ImageId spriteIdx(SPR_TAB_ADMISSION_0);
             if (page == WINDOW_PARK_PAGE_PRICE)
@@ -1267,7 +1267,7 @@ private:
         }
 
         // Statistics tab
-        if (!WidgetIsDisabled(this, WIDX_TAB_5))
+        if (!WidgetIsDisabled(*this, WIDX_TAB_5))
         {
             ImageId spriteIdx(SPR_TAB_STATS_0);
             if (page == WINDOW_PARK_PAGE_STATS)
@@ -1276,7 +1276,7 @@ private:
         }
 
         // Objective tab
-        if (!WidgetIsDisabled(this, WIDX_TAB_6))
+        if (!WidgetIsDisabled(*this, WIDX_TAB_6))
         {
             ImageId spriteIdx(SPR_TAB_OBJECTIVE_0);
             if (page == WINDOW_PARK_PAGE_OBJECTIVE)
@@ -1285,7 +1285,7 @@ private:
         }
 
         // Awards tab
-        if (!WidgetIsDisabled(this, WIDX_TAB_7))
+        if (!WidgetIsDisabled(*this, WIDX_TAB_7))
         {
             gfx_draw_sprite(
                 &dpi, ImageId(SPR_TAB_AWARDS), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_7].left, widgets[WIDX_TAB_7].top });

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -436,7 +436,7 @@ private:
     void OnResizeEntrance()
     {
         flags |= WF_RESIZABLE;
-        window_set_resize(this, 230, 174 + 9, 230 * 3, (274 + 9) * 3);
+        window_set_resize(*this, 230, 174 + 9, 230 * 3, (274 + 9) * 3);
         InitViewport();
     }
 
@@ -486,7 +486,7 @@ private:
     void OnUpdateEntrance()
     {
         frame_no++;
-        widget_invalidate(this, WIDX_TAB_1);
+        widget_invalidate(*this, WIDX_TAB_1);
     }
 
     void OnTextInputEntrance(rct_widgetindex widgetIndex, std::string_view text)
@@ -592,7 +592,7 @@ private:
         // Draw viewport
         if (viewport != nullptr)
         {
-            window_draw_viewport(&dpi, this);
+            window_draw_viewport(&dpi, *this);
             if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
                 gfx_draw_sprite(&dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
         }
@@ -659,13 +659,13 @@ private:
 #pragma region Rating page
     void OnResizeRating()
     {
-        window_set_resize(this, 255, 182, 255, 182);
+        window_set_resize(*this, 255, 182, 255, 182);
     }
 
     void OnUpdateRating()
     {
         frame_no++;
-        widget_invalidate(this, WIDX_TAB_2);
+        widget_invalidate(*this, WIDX_TAB_2);
     }
 
     void OnPrepareDrawRating()
@@ -731,14 +731,14 @@ private:
 #pragma region Guests page
     void OnResizeGuests()
     {
-        window_set_resize(this, 255, 182, 255, 182);
+        window_set_resize(*this, 255, 182, 255, 182);
     }
 
     void OnUpdateGuests()
     {
         frame_no++;
         _peepAnimationFrame = (_peepAnimationFrame + 1) % 24;
-        widget_invalidate(this, WIDX_TAB_3);
+        widget_invalidate(*this, WIDX_TAB_3);
     }
 
     void OnPrepareDrawGuests()
@@ -817,7 +817,7 @@ private:
 #pragma region Price page
     void OnResizePrice()
     {
-        window_set_resize(this, 230, 124, 230, 124);
+        window_set_resize(*this, 230, 124, 230, 124);
     }
 
     void OnMouseDownPrice(rct_widgetindex widgetIndex)
@@ -842,7 +842,7 @@ private:
     void OnUpdatePrice()
     {
         frame_no++;
-        widget_invalidate(this, WIDX_TAB_4);
+        widget_invalidate(*this, WIDX_TAB_4);
     }
 
     void OnPrepareDrawPrice()
@@ -908,20 +908,20 @@ private:
 #pragma region Stats page
     void OnResizeStats()
     {
-        window_set_resize(this, 230, 119, 230, 119);
+        window_set_resize(*this, 230, 119, 230, 119);
     }
 
     void OnUpdateStats()
     {
         frame_no++;
-        widget_invalidate(this, WIDX_TAB_5);
+        widget_invalidate(*this, WIDX_TAB_5);
 
         // Invalidate ride count if changed
         const auto rideCount = ride_get_count();
         if (_numberOfRides != rideCount)
         {
             _numberOfRides = rideCount;
-            widget_invalidate(this, WIDX_PAGE_BACKGROUND);
+            widget_invalidate(*this, WIDX_PAGE_BACKGROUND);
         }
 
         // Invalidate number of staff if changed
@@ -929,7 +929,7 @@ private:
         if (_numberOfStaff != staffCount)
         {
             _numberOfStaff = staffCount;
-            widget_invalidate(this, WIDX_PAGE_BACKGROUND);
+            widget_invalidate(*this, WIDX_PAGE_BACKGROUND);
         }
     }
 
@@ -1017,16 +1017,16 @@ private:
     {
 #ifndef NO_TTF
         if (gCurrentTTFFontSet != nullptr)
-            window_set_resize(this, 230, 270, 230, 270);
+            window_set_resize(*this, 230, 270, 230, 270);
         else
 #endif
-            window_set_resize(this, 230, 226, 230, 226);
+            window_set_resize(*this, 230, 226, 230, 226);
     }
 
     void OnUpdateObjective()
     {
         frame_no++;
-        widget_invalidate(this, WIDX_TAB_6);
+        widget_invalidate(*this, WIDX_TAB_6);
     }
 
     void OnTextInputObjective(rct_widgetindex widgetIndex, std::string_view text)
@@ -1123,13 +1123,13 @@ private:
 #pragma region Awards page
     void OnResizeAwards()
     {
-        window_set_resize(this, 230, 182, 230, 182);
+        window_set_resize(*this, 230, 182, 230, 182);
     }
 
     void OnUpdateAwards()
     {
         frame_no++;
-        widget_invalidate(this, WIDX_TAB_7);
+        widget_invalidate(*this, WIDX_TAB_7);
     }
 
     void OnPrepareDrawAwards()

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -56,7 +56,7 @@ public:
     {
         widgets = PatrolAreaWidgets;
         hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         window_push_others_below(this);
         gLandToolSize = 4;
     }

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -57,7 +57,7 @@ public:
         widgets = PatrolAreaWidgets;
         hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
         WindowInitScrollWidgets(*this);
-        window_push_others_below(this);
+        window_push_others_below(*this);
         gLandToolSize = 4;
     }
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -163,7 +163,7 @@ rct_window* WindowPlayerOpen(uint8_t id)
     window->event_handlers = window_player_page_events[WINDOW_PLAYER_PAGE_OVERVIEW];
     window->pressed_widgets = 0;
 
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
     WindowPlayerSetPage(window, WINDOW_PLAYER_PAGE_OVERVIEW);
 
     return window;
@@ -302,7 +302,7 @@ void WindowPlayerOverviewUpdate(rct_window* w)
 
 void WindowPlayerOverviewPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowPlayerDrawTabImages(dpi, w);
 
     int32_t player = network_get_player_index(static_cast<uint8_t>(w->number));
@@ -370,7 +370,7 @@ void WindowPlayerOverviewInvalidate(rct_window* w)
     if (window_player_page_widgets[w->page] != w->widgets)
     {
         w->widgets = window_player_page_widgets[w->page];
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     w->pressed_widgets &= ~(WIDX_TAB_1);
@@ -463,7 +463,7 @@ void WindowPlayerStatisticsInvalidate(rct_window* w)
     if (window_player_page_widgets[w->page] != w->widgets)
     {
         w->widgets = window_player_page_widgets[w->page];
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     w->pressed_widgets &= ~(WIDX_TAB_1);
@@ -485,7 +485,7 @@ void WindowPlayerStatisticsInvalidate(rct_window* w)
 
 void WindowPlayerStatisticsPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowPlayerDrawTabImages(dpi, w);
 
     int32_t player = network_get_player_index(static_cast<uint8_t>(w->number));
@@ -525,7 +525,7 @@ static void WindowPlayerSetPage(rct_window* w, int32_t page)
     w->Invalidate();
     window_event_resize_call(w);
     window_event_invalidate_call(w);
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->Invalidate();
 
     if (page == WINDOW_PLAYER_PAGE_OVERVIEW)

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -205,7 +205,7 @@ void WindowPlayerOverviewMouseUp(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -224,7 +224,7 @@ void WindowPlayerOverviewMouseUp(rct_window* w, rct_widgetindex widgetIndex)
                 auto coord = network_get_player_last_action_coord(player);
                 if (coord.x || coord.y || coord.z)
                 {
-                    window_scroll_to_location(mainWindow, coord);
+                    window_scroll_to_location(*mainWindow, coord);
                 }
             }
         }
@@ -274,17 +274,17 @@ void WindowPlayerOverviewDropdown(rct_window* w, rct_widgetindex widgetIndex, in
 
 void WindowPlayerOverviewResize(rct_window* w)
 {
-    window_set_resize(w, 240, 170, 500, 300);
+    window_set_resize(*w, 240, 170, 500, 300);
 }
 
 void WindowPlayerOverviewUpdate(rct_window* w)
 {
     w->frame_no++;
-    widget_invalidate(w, WIDX_TAB_1 + w->page);
+    widget_invalidate(*w, WIDX_TAB_1 + w->page);
 
     if (network_get_player_index(static_cast<uint8_t>(w->number)) == -1)
     {
-        window_close(w);
+        window_close(*w);
         return;
     }
 
@@ -355,7 +355,7 @@ void WindowPlayerOverviewPaint(rct_window* w, rct_drawpixelinfo* dpi)
 
     if (w->viewport != nullptr && w->var_492 != -1)
     {
-        window_draw_viewport(dpi, w);
+        window_draw_viewport(dpi, *w);
     }
 }
 
@@ -433,7 +433,7 @@ void WindowPlayerStatisticsMouseUp(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -444,17 +444,17 @@ void WindowPlayerStatisticsMouseUp(rct_window* w, rct_widgetindex widgetIndex)
 
 void WindowPlayerStatisticsResize(rct_window* w)
 {
-    window_set_resize(w, 210, 80, 210, 80);
+    window_set_resize(*w, 210, 80, 210, 80);
 }
 
 void WindowPlayerStatisticsUpdate(rct_window* w)
 {
     w->frame_no++;
-    widget_invalidate(w, WIDX_TAB_1 + w->page);
+    widget_invalidate(*w, WIDX_TAB_1 + w->page);
 
     if (network_get_player_index(static_cast<uint8_t>(w->number)) == -1)
     {
-        window_close(w);
+        window_close(*w);
     }
 }
 
@@ -611,7 +611,7 @@ static void WindowPlayerUpdateViewport(rct_window* w, bool scroll)
                 {
                     w->viewport->viewPos = centreLoc.value();
                 }
-                widget_invalidate(w, WIDX_VIEWPORT);
+                widget_invalidate(*w, WIDX_VIEWPORT);
             }
 
             // Draw the viewport

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -417,7 +417,7 @@ void WindowPlayerOverviewInvalidate(rct_window* w)
     const bool canKick = network_can_perform_action(network_get_current_player_group_index(), NetworkPermission::KickPlayer);
     const bool isServer = network_get_player_flags(playerIndex) & NETWORK_PLAYER_FLAG_ISSERVER;
     const bool isOwnWindow = (network_get_current_player_id() == w->number);
-    WidgetSetEnabled(w, WIDX_KICK, canKick && !isOwnWindow && !isServer);
+    WidgetSetEnabled(*w, WIDX_KICK, canKick && !isOwnWindow && !isServer);
 }
 
 void WindowPlayerStatisticsClose(rct_window* w)
@@ -555,7 +555,7 @@ static void WindowPlayerDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
     rct_widget* widget;
 
     // Tab 1
-    if (!WidgetIsDisabled(w, WIDX_TAB_1))
+    if (!WidgetIsDisabled(*w, WIDX_TAB_1))
     {
         widget = &w->widgets[WIDX_TAB_1];
         auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
@@ -563,7 +563,7 @@ static void WindowPlayerDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
     }
 
     // Tab 2
-    if (!WidgetIsDisabled(w, WIDX_TAB_2))
+    if (!WidgetIsDisabled(*w, WIDX_TAB_2))
     {
         widget = &w->widgets[WIDX_TAB_2];
         auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -52,7 +52,7 @@ public:
     void OnOpen() override
     {
         widgets = window_ride_refurbish_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
     }
 
     void OnMouseUp(rct_widgetindex widgetIndex) override
@@ -74,7 +74,7 @@ public:
 
     void OnDraw(rct_drawpixelinfo& dpi) override
     {
-        WindowDrawWidgets(this, &dpi);
+        WindowDrawWidgets(*this, &dpi);
 
         auto currentRide = get_ride(rideId);
         if (currentRide != nullptr)

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -99,7 +99,7 @@ rct_window* WindowRideRefurbishPromptOpen(Ride* ride)
     if (w != nullptr)
     {
         auto windowPos = w->windowPos;
-        window_close(w);
+        window_close(*w);
         newWindow = WindowCreate<RefurbishRidePromptWindow>(WC_DEMOLISH_RIDE_PROMPT, windowPos, WW, WH, WF_TRANSPARENT);
     }
     else

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -200,7 +200,7 @@ static void WindowResearchDevelopmentMouseup(rct_window* w, rct_widgetindex widg
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -221,7 +221,7 @@ static void WindowResearchDevelopmentUpdate(rct_window* w)
     // Tab animation
     if (++w->frame_no >= window_research_tab_animation_loops[w->page])
         w->frame_no = 0;
-    widget_invalidate(w, WIDX_TAB_1);
+    widget_invalidate(*w, WIDX_TAB_1);
 }
 
 /**
@@ -396,7 +396,7 @@ static void WindowResearchFundingMouseup(rct_window* w, rct_widgetindex widgetIn
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -468,7 +468,7 @@ static void WindowResearchFundingUpdate(rct_window* w)
     // Tab animation
     if (++w->frame_no >= window_research_tab_animation_loops[w->page])
         w->frame_no = 0;
-    widget_invalidate(w, WIDX_TAB_2);
+    widget_invalidate(*w, WIDX_TAB_2);
 }
 
 /**

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -600,7 +600,7 @@ static void WindowResearchDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, in
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + page;
 
-    if (!WidgetIsDisabled(w, widgetIndex))
+    if (!WidgetIsDisabled(*w, widgetIndex))
     {
         if (w->page == page)
         {

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -184,7 +184,7 @@ rct_window* WindowResearchOpen()
     w->event_handlers = window_research_page_events[0];
     w->pressed_widgets = 0;
     w->disabled_widgets = 0;
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
 
     return w;
 }
@@ -233,7 +233,7 @@ static void WindowResearchDevelopmentInvalidate(rct_window* w)
     if (w->widgets != window_research_page_widgets[WINDOW_RESEARCH_PAGE_DEVELOPMENT])
     {
         w->widgets = window_research_page_widgets[WINDOW_RESEARCH_PAGE_DEVELOPMENT];
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowResearchSetPressedTab(w);
@@ -255,7 +255,7 @@ static void WindowResearchDevelopmentInvalidate(rct_window* w)
  */
 static void WindowResearchDevelopmentPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowResearchDrawTabImages(dpi, w);
 
     WindowResearchDevelopmentPagePaint(w, dpi, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
@@ -480,7 +480,7 @@ static void WindowResearchFundingInvalidate(rct_window* w)
     if (w->widgets != window_research_page_widgets[WINDOW_RESEARCH_PAGE_FUNDING])
     {
         w->widgets = window_research_page_widgets[WINDOW_RESEARCH_PAGE_FUNDING];
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowResearchSetPressedTab(w);
@@ -533,7 +533,7 @@ static void WindowResearchFundingInvalidate(rct_window* w)
  */
 static void WindowResearchFundingPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowResearchDrawTabImages(dpi, w);
 
     WindowResearchFundingPagePaint(w, dpi, WIDX_RESEARCH_FUNDING);
@@ -584,7 +584,7 @@ static void WindowResearchSetPage(rct_window* w, int32_t page)
     window_event_resize_call(w);
     window_event_invalidate_call(w);
 
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->Invalidate();
 }
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -864,7 +864,7 @@ static void WindowRideDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int32_
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + page;
 
-    if (!WidgetIsDisabled(w, widgetIndex))
+    if (!WidgetIsDisabled(*w, widgetIndex))
     {
         if (w->page == page)
         {
@@ -884,7 +884,7 @@ static void WindowRideDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int32_
 static void WindowRideDrawTabMain(rct_drawpixelinfo* dpi, rct_window* w)
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + WINDOW_RIDE_PAGE_MAIN;
-    if (!WidgetIsDisabled(w, widgetIndex))
+    if (!WidgetIsDisabled(*w, widgetIndex))
     {
         auto ride = get_ride(w->rideId);
         if (ride != nullptr)
@@ -924,7 +924,7 @@ static void WindowRideDrawTabVehicle(rct_drawpixelinfo* dpi, rct_window* w)
     rct_widgetindex widgetIndex = WIDX_TAB_1 + WINDOW_RIDE_PAGE_VEHICLE;
     const auto& widget = w->widgets[widgetIndex];
 
-    if (!WidgetIsDisabled(w, widgetIndex))
+    if (!WidgetIsDisabled(*w, widgetIndex))
     {
         auto screenCoords = ScreenCoordsXY{ widget.left + 1, widget.top + 1 };
         int32_t width = widget.right - screenCoords.x;
@@ -994,7 +994,7 @@ static void WindowRideDrawTabCustomer(rct_drawpixelinfo* dpi, rct_window* w)
 {
     rct_widgetindex widgetIndex = WIDX_TAB_1 + WINDOW_RIDE_PAGE_CUSTOMER;
 
-    if (!WidgetIsDisabled(w, widgetIndex))
+    if (!WidgetIsDisabled(*w, widgetIndex))
     {
         const auto& widget = w->widgets[widgetIndex];
         int32_t spriteIndex = 0;
@@ -2313,22 +2313,22 @@ static void WindowRideMainInvalidate(rct_window* w)
 
 #ifdef __SIMULATE_IN_RIDE_WINDOW__
     window_ride_main_widgets[WIDX_CLOSE_LIGHT].image = SPR_G2_RCT1_CLOSE_BUTTON_0 + (ride->status == RideStatus::Closed) * 2
-        + WidgetIsPressed(w, WIDX_CLOSE_LIGHT);
+        + WidgetIsPressed(*w, WIDX_CLOSE_LIGHT);
     window_ride_main_widgets[WIDX_SIMULATE_LIGHT].image = SPR_G2_RCT1_SIMULATE_BUTTON_0
-        + (ride->status == RideStatus::Simulating) * 2 + WidgetIsPressed(w, WIDX_SIMULATE_LIGHT);
+        + (ride->status == RideStatus::Simulating) * 2 + WidgetIsPressed(*w, WIDX_SIMULATE_LIGHT);
     window_ride_main_widgets[WIDX_TEST_LIGHT].image = SPR_G2_RCT1_TEST_BUTTON_0 + (ride->status == RideStatus::Testing) * 2
-        + WidgetIsPressed(w, WIDX_TEST_LIGHT);
+        + WidgetIsPressed(*w, WIDX_TEST_LIGHT);
 #else
     window_ride_main_widgets[WIDX_CLOSE_LIGHT].image = SPR_G2_RCT1_CLOSE_BUTTON_0 + (ride->status == RideStatus::Closed) * 2
-        + WidgetIsPressed(w, WIDX_CLOSE_LIGHT);
+        + WidgetIsPressed(*w, WIDX_CLOSE_LIGHT);
 
     auto baseSprite = ride->status == RideStatus::Simulating ? SPR_G2_RCT1_SIMULATE_BUTTON_0 : SPR_G2_RCT1_TEST_BUTTON_0;
     window_ride_main_widgets[WIDX_TEST_LIGHT].image = baseSprite
         + (ride->status == RideStatus::Testing || ride->status == RideStatus::Simulating) * 2
-        + WidgetIsPressed(w, WIDX_TEST_LIGHT);
+        + WidgetIsPressed(*w, WIDX_TEST_LIGHT);
 #endif
     window_ride_main_widgets[WIDX_OPEN_LIGHT].image = SPR_G2_RCT1_OPEN_BUTTON_0 + (ride->status == RideStatus::Open) * 2
-        + WidgetIsPressed(w, WIDX_OPEN_LIGHT);
+        + WidgetIsPressed(*w, WIDX_OPEN_LIGHT);
 
     WindowRideAnchorBorderWidgets(w);
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1254,7 +1254,7 @@ static rct_window* WindowRideOpenStation(Ride* ride, StationIndex stationIndex)
     w->event_handlers = window_ride_page_events[w->page];
     w->pressed_widgets = 0;
     WindowRideDisableTabs(w);
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
 
     // View
     for (int32_t i = stationIndex.ToUnderlying(); i >= 0; i--)
@@ -1391,7 +1391,7 @@ rct_window* WindowRideOpenVehicle(Vehicle* vehicle)
     w->event_handlers = window_ride_page_events[w->page];
     w->pressed_widgets = 0;
     WindowRideDisableTabs(w);
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
 
     w->ride.view = view;
     WindowRideInitViewport(w);
@@ -1449,7 +1449,7 @@ static void WindowRideSetPage(rct_window* w, int32_t page)
 
     window_event_resize_call(w);
     window_event_invalidate_call(w);
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->Invalidate();
 
     if (listen != 0 && w->viewport != nullptr)
@@ -2287,7 +2287,7 @@ static void WindowRideMainInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowRideSetPressedTab(w);
@@ -2561,7 +2561,7 @@ static void WindowRideMainPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     rct_widget* widget;
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
 
     // Viewport and ear icon
@@ -2784,7 +2784,7 @@ static void WindowRideVehicleInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowRideSetPressedTab(w);
@@ -2866,7 +2866,7 @@ static void WindowRideVehicleInvalidate(rct_window* w)
  */
 static void WindowRideVehiclePaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
 
     auto ride = get_ride(w->rideId);
@@ -3463,7 +3463,7 @@ static void WindowRideOperatingInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowRideSetPressedTab(w);
@@ -3700,7 +3700,7 @@ static void WindowRideOperatingInvalidate(rct_window* w)
  */
 static void WindowRideOperatingPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
 
     auto ride = get_ride(w->rideId);
@@ -4053,7 +4053,7 @@ static void WindowRideMaintenanceInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowRideSetPressedTab(w);
@@ -4097,7 +4097,7 @@ static void WindowRideMaintenanceInvalidate(rct_window* w)
  */
 static void WindowRideMaintenancePaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
 
     auto ride = get_ride(w->rideId);
@@ -4618,7 +4618,7 @@ static void WindowRideColourInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowRideSetPressedTab(w);
@@ -4868,7 +4868,7 @@ static void WindowRideColourPaint(rct_window* w, rct_drawpixelinfo* dpi)
     if (ride == nullptr)
         return;
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
 
     // Track / shop item preview
@@ -5196,7 +5196,7 @@ static void WindowRideMusicInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowRideSetPressedTab(w);
@@ -5243,7 +5243,7 @@ static void WindowRideMusicInvalidate(rct_window* w)
  */
 static void WindowRideMusicPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
 }
 
@@ -5568,7 +5568,7 @@ static void WindowRideMeasurementsInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowRideSetPressedTab(w);
@@ -5619,7 +5619,7 @@ static void WindowRideMeasurementsInvalidate(rct_window* w)
  */
 static void WindowRideMeasurementsPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
 
     if (window_ride_measurements_widgets[WIDX_SAVE_DESIGN].type == WindowWidgetType::Button)
@@ -6048,7 +6048,7 @@ static void WindowRideGraphsInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowRideSetPressedTab(w);
@@ -6106,7 +6106,7 @@ static void WindowRideGraphsInvalidate(rct_window* w)
  */
 static void WindowRideGraphsPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
 }
 
@@ -6612,7 +6612,7 @@ static void WindowRideIncomeInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowRideSetPressedTab(w);
@@ -6725,7 +6725,7 @@ static void WindowRideIncomePaint(rct_window* w, rct_drawpixelinfo* dpi)
     money64 profit;
     ShopItem primaryItem, secondaryItem;
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
 
     auto ride = get_ride(w->rideId);
@@ -6914,7 +6914,7 @@ static void WindowRideCustomerInvalidate(rct_window* w)
     if (w->widgets != widgets)
     {
         w->widgets = widgets;
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
     }
 
     WindowRideSetPressedTab(w);
@@ -6952,7 +6952,7 @@ static void WindowRideCustomerPaint(rct_window* w, rct_drawpixelinfo* dpi)
     int16_t popularity, satisfaction, queueTime;
     rct_string_id stringId;
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
 
     auto ride = get_ride(w->rideId);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1624,7 +1624,7 @@ static void WindowRideMainMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -1646,7 +1646,7 @@ static void WindowRideMainMouseup(rct_window* w, rct_widgetindex widgetIndex)
                 ride_construct(ride);
                 if (window_find_by_number(WC_RIDE_CONSTRUCTION, ride->id.ToUnderlying()) != nullptr)
                 {
-                    window_close(w);
+                    window_close(*w);
                 }
             }
             break;
@@ -1721,7 +1721,7 @@ static void WindowRideMainResize(rct_window* w)
     }
 
     w->flags |= WF_RESIZABLE;
-    window_set_resize(w, 316, minHeight, 500, 450);
+    window_set_resize(*w, 316, minHeight, 500, 450);
     // Unlike with other windows, the focus needs to be recentred so it’s best to just reset it.
     w->focus = std::nullopt;
     WindowRideInitViewport(w);
@@ -2220,7 +2220,7 @@ static void WindowRideMainUpdate(rct_window* w)
     // Update tab animation
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_1);
+    widget_invalidate(*w, WIDX_TAB_1);
 
     // Update status
     auto ride = get_ride(w->rideId);
@@ -2246,7 +2246,7 @@ static void WindowRideMainUpdate(rct_window* w)
         }
         ride->window_invalidate_flags &= ~RIDE_INVALIDATE_RIDE_MAIN;
     }
-    widget_invalidate(w, WIDX_STATUS);
+    widget_invalidate(*w, WIDX_STATUS);
 }
 
 /**
@@ -2567,7 +2567,7 @@ static void WindowRideMainPaint(rct_window* w, rct_drawpixelinfo* dpi)
     // Viewport and ear icon
     if (w->viewport != nullptr)
     {
-        window_draw_viewport(dpi, w);
+        window_draw_viewport(dpi, *w);
         if (w->viewport->flags & VIEWPORT_FLAG_SOUND_ON)
             gfx_draw_sprite(dpi, ImageId(SPR_HEARING_VIEWPORT), w->windowPos + ScreenCoordsXY{ 2, 2 });
     }
@@ -2623,7 +2623,7 @@ static void WindowRideVehicleMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -2646,7 +2646,7 @@ static void WindowRideVehicleMouseup(rct_window* w, rct_widgetindex widgetIndex)
  */
 static void WindowRideVehicleResize(rct_window* w)
 {
-    window_set_resize(w, 316, 214, 316, 214);
+    window_set_resize(*w, 316, 214, 316, 214);
 }
 
 /**
@@ -2717,7 +2717,7 @@ static void WindowRideVehicleUpdate(rct_window* w)
 {
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_2);
+    widget_invalidate(*w, WIDX_TAB_2);
 }
 
 static OpenRCT2String WindowRideVehicleTooltip(rct_window* const w, const rct_widgetindex widgetIndex, rct_string_id fallback)
@@ -3152,7 +3152,7 @@ static void WindowRideOperatingMouseup(rct_window* w, rct_widgetindex widgetInde
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -3192,7 +3192,7 @@ static void WindowRideOperatingMouseup(rct_window* w, rct_widgetindex widgetInde
  */
 static void WindowRideOperatingResize(rct_window* w)
 {
-    window_set_resize(w, 316, 186, 316, 186);
+    window_set_resize(*w, 316, 186, 316, 186);
 }
 
 /**
@@ -3392,7 +3392,7 @@ static void WindowRideOperatingUpdate(rct_window* w)
 {
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_3);
+    widget_invalidate(*w, WIDX_TAB_3);
 
     auto ride = get_ride(w->rideId);
     if (ride != nullptr && ride->window_invalidate_flags & RIDE_INVALIDATE_RIDE_OPERATING)
@@ -3787,7 +3787,7 @@ static void WindowRideMaintenanceMouseup(rct_window* w, rct_widgetindex widgetIn
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -3816,7 +3816,7 @@ static void WindowRideMaintenanceMouseup(rct_window* w, rct_widgetindex widgetIn
  */
 static void WindowRideMaintenanceResize(rct_window* w)
 {
-    window_set_resize(w, 316, 135, 316, 135);
+    window_set_resize(*w, 316, 135, 316, 135);
 }
 
 /**
@@ -4033,7 +4033,7 @@ static void WindowRideMaintenanceUpdate(rct_window* w)
 {
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_4);
+    widget_invalidate(*w, WIDX_TAB_4);
 
     auto ride = get_ride(w->rideId);
     if (ride != nullptr && ride->window_invalidate_flags & RIDE_INVALIDATE_RIDE_MAINTENANCE)
@@ -4294,7 +4294,7 @@ static void WindowRideColourMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -4330,7 +4330,7 @@ static void WindowRideColourMouseup(rct_window* w, rct_widgetindex widgetIndex)
  */
 static void WindowRideColourResize(rct_window* w)
 {
-    window_set_resize(w, 316, 207, 316, 207);
+    window_set_resize(*w, 316, 207, 316, 207);
 }
 
 /**
@@ -4581,8 +4581,8 @@ static void WindowRideColourUpdate(rct_window* w)
 {
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_5);
-    widget_invalidate(w, WIDX_VEHICLE_PREVIEW);
+    widget_invalidate(*w, WIDX_TAB_5);
+    widget_invalidate(*w, WIDX_VEHICLE_PREVIEW);
 }
 
 /**
@@ -5044,7 +5044,7 @@ static void WindowRideMusicMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -5071,7 +5071,7 @@ static void WindowRideMusicMouseup(rct_window* w, rct_widgetindex widgetIndex)
 static void WindowRideMusicResize(rct_window* w)
 {
     w->flags |= WF_RESIZABLE;
-    window_set_resize(w, 316, 81, 316, 81);
+    window_set_resize(*w, 316, 81, 316, 81);
 }
 
 static std::string GetMusicString(ObjectEntryIndex musicObjectIndex)
@@ -5183,7 +5183,7 @@ static void WindowRideMusicUpdate(rct_window* w)
 {
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_6);
+    widget_invalidate(*w, WIDX_TAB_6);
 }
 
 /**
@@ -5400,7 +5400,7 @@ static void WindowRideMeasurementsMouseup(rct_window* w, rct_widgetindex widgetI
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -5435,7 +5435,7 @@ static void WindowRideMeasurementsMouseup(rct_window* w, rct_widgetindex widgetI
  */
 static void WindowRideMeasurementsResize(rct_window* w)
 {
-    window_set_resize(w, 316, 234, 316, 234);
+    window_set_resize(*w, 316, 234, 316, 234);
 }
 
 /**
@@ -5494,7 +5494,7 @@ static void WindowRideMeasurementsUpdate(rct_window* w)
 {
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_7);
+    widget_invalidate(*w, WIDX_TAB_7);
 }
 
 /**
@@ -5893,7 +5893,7 @@ static void WindowRideGraphsMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -5916,7 +5916,7 @@ static void WindowRideGraphsMouseup(rct_window* w, rct_widgetindex widgetIndex)
  */
 static void WindowRideGraphsResize(rct_window* w)
 {
-    window_set_resize(w, 316, 182, 500, 450);
+    window_set_resize(*w, 316, 182, 500, 450);
 }
 
 /**
@@ -5953,9 +5953,9 @@ static void WindowRideGraphsUpdate(rct_window* w)
 
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_8);
+    widget_invalidate(*w, WIDX_TAB_8);
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_GRAPH);
+    widget_invalidate(*w, WIDX_GRAPH);
 
     widget = &window_ride_graphs_widgets[WIDX_GRAPH];
     x = w->scrolls[0].h_left;
@@ -6481,7 +6481,7 @@ static void WindowRideIncomeMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -6534,7 +6534,7 @@ static void WindowRideIncomeMouseup(rct_window* w, rct_widgetindex widgetIndex)
  */
 static void WindowRideIncomeResize(rct_window* w)
 {
-    window_set_resize(w, 316, 194, 316, 194);
+    window_set_resize(*w, 316, 194, 316, 194);
 }
 
 /**
@@ -6568,7 +6568,7 @@ static void WindowRideIncomeUpdate(rct_window* w)
 {
     w->frame_no++;
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_9);
+    widget_invalidate(*w, WIDX_TAB_9);
 
     auto ride = get_ride(w->rideId);
     if (ride != nullptr && ride->window_invalidate_flags & RIDE_INVALIDATE_RIDE_INCOME)
@@ -6832,7 +6832,7 @@ static void WindowRideCustomerMouseup(rct_window* w, rct_widgetindex widgetIndex
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_TAB_1:
         case WIDX_TAB_2:
@@ -6880,7 +6880,7 @@ static void WindowRideCustomerMouseup(rct_window* w, rct_widgetindex widgetIndex
 static void WindowRideCustomerResize(rct_window* w)
 {
     w->flags |= WF_RESIZABLE;
-    window_set_resize(w, 316, 163, 316, 163);
+    window_set_resize(*w, 316, 163, 316, 163);
 }
 
 /**
@@ -6894,7 +6894,7 @@ static void WindowRideCustomerUpdate(rct_window* w)
         w->picked_peep_frame = 0;
 
     window_event_invalidate_call(w);
-    widget_invalidate(w, WIDX_TAB_10);
+    widget_invalidate(*w, WIDX_TAB_10);
 
     auto ride = get_ride(w->rideId);
     if (ride != nullptr && ride->window_invalidate_flags & RIDE_INVALIDATE_RIDE_CUSTOMER)

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -5971,7 +5971,7 @@ static void WindowRideGraphsUpdate(rct_window* w)
     }
 
     w->scrolls[0].h_left = std::clamp(x, 0, w->scrolls[0].h_right - (widget->width() - 2));
-    WidgetScrollUpdateThumbs(w, WIDX_GRAPH);
+    WidgetScrollUpdateThumbs(*w, WIDX_GRAPH);
 }
 
 /**

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1983,7 +1983,7 @@ static void WindowRideMainFollowRide(rct_window* w)
                     {
                         auto headVehicleSpriteIndex = vehicle->sprite_index;
                         rct_window* w_main = window_get_main();
-                        window_follow_sprite(w_main, headVehicleSpriteIndex);
+                        window_follow_sprite(*w_main, headVehicleSpriteIndex);
                     }
                 }
             }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -4424,7 +4424,8 @@ void window_ride_construction_keyboard_shortcut_previous_track()
 void window_ride_construction_keyboard_shortcut_next_track()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(*w, WIDX_NEXT_SECTION) || w->widgets[WIDX_NEXT_SECTION].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_NEXT_SECTION)
+        || w->widgets[WIDX_NEXT_SECTION].type == WindowWidgetType::Empty)
     {
         return;
     }

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -176,7 +176,7 @@ static void CloseRideWindowForConstruction(RideId rideId)
 {
     rct_window* w = window_find_by_number(WC_RIDE, rideId.ToUnderlying());
     if (w != nullptr && w->page == 1)
-        window_close(w);
+        window_close(*w);
 }
 
 static void RideConstructPlacedForwardGameActionCallback(const GameAction* ga, const GameActions::Result* result);
@@ -211,7 +211,7 @@ public:
         colours[1] = COLOUR_DARK_BROWN;
         colours[2] = COLOUR_DARK_BROWN;
 
-        window_push_others_right(this);
+        window_push_others_right(*this);
         show_gridlines();
 
         _currentTrackPrice = MONEY32_UNDEFINED;
@@ -851,7 +851,7 @@ public:
         {
             if ((disabledWidgets & (1ULL << i)) != (currentDisabledWidgets & (1ULL << i)))
             {
-                widget_invalidate(this, i);
+                widget_invalidate(*this, i);
             }
         }
         disabled_widgets = disabledWidgets;
@@ -879,7 +879,7 @@ public:
             case TrackElemType::Whirlpool | RideConstructionSpecialPieceSelected:
             case TrackElemType::Rapids | RideConstructionSpecialPieceSelected:
             case TrackElemType::Waterfall | RideConstructionSpecialPieceSelected:
-                widget_invalidate(this, WIDX_CONSTRUCT);
+                widget_invalidate(*this, WIDX_CONSTRUCT);
                 break;
         }
 
@@ -2732,7 +2732,7 @@ static void CloseConstructWindowOnCompletion(Ride* ride)
         {
             if (ride_are_all_possible_entrances_and_exits_built(ride).Successful)
             {
-                window_close(w);
+                window_close(*w);
             }
             else
             {

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -885,7 +885,7 @@ public:
 
         if (_rideConstructionState == RideConstructionState::Place)
         {
-            if (!WidgetIsActiveTool(this, WIDX_CONSTRUCT))
+            if (!WidgetIsActiveTool(*this, WIDX_CONSTRUCT))
             {
                 Close();
                 return;
@@ -894,7 +894,7 @@ public:
 
         if (_rideConstructionState == RideConstructionState::EntranceExit)
         {
-            if (!WidgetIsActiveTool(this, WIDX_ENTRANCE) && !WidgetIsActiveTool(this, WIDX_EXIT))
+            if (!WidgetIsActiveTool(*this, WIDX_ENTRANCE) && !WidgetIsActiveTool(*this, WIDX_EXIT))
             {
                 _rideConstructionState = gRideEntranceExitPlacePreviousRideConstructionState;
                 window_ride_construction_update_active_elements();
@@ -3591,7 +3591,7 @@ void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords)
 void window_ride_construction_keyboard_shortcut_turn_left()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WindowWidgetType::Empty)
     {
         return;
     }
@@ -3599,20 +3599,20 @@ void window_ride_construction_keyboard_shortcut_turn_left()
     switch (_currentTrackCurve)
     {
         case TRACK_CURVE_LEFT_SMALL:
-            if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE_VERY_SMALL)
+            if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_VERY_SMALL);
             }
             break;
         case TRACK_CURVE_LEFT:
-            if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE_SMALL)
+            if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_VERY_SMALL);
@@ -3623,18 +3623,18 @@ void window_ride_construction_keyboard_shortcut_turn_left()
             }
             break;
         case TRACK_CURVE_LEFT_LARGE:
-            if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_VERY_SMALL);
@@ -3645,23 +3645,23 @@ void window_ride_construction_keyboard_shortcut_turn_left()
             }
             break;
         case TRACK_CURVE_NONE:
-            if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE_LARGE)
+            if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE)
                 && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_VERY_SMALL);
@@ -3672,28 +3672,28 @@ void window_ride_construction_keyboard_shortcut_turn_left()
             }
             break;
         case TRACK_CURVE_RIGHT_LARGE:
-            if (!WidgetIsDisabled(w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_STRAIGHT);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE)
                 && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_VERY_SMALL);
@@ -3704,33 +3704,33 @@ void window_ride_construction_keyboard_shortcut_turn_left()
             }
             break;
         case TRACK_CURVE_RIGHT:
-            if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE_LARGE)
+            if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
                 && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_STRAIGHT);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE)
                 && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_VERY_SMALL);
@@ -3741,38 +3741,38 @@ void window_ride_construction_keyboard_shortcut_turn_left()
             }
             break;
         case TRACK_CURVE_RIGHT_SMALL:
-            if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
                 && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_STRAIGHT);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE)
                 && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_VERY_SMALL);
@@ -3783,43 +3783,43 @@ void window_ride_construction_keyboard_shortcut_turn_left()
             }
             break;
         case TRACK_CURVE_RIGHT_VERY_SMALL:
-            if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE_SMALL)
+            if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_SMALL);
             }
-            else if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
                 && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_STRAIGHT);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE)
                 && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_VERY_SMALL);
@@ -3837,7 +3837,7 @@ void window_ride_construction_keyboard_shortcut_turn_left()
 void window_ride_construction_keyboard_shortcut_turn_right()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WindowWidgetType::Empty)
     {
         return;
     }
@@ -3845,20 +3845,20 @@ void window_ride_construction_keyboard_shortcut_turn_right()
     switch (_currentTrackCurve)
     {
         case TRACK_CURVE_RIGHT_SMALL:
-            if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE_VERY_SMALL)
+            if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_VERY_SMALL);
             }
             break;
         case TRACK_CURVE_RIGHT:
-            if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE_SMALL)
+            if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_VERY_SMALL);
@@ -3869,18 +3869,18 @@ void window_ride_construction_keyboard_shortcut_turn_right()
             }
             break;
         case TRACK_CURVE_RIGHT_LARGE:
-            if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_VERY_SMALL);
@@ -3891,23 +3891,23 @@ void window_ride_construction_keyboard_shortcut_turn_right()
             }
             break;
         case TRACK_CURVE_NONE:
-            if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE_LARGE)
+            if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
                 && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_VERY_SMALL);
@@ -3918,28 +3918,28 @@ void window_ride_construction_keyboard_shortcut_turn_right()
             }
             break;
         case TRACK_CURVE_LEFT_LARGE:
-            if (!WidgetIsDisabled(w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_STRAIGHT);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
                 && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_VERY_SMALL);
@@ -3950,33 +3950,33 @@ void window_ride_construction_keyboard_shortcut_turn_right()
             }
             break;
         case TRACK_CURVE_LEFT:
-            if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE_LARGE)
+            if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE)
                 && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_STRAIGHT);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
                 && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_VERY_SMALL);
@@ -3987,38 +3987,38 @@ void window_ride_construction_keyboard_shortcut_turn_right()
             }
             break;
         case TRACK_CURVE_LEFT_SMALL:
-            if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE)
                 && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_STRAIGHT);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
                 && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_VERY_SMALL);
@@ -4029,43 +4029,43 @@ void window_ride_construction_keyboard_shortcut_turn_right()
             }
             break;
         case TRACK_CURVE_LEFT_VERY_SMALL:
-            if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE_SMALL)
+            if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE_SMALL)
                 && w->widgets[WIDX_LEFT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_SMALL);
             }
-            else if (!WidgetIsDisabled(w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_LEFT_CURVE) && w->widgets[WIDX_LEFT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_LEFT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_LEFT_CURVE_LARGE)
                 && w->widgets[WIDX_LEFT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEFT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_STRAIGHT);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_LARGE)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_LARGE)
                 && w->widgets[WIDX_RIGHT_CURVE_LARGE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_LARGE);
             }
-            else if (!WidgetIsDisabled(w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_RIGHT_CURVE) && w->widgets[WIDX_RIGHT_CURVE].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_SMALL);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_RIGHT_CURVE_VERY_SMALL)
+                !WidgetIsDisabled(*w, WIDX_RIGHT_CURVE_VERY_SMALL)
                 && w->widgets[WIDX_RIGHT_CURVE_VERY_SMALL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_RIGHT_CURVE_VERY_SMALL);
@@ -4083,28 +4083,28 @@ void window_ride_construction_keyboard_shortcut_turn_right()
 void window_ride_construction_keyboard_shortcut_use_track_default()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WindowWidgetType::Empty)
     {
         return;
     }
 
-    if (!WidgetIsDisabled(w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
+    if (!WidgetIsDisabled(*w, WIDX_STRAIGHT) && w->widgets[WIDX_STRAIGHT].type != WindowWidgetType::Empty)
     {
         window_event_mouse_down_call(w, WIDX_STRAIGHT);
     }
 
-    if (!WidgetIsDisabled(w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WindowWidgetType::Empty)
+    if (!WidgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WindowWidgetType::Empty)
     {
         window_event_mouse_down_call(w, WIDX_LEVEL);
     }
 
-    if (!WidgetIsDisabled(w, WIDX_CHAIN_LIFT) && w->widgets[WIDX_CHAIN_LIFT].type != WindowWidgetType::Empty
+    if (!WidgetIsDisabled(*w, WIDX_CHAIN_LIFT) && w->widgets[WIDX_CHAIN_LIFT].type != WindowWidgetType::Empty
         && _currentTrackLiftHill & CONSTRUCTION_LIFT_HILL_SELECTED)
     {
         window_event_mouse_down_call(w, WIDX_CHAIN_LIFT);
     }
 
-    if (!WidgetIsDisabled(w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].type != WindowWidgetType::Empty)
+    if (!WidgetIsDisabled(*w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].type != WindowWidgetType::Empty)
     {
         window_event_mouse_down_call(w, WIDX_BANK_STRAIGHT);
     }
@@ -4113,7 +4113,7 @@ void window_ride_construction_keyboard_shortcut_use_track_default()
 void window_ride_construction_keyboard_shortcut_slope_down()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WindowWidgetType::Empty)
     {
         return;
     }
@@ -4121,7 +4121,7 @@ void window_ride_construction_keyboard_shortcut_slope_down()
     switch (_currentTrackSlopeEnd)
     {
         case TRACK_SLOPE_DOWN_60:
-            if (IsTrackEnabled(TRACK_SLOPE_VERTICAL) && !WidgetIsDisabled(w, WIDX_SLOPE_UP_STEEP)
+            if (IsTrackEnabled(TRACK_SLOPE_VERTICAL) && !WidgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP)
                 && w->widgets[WIDX_SLOPE_UP_STEEP].image == SPR_RIDE_CONSTRUCTION_VERTICAL_DROP
                 && w->widgets[WIDX_SLOPE_UP_STEEP].type != WindowWidgetType::Empty)
             {
@@ -4129,14 +4129,14 @@ void window_ride_construction_keyboard_shortcut_slope_down()
             }
             break;
         case TRACK_SLOPE_DOWN_25:
-            if (!WidgetIsDisabled(w, WIDX_SLOPE_DOWN_STEEP)
+            if (!WidgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP)
                 && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_DOWN_STEEP);
             }
             break;
         case TRACK_SLOPE_NONE:
-            if (!WidgetIsDisabled(w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_DOWN);
             }
@@ -4147,7 +4147,7 @@ void window_ride_construction_keyboard_shortcut_slope_down()
                 return;
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_SLOPE_DOWN_STEEP)
+                !WidgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP)
                 && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_DOWN_STEEP);
@@ -4158,16 +4158,16 @@ void window_ride_construction_keyboard_shortcut_slope_down()
             }
             break;
         case TRACK_SLOPE_UP_25:
-            if (!WidgetIsDisabled(w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEVEL);
             }
-            else if (!WidgetIsDisabled(w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_DOWN);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_SLOPE_DOWN_STEEP)
+                !WidgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP)
                 && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_DOWN_STEEP);
@@ -4178,15 +4178,15 @@ void window_ride_construction_keyboard_shortcut_slope_down()
             }
             break;
         case TRACK_SLOPE_UP_60:
-            if (!WidgetIsDisabled(w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_UP);
             }
-            else if (!WidgetIsDisabled(w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEVEL);
             }
-            else if (!WidgetIsDisabled(w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_DOWN);
             }
@@ -4197,7 +4197,7 @@ void window_ride_construction_keyboard_shortcut_slope_down()
                 return;
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_SLOPE_DOWN_STEEP)
+                !WidgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP)
                 && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_DOWN_STEEP);
@@ -4208,7 +4208,7 @@ void window_ride_construction_keyboard_shortcut_slope_down()
             }
             break;
         case TRACK_SLOPE_UP_90:
-            if (IsTrackEnabled(TRACK_SLOPE_VERTICAL) && !WidgetIsDisabled(w, WIDX_SLOPE_UP_STEEP)
+            if (IsTrackEnabled(TRACK_SLOPE_VERTICAL) && !WidgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP)
                 && w->widgets[WIDX_SLOPE_DOWN_STEEP].image == SPR_RIDE_CONSTRUCTION_VERTICAL_RISE
                 && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WindowWidgetType::Empty)
             {
@@ -4223,7 +4223,7 @@ void window_ride_construction_keyboard_shortcut_slope_down()
 void window_ride_construction_keyboard_shortcut_slope_up()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_STRAIGHT) || w->widgets[WIDX_STRAIGHT].type == WindowWidgetType::Empty)
     {
         return;
     }
@@ -4231,7 +4231,7 @@ void window_ride_construction_keyboard_shortcut_slope_up()
     switch (_currentTrackSlopeEnd)
     {
         case TRACK_SLOPE_UP_60:
-            if (IsTrackEnabled(TRACK_SLOPE_VERTICAL) && !WidgetIsDisabled(w, WIDX_SLOPE_DOWN_STEEP)
+            if (IsTrackEnabled(TRACK_SLOPE_VERTICAL) && !WidgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP)
                 && w->widgets[WIDX_SLOPE_DOWN_STEEP].image == SPR_RIDE_CONSTRUCTION_VERTICAL_RISE
                 && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WindowWidgetType::Empty)
             {
@@ -4239,13 +4239,13 @@ void window_ride_construction_keyboard_shortcut_slope_up()
             }
             break;
         case TRACK_SLOPE_UP_25:
-            if (!WidgetIsDisabled(w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_UP_STEEP);
             }
             break;
         case TRACK_SLOPE_NONE:
-            if (!WidgetIsDisabled(w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_UP);
             }
@@ -4256,7 +4256,7 @@ void window_ride_construction_keyboard_shortcut_slope_up()
                 return;
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WindowWidgetType::Empty)
+                !WidgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_UP_STEEP);
             }
@@ -4266,16 +4266,16 @@ void window_ride_construction_keyboard_shortcut_slope_up()
             }
             break;
         case TRACK_SLOPE_DOWN_25:
-            if (!WidgetIsDisabled(w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEVEL);
             }
-            else if (!WidgetIsDisabled(w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_UP);
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WindowWidgetType::Empty)
+                !WidgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_UP_STEEP);
             }
@@ -4285,15 +4285,15 @@ void window_ride_construction_keyboard_shortcut_slope_up()
             }
             break;
         case TRACK_SLOPE_DOWN_60:
-            if (!WidgetIsDisabled(w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_SLOPE_DOWN) && w->widgets[WIDX_SLOPE_DOWN].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_DOWN);
             }
-            else if (!WidgetIsDisabled(w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_LEVEL) && w->widgets[WIDX_LEVEL].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_LEVEL);
             }
-            else if (!WidgetIsDisabled(w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_SLOPE_UP) && w->widgets[WIDX_SLOPE_UP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_UP);
             }
@@ -4304,7 +4304,7 @@ void window_ride_construction_keyboard_shortcut_slope_up()
                 return;
             }
             else if (
-                !WidgetIsDisabled(w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WindowWidgetType::Empty)
+                !WidgetIsDisabled(*w, WIDX_SLOPE_UP_STEEP) && w->widgets[WIDX_SLOPE_UP_STEEP].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_SLOPE_UP_STEEP);
             }
@@ -4314,7 +4314,7 @@ void window_ride_construction_keyboard_shortcut_slope_up()
             }
             break;
         case TRACK_SLOPE_DOWN_90:
-            if (IsTrackEnabled(TRACK_SLOPE_VERTICAL) && !WidgetIsDisabled(w, WIDX_SLOPE_DOWN_STEEP)
+            if (IsTrackEnabled(TRACK_SLOPE_VERTICAL) && !WidgetIsDisabled(*w, WIDX_SLOPE_DOWN_STEEP)
                 && w->widgets[WIDX_SLOPE_UP_STEEP].image == SPR_RIDE_CONSTRUCTION_VERTICAL_DROP
                 && w->widgets[WIDX_SLOPE_DOWN_STEEP].type != WindowWidgetType::Empty)
             {
@@ -4329,7 +4329,7 @@ void window_ride_construction_keyboard_shortcut_slope_up()
 void window_ride_construction_keyboard_shortcut_chain_lift_toggle()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_CHAIN_LIFT) || w->widgets[WIDX_CHAIN_LIFT].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_CHAIN_LIFT) || w->widgets[WIDX_CHAIN_LIFT].type == WindowWidgetType::Empty)
     {
         return;
     }
@@ -4340,7 +4340,7 @@ void window_ride_construction_keyboard_shortcut_chain_lift_toggle()
 void window_ride_construction_keyboard_shortcut_bank_left()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_BANK_STRAIGHT)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_BANK_STRAIGHT)
         || w->widgets[WIDX_BANK_STRAIGHT].type == WindowWidgetType::Empty)
     {
         return;
@@ -4349,17 +4349,17 @@ void window_ride_construction_keyboard_shortcut_bank_left()
     switch (_currentTrackBankEnd)
     {
         case TRACK_BANK_NONE:
-            if (!WidgetIsDisabled(w, WIDX_BANK_LEFT) && w->widgets[WIDX_BANK_LEFT].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_BANK_LEFT) && w->widgets[WIDX_BANK_LEFT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_BANK_LEFT);
             }
             break;
         case TRACK_BANK_RIGHT:
-            if (!WidgetIsDisabled(w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_BANK_STRAIGHT);
             }
-            else if (!WidgetIsDisabled(w, WIDX_BANK_LEFT) && w->widgets[WIDX_BANK_LEFT].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_BANK_LEFT) && w->widgets[WIDX_BANK_LEFT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_BANK_LEFT);
             }
@@ -4376,7 +4376,7 @@ void window_ride_construction_keyboard_shortcut_bank_left()
 void window_ride_construction_keyboard_shortcut_bank_right()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_BANK_STRAIGHT)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_BANK_STRAIGHT)
         || w->widgets[WIDX_BANK_STRAIGHT].type == WindowWidgetType::Empty)
     {
         return;
@@ -4385,17 +4385,17 @@ void window_ride_construction_keyboard_shortcut_bank_right()
     switch (_currentTrackBankEnd)
     {
         case TRACK_BANK_NONE:
-            if (!WidgetIsDisabled(w, WIDX_BANK_RIGHT) && w->widgets[WIDX_BANK_RIGHT].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_BANK_RIGHT) && w->widgets[WIDX_BANK_RIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_BANK_RIGHT);
             }
             break;
         case TRACK_BANK_LEFT:
-            if (!WidgetIsDisabled(w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].type != WindowWidgetType::Empty)
+            if (!WidgetIsDisabled(*w, WIDX_BANK_STRAIGHT) && w->widgets[WIDX_BANK_STRAIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_BANK_STRAIGHT);
             }
-            else if (!WidgetIsDisabled(w, WIDX_BANK_RIGHT) && w->widgets[WIDX_BANK_RIGHT].type != WindowWidgetType::Empty)
+            else if (!WidgetIsDisabled(*w, WIDX_BANK_RIGHT) && w->widgets[WIDX_BANK_RIGHT].type != WindowWidgetType::Empty)
             {
                 window_event_mouse_down_call(w, WIDX_BANK_RIGHT);
             }
@@ -4412,7 +4412,7 @@ void window_ride_construction_keyboard_shortcut_bank_right()
 void window_ride_construction_keyboard_shortcut_previous_track()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_PREVIOUS_SECTION)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_PREVIOUS_SECTION)
         || w->widgets[WIDX_PREVIOUS_SECTION].type == WindowWidgetType::Empty)
     {
         return;
@@ -4424,7 +4424,7 @@ void window_ride_construction_keyboard_shortcut_previous_track()
 void window_ride_construction_keyboard_shortcut_next_track()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_NEXT_SECTION) || w->widgets[WIDX_NEXT_SECTION].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_NEXT_SECTION) || w->widgets[WIDX_NEXT_SECTION].type == WindowWidgetType::Empty)
     {
         return;
     }
@@ -4435,7 +4435,7 @@ void window_ride_construction_keyboard_shortcut_next_track()
 void window_ride_construction_keyboard_shortcut_build_current()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_CONSTRUCT) || w->widgets[WIDX_CONSTRUCT].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_CONSTRUCT) || w->widgets[WIDX_CONSTRUCT].type == WindowWidgetType::Empty)
     {
         return;
     }
@@ -4446,7 +4446,7 @@ void window_ride_construction_keyboard_shortcut_build_current()
 void window_ride_construction_keyboard_shortcut_demolish_current()
 {
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
-    if (w == nullptr || WidgetIsDisabled(w, WIDX_DEMOLISH) || w->widgets[WIDX_DEMOLISH].type == WindowWidgetType::Empty)
+    if (w == nullptr || WidgetIsDisabled(*w, WIDX_DEMOLISH) || w->widgets[WIDX_DEMOLISH].type == WindowWidgetType::Empty)
     {
         return;
     }

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -215,7 +215,7 @@ public:
         switch (widgetIndex)
         {
             case WIDX_CLOSE:
-                window_close(this);
+                window_close(*this);
                 break;
             case WIDX_SORT:
                 list_information_type = _windowRideListInformationType;
@@ -358,7 +358,7 @@ public:
     void OnUpdate() override
     {
         frame_no = (frame_no + 1) % 64;
-        widget_invalidate(this, WIDX_TAB_1 + page);
+        widget_invalidate(*this, WIDX_TAB_1 + page);
         if (_windowRideListInformationType != INFORMATION_TYPE_STATUS)
             Invalidate();
     }

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -164,7 +164,7 @@ public:
     void OnOpen() override
     {
         widgets = window_ride_list_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         page = PAGE_RIDES;
         selected_list_item = -1;
         frame_no = 0;
@@ -513,7 +513,7 @@ public:
      */
     void OnDraw(rct_drawpixelinfo& dpi) override
     {
-        WindowDrawWidgets(this, &dpi);
+        WindowDrawWidgets(*this, &dpi);
         DrawTabImages(&dpi);
 
         // Draw number of attractions on bottom

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -490,9 +490,9 @@ public:
             }
 
             widgets[WIDX_CLOSE_LIGHT].image = SPR_G2_RCT1_CLOSE_BUTTON_0 + (allClosed ? 1 : 0) * 2
-                + WidgetIsPressed(this, WIDX_CLOSE_LIGHT);
+                + WidgetIsPressed(*this, WIDX_CLOSE_LIGHT);
             widgets[WIDX_OPEN_LIGHT].image = SPR_G2_RCT1_OPEN_BUTTON_0 + (allOpen ? 1 : 0) * 2
-                + WidgetIsPressed(this, WIDX_OPEN_LIGHT);
+                + WidgetIsPressed(*this, WIDX_OPEN_LIGHT);
             widgets[WIDX_QUICK_DEMOLISH].top = widgets[WIDX_OPEN_LIGHT].bottom + 3;
         }
         else

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -122,7 +122,7 @@ rct_window* WindowSavePromptOpen()
     window = window_bring_to_front_by_class(WC_SAVE_PROMPT);
     if (window != nullptr)
     {
-        window_close(window);
+        window_close(*window);
     }
 
     if (gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER))
@@ -199,7 +199,7 @@ static void WindowSavePromptMouseup(rct_window* w, rct_widgetindex widgetIndex)
                 break;
             case WQIDX_CLOSE:
             case WQIDX_CANCEL:
-                window_close(w);
+                window_close(*w);
                 break;
         }
         return;
@@ -221,7 +221,7 @@ static void WindowSavePromptMouseup(rct_window* w, rct_widgetindex widgetIndex)
             {
                 intent = create_save_game_as_intent();
             }
-            window_close(w);
+            window_close(*w);
             intent->putExtra(INTENT_EXTRA_CALLBACK, reinterpret_cast<void*>(WindowSavePromptCallback));
             context_open_intent(intent.get());
             break;
@@ -231,7 +231,7 @@ static void WindowSavePromptMouseup(rct_window* w, rct_widgetindex widgetIndex)
             return;
         case WIDX_CLOSE:
         case WIDX_CANCEL:
-            window_close(w);
+            window_close(*w);
             return;
     }
 }

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -146,7 +146,7 @@ rct_window* WindowSavePromptOpen()
     window = WindowCreateCentred(width, height, &window_save_prompt_events, WC_SAVE_PROMPT, WF_TRANSPARENT | WF_STICK_TO_FRONT);
 
     window->widgets = widgets;
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
 
     // Pause the game if not network play.
     if (network_get_mode() == NETWORK_MODE_NONE)
@@ -238,7 +238,7 @@ static void WindowSavePromptMouseup(rct_window* w, rct_widgetindex widgetIndex)
 
 static void WindowSavePromptPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 }
 
 static void WindowSavePromptCallback(int32_t result, const utf8* path)

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -268,7 +268,7 @@ static void WindowScenarioselectMouseup(rct_window* w, rct_widgetindex widgetInd
 {
     if (widgetIndex == WIDX_CLOSE)
     {
-        window_close(w);
+        window_close(*w);
     }
 }
 
@@ -348,7 +348,7 @@ static void WindowScenarioselectScrollmousedown(rct_window* w, int32_t scrollInd
                     _callback(listItem.scenario.scenario->path);
                     if (_titleEditor)
                     {
-                        window_close(w);
+                        window_close(*w);
                     }
                 }
                 break;

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -194,7 +194,7 @@ rct_window* WindowScenarioselectOpen(std::function<void(std::string_view)> callb
     WindowScenarioselectInitTabs(window);
     InitialiseListItems(window);
 
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
     window->highlighted_scenario = nullptr;
 
     return window;
@@ -284,7 +284,7 @@ static void WindowScenarioselectMousedown(rct_window* w, rct_widgetindex widgetI
         w->Invalidate();
         window_event_resize_call(w);
         window_event_invalidate_call(w);
-        WindowInitScrollWidgets(w);
+        WindowInitScrollWidgets(*w);
         w->Invalidate();
     }
 }
@@ -440,7 +440,7 @@ static void WindowScenarioselectPaint(rct_window* w, rct_drawpixelinfo* dpi)
     int32_t format;
     const scenario_index_entry* scenario;
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     format = ScenarioSelectUseSmallFont() ? STR_SMALL_WINDOW_COLOUR_2_STRINGID : STR_WINDOW_COLOUR_2_STRINGID;
     FontSpriteBase fontSpriteBase = ScenarioSelectUseSmallFont() ? FontSpriteBase::SMALL : FontSpriteBase::MEDIUM;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -322,7 +322,7 @@ public:
                 ScreenCoordsXY scrollPos = {};
                 int32_t scrollArea = 0;
                 int32_t scrollId = 0;
-                WidgetScrollGetPart(this, &widgets[WIDX_SCENERY_LIST], state->position, scrollPos, &scrollArea, &scrollId);
+                WidgetScrollGetPart(*this, &widgets[WIDX_SCENERY_LIST], state->position, scrollPos, &scrollArea, &scrollId);
                 if (scrollArea == SCROLL_PART_VIEW)
                 {
                     const ScenerySelection scenery = GetSceneryIdByCursorPos(scrollPos);
@@ -902,7 +902,7 @@ private:
         scrolls[SceneryContentScrollIndex].v_top = ContentRowsHeight(rowSelected);
         scrolls[SceneryContentScrollIndex].v_top = std::min<int32_t>(maxTop, scrolls[SceneryContentScrollIndex].v_top);
 
-        WidgetScrollUpdateThumbs(this, WIDX_SCENERY_LIST);
+        WidgetScrollUpdateThumbs(*this, WIDX_SCENERY_LIST);
     }
 
     SceneryItem ContentCountRowsWithSelectedItem(const size_t tabIndex)

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -160,8 +160,8 @@ public:
             _activeTabIndex = 0;
         }
 
-        window_move_position(this, { context_get_width() - GetRequiredWidth(), 0x1D });
-        window_push_others_below(this);
+        window_move_position(*this, { context_get_width() - GetRequiredWidth(), 0x1D });
+        window_push_others_below(*this);
     }
 
     void OnClose() override
@@ -316,7 +316,7 @@ public:
         {
             // Find out what scenery the cursor is over
             const CursorState* state = context_get_cursor_state();
-            rct_widgetindex widgetIndex = window_find_widget_from_point(this, state->position);
+            rct_widgetindex widgetIndex = window_find_widget_from_point(*this, state->position);
             if (widgetIndex == WIDX_SCENERY_LIST)
             {
                 ScreenCoordsXY scrollPos = {};
@@ -350,7 +350,7 @@ public:
 
             if (window.y < 44 || window.x <= width)
             {
-                rct_widgetindex widgetIndex = window_find_widget_from_point(this, state->position);
+                rct_widgetindex widgetIndex = window_find_widget_from_point(*this, state->position);
                 if (widgetIndex >= WIDX_SCENERY_TAB_CONTENT_PANEL)
                 {
                     _hoverCounter++;

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -59,7 +59,7 @@ public:
     {
         widgets = window_scenery_scatter_widgets;
         hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         window_push_others_below(this);
 
         gWindowSceneryScatterEnabled = true;
@@ -178,7 +178,7 @@ public:
 
     void OnDraw(rct_drawpixelinfo& dpi) override
     {
-        WindowDrawWidgets(this, &dpi);
+        WindowDrawWidgets(*this, &dpi);
 
         // Draw area as a number for tool sizes bigger than 7
         if (gWindowSceneryScatterSize > MAX_TOOL_SIZE_WITH_SPRITE)

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -60,7 +60,7 @@ public:
         widgets = window_scenery_scatter_widgets;
         hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
         WindowInitScrollWidgets(*this);
-        window_push_others_below(this);
+        window_push_others_below(*this);
 
         gWindowSceneryScatterEnabled = true;
         gWindowSceneryScatterSize = 16;
@@ -93,7 +93,7 @@ public:
         switch (widgetIndex)
         {
             case WIDX_CLOSE:
-                window_close(this);
+                window_close(*this);
                 break;
 
             case WIDX_PREVIEW:

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -141,7 +141,7 @@ rct_window* WindowServerListOpen()
     window->page = 0;
     window->list_information_type = 0;
 
-    window_set_resize(window, WWIDTH_MIN, WHEIGHT_MIN, WWIDTH_MAX, WHEIGHT_MAX);
+    window_set_resize(*window, WWIDTH_MIN, WHEIGHT_MIN, WWIDTH_MAX, WHEIGHT_MAX);
 
     safe_strcpy(_playerName, gConfigNetwork.player_name.c_str(), sizeof(_playerName));
 
@@ -164,7 +164,7 @@ static void WindowServerListMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_PLAYER_NAME_INPUT:
             window_start_textbox(w, widgetIndex, STR_STRING, _playerName, 63);
@@ -202,7 +202,7 @@ static void WindowServerListMouseup(rct_window* w, rct_widgetindex widgetIndex)
 
 static void WindowServerListResize(rct_window* w)
 {
-    window_set_resize(w, WWIDTH_MIN, WHEIGHT_MIN, WWIDTH_MAX, WHEIGHT_MAX);
+    window_set_resize(*w, WWIDTH_MIN, WHEIGHT_MIN, WWIDTH_MAX, WHEIGHT_MAX);
 }
 
 static void WindowServerListDropdown(rct_window* w, rct_widgetindex widgetIndex, int32_t dropdownIndex)
@@ -240,7 +240,7 @@ static void WindowServerListUpdate(rct_window* w)
     if (gCurrentTextBox.window.classification == w->classification && gCurrentTextBox.window.number == w->number)
     {
         window_update_textbox_caret();
-        widget_invalidate(w, WIDX_PLAYER_NAME_INPUT);
+        widget_invalidate(*w, WIDX_PLAYER_NAME_INPUT);
     }
     ServerListFetchServersCheck(w);
 }
@@ -326,7 +326,7 @@ static void WindowServerListTextinput(rct_window* w, rct_widgetindex widgetIndex
                 config_save_default();
             }
 
-            widget_invalidate(w, WIDX_PLAYER_NAME_INPUT);
+            widget_invalidate(*w, WIDX_PLAYER_NAME_INPUT);
             break;
 
         case WIDX_ADD_SERVER:

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -167,7 +167,7 @@ static void WindowServerListMouseup(rct_window* w, rct_widgetindex widgetIndex)
             window_close(*w);
             break;
         case WIDX_PLAYER_NAME_INPUT:
-            window_start_textbox(w, widgetIndex, STR_STRING, _playerName, 63);
+            window_start_textbox(*w, widgetIndex, STR_STRING, _playerName, 63);
             break;
         case WIDX_LIST:
         {

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -129,7 +129,7 @@ rct_window* WindowServerListOpen()
 
     window_server_list_widgets[WIDX_PLAYER_NAME_INPUT].string = _playerName;
     window->widgets = window_server_list_widgets;
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
     window->no_list_items = 0;
     window->selected_list_item = -1;
     window->frame_no = 0;
@@ -380,7 +380,7 @@ static void WindowServerListInvalidate(rct_window* w)
 
 static void WindowServerListPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     DrawTextBasic(
         dpi, w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_PLAYER_NAME_INPUT].top }, STR_PLAYER_NAME, {}, { COLOUR_WHITE });

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -149,7 +149,7 @@ public:
     {
         ColourSchemeUpdateByClass(this, WC_SERVER_LIST);
 
-        WidgetSetCheckboxValue(this, WIDX_ADVERTISE_CHECKBOX, gConfigNetwork.advertise);
+        WidgetSetCheckboxValue(*this, WIDX_ADVERTISE_CHECKBOX, gConfigNetwork.advertise);
         auto ft = Formatter::Common();
         ft.Increment(18);
         ft.Add<uint16_t>(gConfigNetwork.maxplayers);

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -97,19 +97,19 @@ public:
                 Close();
                 break;
             case WIDX_PORT_INPUT:
-                window_start_textbox(this, widgetIndex, STR_STRING, _port, 6);
+                window_start_textbox(*this, widgetIndex, STR_STRING, _port, 6);
                 break;
             case WIDX_NAME_INPUT:
-                window_start_textbox(this, widgetIndex, STR_STRING, _name, 64);
+                window_start_textbox(*this, widgetIndex, STR_STRING, _name, 64);
                 break;
             case WIDX_DESCRIPTION_INPUT:
-                window_start_textbox(this, widgetIndex, STR_STRING, _description, MAX_SERVER_DESCRIPTION_LENGTH);
+                window_start_textbox(*this, widgetIndex, STR_STRING, _description, MAX_SERVER_DESCRIPTION_LENGTH);
                 break;
             case WIDX_GREETING_INPUT:
-                window_start_textbox(this, widgetIndex, STR_STRING, _greeting, CHAT_INPUT_SIZE);
+                window_start_textbox(*this, widgetIndex, STR_STRING, _greeting, CHAT_INPUT_SIZE);
                 break;
             case WIDX_PASSWORD_INPUT:
-                window_start_textbox(this, widgetIndex, STR_STRING, _password, 32);
+                window_start_textbox(*this, widgetIndex, STR_STRING, _password, 32);
                 break;
             case WIDX_MAXPLAYERS_INCREASE:
                 if (gConfigNetwork.maxplayers < 255)

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -159,10 +159,10 @@ public:
         if (gCurrentTextBox.window.classification == classification && gCurrentTextBox.window.number == number)
         {
             window_update_textbox_caret();
-            widget_invalidate(this, WIDX_NAME_INPUT);
-            widget_invalidate(this, WIDX_DESCRIPTION_INPUT);
-            widget_invalidate(this, WIDX_GREETING_INPUT);
-            widget_invalidate(this, WIDX_PASSWORD_INPUT);
+            widget_invalidate(*this, WIDX_NAME_INPUT);
+            widget_invalidate(*this, WIDX_DESCRIPTION_INPUT);
+            widget_invalidate(*this, WIDX_GREETING_INPUT);
+            widget_invalidate(*this, WIDX_PASSWORD_INPUT);
         }
     }
     void OnTextInput(rct_widgetindex widgetIndex, std::string_view text) override
@@ -187,7 +187,7 @@ public:
                 gConfigNetwork.default_port = atoi(_port);
                 config_save_default();
 
-                widget_invalidate(this, WIDX_NAME_INPUT);
+                widget_invalidate(*this, WIDX_NAME_INPUT);
                 break;
             case WIDX_NAME_INPUT:
                 if (strcmp(_name, temp.c_str()) == 0)
@@ -205,7 +205,7 @@ public:
                     config_save_default();
                 }
 
-                widget_invalidate(this, WIDX_NAME_INPUT);
+                widget_invalidate(*this, WIDX_NAME_INPUT);
                 break;
             case WIDX_DESCRIPTION_INPUT:
                 if (strcmp(_description, temp.c_str()) == 0)
@@ -223,7 +223,7 @@ public:
                     config_save_default();
                 }
 
-                widget_invalidate(this, WIDX_DESCRIPTION_INPUT);
+                widget_invalidate(*this, WIDX_DESCRIPTION_INPUT);
                 break;
             case WIDX_GREETING_INPUT:
                 if (strcmp(_greeting, temp.c_str()) == 0)
@@ -241,7 +241,7 @@ public:
                     config_save_default();
                 }
 
-                widget_invalidate(this, WIDX_GREETING_INPUT);
+                widget_invalidate(*this, WIDX_GREETING_INPUT);
                 break;
             case WIDX_PASSWORD_INPUT:
                 if (strcmp(_password, temp.c_str()) == 0)
@@ -253,7 +253,7 @@ public:
                     safe_strcpy(_password, temp.c_str(), sizeof(_password));
                 }
 
-                widget_invalidate(this, WIDX_PASSWORD_INPUT);
+                widget_invalidate(*this, WIDX_PASSWORD_INPUT);
                 break;
         }
     }

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -200,7 +200,7 @@ public:
     void OnUpdate() override
     {
         // Remove highlight when the mouse is not hovering over the list
-        if (_highlightedItem != -1 && !WidgetIsHighlighted(this, WIDX_SCROLL))
+        if (_highlightedItem != -1 && !WidgetIsHighlighted(*this, WIDX_SCROLL))
         {
             _highlightedItem = -1;
             InvalidateWidget(WIDX_SCROLL);

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -194,7 +194,7 @@ public:
 
     void OnResize() override
     {
-        window_set_resize(this, min_width, min_height, max_width, max_height);
+        window_set_resize(*this, min_width, min_height, max_width, max_height);
     }
 
     void OnUpdate() override

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -95,7 +95,7 @@ public:
     void OnOpen() override
     {
         widgets = window_shortcut_change_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
     }
 
     void OnClose() override
@@ -445,7 +445,7 @@ private:
         _widgets.push_back(WIDGETS_END);
         widgets = _widgets.data();
 
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
     }
 
     void SetTab(size_t index)

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -285,7 +285,7 @@ public:
 
         if (viewport != nullptr)
         {
-            window_draw_viewport(&dpi, this);
+            window_draw_viewport(&dpi, *this);
         }
     }
 

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -81,7 +81,7 @@ public:
     void OnOpen() override
     {
         widgets = window_sign_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
     }
 
     /*

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -528,7 +528,7 @@ private:
         // Draw the viewport no sound sprite
         if (viewport != nullptr)
         {
-            window_draw_viewport(dpi, this);
+            window_draw_viewport(dpi, *this);
 
             if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
             {

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -1200,7 +1200,7 @@ private:
     void FollowPeep()
     {
         rct_window* main = window_get_main();
-        window_follow_sprite(main, EntityId::FromUnderlying(number));
+        window_follow_sprite(*main, EntityId::FromUnderlying(number));
     }
 
     void DrawTabImages(rct_drawpixelinfo* dpi)

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -88,7 +88,7 @@ static void WindowStaffFireMouseup(rct_window* w, rct_widgetindex widgetIndex)
         }
         case WIDX_CANCEL:
         case WIDX_CLOSE:
-            window_close(w);
+            window_close(*w);
     }
 }
 

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -65,7 +65,7 @@ rct_window* WindowStaffFirePromptOpen(Peep* peep)
     w = WindowCreateCentred(WW, WH, &window_staff_fire_events, WC_FIRE_PROMPT, WF_TRANSPARENT);
     w->widgets = window_staff_fire_widgets;
 
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
 
     w->number = peep->sprite_index.ToUnderlying();
 
@@ -98,7 +98,7 @@ static void WindowStaffFireMouseup(rct_window* w, rct_widgetindex widgetIndex)
  */
 static void WindowStaffFirePaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     Peep* peep = GetEntity<Staff>(EntityId::FromUnderlying(w->number));
     auto ft = Formatter();

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -104,7 +104,7 @@ public:
     void OnOpen() override
     {
         widgets = window_staff_list_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
 
         widgets[WIDX_STAFF_LIST_UNIFORM_COLOUR_PICKER].type = WindowWidgetType::Empty;
         min_width = WW;

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -61,7 +61,7 @@ public:
     void OnOpen() override
     {
         widgets = window_text_input_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         SetParentWindow(nullptr, 0);
     }
 

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -134,7 +134,7 @@ public:
             auto parentWindow = GetParentWindow();
             if (parentWindow == nullptr)
             {
-                window_close(this);
+                window_close(*this);
                 return;
             }
         }
@@ -155,12 +155,12 @@ public:
             case WIDX_CLOSE:
                 context_stop_text_input();
                 ExecuteCallback(false);
-                window_close(this);
+                window_close(*this);
                 break;
             case WIDX_OKAY:
                 context_stop_text_input();
                 ExecuteCallback(true);
-                window_close(this);
+                window_close(*this);
         }
     }
 
@@ -170,7 +170,7 @@ public:
         int32_t newHeight = CalculateWindowHeight(_buffer.data());
         if (newHeight != height)
         {
-            window_set_resize(this, WW, newHeight, WW, newHeight);
+            window_set_resize(*this, WW, newHeight, WW, newHeight);
         }
 
         widgets[WIDX_OKAY].top = newHeight - 22;
@@ -299,7 +299,7 @@ public:
     {
         context_stop_text_input();
         ExecuteCallback(true);
-        window_close(this);
+        window_close(*this);
     }
 
     static int32_t CalculateWindowHeight(std::string_view text)

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -348,7 +348,7 @@ static void WindowThemesMouseup(rct_window* w, rct_widgetindex widgetIndex)
     switch (widgetIndex)
     {
         case WIDX_THEMES_CLOSE:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_THEMES_DUPLICATE_BUTTON:;
             activeAvailableThemeIndex = ThemeManagerGetAvailableThemeIndex();
@@ -596,7 +596,7 @@ void WindowThemesUpdate(rct_window* w)
     if (w->frame_no >= window_themes_tab_animation_loops[_selected_tab])
         w->frame_no = 0;
 
-    widget_invalidate(w, WIDX_THEMES_SETTINGS_TAB + _selected_tab);
+    widget_invalidate(*w, WIDX_THEMES_SETTINGS_TAB + _selected_tab);
 }
 
 void WindowThemesScrollgetsize(rct_window* w, int32_t scrollIndex, int32_t* width, int32_t* height)
@@ -654,7 +654,7 @@ void WindowThemesScrollmousedown(rct_window* w, int32_t scrollIndex, const Scree
 
                     uint8_t colour = ThemeGetColour(wc, _colour_index_2);
                     WindowDropdownShowColour(w, &(window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK]), w->colours[1], colour);
-                    widget_invalidate(w, WIDX_THEMES_LIST);
+                    widget_invalidate(*w, WIDX_THEMES_LIST);
                 }
             }
             else if (

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -328,7 +328,7 @@ rct_window* WindowThemesOpen()
 
     WindowThemesInitVars();
 
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
     window->list_information_type = 0;
     _colour_index_1 = -1;
     _colour_index_2 = -1;
@@ -810,7 +810,7 @@ void WindowThemesInvalidate(rct_window* w)
 void WindowThemesPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     // Widgets
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
     WindowThemesDrawTabImages(dpi, w);
 
     if (_selected_tab == WINDOW_THEMES_TAB_SETTINGS)

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -783,11 +783,11 @@ void WindowThemesInvalidate(rct_window* w)
         window_themes_widgets[WIDX_THEMES_PRESETS_DROPDOWN].type = WindowWidgetType::Empty;
         window_themes_widgets[WIDX_THEMES_COLOURBTN_MASK].type = WindowWidgetType::Empty;
 
-        WidgetSetCheckboxValue(w, WIDX_THEMES_RCT1_RIDE_LIGHTS, ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_RIDE);
-        WidgetSetCheckboxValue(w, WIDX_THEMES_RCT1_PARK_LIGHTS, ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_PARK);
+        WidgetSetCheckboxValue(*w, WIDX_THEMES_RCT1_RIDE_LIGHTS, ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_RIDE);
+        WidgetSetCheckboxValue(*w, WIDX_THEMES_RCT1_PARK_LIGHTS, ThemeGetFlags() & UITHEME_FLAG_USE_LIGHTS_PARK);
         WidgetSetCheckboxValue(
-            w, WIDX_THEMES_RCT1_SCENARIO_FONT, ThemeGetFlags() & UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT);
-        WidgetSetCheckboxValue(w, WIDX_THEMES_RCT1_BOTTOM_TOOLBAR, ThemeGetFlags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR);
+            *w, WIDX_THEMES_RCT1_SCENARIO_FONT, ThemeGetFlags() & UITHEME_FLAG_USE_ALTERNATIVE_SCENARIO_SELECT_FONT);
+        WidgetSetCheckboxValue(*w, WIDX_THEMES_RCT1_BOTTOM_TOOLBAR, ThemeGetFlags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR);
     }
     else
     {

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -527,7 +527,7 @@ rct_window* WindowTileInspectorOpen()
     window->max_width = MAX_WW;
     window->max_height = MAX_WH;
     windowTileInspectorSelectedIndex = -1;
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
 
     windowTileInspectorTileSelected = false;
 
@@ -1720,7 +1720,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
 
 static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     ScreenCoordsXY screenCoords(w->windowPos.x, w->windowPos.y);
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -897,7 +897,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
                     break;
                 case WIDX_TRACK_CHECK_CHAIN_LIFT:
                 {
-                    bool entireTrackBlock = WidgetIsPressed(w, WIDX_TRACK_CHECK_APPLY_TO_ALL);
+                    bool entireTrackBlock = WidgetIsPressed(*w, WIDX_TRACK_CHECK_APPLY_TO_ALL);
                     bool newLift = !tileElement->AsTrack()->HasChain();
                     WindowTileInspectorTrackBlockSetLift(windowTileInspectorSelectedIndex, entireTrackBlock, newLift);
                     break;
@@ -1042,7 +1042,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
             switch (widgetIndex)
             {
                 case WIDX_TRACK_SPINNER_HEIGHT_INCREASE:
-                    if (WidgetIsPressed(w, WIDX_TRACK_CHECK_APPLY_TO_ALL))
+                    if (WidgetIsPressed(*w, WIDX_TRACK_CHECK_APPLY_TO_ALL))
                     {
                         WindowTileInspectorTrackBlockHeightOffset(windowTileInspectorSelectedIndex, 1);
                     }
@@ -1052,7 +1052,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
                     }
                     break;
                 case WIDX_TRACK_SPINNER_HEIGHT_DECREASE:
-                    if (WidgetIsPressed(w, WIDX_TRACK_CHECK_APPLY_TO_ALL))
+                    if (WidgetIsPressed(*w, WIDX_TRACK_CHECK_APPLY_TO_ALL))
                     {
                         WindowTileInspectorTrackBlockHeightOffset(windowTileInspectorSelectedIndex, -1);
                     }
@@ -1161,7 +1161,7 @@ static void WindowTileInspectorMousedown(rct_window* w, rct_widgetindex widgetIn
 static void WindowTileInspectorUpdate(rct_window* w)
 {
     // Check if the mouse is hovering over the list
-    if (!WidgetIsHighlighted(w, WIDX_LIST))
+    if (!WidgetIsHighlighted(*w, WIDX_LIST))
     {
         windowTileInspectorHighlightedIndex = -1;
         widget_invalidate(w, WIDX_LIST);
@@ -1406,35 +1406,35 @@ static void WindowTileInspectorInvalidate(rct_window* w)
 
     // X and Y spinners
     WidgetSetEnabled(
-        w, WIDX_SPINNER_X_INCREASE,
+        *w, WIDX_SPINNER_X_INCREASE,
         (windowTileInspectorTileSelected && ((windowTileInspectorToolMap.x / 32) < MAXIMUM_MAP_SIZE_TECHNICAL - 1)));
     WidgetSetEnabled(
-        w, WIDX_SPINNER_X_DECREASE, (windowTileInspectorTileSelected && ((windowTileInspectorToolMap.x / 32) > 0)));
+        *w, WIDX_SPINNER_X_DECREASE, (windowTileInspectorTileSelected && ((windowTileInspectorToolMap.x / 32) > 0)));
     WidgetSetEnabled(
-        w, WIDX_SPINNER_Y_INCREASE,
+        *w, WIDX_SPINNER_Y_INCREASE,
         (windowTileInspectorTileSelected && ((windowTileInspectorToolMap.y / 32) < MAXIMUM_MAP_SIZE_TECHNICAL - 1)));
     WidgetSetEnabled(
-        w, WIDX_SPINNER_Y_DECREASE, (windowTileInspectorTileSelected && ((windowTileInspectorToolMap.y / 32) > 0)));
+        *w, WIDX_SPINNER_Y_DECREASE, (windowTileInspectorTileSelected && ((windowTileInspectorToolMap.y / 32) > 0)));
 
     // Sort buttons
-    WidgetSetEnabled(w, WIDX_BUTTON_SORT, (windowTileInspectorTileSelected && windowTileInspectorElementCount > 1));
+    WidgetSetEnabled(*w, WIDX_BUTTON_SORT, (windowTileInspectorTileSelected && windowTileInspectorElementCount > 1));
 
     // Move Up button
     WidgetSetEnabled(
-        w, WIDX_BUTTON_MOVE_UP,
+        *w, WIDX_BUTTON_MOVE_UP,
         (windowTileInspectorSelectedIndex != -1 && windowTileInspectorSelectedIndex < windowTileInspectorElementCount - 1));
     widget_invalidate(w, WIDX_BUTTON_MOVE_UP);
 
     // Move Down button
-    WidgetSetEnabled(w, WIDX_BUTTON_MOVE_DOWN, (windowTileInspectorSelectedIndex > 0));
+    WidgetSetEnabled(*w, WIDX_BUTTON_MOVE_DOWN, (windowTileInspectorSelectedIndex > 0));
     widget_invalidate(w, WIDX_BUTTON_MOVE_DOWN);
 
     // Copy button
-    WidgetSetEnabled(w, WIDX_BUTTON_COPY, windowTileInspectorSelectedIndex >= 0);
+    WidgetSetEnabled(*w, WIDX_BUTTON_COPY, windowTileInspectorSelectedIndex >= 0);
     widget_invalidate(w, WIDX_BUTTON_COPY);
 
     // Paste button
-    WidgetSetEnabled(w, WIDX_BUTTON_PASTE, windowTileInspectorTileSelected && windowTileInspectorElementCopied);
+    WidgetSetEnabled(*w, WIDX_BUTTON_PASTE, windowTileInspectorTileSelected && windowTileInspectorElementCopied);
     widget_invalidate(w, WIDX_BUTTON_PASTE);
 
     w->widgets[WIDX_BACKGROUND].bottom = w->height - 1;
@@ -1495,19 +1495,19 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             w->widgets[WIDX_SURFACE_CHECK_DIAGONAL].top = GBBT(propertiesAnchor, 3) + 7 * 1;
             w->widgets[WIDX_SURFACE_CHECK_DIAGONAL].bottom = w->widgets[WIDX_SURFACE_CHECK_DIAGONAL].top + 13;
             WidgetSetCheckboxValue(
-                w, WIDX_SURFACE_CHECK_CORNER_N,
+                *w, WIDX_SURFACE_CHECK_CORNER_N,
                 tileElement->AsSurface()->GetSlope() & (1 << ((2 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_SURFACE_CHECK_CORNER_E,
+                *w, WIDX_SURFACE_CHECK_CORNER_E,
                 tileElement->AsSurface()->GetSlope() & (1 << ((3 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_SURFACE_CHECK_CORNER_S,
+                *w, WIDX_SURFACE_CHECK_CORNER_S,
                 tileElement->AsSurface()->GetSlope() & (1 << ((0 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_SURFACE_CHECK_CORNER_W,
+                *w, WIDX_SURFACE_CHECK_CORNER_W,
                 tileElement->AsSurface()->GetSlope() & (1 << ((1 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_SURFACE_CHECK_DIAGONAL, tileElement->AsSurface()->GetSlope() & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT);
+                *w, WIDX_SURFACE_CHECK_DIAGONAL, tileElement->AsSurface()->GetSlope() & TILE_ELEMENT_SLOPE_DOUBLE_HEIGHT);
             break;
         case TileElementType::Path:
             w->widgets[WIDX_PATH_SPINNER_HEIGHT].top = GBBT(propertiesAnchor, 0) + 3;
@@ -1536,24 +1536,24 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             w->widgets[WIDX_PATH_CHECK_EDGE_W].bottom = w->widgets[WIDX_PATH_CHECK_EDGE_W].top + 13;
             w->widgets[WIDX_PATH_CHECK_EDGE_NW].top = GBBT(propertiesAnchor, 3) + 7 * 1;
             w->widgets[WIDX_PATH_CHECK_EDGE_NW].bottom = w->widgets[WIDX_PATH_CHECK_EDGE_NW].top + 13;
-            WidgetSetCheckboxValue(w, WIDX_PATH_CHECK_SLOPED, tileElement->AsPath()->IsSloped());
-            WidgetSetCheckboxValue(w, WIDX_PATH_CHECK_BROKEN, tileElement->AsPath()->IsBroken());
+            WidgetSetCheckboxValue(*w, WIDX_PATH_CHECK_SLOPED, tileElement->AsPath()->IsSloped());
+            WidgetSetCheckboxValue(*w, WIDX_PATH_CHECK_BROKEN, tileElement->AsPath()->IsBroken());
             WidgetSetCheckboxValue(
-                w, WIDX_PATH_CHECK_EDGE_NE, tileElement->AsPath()->GetEdges() & (1 << ((0 - get_current_rotation()) & 3)));
+                *w, WIDX_PATH_CHECK_EDGE_NE, tileElement->AsPath()->GetEdges() & (1 << ((0 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_PATH_CHECK_EDGE_SE, tileElement->AsPath()->GetEdges() & (1 << ((1 - get_current_rotation()) & 3)));
+                *w, WIDX_PATH_CHECK_EDGE_SE, tileElement->AsPath()->GetEdges() & (1 << ((1 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_PATH_CHECK_EDGE_SW, tileElement->AsPath()->GetEdges() & (1 << ((2 - get_current_rotation()) & 3)));
+                *w, WIDX_PATH_CHECK_EDGE_SW, tileElement->AsPath()->GetEdges() & (1 << ((2 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_PATH_CHECK_EDGE_NW, tileElement->AsPath()->GetEdges() & (1 << ((3 - get_current_rotation()) & 3)));
+                *w, WIDX_PATH_CHECK_EDGE_NW, tileElement->AsPath()->GetEdges() & (1 << ((3 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_PATH_CHECK_EDGE_E, tileElement->AsPath()->GetCorners() & (1 << ((0 - get_current_rotation()) & 3)));
+                *w, WIDX_PATH_CHECK_EDGE_E, tileElement->AsPath()->GetCorners() & (1 << ((0 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_PATH_CHECK_EDGE_S, tileElement->AsPath()->GetCorners() & (1 << ((1 - get_current_rotation()) & 3)));
+                *w, WIDX_PATH_CHECK_EDGE_S, tileElement->AsPath()->GetCorners() & (1 << ((1 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_PATH_CHECK_EDGE_W, tileElement->AsPath()->GetCorners() & (1 << ((2 - get_current_rotation()) & 3)));
+                *w, WIDX_PATH_CHECK_EDGE_W, tileElement->AsPath()->GetCorners() & (1 << ((2 - get_current_rotation()) & 3)));
             WidgetSetCheckboxValue(
-                w, WIDX_PATH_CHECK_EDGE_N, tileElement->AsPath()->GetCorners() & (1 << ((3 - get_current_rotation()) & 3)));
+                *w, WIDX_PATH_CHECK_EDGE_N, tileElement->AsPath()->GetCorners() & (1 << ((3 - get_current_rotation()) & 3)));
             break;
         case TileElementType::Track:
             w->widgets[WIDX_TRACK_CHECK_APPLY_TO_ALL].top = GBBT(propertiesAnchor, 0);
@@ -1570,10 +1570,10 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             w->widgets[WIDX_TRACK_CHECK_BLOCK_BRAKE_CLOSED].bottom = GBBB(propertiesAnchor, 3);
             w->widgets[WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE].top = GBBT(propertiesAnchor, 4);
             w->widgets[WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE].bottom = GBBB(propertiesAnchor, 4);
-            WidgetSetCheckboxValue(w, WIDX_TRACK_CHECK_APPLY_TO_ALL, windowTileInspectorApplyToAll);
-            WidgetSetCheckboxValue(w, WIDX_TRACK_CHECK_CHAIN_LIFT, tileElement->AsTrack()->HasChain());
-            WidgetSetCheckboxValue(w, WIDX_TRACK_CHECK_BLOCK_BRAKE_CLOSED, tileElement->AsTrack()->BlockBrakeClosed());
-            WidgetSetCheckboxValue(w, WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE, tileElement->AsTrack()->IsIndestructible());
+            WidgetSetCheckboxValue(*w, WIDX_TRACK_CHECK_APPLY_TO_ALL, windowTileInspectorApplyToAll);
+            WidgetSetCheckboxValue(*w, WIDX_TRACK_CHECK_CHAIN_LIFT, tileElement->AsTrack()->HasChain());
+            WidgetSetCheckboxValue(*w, WIDX_TRACK_CHECK_BLOCK_BRAKE_CLOSED, tileElement->AsTrack()->BlockBrakeClosed());
+            WidgetSetCheckboxValue(*w, WIDX_TRACK_CHECK_IS_INDESTRUCTIBLE, tileElement->AsTrack()->IsIndestructible());
             break;
         case TileElementType::SmallScenery:
         {
@@ -1599,10 +1599,10 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             bool E = tileElement->AsSmallScenery()->GetSceneryQuadrant() == ((1 - get_current_rotation()) & 3);
             bool S = tileElement->AsSmallScenery()->GetSceneryQuadrant() == ((2 - get_current_rotation()) & 3);
             bool W = tileElement->AsSmallScenery()->GetSceneryQuadrant() == ((3 - get_current_rotation()) & 3);
-            WidgetSetCheckboxValue(w, WIDX_SCENERY_CHECK_QUARTER_N, N);
-            WidgetSetCheckboxValue(w, WIDX_SCENERY_CHECK_QUARTER_E, E);
-            WidgetSetCheckboxValue(w, WIDX_SCENERY_CHECK_QUARTER_S, S);
-            WidgetSetCheckboxValue(w, WIDX_SCENERY_CHECK_QUARTER_W, W);
+            WidgetSetCheckboxValue(*w, WIDX_SCENERY_CHECK_QUARTER_N, N);
+            WidgetSetCheckboxValue(*w, WIDX_SCENERY_CHECK_QUARTER_E, E);
+            WidgetSetCheckboxValue(*w, WIDX_SCENERY_CHECK_QUARTER_S, S);
+            WidgetSetCheckboxValue(*w, WIDX_SCENERY_CHECK_QUARTER_W, W);
 
             // Collision checkboxes
             w->widgets[WIDX_SCENERY_CHECK_COLLISION_N].top = GBBT(propertiesAnchor, 2) + 5 + 7 * 0;
@@ -1618,10 +1618,10 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             E = (occupiedQuadrants & (1 << ((3 - get_current_rotation()) & 3))) != 0;
             S = (occupiedQuadrants & (1 << ((0 - get_current_rotation()) & 3))) != 0;
             W = (occupiedQuadrants & (1 << ((1 - get_current_rotation()) & 3))) != 0;
-            WidgetSetCheckboxValue(w, WIDX_SCENERY_CHECK_COLLISION_N, N);
-            WidgetSetCheckboxValue(w, WIDX_SCENERY_CHECK_COLLISION_E, E);
-            WidgetSetCheckboxValue(w, WIDX_SCENERY_CHECK_COLLISION_S, S);
-            WidgetSetCheckboxValue(w, WIDX_SCENERY_CHECK_COLLISION_W, W);
+            WidgetSetCheckboxValue(*w, WIDX_SCENERY_CHECK_COLLISION_N, N);
+            WidgetSetCheckboxValue(*w, WIDX_SCENERY_CHECK_COLLISION_E, E);
+            WidgetSetCheckboxValue(*w, WIDX_SCENERY_CHECK_COLLISION_S, S);
+            WidgetSetCheckboxValue(*w, WIDX_SCENERY_CHECK_COLLISION_W, W);
             break;
         }
         case TileElementType::Entrance:
@@ -1634,7 +1634,7 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             w->widgets[WIDX_ENTRANCE_BUTTON_MAKE_USABLE].top = GBBT(propertiesAnchor, 1);
             w->widgets[WIDX_ENTRANCE_BUTTON_MAKE_USABLE].bottom = GBBB(propertiesAnchor, 1);
             WidgetSetEnabled(
-                w, WIDX_ENTRANCE_BUTTON_MAKE_USABLE,
+                *w, WIDX_ENTRANCE_BUTTON_MAKE_USABLE,
                 tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE);
             break;
         case TileElementType::Wall:
@@ -1667,14 +1667,14 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             w->widgets[WIDX_WALL_SPINNER_ANIMATION_FRAME_DECREASE].bottom = GBBB(propertiesAnchor, 2) - 4;
 
             // Wall slope dropdown
-            WidgetSetEnabled(w, WIDX_WALL_DROPDOWN_SLOPE, canBeSloped);
+            WidgetSetEnabled(*w, WIDX_WALL_DROPDOWN_SLOPE, canBeSloped);
             widget_invalidate(w, WIDX_WALL_DROPDOWN_SLOPE);
-            WidgetSetEnabled(w, WIDX_WALL_DROPDOWN_SLOPE_BUTTON, canBeSloped);
+            WidgetSetEnabled(*w, WIDX_WALL_DROPDOWN_SLOPE_BUTTON, canBeSloped);
             widget_invalidate(w, WIDX_WALL_DROPDOWN_SLOPE_BUTTON);
             // Wall animation frame spinner
-            WidgetSetEnabled(w, WIDX_WALL_SPINNER_ANIMATION_FRAME, hasAnimation);
-            WidgetSetEnabled(w, WIDX_WALL_SPINNER_ANIMATION_FRAME_INCREASE, hasAnimation);
-            WidgetSetEnabled(w, WIDX_WALL_SPINNER_ANIMATION_FRAME_DECREASE, hasAnimation);
+            WidgetSetEnabled(*w, WIDX_WALL_SPINNER_ANIMATION_FRAME, hasAnimation);
+            WidgetSetEnabled(*w, WIDX_WALL_SPINNER_ANIMATION_FRAME_INCREASE, hasAnimation);
+            WidgetSetEnabled(*w, WIDX_WALL_SPINNER_ANIMATION_FRAME_DECREASE, hasAnimation);
             break;
         }
         case TileElementType::LargeScenery:
@@ -1701,16 +1701,16 @@ static void WindowTileInspectorInvalidate(rct_window* w)
             w->widgets[WIDX_BANNER_CHECK_BLOCK_NW].top = GBBT(propertiesAnchor, 1);
             w->widgets[WIDX_BANNER_CHECK_BLOCK_NW].bottom = GBBB(propertiesAnchor, 1);
             WidgetSetCheckboxValue(
-                w, WIDX_BANNER_CHECK_BLOCK_NE,
+                *w, WIDX_BANNER_CHECK_BLOCK_NE,
                 !(tileElement->AsBanner()->GetAllowedEdges() & (1 << ((0 - get_current_rotation()) & 3))));
             WidgetSetCheckboxValue(
-                w, WIDX_BANNER_CHECK_BLOCK_SE,
+                *w, WIDX_BANNER_CHECK_BLOCK_SE,
                 !(tileElement->AsBanner()->GetAllowedEdges() & (1 << ((1 - get_current_rotation()) & 3))));
             WidgetSetCheckboxValue(
-                w, WIDX_BANNER_CHECK_BLOCK_SW,
+                *w, WIDX_BANNER_CHECK_BLOCK_SW,
                 !(tileElement->AsBanner()->GetAllowedEdges() & (1 << ((2 - get_current_rotation()) & 3))));
             WidgetSetCheckboxValue(
-                w, WIDX_BANNER_CHECK_BLOCK_NW,
+                *w, WIDX_BANNER_CHECK_BLOCK_NW,
                 !(tileElement->AsBanner()->GetAllowedEdges() & (1 << ((3 - get_current_rotation()) & 3))));
             break;
         default:
@@ -2153,7 +2153,7 @@ static void WindowTileInspectorPaint(rct_window* w, rct_drawpixelinfo* dpi)
 
                 // Current animation frame
                 colour_t colour = w->colours[1];
-                if (WidgetIsDisabled(w, WIDX_WALL_SPINNER_ANIMATION_FRAME))
+                if (WidgetIsDisabled(*w, WIDX_WALL_SPINNER_ANIMATION_FRAME))
                 {
                     colour = w->colours[0] | COLOUR_FLAG_INSET;
                 }

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -782,7 +782,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
     {
         case WIDX_CLOSE:
             tool_cancel();
-            window_close(w);
+            window_close(*w);
             return;
         case WIDX_BUTTON_REMOVE:
         {
@@ -893,7 +893,7 @@ static void WindowTileInspectorMouseup(rct_window* w, rct_widgetindex widgetInde
             {
                 case WIDX_TRACK_CHECK_APPLY_TO_ALL:
                     windowTileInspectorApplyToAll ^= 1;
-                    widget_invalidate(w, widgetIndex);
+                    widget_invalidate(*w, widgetIndex);
                     break;
                 case WIDX_TRACK_CHECK_CHAIN_LIFT:
                 {
@@ -1164,11 +1164,11 @@ static void WindowTileInspectorUpdate(rct_window* w)
     if (!WidgetIsHighlighted(*w, WIDX_LIST))
     {
         windowTileInspectorHighlightedIndex = -1;
-        widget_invalidate(w, WIDX_LIST);
+        widget_invalidate(*w, WIDX_LIST);
     }
 
     if (gCurrentToolWidget.window_classification != WC_TILE_INSPECTOR)
-        window_close(w);
+        window_close(*w);
 }
 
 static void WindowTileInspectorDropdown(rct_window* w, rct_widgetindex widgetIndex, int32_t dropdownIndex)
@@ -1358,7 +1358,7 @@ static void WindowTileInspectorScrollmouseover(rct_window* w, int32_t scrollInde
     else
         windowTileInspectorHighlightedIndex = index;
 
-    widget_invalidate(w, WIDX_LIST);
+    widget_invalidate(*w, WIDX_LIST);
 }
 
 static void WindowTileInspectorInvalidate(rct_window* w)
@@ -1423,19 +1423,19 @@ static void WindowTileInspectorInvalidate(rct_window* w)
     WidgetSetEnabled(
         *w, WIDX_BUTTON_MOVE_UP,
         (windowTileInspectorSelectedIndex != -1 && windowTileInspectorSelectedIndex < windowTileInspectorElementCount - 1));
-    widget_invalidate(w, WIDX_BUTTON_MOVE_UP);
+    widget_invalidate(*w, WIDX_BUTTON_MOVE_UP);
 
     // Move Down button
     WidgetSetEnabled(*w, WIDX_BUTTON_MOVE_DOWN, (windowTileInspectorSelectedIndex > 0));
-    widget_invalidate(w, WIDX_BUTTON_MOVE_DOWN);
+    widget_invalidate(*w, WIDX_BUTTON_MOVE_DOWN);
 
     // Copy button
     WidgetSetEnabled(*w, WIDX_BUTTON_COPY, windowTileInspectorSelectedIndex >= 0);
-    widget_invalidate(w, WIDX_BUTTON_COPY);
+    widget_invalidate(*w, WIDX_BUTTON_COPY);
 
     // Paste button
     WidgetSetEnabled(*w, WIDX_BUTTON_PASTE, windowTileInspectorTileSelected && windowTileInspectorElementCopied);
-    widget_invalidate(w, WIDX_BUTTON_PASTE);
+    widget_invalidate(*w, WIDX_BUTTON_PASTE);
 
     w->widgets[WIDX_BACKGROUND].bottom = w->height - 1;
 
@@ -1668,9 +1668,9 @@ static void WindowTileInspectorInvalidate(rct_window* w)
 
             // Wall slope dropdown
             WidgetSetEnabled(*w, WIDX_WALL_DROPDOWN_SLOPE, canBeSloped);
-            widget_invalidate(w, WIDX_WALL_DROPDOWN_SLOPE);
+            widget_invalidate(*w, WIDX_WALL_DROPDOWN_SLOPE);
             WidgetSetEnabled(*w, WIDX_WALL_DROPDOWN_SLOPE_BUTTON, canBeSloped);
-            widget_invalidate(w, WIDX_WALL_DROPDOWN_SLOPE_BUTTON);
+            widget_invalidate(*w, WIDX_WALL_DROPDOWN_SLOPE_BUTTON);
             // Wall animation frame spinner
             WidgetSetEnabled(*w, WIDX_WALL_SPINNER_ANIMATION_FRAME, hasAnimation);
             WidgetSetEnabled(*w, WIDX_WALL_SPINNER_ANIMATION_FRAME_INCREASE, hasAnimation);

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -47,7 +47,7 @@ rct_window* WindowTitleExitOpen()
         ScreenCoordsXY(context_get_width() - 40, context_get_height() - 64), 40, 64, &window_title_exit_events, WC_TITLE_EXIT,
         WF_STICK_TO_BACK | WF_TRANSPARENT);
     window->widgets = window_title_exit_widgets;
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
 
     return window;
 }
@@ -76,5 +76,5 @@ static void WindowTitleExitMouseup(rct_window* w, rct_widgetindex widgetIndex)
  */
 static void WindowTitleExitPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 }

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -47,7 +47,7 @@ rct_window* WindowTitleLogoOpen()
     rct_window* window = WindowCreate(
         ScreenCoordsXY(0, 0), WW, WH, &window_title_logo_events, WC_TITLE_LOGO, WF_STICK_TO_BACK | WF_TRANSPARENT);
     window->widgets = window_title_logo_widgets;
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
     window->colours[0] = TRANSLUCENT(COLOUR_GREY);
     window->colours[1] = TRANSLUCENT(COLOUR_GREY);
     window->colours[2] = TRANSLUCENT(COLOUR_GREY);

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -110,7 +110,7 @@ rct_window* WindowTitleMenuOpen()
     window->windowPos.x = (context_get_width() - window->width) / 2;
     window->colours[1] = TRANSLUCENT(COLOUR_LIGHT_ORANGE);
 
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
 
     return window;
 }
@@ -296,5 +296,5 @@ static void WindowTitleMenuInvalidate(rct_window* w)
 static void WindowTitleMenuPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     gfx_filter_rect(dpi, _filterRect, FilterPaletteID::Palette51);
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 }

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -133,7 +133,7 @@ static void WindowTitleMenuMouseup(rct_window* w, rct_widgetindex widgetIndex)
             windowToOpen = window_find_by_class(WC_SCENARIO_SELECT);
             if (windowToOpen != nullptr)
             {
-                window_bring_to_front(windowToOpen);
+                window_bring_to_front(*windowToOpen);
             }
             else
             {
@@ -146,7 +146,7 @@ static void WindowTitleMenuMouseup(rct_window* w, rct_widgetindex widgetIndex)
             windowToOpen = window_find_by_class(WC_LOADSAVE);
             if (windowToOpen != nullptr)
             {
-                window_bring_to_front(windowToOpen);
+                window_bring_to_front(*windowToOpen);
             }
             else
             {
@@ -160,7 +160,7 @@ static void WindowTitleMenuMouseup(rct_window* w, rct_widgetindex widgetIndex)
             windowToOpen = window_find_by_class(WC_SERVER_LIST);
             if (windowToOpen != nullptr)
             {
-                window_bring_to_front(windowToOpen);
+                window_bring_to_front(*windowToOpen);
             }
             else
             {

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -43,7 +43,7 @@ rct_window* WindowTitleOptionsOpen()
         ScreenCoordsXY(context_get_width() - 80, 0), 80, 15, &window_title_options_events, WC_TITLE_OPTIONS,
         WF_STICK_TO_BACK | WF_TRANSPARENT);
     window->widgets = window_title_options_widgets;
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
 
     return window;
 }
@@ -63,5 +63,5 @@ static void WindowTitleOptionsMouseup(rct_window* w, rct_widgetindex widgetIndex
 
 static void WindowTitleOptionsPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -366,11 +366,11 @@ static void WindowTopToolbarMouseup(rct_window* w, rct_widgetindex widgetIndex)
             break;
         case WIDX_ZOOM_OUT:
             if ((mainWindow = window_get_main()) != nullptr)
-                window_zoom_out(mainWindow, false);
+                window_zoom_out(*mainWindow, false);
             break;
         case WIDX_ZOOM_IN:
             if ((mainWindow = window_get_main()) != nullptr)
-                window_zoom_in(mainWindow, false);
+                window_zoom_in(*mainWindow, false);
             break;
         case WIDX_CLEAR_SCENERY:
             ToggleClearSceneryWindow(w, WIDX_CLEAR_SCENERY);
@@ -3073,7 +3073,7 @@ static void WindowTopToolbarLandToolDrag(const ScreenCoordsXY& screenPos)
     rct_window* window = window_find_from_point(screenPos);
     if (window == nullptr)
         return;
-    rct_widgetindex widget_index = window_find_widget_from_point(window, screenPos);
+    rct_widgetindex widget_index = window_find_widget_from_point(*window, screenPos);
     if (widget_index == -1)
         return;
     const auto& widget = window->widgets[widget_index];
@@ -3116,7 +3116,7 @@ static void WindowTopToolbarWaterToolDrag(const ScreenCoordsXY& screenPos)
     rct_window* window = window_find_from_point(screenPos);
     if (!window)
         return;
-    rct_widgetindex widget_index = window_find_widget_from_point(window, screenPos);
+    rct_widgetindex widget_index = window_find_widget_from_point(*window, screenPos);
     if (widget_index == -1)
         return;
     const auto& widget = window->widgets[widget_index];
@@ -3446,12 +3446,12 @@ static void TopToolbarRotateMenuDropdown(int16_t dropdownIndex)
     {
         if (dropdownIndex == 0)
         {
-            window_rotate_camera(w, 1);
+            window_rotate_camera(*w, 1);
             w->Invalidate();
         }
         else if (dropdownIndex == 1)
         {
-            window_rotate_camera(w, -1);
+            window_rotate_camera(*w, -1);
             w->Invalidate();
         }
     }

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -893,7 +893,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
         screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_STAFF].left,
                       w->windowPos.y + window_top_toolbar_widgets[WIDX_STAFF].top };
         imgId = SPR_TOOLBAR_STAFF;
-        if (WidgetIsPressed(w, WIDX_STAFF))
+        if (WidgetIsPressed(*w, WIDX_STAFF))
             imgId++;
         gfx_draw_sprite(dpi, ImageId(imgId, gStaffHandymanColour, gStaffMechanicColour), screenPos);
     }
@@ -903,7 +903,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         screenPos = { w->windowPos.x + window_top_toolbar_widgets[WIDX_FASTFORWARD].left + 0,
                       w->windowPos.y + window_top_toolbar_widgets[WIDX_FASTFORWARD].top + 0 };
-        if (WidgetIsPressed(w, WIDX_FASTFORWARD))
+        if (WidgetIsPressed(*w, WIDX_FASTFORWARD))
             screenPos.y++;
         gfx_draw_sprite(dpi, ImageId(SPR_G2_FASTFORWARD), screenPos + ScreenCoordsXY{ 6, 3 });
 
@@ -923,7 +923,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
         screenPos = w->windowPos
             + ScreenCoordsXY{ window_top_toolbar_widgets[WIDX_CHEATS].left - 1,
                               window_top_toolbar_widgets[WIDX_CHEATS].top - 1 };
-        if (WidgetIsPressed(w, WIDX_CHEATS))
+        if (WidgetIsPressed(*w, WIDX_CHEATS))
             screenPos.y++;
         gfx_draw_sprite(dpi, ImageId(SPR_G2_SANDBOX), screenPos);
 
@@ -941,7 +941,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         screenPos = w->windowPos
             + ScreenCoordsXY{ window_top_toolbar_widgets[WIDX_CHAT].left, window_top_toolbar_widgets[WIDX_CHAT].top - 2 };
-        if (WidgetIsPressed(w, WIDX_CHAT))
+        if (WidgetIsPressed(*w, WIDX_CHAT))
             screenPos.y++;
         gfx_draw_sprite(dpi, ImageId(SPR_G2_CHAT), screenPos);
     }
@@ -951,7 +951,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         screenPos = w->windowPos
             + ScreenCoordsXY{ window_top_toolbar_widgets[WIDX_DEBUG].left, window_top_toolbar_widgets[WIDX_DEBUG].top - 1 };
-        if (WidgetIsPressed(w, WIDX_DEBUG))
+        if (WidgetIsPressed(*w, WIDX_DEBUG))
             screenPos.y++;
         gfx_draw_sprite(dpi, ImageId(SPR_TAB_GEARS_0), screenPos);
     }
@@ -962,7 +962,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
         screenPos = w->windowPos
             + ScreenCoordsXY{ window_top_toolbar_widgets[WIDX_RESEARCH].left - 1,
                               window_top_toolbar_widgets[WIDX_RESEARCH].top };
-        if (WidgetIsPressed(w, WIDX_RESEARCH))
+        if (WidgetIsPressed(*w, WIDX_RESEARCH))
             screenPos.y++;
         gfx_draw_sprite(dpi, ImageId(SPR_TAB_FINANCES_RESEARCH_0), screenPos);
     }
@@ -973,7 +973,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
         screenPos = w->windowPos
             + ScreenCoordsXY{ window_top_toolbar_widgets[WIDX_FINANCES].left + 3,
                               window_top_toolbar_widgets[WIDX_FINANCES].top + 1 };
-        if (WidgetIsPressed(w, WIDX_FINANCES))
+        if (WidgetIsPressed(*w, WIDX_FINANCES))
             screenPos.y++;
         gfx_draw_sprite(dpi, ImageId(SPR_FINANCE), screenPos);
     }
@@ -983,7 +983,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
     {
         screenPos = w->windowPos
             + ScreenCoordsXY{ window_top_toolbar_widgets[WIDX_NEWS].left + 3, window_top_toolbar_widgets[WIDX_NEWS].top + 0 };
-        if (WidgetIsPressed(w, WIDX_NEWS))
+        if (WidgetIsPressed(*w, WIDX_NEWS))
             screenPos.y++;
         gfx_draw_sprite(dpi, ImageId(SPR_G2_TAB_NEWS), screenPos);
     }
@@ -994,7 +994,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
         screenPos = w->windowPos
             + ScreenCoordsXY{ window_top_toolbar_widgets[WIDX_NETWORK].left + 3,
                               window_top_toolbar_widgets[WIDX_NETWORK].top + 0 };
-        if (WidgetIsPressed(w, WIDX_NETWORK))
+        if (WidgetIsPressed(*w, WIDX_NETWORK))
             screenPos.y++;
 
         // Draw (de)sync icon.

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -342,7 +342,7 @@ rct_window* WindowTopToolbarOpen()
         WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_BACKGROUND);
     window->widgets = window_top_toolbar_widgets;
 
-    WindowInitScrollWidgets(window);
+    WindowInitScrollWidgets(*window);
 
     return window;
 }
@@ -884,7 +884,7 @@ static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     int32_t imgId;
 
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     ScreenCoordsXY screenPos{};
     // Draw staff button image (setting masks to the staff colours)

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -99,7 +99,7 @@ rct_window* WindowTrackManageOpen(TrackDesignFileRef* tdFileRef)
     rct_window* w = WindowCreateCentred(
         WW, WH, &window_track_manage_events, WC_MANAGE_TRACK_DESIGN, WF_STICK_TO_FRONT | WF_TRANSPARENT);
     w->widgets = window_track_manage_widgets;
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
 
     rct_window* trackDesignListWindow = window_find_by_class(WC_TRACK_DESIGN_LIST);
     if (trackDesignListWindow != nullptr)
@@ -190,7 +190,7 @@ static void WindowTrackManageTextinput(rct_window* w, rct_widgetindex widgetInde
 static void WindowTrackManagePaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
     Formatter::Common().Add<const utf8*>(_trackDesignFileReference->name.c_str());
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 }
 
 /**
@@ -208,7 +208,7 @@ static void WindowTrackDeletePromptOpen()
             std::max(TOP_TOOLBAR_HEIGHT + 1, (screenWidth - WW_DELETE_PROMPT) / 2), (screenHeight - WH_DELETE_PROMPT) / 2),
         WW_DELETE_PROMPT, WH_DELETE_PROMPT, &window_track_delete_prompt_events, WC_TRACK_DELETE_PROMPT, WF_STICK_TO_FRONT);
     w->widgets = window_track_delete_prompt_widgets;
-    WindowInitScrollWidgets(w);
+    WindowInitScrollWidgets(*w);
     w->flags |= WF_TRANSPARENT;
 }
 
@@ -245,7 +245,7 @@ static void WindowTrackDeletePromptMouseup(rct_window* w, rct_widgetindex widget
  */
 static void WindowTrackDeletePromptPaint(rct_window* w, rct_drawpixelinfo* dpi)
 {
-    WindowDrawWidgets(w, dpi);
+    WindowDrawWidgets(*w, dpi);
 
     auto ft = Formatter();
     ft.Add<const utf8*>(_trackDesignFileReference->name.c_str());

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -135,7 +135,7 @@ static void WindowTrackManageMouseup(rct_window* w, rct_widgetindex widgetIndex)
     {
         case WIDX_CLOSE:
             window_close_by_class(WC_TRACK_DELETE_PROMPT);
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_RENAME:
             WindowTextInputRawOpen(
@@ -174,7 +174,7 @@ static void WindowTrackManageTextinput(rct_window* w, rct_widgetindex widgetInde
     if (track_repository_rename(_trackDesignFileReference->path, text))
     {
         window_close_by_class(WC_TRACK_DELETE_PROMPT);
-        window_close(w);
+        window_close(*w);
         WindowTrackDesignListReloadTracks();
     }
     else
@@ -222,10 +222,10 @@ static void WindowTrackDeletePromptMouseup(rct_window* w, rct_widgetindex widget
     {
         case WIDX_CLOSE:
         case WIDX_PROMPT_CANCEL:
-            window_close(w);
+            window_close(*w);
             break;
         case WIDX_PROMPT_DELETE:
-            window_close(w);
+            window_close(*w);
             if (track_repository_delete(_trackDesignFileReference->path))
             {
                 window_close_by_class(WC_MANAGE_TRACK_DESIGN);

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -78,7 +78,7 @@ public:
     void OnOpen() override
     {
         widgets = window_track_place_widgets;
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         tool_set(*this, WIDX_PRICE, Tool::Crosshair);
         input_set_flag(INPUT_FLAG_6, true);
         window_push_others_right(this);
@@ -288,7 +288,7 @@ public:
     {
         auto ft = Formatter::Common();
         ft.Add<char*>(_trackDesign->name.c_str());
-        WindowDrawWidgets(this, &dpi);
+        WindowDrawWidgets(*this, &dpi);
 
         // Draw mini tile preview
         rct_drawpixelinfo clippedDpi;

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -81,7 +81,7 @@ public:
         WindowInitScrollWidgets(*this);
         tool_set(*this, WIDX_PRICE, Tool::Crosshair);
         input_set_flag(INPUT_FLAG_6, true);
-        window_push_others_right(this);
+        window_push_others_right(*this);
         show_gridlines();
         _miniPreview.resize(TRACK_MINI_PREVIEW_SIZE);
         _placementCost = MONEY32_UNDEFINED;
@@ -200,7 +200,7 @@ public:
         if (cost != _placementCost)
         {
             _placementCost = cost;
-            widget_invalidate(this, WIDX_PRICE);
+            widget_invalidate(*this, WIDX_PRICE);
         }
 
         TrackDesignPreviewDrawOutlines(tds, _trackDesign.get(), GetOrAllocateRide(PreviewRideId), trackLoc);
@@ -243,7 +243,7 @@ public:
                             intent.putExtra(INTENT_EXTRA_RIDE_ID, rideId.ToUnderlying());
                             context_open_intent(&intent);
                             auto wnd = window_find_by_class(WC_TRACK_DESIGN_PLACE);
-                            window_close(wnd);
+                            window_close(*wnd);
                         }
                         else
                         {

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -279,7 +279,7 @@ public:
                 }
                 break;
             case WIDX_FILTER_STRING:
-                window_start_textbox(this, widgetIndex, STR_STRING, _filterString, sizeof(_filterString)); // TODO check this
+                window_start_textbox(*this, widgetIndex, STR_STRING, _filterString, sizeof(_filterString)); // TODO check this
                                                                                                            // out
                 break;
             case WIDX_FILTER_CLEAR:

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -223,7 +223,7 @@ public:
             selected_list_item = 1;
         }
         gTrackDesignSceneryToggle = false;
-        window_push_others_right(this);
+        window_push_others_right(*this);
         _currentTrackPieceDirection = 2;
         _trackDesignPreviewPixels.resize(4 * TRACK_PREVIEW_IMAGE_SIZE);
 
@@ -421,7 +421,7 @@ public:
         if (gCurrentTextBox.window.classification == classification && gCurrentTextBox.window.number == number)
         {
             window_update_textbox_caret();
-            widget_invalidate(this, WIDX_FILTER_STRING); // TODO Check this
+            widget_invalidate(*this, WIDX_FILTER_STRING); // TODO Check this
         }
 
         if (track_list.reload_track_designs)

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -213,7 +213,7 @@ public:
             widgets[WIDX_BACK].type = WindowWidgetType::TableHeader;
         }
 
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         track_list.track_list_being_updated = false;
         track_list.reload_track_designs = false;
         // Start with first track highlighted

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -279,8 +279,8 @@ public:
                 }
                 break;
             case WIDX_FILTER_STRING:
-                window_start_textbox(*this, widgetIndex, STR_STRING, _filterString, sizeof(_filterString)); // TODO check this
-                                                                                                           // out
+                window_start_textbox(
+                    *this, widgetIndex, STR_STRING, _filterString, sizeof(_filterString)); // TODO check this out
                 break;
             case WIDX_FILTER_CLEAR:
                 // Keep the highlighted item selected

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -93,7 +93,7 @@ public:
     void OnOpen() override
     {
         widgets = window_transparency_main_widgets;
-        window_push_others_below(this);
+        window_push_others_below(*this);
 
         auto* w = window_get_main();
         if (w != nullptr)

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -274,7 +274,7 @@ public:
 
     void OnDraw(rct_drawpixelinfo& dpi) override
     {
-        WindowDrawWidgets(this, &dpi);
+        WindowDrawWidgets(*this, &dpi);
 
         // Clip height value
         auto screenCoords = this->windowPos + ScreenCoordsXY{ 8, this->widgets[WIDX_CLIP_HEIGHT_VALUE].top };
@@ -345,7 +345,7 @@ public:
     {
         this->widgets = window_view_clipping_widgets;
         this->hold_down_widgets = (1ULL << WIDX_CLIP_HEIGHT_INCREASE) | (1UL << WIDX_CLIP_HEIGHT_DECREASE);
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
 
         _clipHeightDisplayType = DisplayType::DisplayUnits;
 

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -86,7 +86,7 @@ public:
         switch (widgetIndex)
         {
             case WIDX_CLOSE:
-                window_close(this);
+                window_close(*this);
                 break;
             case WIDX_CLIP_CHECKBOX_ENABLE:
             {
@@ -188,7 +188,7 @@ public:
             gClipSelectionB = _previousClipSelectionB;
         }
 
-        widget_invalidate(this, WIDX_CLIP_HEIGHT_SLIDER);
+        widget_invalidate(*this, WIDX_CLIP_HEIGHT_SLIDER);
     }
 
     void OnToolUpdate(rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords) override
@@ -352,7 +352,7 @@ public:
         // Initialise the clip height slider from the current clip height value.
         this->SetClipHeight(gClipHeight);
 
-        window_push_others_below(this);
+        window_push_others_below(*this);
 
         // Get the main viewport to set the view clipping flag.
         rct_window* mainWindow = window_get_main();

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -259,7 +259,7 @@ public:
         rct_window* mainWindow = window_get_main();
         if (mainWindow != nullptr)
         {
-            WidgetSetCheckboxValue(this, WIDX_CLIP_CHECKBOX_ENABLE, mainWindow->viewport->flags & VIEWPORT_FLAG_CLIP_VIEW);
+            WidgetSetCheckboxValue(*this, WIDX_CLIP_CHECKBOX_ENABLE, mainWindow->viewport->flags & VIEWPORT_FLAG_CLIP_VIEW);
         }
 
         if (IsActive())

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -254,7 +254,7 @@ public:
 
     void OnPrepareDraw() override
     {
-        WidgetScrollUpdateThumbs(this, WIDX_CLIP_HEIGHT_SLIDER);
+        WidgetScrollUpdateThumbs(*this, WIDX_CLIP_HEIGHT_SLIDER);
 
         rct_window* mainWindow = window_get_main();
         if (mainWindow != nullptr)

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -114,7 +114,7 @@ public:
         }
 
         // Not sure how to invalidate part of the viewport that has changed, this will have to do for now
-        // widget_invalidate(this, WIDX_VIEWPORT);
+        // widget_invalidate(*this, WIDX_VIEWPORT);
     }
 
     void OnMouseUp(rct_widgetindex widgetIndex) override
@@ -144,7 +144,7 @@ public:
                 {
                     auto info = get_map_coordinates_from_pos(
                         { windowPos.x + (width / 2), windowPos.y + (height / 2) }, ViewportInteractionItemAll);
-                    window_scroll_to_location(mainWindow, { info.Loc, tile_element_height(info.Loc) });
+                    window_scroll_to_location(*mainWindow, { info.Loc, tile_element_height(info.Loc) });
                 }
                 break;
         }
@@ -156,7 +156,7 @@ public:
 
         // Draw viewport
         if (viewport != nullptr)
-            window_draw_viewport(&dpi, this);
+            window_draw_viewport(&dpi, *this);
     }
 
     void OnResize() override
@@ -170,7 +170,7 @@ public:
         min_width = WW;
         min_height = WH;
 
-        window_set_resize(this, min_width, min_height, max_width, max_height);
+        window_set_resize(*this, min_width, min_height, max_width, max_height);
     }
 
     void OnPrepareDraw() override

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -48,7 +48,7 @@ public:
         widgets = window_water_widgets;
         hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
         WindowInitScrollWidgets(*this);
-        window_push_others_below(this);
+        window_push_others_below(*this);
 
         gLandToolSize = 1;
         gWaterToolRaiseCost = MONEY64_UNDEFINED;

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -47,7 +47,7 @@ public:
     {
         widgets = window_water_widgets;
         hold_down_widgets = (1ULL << WIDX_INCREMENT) | (1ULL << WIDX_DECREMENT);
-        WindowInitScrollWidgets(this);
+        WindowInitScrollWidgets(*this);
         window_push_others_below(this);
 
         gLandToolSize = 1;

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -468,7 +468,7 @@ void game_load_init()
     else
     {
         auto* mainWindow = window_get_main();
-        window_unfollow_sprite(mainWindow);
+        window_unfollow_sprite(*mainWindow);
     }
 
     auto windowManager = GetContext()->GetUiContext()->GetWindowManager();

--- a/src/openrct2/Input.h
+++ b/src/openrct2/Input.h
@@ -92,7 +92,7 @@ extern InputState _inputState;
 extern uint8_t _inputFlags;
 extern uint16_t _tooltipNotShownTicks;
 
-void InputWindowPositionBegin(rct_window* w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
+void InputWindowPositionBegin(rct_window& w, rct_widgetindex widgetIndex, const ScreenCoordsXY& screenCoords);
 
 void title_handle_keyboard_input();
 void GameHandleInput();

--- a/src/openrct2/ReplayManager.cpp
+++ b/src/openrct2/ReplayManager.cpp
@@ -855,7 +855,7 @@ namespace OpenRCT2
                 {
                     auto* mainWindow = window_get_main();
                     if (mainWindow != nullptr)
-                        window_scroll_to_location(mainWindow, result.Position);
+                        window_scroll_to_location(*mainWindow, result.Position);
                 }
 
                 replayQueue.erase(replayQueue.begin());

--- a/src/openrct2/actions/RideSetStatusAction.cpp
+++ b/src/openrct2/actions/RideSetStatusAction.cpp
@@ -203,7 +203,7 @@ GameActions::Result RideSetStatusAction::Execute() const
             rct_window* constructionWindow = window_find_by_number(WC_RIDE_CONSTRUCTION, _rideIndex.ToUnderlying());
             if (constructionWindow != nullptr)
             {
-                window_close(constructionWindow);
+                window_close(*constructionWindow);
             }
 
             if (_status == RideStatus::Testing)

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1148,7 +1148,7 @@ static int32_t cc_set(InteractiveConsole& console, const arguments_t& argv)
             }
             else if (newRotation != currentRotation && mainWindow != nullptr)
             {
-                window_rotate_camera(mainWindow, newRotation - currentRotation);
+                window_rotate_camera(*mainWindow, newRotation - currentRotation);
             }
             console.Execute("get current_rotation");
         }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1919,7 +1919,7 @@ void viewport_invalidate(const rct_viewport* viewport, const ScreenRect& screenR
         if (owner != nullptr && owner->classification != WC_MAIN_WINDOW)
         {
             // note, window_is_visible will update viewport->visibility, so this should have a low hit count
-            if (!window_is_visible(owner))
+            if (!window_is_visible(*owner))
             {
                 return;
             }

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -144,8 +144,8 @@ constexpr rct_widget MakeDropdownButtonWidget(
     return MakeWidget({ xPos, yPos }, { width, height }, WindowWidgetType::Button, colour, STR_DROPDOWN_GLYPH, tooltip);
 }
 
-void WidgetScrollUpdateThumbs(rct_window* w, rct_widgetindex widget_index);
-void WidgetDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
+void WidgetScrollUpdateThumbs(rct_window& w, rct_widgetindex widget_index);
+void WidgetDraw(rct_drawpixelinfo* dpi, rct_window& w, rct_widgetindex widgetIndex);
 
 bool WidgetIsDisabled(const rct_window& w, rct_widgetindex widgetIndex);
 bool WidgetIsHoldable(const rct_window& w, rct_widgetindex widgetIndex);
@@ -154,7 +154,7 @@ bool WidgetIsPressed(const rct_window& w, rct_widgetindex widgetIndex);
 bool WidgetIsHighlighted(const rct_window& w, rct_widgetindex widgetIndex);
 bool WidgetIsActiveTool(const rct_window& w, rct_widgetindex widgetIndex);
 void WidgetScrollGetPart(
-    rct_window* w, const rct_widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
+    rct_window& w, const rct_widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
     int32_t* output_scroll_area, int32_t* scroll_id);
 
 void WidgetSetEnabled(rct_window& w, rct_widgetindex widgetIndex, bool enabled);

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -147,19 +147,19 @@ constexpr rct_widget MakeDropdownButtonWidget(
 void WidgetScrollUpdateThumbs(rct_window* w, rct_widgetindex widget_index);
 void WidgetDraw(rct_drawpixelinfo* dpi, rct_window* w, rct_widgetindex widgetIndex);
 
-bool WidgetIsDisabled(const rct_window* w, rct_widgetindex widgetIndex);
-bool WidgetIsHoldable(const rct_window* w, rct_widgetindex widgetIndex);
-bool WidgetIsVisible(const rct_window* w, rct_widgetindex widgetIndex);
-bool WidgetIsPressed(const rct_window* w, rct_widgetindex widgetIndex);
-bool WidgetIsHighlighted(const rct_window* w, rct_widgetindex widgetIndex);
-bool WidgetIsActiveTool(const rct_window* w, rct_widgetindex widgetIndex);
+bool WidgetIsDisabled(const rct_window& w, rct_widgetindex widgetIndex);
+bool WidgetIsHoldable(const rct_window& w, rct_widgetindex widgetIndex);
+bool WidgetIsVisible(const rct_window& w, rct_widgetindex widgetIndex);
+bool WidgetIsPressed(const rct_window& w, rct_widgetindex widgetIndex);
+bool WidgetIsHighlighted(const rct_window& w, rct_widgetindex widgetIndex);
+bool WidgetIsActiveTool(const rct_window& w, rct_widgetindex widgetIndex);
 void WidgetScrollGetPart(
     rct_window* w, const rct_widget* widget, const ScreenCoordsXY& screenCoords, ScreenCoordsXY& retScreenCoords,
     int32_t* output_scroll_area, int32_t* scroll_id);
 
-void WidgetSetEnabled(rct_window* w, rct_widgetindex widgetIndex, bool enabled);
-void WidgetSetDisabled(rct_window* w, rct_widgetindex widgetIndex, bool value);
-void WidgetSetHoldable(rct_window* w, rct_widgetindex widgetIndex, bool value);
-void WidgetSetVisible(rct_window* w, rct_widgetindex widgetIndex, bool value);
-void WidgetSetPressed(rct_window* w, rct_widgetindex widgetIndex, bool value);
-void WidgetSetCheckboxValue(rct_window* w, rct_widgetindex widgetIndex, bool value);
+void WidgetSetEnabled(rct_window& w, rct_widgetindex widgetIndex, bool enabled);
+void WidgetSetDisabled(rct_window& w, rct_widgetindex widgetIndex, bool value);
+void WidgetSetHoldable(rct_window& w, rct_widgetindex widgetIndex, bool value);
+void WidgetSetVisible(rct_window& w, rct_widgetindex widgetIndex, bool value);
+void WidgetSetPressed(rct_window& w, rct_widgetindex widgetIndex, bool value);
+void WidgetSetCheckboxValue(rct_window& w, rct_widgetindex widgetIndex, bool value);

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -626,7 +626,7 @@ void window_update_scroll_widgets(rct_window* w)
 
         if (scrollPositionChanged)
         {
-            WidgetScrollUpdateThumbs(w, widgetIndex);
+            WidgetScrollUpdateThumbs(*w, widgetIndex);
             w->Invalidate();
         }
         scrollIndex++;
@@ -2195,10 +2195,10 @@ rct_windowclass window_get_classification(rct_window* window)
  *
  *  rct2: 0x006EAF26
  */
-void WidgetScrollUpdateThumbs(rct_window* w, rct_widgetindex widget_index)
+void WidgetScrollUpdateThumbs(rct_window& w, rct_widgetindex widget_index)
 {
-    const auto& widget = w->widgets[widget_index];
-    auto& scroll = w->scrolls[window_get_scroll_data_index(w, widget_index)];
+    const auto& widget = w.widgets[widget_index];
+    auto& scroll = w.scrolls[window_get_scroll_data_index(&w, widget_index)];
 
     if (scroll.flags & HSCROLLBAR_VISIBLE)
     {

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -631,7 +631,7 @@ void window_update_scroll_widgets(rct_window& w)
     }
 }
 
-int32_t window_get_scroll_data_index(rct_window& w, rct_widgetindex widget_index)
+int32_t window_get_scroll_data_index(const rct_window& w, rct_widgetindex widget_index)
 {
     int32_t i, result;
 
@@ -953,7 +953,7 @@ void window_rotate_camera(rct_window& w, int32_t direction)
 }
 
 void window_viewport_get_map_coords_by_cursor(
-    rct_window& w, int32_t* map_x, int32_t* map_y, int32_t* offset_x, int32_t* offset_y)
+    const rct_window& w, int32_t* map_x, int32_t* map_y, int32_t* offset_x, int32_t* offset_y)
 {
     // Get mouse position to offset against.
     auto mouseCoords = context_get_cursor_position_scaled();
@@ -1953,7 +1953,7 @@ void window_move_and_snap(rct_window& w, ScreenCoordsXY newWindowCoords, int32_t
     window_set_position(w, newWindowCoords);
 }
 
-int32_t window_can_resize(rct_window& w)
+int32_t window_can_resize(const rct_window& w)
 {
     return (w.flags & WF_RESIZABLE) && (w.min_width != w.max_width || w.min_height != w.max_height);
 }
@@ -2178,7 +2178,7 @@ rct_window* window_get_listening()
     return nullptr;
 }
 
-rct_windowclass window_get_classification(rct_window& window)
+rct_windowclass window_get_classification(const rct_window& window)
 {
     return window.classification;
 }

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -731,8 +731,6 @@ void window_zoom_in(rct_window& w, bool atCursor);
 void window_zoom_out(rct_window& w, bool atCursor);
 void main_window_zoom(bool zoomIn, bool atCursor);
 
-void window_show_textinput(rct_window& w, rct_widgetindex widgetIndex, uint16_t title, uint16_t text, int32_t value);
-
 void window_draw_all(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
 void window_draw(rct_drawpixelinfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
 void WindowDrawWidgets(rct_window& w, rct_drawpixelinfo* dpi);
@@ -756,12 +754,9 @@ rct_viewport* window_get_viewport(rct_window* window);
 void window_relocate_windows(int32_t width, int32_t height);
 void window_resize_gui(int32_t width, int32_t height);
 void window_resize_gui_scenario_editor(int32_t width, int32_t height);
-void window_ride_construct(rct_window* w);
 void ride_construction_toolupdate_entrance_exit(const ScreenCoordsXY& screenCoords);
 void ride_construction_toolupdate_construct(const ScreenCoordsXY& screenCoords);
 void ride_construction_tooldown_construct(const ScreenCoordsXY& screenCoords);
-
-void window_staff_list_init_vars();
 
 void window_event_close_call(rct_window* w);
 void window_event_mouse_up_call(rct_window* w, rct_widgetindex widgetIndex);
@@ -811,9 +806,6 @@ bool scenery_tool_is_active();
 rct_viewport* window_get_previous_viewport(rct_viewport* current);
 void window_reset_visibilities();
 void window_init_all();
-
-// Cheat: in-game land ownership editor
-void toggle_ingame_land_ownership_editor();
 
 void window_ride_construction_keyboard_shortcut_turn_left();
 void window_ride_construction_keyboard_shortcut_turn_right();

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -711,7 +711,7 @@ void window_invalidate_all();
 void widget_invalidate(rct_window* w, rct_widgetindex widgetIndex);
 void widget_invalidate_by_class(rct_windowclass cls, rct_widgetindex widgetIndex);
 void widget_invalidate_by_number(rct_windowclass cls, rct_windownumber number, rct_widgetindex widgetIndex);
-void WindowInitScrollWidgets(rct_window* w);
+void WindowInitScrollWidgets(rct_window& w);
 void window_update_scroll_widgets(rct_window* w);
 int32_t window_get_scroll_data_index(rct_window* w, rct_widgetindex widget_index);
 
@@ -735,7 +735,7 @@ void window_show_textinput(rct_window* w, rct_widgetindex widgetIndex, uint16_t 
 
 void window_draw_all(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
 void window_draw(rct_drawpixelinfo* dpi, rct_window* w, int32_t left, int32_t top, int32_t right, int32_t bottom);
-void WindowDrawWidgets(rct_window* w, rct_drawpixelinfo* dpi);
+void WindowDrawWidgets(rct_window& w, rct_drawpixelinfo* dpi);
 void window_draw_viewport(rct_drawpixelinfo* dpi, rct_window* w);
 
 void window_set_position(rct_window* w, const ScreenCoordsXY& screenCoords);

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -691,7 +691,7 @@ rct_window* WindowCreateAutoPos(
 rct_window* WindowCreateCentred(
     int32_t width, int32_t height, rct_window_event_list* event_handlers, rct_windowclass cls, uint32_t flags);
 
-void window_close(rct_window* window);
+void window_close(rct_window& window);
 void window_close_by_class(rct_windowclass cls);
 void window_close_by_number(rct_windowclass cls, rct_windownumber number);
 void window_close_by_number(rct_windowclass cls, EntityId number);
@@ -703,45 +703,45 @@ rct_window* window_find_by_class(rct_windowclass cls);
 rct_window* window_find_by_number(rct_windowclass cls, rct_windownumber number);
 rct_window* window_find_by_number(rct_windowclass cls, EntityId id);
 rct_window* window_find_from_point(const ScreenCoordsXY& screenCoords);
-rct_widgetindex window_find_widget_from_point(rct_window* w, const ScreenCoordsXY& screenCoords);
+rct_widgetindex window_find_widget_from_point(rct_window& w, const ScreenCoordsXY& screenCoords);
 void window_invalidate_by_class(rct_windowclass cls);
 void window_invalidate_by_number(rct_windowclass cls, rct_windownumber number);
 void window_invalidate_by_number(rct_windowclass cls, EntityId id);
 void window_invalidate_all();
-void widget_invalidate(rct_window* w, rct_widgetindex widgetIndex);
+void widget_invalidate(rct_window& w, rct_widgetindex widgetIndex);
 void widget_invalidate_by_class(rct_windowclass cls, rct_widgetindex widgetIndex);
 void widget_invalidate_by_number(rct_windowclass cls, rct_windownumber number, rct_widgetindex widgetIndex);
 void WindowInitScrollWidgets(rct_window& w);
-void window_update_scroll_widgets(rct_window* w);
-int32_t window_get_scroll_data_index(rct_window* w, rct_widgetindex widget_index);
+void window_update_scroll_widgets(rct_window& w);
+int32_t window_get_scroll_data_index(rct_window& w, rct_widgetindex widget_index);
 
-void window_push_others_right(rct_window* w);
-void window_push_others_below(rct_window* w1);
+void window_push_others_right(rct_window& w);
+void window_push_others_below(rct_window& w1);
 
 rct_window* window_get_main();
 
-void window_scroll_to_location(rct_window* w, const CoordsXYZ& coords);
-void window_rotate_camera(rct_window* w, int32_t direction);
+void window_scroll_to_location(rct_window& w, const CoordsXYZ& coords);
+void window_rotate_camera(rct_window& w, int32_t direction);
 void window_viewport_get_map_coords_by_cursor(
-    rct_window* w, int32_t* map_x, int32_t* map_y, int32_t* offset_x, int32_t* offset_y);
-void window_viewport_centre_tile_around_cursor(rct_window* w, int32_t map_x, int32_t map_y, int32_t offset_x, int32_t offset_y);
+    rct_window& w, int32_t* map_x, int32_t* map_y, int32_t* offset_x, int32_t* offset_y);
+void window_viewport_centre_tile_around_cursor(rct_window& w, int32_t map_x, int32_t map_y, int32_t offset_x, int32_t offset_y);
 void window_check_all_valid_zoom();
-void window_zoom_set(rct_window* w, ZoomLevel zoomLevel, bool atCursor);
-void window_zoom_in(rct_window* w, bool atCursor);
-void window_zoom_out(rct_window* w, bool atCursor);
+void window_zoom_set(rct_window& w, ZoomLevel zoomLevel, bool atCursor);
+void window_zoom_in(rct_window& w, bool atCursor);
+void window_zoom_out(rct_window& w, bool atCursor);
 void main_window_zoom(bool zoomIn, bool atCursor);
 
-void window_show_textinput(rct_window* w, rct_widgetindex widgetIndex, uint16_t title, uint16_t text, int32_t value);
+void window_show_textinput(rct_window& w, rct_widgetindex widgetIndex, uint16_t title, uint16_t text, int32_t value);
 
 void window_draw_all(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
-void window_draw(rct_drawpixelinfo* dpi, rct_window* w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+void window_draw(rct_drawpixelinfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
 void WindowDrawWidgets(rct_window& w, rct_drawpixelinfo* dpi);
-void window_draw_viewport(rct_drawpixelinfo* dpi, rct_window* w);
+void window_draw_viewport(rct_drawpixelinfo* dpi, rct_window& w);
 
-void window_set_position(rct_window* w, const ScreenCoordsXY& screenCoords);
-void window_move_position(rct_window* w, const ScreenCoordsXY& screenCoords);
-void window_resize(rct_window* w, int32_t dw, int32_t dh);
-void window_set_resize(rct_window* w, int32_t minWidth, int32_t minHeight, int32_t maxWidth, int32_t maxHeight);
+void window_set_position(rct_window& w, const ScreenCoordsXY& screenCoords);
+void window_move_position(rct_window& w, const ScreenCoordsXY& screenCoords);
+void window_resize(rct_window& w, int32_t dw, int32_t dh);
+void window_set_resize(rct_window& w, int32_t minWidth, int32_t minHeight, int32_t maxWidth, int32_t maxHeight);
 
 bool tool_set(const rct_window& w, rct_widgetindex widgetIndex, Tool tool);
 void tool_cancel();
@@ -795,8 +795,8 @@ void window_event_scroll_paint_call(rct_window* w, rct_drawpixelinfo* dpi, int32
 void InvalidateAllWindowsAfterInput();
 void textinput_cancel();
 
-void window_move_and_snap(rct_window* w, ScreenCoordsXY newWindowCoords, int32_t snapProximity);
-int32_t window_can_resize(rct_window* w);
+void window_move_and_snap(rct_window& w, ScreenCoordsXY newWindowCoords, int32_t snapProximity);
+int32_t window_can_resize(rct_window& w);
 
 void window_start_textbox(
     rct_window* call_w, rct_widgetindex call_widget, rct_string_id existing_text, char* existing_args, int32_t maxLength);

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -713,7 +713,7 @@ void widget_invalidate_by_class(rct_windowclass cls, rct_widgetindex widgetIndex
 void widget_invalidate_by_number(rct_windowclass cls, rct_windownumber number, rct_widgetindex widgetIndex);
 void WindowInitScrollWidgets(rct_window& w);
 void window_update_scroll_widgets(rct_window& w);
-int32_t window_get_scroll_data_index(rct_window& w, rct_widgetindex widget_index);
+int32_t window_get_scroll_data_index(const rct_window& w, rct_widgetindex widget_index);
 
 void window_push_others_right(rct_window& w);
 void window_push_others_below(rct_window& w1);
@@ -723,7 +723,7 @@ rct_window* window_get_main();
 void window_scroll_to_location(rct_window& w, const CoordsXYZ& coords);
 void window_rotate_camera(rct_window& w, int32_t direction);
 void window_viewport_get_map_coords_by_cursor(
-    rct_window& w, int32_t* map_x, int32_t* map_y, int32_t* offset_x, int32_t* offset_y);
+    const rct_window& w, int32_t* map_x, int32_t* map_y, int32_t* offset_x, int32_t* offset_y);
 void window_viewport_centre_tile_around_cursor(rct_window& w, int32_t map_x, int32_t map_y, int32_t offset_x, int32_t offset_y);
 void window_check_all_valid_zoom();
 void window_zoom_set(rct_window& w, ZoomLevel zoomLevel, bool atCursor);
@@ -791,7 +791,7 @@ void InvalidateAllWindowsAfterInput();
 void textinput_cancel();
 
 void window_move_and_snap(rct_window& w, ScreenCoordsXY newWindowCoords, int32_t snapProximity);
-int32_t window_can_resize(rct_window& w);
+int32_t window_can_resize(const rct_window& w);
 
 void window_start_textbox(
     rct_window& call_w, rct_widgetindex call_widget, rct_string_id existing_text, char* existing_args, int32_t maxLength);
@@ -840,4 +840,4 @@ money32 place_provisional_track_piece(
 extern RideConstructionState _rideConstructionState2;
 
 rct_window* window_get_listening();
-rct_windowclass window_get_classification(rct_window& window);
+rct_windowclass window_get_classification(const rct_window& window);

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -645,7 +645,7 @@ void window_update_all();
 
 void window_set_window_limit(int32_t value);
 
-rct_window* window_bring_to_front(rct_window* w);
+rct_window* window_bring_to_front(rct_window& w);
 rct_window* window_bring_to_front_by_class(rct_windowclass cls);
 rct_window* window_bring_to_front_by_class_with_flags(rct_windowclass cls, uint16_t flags);
 rct_window* window_bring_to_front_by_number(rct_windowclass cls, rct_windownumber number);
@@ -799,12 +799,12 @@ void window_move_and_snap(rct_window& w, ScreenCoordsXY newWindowCoords, int32_t
 int32_t window_can_resize(rct_window& w);
 
 void window_start_textbox(
-    rct_window* call_w, rct_widgetindex call_widget, rct_string_id existing_text, char* existing_args, int32_t maxLength);
+    rct_window& call_w, rct_widgetindex call_widget, rct_string_id existing_text, char* existing_args, int32_t maxLength);
 void window_cancel_textbox();
 void window_update_textbox_caret();
 void window_update_textbox();
 
-bool window_is_visible(rct_window* w);
+bool window_is_visible(rct_window& w);
 
 bool scenery_tool_is_active();
 
@@ -835,8 +835,8 @@ void window_footpath_keyboard_shortcut_slope_up();
 void window_footpath_keyboard_shortcut_build_current();
 void window_footpath_keyboard_shortcut_demolish_current();
 
-void window_follow_sprite(rct_window* w, EntityId spriteIndex);
-void window_unfollow_sprite(rct_window* w);
+void window_follow_sprite(rct_window& w, EntityId spriteIndex);
+void window_unfollow_sprite(rct_window& w);
 
 bool window_ride_construction_update_state(
     int32_t* trackType, int32_t* trackDirection, RideId* rideIndex, int32_t* _liftHillAndAlternativeState, CoordsXYZ* trackPos,
@@ -848,4 +848,4 @@ money32 place_provisional_track_piece(
 extern RideConstructionState _rideConstructionState2;
 
 rct_window* window_get_listening();
-rct_windowclass window_get_classification(rct_window* window);
+rct_windowclass window_get_classification(rct_window& window);

--- a/src/openrct2/interface/Window_internal.cpp
+++ b/src/openrct2/interface/Window_internal.cpp
@@ -7,7 +7,7 @@
 
 void rct_window::SetLocation(const CoordsXYZ& coords)
 {
-    window_scroll_to_location(this, coords);
+    window_scroll_to_location(*this, coords);
     flags &= ~WF_SCROLLING_TO_LOCATION;
 }
 
@@ -20,7 +20,7 @@ void rct_window::ScrollToViewport()
 
     auto mainWindow = window_get_main();
     if (mainWindow != nullptr)
-        window_scroll_to_location(mainWindow, newCoords);
+        window_scroll_to_location(*mainWindow, newCoords);
 }
 
 void rct_window::Invalidate()

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3808,7 +3808,7 @@ void Ride::ConstructMissingEntranceOrExit() const
     if (type != RIDE_TYPE_MAZE)
     {
         auto location = incompleteStation->GetStart();
-        window_scroll_to_location(w, location);
+        window_scroll_to_location(*w, location);
 
         CoordsXYE trackElement;
         ride_try_get_origin_element(this, &trackElement);
@@ -3834,7 +3834,7 @@ static void ride_scroll_to_track_error(CoordsXYE* trackElement)
     auto* w = window_get_main();
     if (w != nullptr)
     {
-        window_scroll_to_location(w, { *trackElement, trackElement->element->GetBaseZ() });
+        window_scroll_to_location(*w, { *trackElement, trackElement->element->GetBaseZ() });
         ride_modify(trackElement);
     }
 }

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -142,7 +142,7 @@ void ride_construct(Ride* ride)
 
         rct_window* w = window_get_main();
         if (w != nullptr && ride_modify(&trackElement))
-            window_scroll_to_location(w, { trackElement, trackElement.element->GetBaseZ() });
+            window_scroll_to_location(*w, { trackElement, trackElement.element->GetBaseZ() });
     }
     else
     {

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -804,7 +804,7 @@ bool Vehicle::SoundCanPlay() const
     auto left = g_music_tracking_viewport->viewPos.x;
     auto bottom = g_music_tracking_viewport->viewPos.y;
 
-    if (window_get_classification(gWindowAudioExclusive) == WC_MAIN_WINDOW)
+    if (window_get_classification(*gWindowAudioExclusive) == WC_MAIN_WINDOW)
     {
         left -= quarter_w;
         bottom -= quarter_h;
@@ -816,7 +816,7 @@ bool Vehicle::SoundCanPlay() const
     auto right = g_music_tracking_viewport->view_width + left;
     auto top = g_music_tracking_viewport->view_height + bottom;
 
-    if (window_get_classification(gWindowAudioExclusive) == WC_MAIN_WINDOW)
+    if (window_get_classification(*gWindowAudioExclusive) == WC_MAIN_WINDOW)
     {
         right += quarter_w + quarter_w;
         top += quarter_h + quarter_h;

--- a/src/openrct2/title/Command/FollowEntity.cpp
+++ b/src/openrct2/title/Command/FollowEntity.cpp
@@ -18,7 +18,7 @@ namespace OpenRCT2::Title
         auto* w = window_get_main();
         if (w != nullptr)
         {
-            window_follow_sprite(w, Follow.SpriteIndex);
+            window_follow_sprite(*w, Follow.SpriteIndex);
         }
 
         return 0;

--- a/src/openrct2/title/Command/RotateView.cpp
+++ b/src/openrct2/title/Command/RotateView.cpp
@@ -20,7 +20,7 @@ namespace OpenRCT2::Title
         {
             for (uint_fast8_t i = 0; i < Rotations; i++)
             {
-                window_rotate_camera(w, 1);
+                window_rotate_camera(*w, 1);
             }
         }
 

--- a/src/openrct2/title/Command/SetZoom.cpp
+++ b/src/openrct2/title/Command/SetZoom.cpp
@@ -19,7 +19,7 @@ namespace OpenRCT2::Title
         rct_window* w = window_get_main();
         if (w != nullptr)
         {
-            window_zoom_set(w, ZoomLevel{ static_cast<int8_t>(Zoom) }, false);
+            window_zoom_set(*w, ZoomLevel{ static_cast<int8_t>(Zoom) }, false);
         }
 
         return 0;

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -89,7 +89,7 @@ void TitleScreen::StopPreviewingSequence()
         rct_window* mainWindow = window_get_main();
         if (mainWindow != nullptr)
         {
-            window_unfollow_sprite(mainWindow);
+            window_unfollow_sprite(*mainWindow);
         }
         _previewingSequence = false;
         _currentSequence = title_get_config_sequence();


### PR DESCRIPTION
This PR changes many of the window functions that did not have null-checks inside them to take references instead of pointers. The window classes themselves, as well as some specific parts that would cause a waterfall on the window classes (like the window events) were only changed where needed. These can be refactored later, ideally when there are no window-to-class refactor PRs open.