### PR TITLE
Add MusicTrackOffsetLength field to RTD

### DIFF
--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -283,13 +283,13 @@ namespace OpenRCT2::RideAudio
         }
     }
 
-    static std::pair<size_t, size_t> RideMusicGetTrackOffsetLength(const Ride& ride)
+    std::pair<size_t, size_t> RideMusicGetTrackOffsetLength_Circus(const Ride& ride)
     {
-        if (ride.type == RIDE_TYPE_CIRCUS)
-        {
-            return { 1378, 12427456 };
-        }
+        return { 1378, 12427456 };
+    }
 
+    std::pair<size_t, size_t> RideMusicGetTrackOffsetLength_Default(const Ride& ride)
+    {
         auto& objManager = GetContext()->GetObjectManager();
         auto musicObj = static_cast<MusicObject*>(objManager.GetLoadedObject(ObjectType::Music, ride.music));
         if (musicObj != nullptr)
@@ -302,6 +302,12 @@ namespace OpenRCT2::RideAudio
             }
         }
         return { 0, 0 };
+    }
+
+    static std::pair<size_t, size_t> RideMusicGetTrackOffsetLength(const Ride& ride)
+    {
+        const auto& rtd = ride.GetRideTypeDescriptor();
+        return rtd.MusicTrackOffsetLength(ride);
     }
 
     static void RideUpdateMusicPosition(Ride& ride)

--- a/src/openrct2/ride/RideAudio.h
+++ b/src/openrct2/ride/RideAudio.h
@@ -12,6 +12,7 @@
 #include "../Identifiers.h"
 
 #include <cstdint>
+#include <utility>
 
 struct CoordsXYZ;
 struct Ride;
@@ -40,4 +41,7 @@ namespace OpenRCT2::RideAudio
 
     void DefaultStartRideMusicChannel(const ViewportRideMusicInstance& instance);
     void CircusStartRideMusicChannel(const ViewportRideMusicInstance& instance);
+
+    std::pair<size_t, size_t> RideMusicGetTrackOffsetLength_Circus(const Ride& ride);
+    std::pair<size_t, size_t> RideMusicGetTrackOffsetLength_Default(const Ride& ride);
 } // namespace OpenRCT2::RideAudio

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -161,6 +161,7 @@ using PeepUpdateRideLeaveEntranceFunc = void (*)(Guest*, Ride*, CoordsXYZD&);
 using StartRideMusicFunction = void (*)(const OpenRCT2::RideAudio::ViewportRideMusicInstance&);
 using LightFXAddLightsMagicVehicleFunction = void (*)(const Vehicle* vehicle);
 using RideUpdateMeasurementsSpecialElementsFunc = void (*)(Ride* ride, const track_type_t trackType);
+using MusicTrackOffsetLengthFunc = std::pair<size_t, size_t> (*)(const Ride& ride);
 
 enum class RideConstructionWindowContext : uint8_t
 {
@@ -229,6 +230,8 @@ struct RideTypeDescriptor
     RideConstructionWindowContext ConstructionWindowContext = RideConstructionWindowContext::Default;
 
     RideUpdateMeasurementsSpecialElementsFunc UpdateMeasurementsSpecialElements = RideUpdateMeasurementsSpecialElements_Default;
+
+    MusicTrackOffsetLengthFunc MusicTrackOffsetLength = OpenRCT2::RideAudio::RideMusicGetTrackOffsetLength_Default;
 
     bool HasFlag(uint64_t flag) const;
     void GetAvailableTrackPieces(RideTrackGroup& res) const;

--- a/src/openrct2/ride/gentle/meta/Circus.h
+++ b/src/openrct2/ride/gentle/meta/Circus.h
@@ -54,5 +54,10 @@ constexpr const RideTypeDescriptor CircusRTD =
     SET_FIELD(StartRideMusic, OpenRCT2::RideAudio::CircusStartRideMusicChannel),
     SET_FIELD(DesignCreateMode, TrackDesignCreateMode::Default),
     SET_FIELD(MusicUpdateFunction, CircusMusicUpdate),
+    SET_FIELD(Classification,RideClassification::Ride),
+    SET_FIELD(UpdateLeaveEntrance,PeepUpdateRideLeaveEntranceDefault),
+    SET_FIELD(ConstructionWindowContext, RideConstructionWindowContext::Default),
+    SET_FIELD(UpdateMeasurementsSpecialElements, RideUpdateMeasurementsSpecialElements_Default),
+    SET_FIELD(MusicTrackOffsetLength, OpenRCT2::RideAudio::RideMusicGetTrackOffsetLength_Circus),
 };
 // clang-format on


### PR DESCRIPTION
Circus return a constant pair for the MusicTrackOffsetLength, while the other ride types read from the music object file.