### PR TITLE
Fix .obj conflicts between same named source files

### DIFF
--- a/src/openrct2-cli/openrct2-cli.vcxproj
+++ b/src/openrct2-cli/openrct2-cli.vcxproj
@@ -45,6 +45,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>$(OPENRCT2_CL_ADDITIONALOPTIONS) %(AdditionalOptions)</AdditionalOptions>
+      <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
       <AdditionalDependencies>libopenrct2.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/openrct2-ui/libopenrct2ui.vcxproj
+++ b/src/openrct2-ui/libopenrct2ui.vcxproj
@@ -223,6 +223,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>$(OPENRCT2_CL_ADDITIONALOPTIONS) %(AdditionalOptions)</AdditionalOptions>
+      <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Lib>
       <TargetMachine Condition="'$(Platform)'=='Win32'">MachineX86</TargetMachine>

--- a/src/openrct2-win/openrct2-win.vcxproj
+++ b/src/openrct2-win/openrct2-win.vcxproj
@@ -45,6 +45,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>$(OPENRCT2_CL_ADDITIONALOPTIONS) %(AdditionalOptions)</AdditionalOptions>
+      <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
       <AdditionalDependencies>libopenrct2.lib;libopenrct2ui.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -47,6 +47,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>$(OPENRCT2_CL_ADDITIONALOPTIONS) %(AdditionalOptions)</AdditionalOptions>
+      <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Lib>
       <TargetMachine Condition="'$(Platform)'=='Win32'">MachineX86</TargetMachine>

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -47,6 +47,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <PreprocessorDefinitions>GTEST_LANG_CXX11;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ObjectFileName>$(IntDir)%(RelativeDir)</ObjectFileName>
     </ClCompile>
     <Link>
       <AdditionalDependencies>libopenrct2.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
Our CI jobs bumped into this issue in https://github.com/OpenRCT2/OpenRCT2/pull/17649

When two source files in the same project share their name, their respective .obj files would collide. This PR makes it so that these files are placed inside subfolders inside the intermediate directory, so naming conflicts will not happen.

I tried setting this in `openrct2.common.props` too, but since `$(IntDir)` is used for more than just the object files, things didn't work too well.

One undesired side-effect of this change is that a folder literally named `%(RelativeDir)` will be created for the libopenrct2 project, though this is not a problem.

----

I'm not sure if this was the reason for naming some of our source files "Paint.Surface.cpp" for example. The "Paint." part could be dropped now if this error was the reason. Pinging @janisozaur since you may remember why this was done.