### PR TITLE
Fix #17600: Notifications aren't cleared on park load

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#17542] Stalls will autorotate towards paths outside the park.
 - Fix: [#17553] Crash when moving invention list items to empty list.
 - Fix: [#17571] All researched tracked rides show up as new vehicles in .park scenarios.
+- Fix: [#17600] Notifications are not properly cleared when loading a park.
 - Fix: [#17605] Crash when opening parks which have had objects removed externally.
 - Fix: [#17639] When building upside down, the special elements list contains many items twice (original bug).
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -926,6 +926,10 @@ namespace OpenRCT2
                     {
                         gNewsItems[offset + i] = archived[i];
                     }
+
+                    // Still need to set the correct type to properly terminate the queue
+                    if (archived.size() < News::MaxItemsArchive)
+                        gNewsItems[offset + archived.size()].Type = News::ItemType::Null;
                 }
                 else
                 {


### PR DESCRIPTION
When loading a save using the New Save Format (.park files), the notification (news) list is not properly terminated and is preserving previously loaded news from other save files, including the main menu ones.