### PR TITLE
Add AccelerationFactor field to RTD

### DIFF
--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -32,6 +32,7 @@
 #include "ShopItem.h"
 #include "Track.h"
 #include "TrackPaint.h"
+#include "Vehicle.h"
 
 enum class ResearchCategory : uint8_t;
 
@@ -127,7 +128,8 @@ struct RideOperatingSettings
     uint8_t MaxBrakesSpeed;
     uint8_t PoweredLiftAcceleration;
     uint8_t BoosterAcceleration;
-    int8_t BoosterSpeedFactor;              // The factor to shift the raw booster speed with
+    int8_t BoosterSpeedFactor; // The factor to shift the raw booster speed with
+    uint16_t AccelerationFactor = 12;
     uint8_t OperatingSettingMultiplier = 1; // Used for the Ride window, cosmetic only.
 };
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3157,7 +3157,7 @@ void Vehicle::UpdateDeparting()
     }
 
     CarEntry* carEntry = &rideEntry->Cars[vehicle_type];
-
+    const auto& rtd = curRide->GetRideTypeDescriptor();
     switch (curRide->mode)
     {
         case RideMode::ReverseInclineLaunchedShuttle:
@@ -3169,17 +3169,10 @@ void Vehicle::UpdateDeparting()
         case RideMode::PoweredLaunchBlockSectioned:
         case RideMode::LimPoweredLaunch:
         case RideMode::UpwardLaunch:
-            if (curRide->type == RIDE_TYPE_AIR_POWERED_VERTICAL_COASTER)
-            {
-                if ((curRide->launch_speed << 16) > velocity)
-                {
-                    acceleration = curRide->launch_speed << 13;
-                }
-                break;
-            }
-
             if ((curRide->launch_speed << 16) > velocity)
-                acceleration = curRide->launch_speed << 12;
+            {
+                acceleration = curRide->launch_speed << rtd.OperatingSettings.AccelerationFactor;
+            }
             break;
         case RideMode::DownwardLaunch:
             if (NumLaunches >= 1)

--- a/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
+++ b/src/openrct2/ride/coaster/meta/AirPoweredVerticalCoaster.h
@@ -27,7 +27,7 @@ constexpr const RideTypeDescriptor AirPoweredVerticalCoasterRTD =
     SET_FIELD(Flags, RIDE_TYPE_FLAGS_TRACK_HAS_3_COLOURS | RIDE_TYPE_FLAGS_COMMON_COASTER | RIDE_TYPE_FLAGS_COMMON_COASTER_NON_ALT | RIDE_TYPE_FLAG_PEEP_CHECK_GFORCES),
     SET_FIELD(RideModes, EnumsToFlags(RideMode::PoweredLaunchPasstrough, RideMode::PoweredLaunch)),
     SET_FIELD(DefaultMode, RideMode::PoweredLaunchPasstrough),
-    SET_FIELD(OperatingSettings, { 30, 50, 30, 40, 40, 0 }),
+    SET_FIELD(OperatingSettings, { 30, 50, 30, 40, 40, 0, 13 }),
     SET_FIELD(Naming, { STR_RIDE_NAME_AIR_POWERED_VERTICAL_COASTER, STR_RIDE_DESCRIPTION_AIR_POWERED_VERTICAL_COASTER }),
     SET_FIELD(NameConvention, { RideComponentType::Train, RideComponentType::Track, RideComponentType::Station }),
     SET_FIELD(EnumName, nameof(RIDE_TYPE_AIR_POWERED_VERTICAL_COASTER)),

--- a/src/openrct2/ride/thrill/meta/Twist.h
+++ b/src/openrct2/ride/thrill/meta/Twist.h
@@ -29,7 +29,7 @@ constexpr const RideTypeDescriptor TwistRTD =
                      RIDE_TYPE_FLAG_SINGLE_SESSION | RIDE_TYPE_FLAG_INTERESTING_TO_LOOK_AT | RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY),
     SET_FIELD(RideModes, EnumsToFlags(RideMode::Rotation)),
     SET_FIELD(DefaultMode, RideMode::Rotation),
-    SET_FIELD(OperatingSettings, { 3, 6, 0, 0, 0, 0, 3 }),
+    SET_FIELD(OperatingSettings, { 3, 6, 0, 0, 0, 0, 12, 3 }),
     SET_FIELD(Naming, { STR_RIDE_NAME_TWIST, STR_RIDE_DESCRIPTION_TWIST }),
     SET_FIELD(NameConvention, { RideComponentType::Structure, RideComponentType::Structure, RideComponentType::Station }),
     SET_FIELD(EnumName, nameof(RIDE_TYPE_TWIST)),


### PR DESCRIPTION
AirPoweredVerticalCoaster seem to have a higher departure acceleration than the other ride types in the upward launch.