### PR TITLE
Fix guests leaving queue if other guest rejoins it from entrance building

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -41,6 +41,7 @@
 - Fix: [#17703] (undefined string) when building on invalid height.
 - Fix: [#17776] “Other Parks” tab uses separate lists for SC4/SC6 and .park scenarios.
 - Fix: [#17784] Colour preset RNG is biased (original bug).
+- Fix: [#17788] Guests could leave queue if another guest rejoins it from the entrance building.
 - Fix: [#17834] Finance window becomes blank after 4096 years.
 - Fix: [#17905] The chain button in the map window is enabled for rectangular maps when (re)opened.
 

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5497,14 +5497,8 @@ void Guest::UpdateQueuing()
             DestinationTolerance = 0;
             SetState(PeepState::QueuingFront);
             RideSubState = PeepRideSubState::AtEntrance;
-            return;
         }
 
-        // Give up queueing for the ride
-        sprite_direction ^= (1 << 4);
-        Invalidate();
-        RemoveFromQueue();
-        SetState(PeepState::One);
         return;
     }
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "10"
+#define NETWORK_STREAM_VERSION "11"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
If another guest returns to the queue from the entrance building, guests arriving at the entrance building through the queue could decide to leave it.

**Before:**
![OpenRCT2 Guests leaving queue at entrance](https://user-images.githubusercontent.com/30838294/184301351-74a698ae-8791-47dd-80b5-52dc8b15f6be.gif)

**After:**
![OpenRCT2 Guests not leaving queue at entrance](https://user-images.githubusercontent.com/30838294/184301361-b41dc5c6-fd8e-4e40-b2b0-63e9971f9e7c.gif)

