### PR TITLE
Fixed #17562 Ride exit next to park boundary exploit

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3635,7 +3635,7 @@ STR_6529    :Invalid colour scheme parameter!
 STR_6530    :User Created Expansion Set
 STR_6531    :The Time Machine (2003)
 STR_6532    :Katy’s Dreamworld (2003)
-STR_6533    :Facing park fence!
+STR_6533    :Cannot connect to a path from here!
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3635,6 +3635,7 @@ STR_6529    :Invalid colour scheme parameter!
 STR_6530    :User Created Expansion Set
 STR_6531    :The Time Machine (2003)
 STR_6532    :Katy’s Dreamworld (2003)
+STR_6533    :Facing park fence!
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#17067] Random Staff Patrol Area clicks.
 - Fix: [#17316] Sides of River Rapids’ corners overlay other parts of the track.
 - Fix: [#17657] When switching from buying land rights to buying construction rights, grid disables and won't re-enable afterwards.
+- Fix: [#17562] Ride exit next to park boundary exploit.
 - Fix: [#17763] Missing validation on invalid characters in file name.
 - Fix: [#17853] Invention name tears while being dragged.
 - Fix: [#18064] Unable to dismiss notification messages.

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -97,6 +97,11 @@ GameActions::Result RideEntranceExitPlaceAction::Query() const
         return GameActions::Result(GameActions::Status::NotOwned, errorTitle, STR_LAND_NOT_OWNED_BY_PARK);
     }
 
+    if (!map_is_location_in_park(_loc - CoordsDirectionDelta[_direction]))
+    {
+        return GameActions::Result(GameActions::Status::NotOwned, errorTitle, STR_FACING_PARK_FENCE);
+    }
+
     if (!MapCheckCapacityAndReorganise(_loc))
     {
         return GameActions::Result(GameActions::Status::NoFreeElements, errorTitle, STR_TILE_ELEMENT_LIMIT_REACHED);

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -97,7 +97,8 @@ GameActions::Result RideEntranceExitPlaceAction::Query() const
         return GameActions::Result(GameActions::Status::NotOwned, errorTitle, STR_LAND_NOT_OWNED_BY_PARK);
     }
 
-    if (!map_is_location_in_park(_loc - CoordsDirectionDelta[_direction]))
+    CoordsXYZ pathLocation = { _loc - CoordsDirectionDelta[_direction], z };
+    if (!LocationValid(pathLocation) || !MapIsLocationOwned(pathLocation))
     {
         return GameActions::Result(GameActions::Status::NotOwned, errorTitle, STR_FACING_PARK_FENCE);
     }

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -97,12 +97,6 @@ GameActions::Result RideEntranceExitPlaceAction::Query() const
         return GameActions::Result(GameActions::Status::NotOwned, errorTitle, STR_LAND_NOT_OWNED_BY_PARK);
     }
 
-    CoordsXYZ pathLocation = { _loc - CoordsDirectionDelta[_direction], z };
-    if (!LocationValid(pathLocation) || !MapIsLocationOwned(pathLocation))
-    {
-        return GameActions::Result(GameActions::Status::NotOwned, errorTitle, STR_FACING_PARK_FENCE);
-    }
-
     if (!MapCheckCapacityAndReorganise(_loc))
     {
         return GameActions::Result(GameActions::Status::NoFreeElements, errorTitle, STR_TILE_ELEMENT_LIMIT_REACHED);
@@ -113,6 +107,15 @@ GameActions::Result RideEntranceExitPlaceAction::Query() const
     {
         canBuild.ErrorTitle = errorTitle;
         return canBuild;
+    }
+
+    CoordsXYZ pathLocation = { _loc - CoordsDirectionDelta[_direction], z };
+    QuarterTile quarterTile{ 0b1111, 0 };
+    canBuild = MapCanConstructWithClearAt(
+        { pathLocation, 4 * COORDS_Z_STEP }, &MapPlaceNonSceneryClearFunc, quarterTile, GetFlags());
+    if (canBuild.Error != GameActions::Status::Ok)
+    {
+        return GameActions::Result(GameActions::Status::NotOwned, errorTitle, STR_FACING_PARK_FENCE);
     }
 
     const auto clearanceData = canBuild.GetData<ConstructClearResult>();

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3921,6 +3921,9 @@ enum : uint16_t
     STR_SCENARIO_CATEGORY_UCES = 6530,
     STR_UCES_TM = 6531,
     STR_UCES_KD = 6532,
+
+    STR_FACING_PARK_FENCE = 6533,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -145,6 +145,13 @@ GameActions::Result MapCanConstructWithClearAt(
         return res;
     }
 
+    if (!MapIsLocationOwnedOrHasRights(pos))
+    {
+        res.Error = GameActions::Status::NotOwned;
+        res.ErrorMessage = STR_LAND_NOT_OWNED_BY_PARK;
+        return res;
+    }
+
     do
     {
         if (tileElement->GetType() != TileElementType::Surface)


### PR DESCRIPTION
![amr4b5gRUX](https://user-images.githubusercontent.com/68320206/182576138-b07a34dd-ac73-495c-9d2e-e828f1d4a1f4.gif)

Added a check to prevent building exits and entrances that are facing the park fence. Technically only required for exits, but added entrances for a more what is IMO a more consistent user experience. This fixes https://github.com/OpenRCT2/OpenRCT2/issues/17562