### PR TITLE
Make rct_window non-copyable and non-assignable

### DIFF
--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -102,7 +102,10 @@ struct rct_window
     void RemoveViewport();
 
     rct_window() = default;
+    rct_window(rct_window&) = delete;
     virtual ~rct_window() = default;
+
+    rct_window& operator=(const rct_window&) = delete;
 
     virtual bool IsLegacy()
     {


### PR DESCRIPTION
As suggested by @tupaschoal here: https://github.com/OpenRCT2/OpenRCT2/pull/17678

This prevents accidentally creating copies of `rct_window` instances.

I'm created this PR as a draft, since if we want to apply this restriction to more classes (which I think is a good idea), we could implement this in a cleaner way by inheriting from a common base:

```cpp
struct NonCopyAssignable
{
    NonCopyAssignable() = default;
    NonCopyAssignable(NonCopyAssignable&) = delete;
    NonCopyAssignable& operator=(const NonCopyAssignable&) = delete;
};

struct rct_window : public NonCopyAssignable
{
    rct_window() = default;
    ~rct_window() = default;
    int all, sorts, of, properties;
};

void take_copy(rct_window w) { /*...*/ }

void take_ref(rct_window& w) { /*...*/ }

int main()
{
    rct_window w1, w2;
    w1 = w2;       // error
    take_copy(w1); // error
    take_ref(w1);  // all good
}
```