### PR TITLE
Fix .park scenarios messing up Other Parks tab

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -31,6 +31,7 @@
 - Fix: [#17605] Crash when opening parks which have had objects removed externally.
 - Fix: [#17639] When building upside down, the special elements list contains many items twice (original bug).
 - Fix: [#17703] (undefined string) when building on invalid height.
+- Fix: [#17776] “Other Parks” tab uses separate lists for SC4/SC6 and .park scenarios.
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/scenario/ScenarioRepository.h
+++ b/src/openrct2/scenario/ScenarioRepository.h
@@ -44,7 +44,7 @@ struct scenario_index_entry
     // Category / sequence
     uint8_t category;
     ScenarioSource source_game;
-    int16_t source_index;
+    int16_t source_index = -1;
     uint16_t sc_id;
 
     // Objective


### PR DESCRIPTION
Before
![Schermafdruk van 2022-08-11 01-26-06](https://user-images.githubusercontent.com/1478678/184040114-2cdcf158-cbd1-4ac3-91fc-ea305956c00c.png)
After
![Schermafdruk van 2022-08-11 01-25-26](https://user-images.githubusercontent.com/1478678/184040118-d041c5e8-ac9b-49c3-8074-9c4d16faf254.png)
![Schermafdruk van 2022-08-11 01-29-37](https://user-images.githubusercontent.com/1478678/184040331-7d579237-34e5-48d4-be79-3a57ed4d4221.png)

