### PR TITLE
Make maintenance of Mini-Golf less hateful.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Change: [#17319] Giant screenshots are now cropped to the horizontal view-clipping selection.
 - Change: [#17499] Update error text when using vehicle incompatible with TD6 and add error when using incompatible track elements.
 - Change: [#17655] Lower default price for the Crooked House.
+- Change: [#17745] Make maintenance cost of Mini-Golf more balanced.
 - Change: [#17762] Use vertical tabs in the New Game dialog.
 - Fix: [#5141] Headless server is counted as a player.
 - Fix: [#7466] Coaster track not drawn at tunnel exit.

--- a/src/openrct2/ride/gentle/meta/MiniGolf.h
+++ b/src/openrct2/ride/gentle/meta/MiniGolf.h
@@ -39,7 +39,7 @@ constexpr const RideTypeDescriptor MiniGolfRTD =
     SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::Null, 5, 5 }),
     SET_FIELD(RatingsCalculationFunction, ride_ratings_calculate_mini_golf),
     SET_FIELD(RatingsMultipliers, { 50, 30, 10 }),
-    SET_FIELD(UpkeepCosts, { 30, 20, 80, 11, 3, 10 }),
+    SET_FIELD(UpkeepCosts, { 30, 60, 0, 0, 0, 0 }),
     SET_FIELD(BuildCosts, { 25.00_GBP, 3.50_GBP, 20, }),
     SET_FIELD(DefaultPrices, { 10, 0 }),
     SET_FIELD(DefaultMusic, MUSIC_OBJECT_SUMMER),


### PR DESCRIPTION
I have equalized the Mini-Golf's operating costs with the Maze & Merry-Go-Round amongst others so the Mini-Golf is a bit more equal with the other rides in this category and can actually pull a profit.

This PR gets rid of Diamond Golf Balls (https://youtu.be/Szk3iPckVTo?t=106)