### PR TITLE
Fix #17535: Multiplayer desync when placing rides with scenery

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,7 +24,7 @@
 - Fix: [#17508] Grid doesn’t disable after setting patrol area.
 - Fix: [#17532] Object Selection window allows unselecting all station types.
 - Fix: [#17533] Missing audio when specifying ‘--rct2-data-path’.
-- Fix: [#17535] Network desync when placing rides with scenery.
+- Fix: [#17535] Multiplayer desync when placing rides with scenery.
 - Fix: [#17541] Station style not correctly saved to TD6.
 - Fix: [#17542] Stalls will autorotate towards paths outside the park.
 - Fix: [#17553] Crash when moving invention list items to empty list.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -24,6 +24,7 @@
 - Fix: [#17508] Grid doesn’t disable after setting patrol area.
 - Fix: [#17532] Object Selection window allows unselecting all station types.
 - Fix: [#17533] Missing audio when specifying ‘--rct2-data-path’.
+- Fix: [#17535] Network desync when placing rides with scenery.
 - Fix: [#17541] Station style not correctly saved to TD6.
 - Fix: [#17542] Stalls will autorotate towards paths outside the park.
 - Fix: [#17553] Crash when moving invention list items to empty list.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1298,7 +1298,7 @@ static GameActions::Result TrackDesignPlaceSceneryElement(
  *  rct2: 0x006D0964
  */
 static GameActions::Result TrackDesignPlaceAllScenery(
-    TrackDesignState& tds, const std::vector<TrackDesignSceneryElement>& sceneryList)
+    TrackDesignState& tds, const std::vector<TrackDesignSceneryElement>& sceneryList, uint8_t rotation)
 {
     const auto& origin = tds.Origin;
 
@@ -1318,8 +1318,6 @@ static GameActions::Result TrackDesignPlaceAllScenery(
 
         for (const auto& scenery : sceneryList)
         {
-            uint8_t rotation = _currentTrackPieceDirection;
-
             auto mapCoord = CoordsXYZ{ CoordsXY(origin) + scenery.loc.Rotate(rotation), origin.z };
             TrackDesignUpdatePreviewBounds(tds, mapCoord);
 
@@ -1889,7 +1887,7 @@ static GameActions::Result TrackDesignPlaceVirtual(
     }
 
     // Scenery elements
-    auto sceneryPlaceRes = TrackDesignPlaceAllScenery(tds, td6->scenery_elements);
+    auto sceneryPlaceRes = TrackDesignPlaceAllScenery(tds, td6->scenery_elements, coords.direction);
     if (sceneryPlaceRes.Error != GameActions::Status::Ok)
     {
         return sceneryPlaceRes;


### PR DESCRIPTION
Works on my machineᵀᴹ

I'm not passing the full `coords` as its other fields aren't used, but this is inconsistent with the other functions so I'm wondering if it's fine this way.
I double-checked as much around my changes as possible, but seeing as this is my first time here, chances are fair I've missed something.

Lastly, should the network version be bumped?