### PR TITLE
Fix sprintf deprecation error on MacOS build

### DIFF
--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -407,7 +407,8 @@ void format_readable_size(char* buf, size_t bufSize, uint64_t sizeBytes)
     char sizeType[128] = {};
     format_string(sizeType, sizeof(sizeType), SizeTable[idx], nullptr);
 
-    sprintf(buf, "%.03f %s", size, sizeType);
+    // sprintf(buf, "%.03f %s", size, sizeType);
+    snprintf(buf, sizeof(buf), "%.03f %s", size, sizeType);
 }
 
 void format_readable_speed(char* buf, size_t bufSize, uint64_t sizeBytes)

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -407,7 +407,6 @@ void format_readable_size(char* buf, size_t bufSize, uint64_t sizeBytes)
     char sizeType[128] = {};
     format_string(sizeType, sizeof(sizeType), SizeTable[idx], nullptr);
 
-    // sprintf(buf, "%.03f %s", size, sizeType);
     snprintf(buf, sizeof(buf), "%.03f %s", size, sizeType);
 }
 

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -407,7 +407,7 @@ void format_readable_size(char* buf, size_t bufSize, uint64_t sizeBytes)
     char sizeType[128] = {};
     format_string(sizeType, sizeof(sizeType), SizeTable[idx], nullptr);
 
-    snprintf(buf, sizeof(buf), "%.03f %s", size, sizeType);
+    snprintf(buf, bufSize, "%.03f %s", size, sizeType);
 }
 
 void format_readable_speed(char* buf, size_t bufSize, uint64_t sizeBytes)


### PR DESCRIPTION
Following the build directions for MacOS on the OpenRCT wiki [here](https://github.com/OpenRCT2/OpenRCT2/wiki/Building-OpenRCT2-on-macOS-using-CMake) results in a build error during this step `make -j$(sysctl -n hw.logicalcpu) install`, failing with an error:

```.../src/openrct2/localisation/Localisation.cpp:410:5: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
    sprintf(buf, "%.03f %s", size, sizeType);
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.0.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.0.sdk/usr/include/sys/cdefs.h:214:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
1 error generated.
make[2]: *** [CMakeFiles/libopenrct2.dir/src/openrct2/localisation/Localisation.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/libopenrct2.dir/all] Error 2
make: *** [all] Error 2
```

This pr fixes the error by changing **sprintf** to **snprintf** using the `sizeof(buf)` argument.

System: MacOS Monterey 12.5, M1 Macbook Air