### PR TITLE
Add support for RCTC music and audio

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#16662] Show a warning message when g2.dat is mismatched.
 - Feature: [#17107] Ride operating settings can be set via text input.
 - Feature: [#17638] Added Zero G rolls, medium loops and large corkscrews to the Hybrid and Single-Rail coasters.
+- Feature: [#00000] Support for music and audio files from RollerCoaster Tycoon Classic. 
 - Feature: [objects#198] Add additional pirate roofs.
 - Improved: [#15358] Park and scenario names can now contain up to 128 characters.
 - Improved: [#16840] Add support for rectangular heightmaps.

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -12,6 +12,7 @@
 #include "../Context.h"
 #include "../Intro.h"
 #include "../OpenRCT2.h"
+#include "../PlatformEnvironment.h"
 #include "../config/Config.h"
 #include "../core/File.h"
 #include "../core/FileStream.h"
@@ -97,8 +98,18 @@ namespace OpenRCT2::Audio
 
     void LoadAudioObjects()
     {
+        auto env = GetContext()->GetPlatformEnvironment();
+        auto css1Path = env->FindFile(DIRBASE::RCT2, DIRID::DATA, "CSS1.DAT");
+        auto isRCTC = css1Path.empty();
+        log_error(css1Path.c_str());
+
         auto& objManager = GetContext()->GetObjectManager();
-        auto* baseAudio = objManager.LoadObject(AudioObjectIdentifiers::Rct2Base);
+        Object* baseAudio;
+        if (isRCTC)
+            baseAudio = objManager.LoadObject(AudioObjectIdentifiers::Rct2BaseRCTC);
+        else
+            baseAudio = objManager.LoadObject(AudioObjectIdentifiers::Rct2Base);
+
         if (baseAudio != nullptr)
         {
             _soundsAudioObjectEntryIndex = objManager.GetLoadedObjectEntryIndex(baseAudio);

--- a/src/openrct2/audio/audio.h
+++ b/src/openrct2/audio/audio.h
@@ -137,6 +137,7 @@ namespace OpenRCT2::Audio
     {
         constexpr std::string_view Rct1Title = "rct1.audio.title";
         constexpr std::string_view Rct2Base = "rct2.audio.base";
+        constexpr std::string_view Rct2BaseRCTC = "rct2.audio.base-rctc";
         constexpr std::string_view Rct2Title = "rct2.audio.title";
         constexpr std::string_view Rct2Circus = "rct2.audio.circus";
     } // namespace AudioObjectIdentifiers

--- a/src/openrct2/object/AudioSampleTable.cpp
+++ b/src/openrct2/object/AudioSampleTable.cpp
@@ -87,7 +87,11 @@ static SourceInfo ParseSource(std::string_view source)
         }
 
         auto env = GetContext()->GetPlatformEnvironment();
-        info.Path = env->FindFile(DIRBASE::RCT2, DIRID::DATA, name);
+        auto path = env->FindFile(DIRBASE::RCT2, DIRID::DATA, name);
+        if (path.empty())
+            path = env->FindFile(DIRBASE::RCT2, DIRID::DATA, u8string(name.substr(0, name.length() - 3)) + "ogg");
+
+        info.Path = path;
     }
     else if (String::StartsWith(source, "$["))
     {

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -14,6 +14,7 @@
 #include "../PlatformEnvironment.h"
 #include "../audio/AudioContext.h"
 #include "../audio/AudioSource.h"
+#include "../core/File.h"
 #include "../core/IStream.hpp"
 #include "../core/Json.hpp"
 #include "../core/Path.hpp"
@@ -187,7 +188,13 @@ ObjectAsset MusicObject::GetAsset(IReadObjectContext& context, std::string_view 
     {
         auto platformEnvironment = GetContext()->GetPlatformEnvironment();
         auto dir = platformEnvironment->GetDirectoryPath(DIRBASE::RCT2, DIRID::DATA);
-        auto path2 = Path::Combine(dir, std::string(path.substr(11)));
+        auto datPath = std::string(path.substr(11));
+        auto path2 = Path::Combine(dir, datPath);
+        if (!File::Exists(path2))
+        {
+            path2 = path2.substr(0, path2.length() - 3) + "ogg";
+        }
+
         return ObjectAsset(path2);
     }
 


### PR DESCRIPTION
This requires the addition of an object to the `objects` repo. I will add it once this PR is approved, and do all the object release stuff.

For testing, here are the contents of that file:
```
{
    "id": "rct2.audio.base-rctc",
    "authors": [
        "Chris Sawyer",
        "Allister Brimble"
    ],
    "version": "1.0",
    "sourceGame": [
        "rct2"
    ],
    "objectType": "audio",
    "samples": [
        "$RCT2:DATA/CLIMB4.ogg",
        "$RCT2:DATA/TRACKS1.ogg",
        "$RCT2:DATA/TRACKS3.ogg",
        "$RCT2:DATA/COASTER4.ogg",
        "$RCT2:DATA/BCLICK2.ogg",
        "$RCT2:DATA/BRELESE1.ogg",
        "$RCT2:DATA/BUILDLAN.ogg",
        "$RCT2:DATA/COASTER2.ogg",
        "$RCT2:DATA/COASTER3.ogg",
        "$RCT2:DATA/COASTER5.ogg",
        "$RCT2:DATA/COASTER7.ogg",
        "$RCT2:DATA/COASTER8.ogg",
        "$RCT2:DATA/TRACKS2.ogg",
        {
            "source": "$RCT2:DATA/BUY1.ogg",
            "modifier": -400
        },
        "$RCT2:DATA/EXPLOS1.ogg",
        "$RCT2:DATA/SPLOSH1.ogg",
        "$RCT2:DATA/BSPLASH2.ogg",
        "$RCT2:DATA/SSPLASH1.ogg",
        "$RCT2:DATA/STEAMWH6.ogg",
        "$RCT2:DATA/train+steamwhistle.ogg",
        {
            "source": "$RCT2:DATA/coaster_splash1.ogg",
            "modifier": -1000
        },
        "$RCT2:DATA/kart4.ogg",
        {
            "source": "$RCT2:DATA/Rocket_launch1.ogg",
            "modifier": -800
        },
        {
            "source": "$RCT2:DATA/Rocket_launch2.ogg",
            "modifier": -1700
        },
        {
            "source": "$RCT2:DATA/Vomit1.ogg",
            "modifier": -700
        },
        {
            "source": "$RCT2:DATA/Vomit2.ogg",
            "modifier": -700
        },
        {
            "source": "$RCT2:DATA/Vomit3.ogg",
            "modifier": -700
        },
        {
            "source": "$RCT2:DATA/Vomit4.ogg",
            "modifier": -700
        },
        "$RCT2:DATA/Rain4_stereo.ogg",
        "$RCT2:DATA/Thunder1.ogg",
        "$RCT2:DATA/Thunder2.ogg",
        "$RCT2:DATA/Train_tracks.ogg",
        "$RCT2:DATA/Water_river.ogg",
        "$RCT2:DATA/Balloonpop2.ogg",
        {
            "source": "$RCT2:DATA/Metal_Hammer3.ogg",
            "modifier": -700
        },
        "$RCT2:DATA/Screams1.ogg",
        {
            "source": "$RCT2:DATA/toilet3.ogg",
            "modifier": -2500
        },
        "$RCT2:DATA/BCLICK3.ogg",
        "$RCT2:DATA/duck2.ogg",
        "$RCT2:DATA/warning1.ogg",
        "$RCT2:DATA/window1.ogg",
        {
            "source": "$RCT2:DATA/Laugh6.ogg",
            "modifier": -900
        },
        {
            "source": "$RCT2:DATA/Laugh8.ogg",
            "modifier": -900
        },
        {
            "source": "$RCT2:DATA/Laugh17.ogg",
            "modifier": -900
        },
        "$RCT2:DATA/Applause.ogg",
        {
            "source": "$RCT2:DATA/Horror_effect3.ogg",
            "modifier": -600
        },
        {
            "source": "$RCT2:DATA/Scream_3.ogg",
            "modifier": -700
        },
        {
            "source": "$RCT2:DATA/Scream_2.ogg",
            "modifier": -700
        },
        {
            "source": "$RCT2:DATA/airbrakes4.ogg",
            "modifier": -2550
        },
        {
            "source": "$RCT2:DATA/airbrakes3.ogg",
            "modifier": -2900
        },
        "$RCT2:DATA/error_1.ogg",
        {
            "source": "$RCT2:DATA/airbrakes2a.ogg",
            "modifier": -3400
        },
        "$RCT2:DATA/Dragon_Fyre_lift_hill_(Arrow_steel).ogg",
        "$RCT2:DATA/Comet_lift_hill_(woodie)_2.ogg",
        "$RCT2:DATA/Zachs_Zoomer_running_(woodie)_2.ogg",
        "$RCT2:DATA/Arrow_wild_mouse_lift_hill_2.ogg",
        "$RCT2:DATA/Raging_Bull_lift_hill_(B&M_steel)_2.ogg",
        "$RCT2:DATA/Chang_running_roar_2.ogg",
        "$RCT2:DATA/Scream_1a.ogg",
        "$RCT2:DATA/bell5_streetcar_double_2.ogg",
        {
            "source": "$RCT2:DATA/doorcreak6.ogg",
            "modifier": -2000
        },
        {
            "source": "$RCT2:DATA/doorcreak6r.ogg",
            "modifier": -2700
        },
        {
            "source": "$RCT2:DATA/portcullis1.ogg",
            "modifier": -700
        },
        "$RCT2:DATA/css2.ogg"
    ],
    "strings": {
        "name": {
            "en-GB": "Base audio for the game.",
            "de-DE": "Basisaudio für das Spiel."
        }
    }
}

```