### PR TITLE
Fix #17657: Grid won't re-enable after buying Construction Rights

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Change: [#18381] Convert custom invisible paths to the built-in ones.
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#17316] Sides of River Rapids’ corners overlay other parts of the track.
+- Fix: [#17657] When switching from buying lands rights to buying construction rights, grid disables and won't re-enable afterwards.
 - Fix: [#17763] Missing validation on invalid characters in file name.
 - Fix: [#17853] Invention name tears while being dragged.
 - Fix: [#18064] Unable to dismiss notification messages.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,7 +8,7 @@
 - Change: [#18381] Convert custom invisible paths to the built-in ones.
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#17316] Sides of River Rapids’ corners overlay other parts of the track.
-- Fix: [#17657] When switching from buying lands rights to buying construction rights, grid disables and won't re-enable afterwards.
+- Fix: [#17657] When switching from buying land rights to buying construction rights, grid disables and won't re-enable afterwards.
 - Fix: [#17763] Missing validation on invalid characters in file name.
 - Fix: [#17853] Invention name tears while being dragged.
 - Fix: [#18064] Unable to dismiss notification messages.

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -66,6 +66,7 @@ public:
 
         gLandToolSize = 1;
 
+        show_gridlines();
         tool_set(*this, WIDX_BUY_LAND_RIGHTS, Tool::UpArrow);
         input_set_flag(INPUT_FLAG_6, true);
 
@@ -79,6 +80,7 @@ public:
 
     void OnClose() override
     {
+        hide_gridlines();
         if (gLandRemainingConstructionSales == 0)
         {
             hide_construction_rights();

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -66,7 +66,6 @@ public:
 
         gLandToolSize = 1;
 
-        show_gridlines();
         tool_set(*this, WIDX_BUY_LAND_RIGHTS, Tool::UpArrow);
         input_set_flag(INPUT_FLAG_6, true);
 
@@ -318,7 +317,6 @@ public:
 
     void OnToolAbort(WidgetIndex widgetIndex) override
     {
-        hide_gridlines();
         if (_landRightsMode == LAND_RIGHTS_MODE_BUY_LAND)
         {
             hide_land_rights();

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1230,7 +1230,6 @@ void show_land_rights()
         {
             if (!(mainWindow->viewport->flags & VIEWPORT_FLAG_LAND_OWNERSHIP))
             {
-                show_gridlines();
                 mainWindow->viewport->flags |= VIEWPORT_FLAG_LAND_OWNERSHIP;
                 mainWindow->Invalidate();
             }
@@ -1253,7 +1252,6 @@ void hide_land_rights()
         {
             if (mainWindow->viewport->flags & VIEWPORT_FLAG_LAND_OWNERSHIP)
             {
-                hide_gridlines();
                 mainWindow->viewport->flags &= ~VIEWPORT_FLAG_LAND_OWNERSHIP;
                 mainWindow->Invalidate();
             }
@@ -1274,7 +1272,6 @@ void show_construction_rights()
         {
             if (!(mainWindow->viewport->flags & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS))
             {
-                show_gridlines();
                 mainWindow->viewport->flags |= VIEWPORT_FLAG_CONSTRUCTION_RIGHTS;
                 mainWindow->Invalidate();
             }
@@ -1297,7 +1294,6 @@ void hide_construction_rights()
         {
             if (mainWindow->viewport->flags & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS)
             {
-                hide_gridlines();
                 mainWindow->viewport->flags &= ~VIEWPORT_FLAG_CONSTRUCTION_RIGHTS;
                 mainWindow->Invalidate();
             }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1230,6 +1230,7 @@ void show_land_rights()
         {
             if (!(mainWindow->viewport->flags & VIEWPORT_FLAG_LAND_OWNERSHIP))
             {
+                show_gridlines();
                 mainWindow->viewport->flags |= VIEWPORT_FLAG_LAND_OWNERSHIP;
                 mainWindow->Invalidate();
             }
@@ -1252,6 +1253,7 @@ void hide_land_rights()
         {
             if (mainWindow->viewport->flags & VIEWPORT_FLAG_LAND_OWNERSHIP)
             {
+                hide_gridlines();
                 mainWindow->viewport->flags &= ~VIEWPORT_FLAG_LAND_OWNERSHIP;
                 mainWindow->Invalidate();
             }
@@ -1272,6 +1274,7 @@ void show_construction_rights()
         {
             if (!(mainWindow->viewport->flags & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS))
             {
+                show_gridlines();
                 mainWindow->viewport->flags |= VIEWPORT_FLAG_CONSTRUCTION_RIGHTS;
                 mainWindow->Invalidate();
             }
@@ -1294,6 +1297,7 @@ void hide_construction_rights()
         {
             if (mainWindow->viewport->flags & VIEWPORT_FLAG_CONSTRUCTION_RIGHTS)
             {
+                hide_gridlines();
                 mainWindow->viewport->flags &= ~VIEWPORT_FLAG_CONSTRUCTION_RIGHTS;
                 mainWindow->Invalidate();
             }


### PR DESCRIPTION
Fixes https://github.com/OpenRCT2/OpenRCT2/issues/17657

Issue: When switching from purchasing land rights to construction rights, the grid disappears and will not reappear.

Fix: Removed show_gridlines on tool start and hide_gridlines on tool abort, and instead added show_gridlines to show_land_rights and show_construction_rights functions, and hide_gridlines to hide_land_rights and hide_construction_rights functions.

Note: Needed to create a new request because my last request was closed due to me accidentally deleting my forked branch.