### PR TITLE
 Fix #17797: NPE in ride_check_block_brakes() 

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -565,7 +565,7 @@ bool ViewportInteractionRightClick(const ScreenCoordsXY& screenCoords)
         break;
         case ViewportInteractionItem::Ride:
             tileElement = { info.Loc, info.Element };
-            ride_modify(&tileElement);
+            ride_modify(tileElement);
             break;
         case ViewportInteractionItem::Scenery:
             ViewportInteractionRemoveScenery(info.Element, info.Loc);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3818,7 +3818,7 @@ void Ride::ConstructMissingEntranceOrExit() const
         CoordsXYE trackElement;
         ride_try_get_origin_element(this, &trackElement);
         ride_find_track_gap(this, &trackElement, &trackElement);
-        int32_t ok = ride_modify(&trackElement);
+        int32_t ok = ride_modify(trackElement);
         if (ok == 0)
         {
             return;
@@ -3834,12 +3834,15 @@ void Ride::ConstructMissingEntranceOrExit() const
  *
  *  rct2: 0x006B528A
  */
-static void ride_scroll_to_track_error(CoordsXYE* trackElement)
+static void ride_scroll_to_track_error(const CoordsXYE& trackElement)
 {
+    if (trackElement.element == nullptr)
+        return;
+
     auto* w = window_get_main();
     if (w != nullptr)
     {
-        window_scroll_to_location(*w, { *trackElement, trackElement->element->GetBaseZ() });
+        window_scroll_to_location(*w, { trackElement, trackElement.element->GetBaseZ() });
         ride_modify(trackElement);
     }
 }
@@ -3922,7 +3925,7 @@ ResultWithMessage Ride::Test(RideStatus newStatus, bool isApplying)
         if (ride_find_track_gap(this, &trackElement, &problematicTrackElement)
             && (newStatus != RideStatus::Simulating || IsBlockSectioned()))
         {
-            ride_scroll_to_track_error(&problematicTrackElement);
+            ride_scroll_to_track_error(problematicTrackElement);
             return { false, STR_TRACK_IS_NOT_A_COMPLETE_CIRCUIT };
         }
     }
@@ -3932,7 +3935,7 @@ ResultWithMessage Ride::Test(RideStatus newStatus, bool isApplying)
         auto blockBrakeCheck = RideCheckBlockBrakes(trackElement, &problematicTrackElement);
         if (!blockBrakeCheck.Successful)
         {
-            ride_scroll_to_track_error(&problematicTrackElement);
+            ride_scroll_to_track_error(problematicTrackElement);
             return { false, blockBrakeCheck.Message };
         }
     }
@@ -3944,7 +3947,7 @@ ResultWithMessage Ride::Test(RideStatus newStatus, bool isApplying)
         {
             if (ride_check_track_contains_inversions(&trackElement, &problematicTrackElement))
             {
-                ride_scroll_to_track_error(&problematicTrackElement);
+                ride_scroll_to_track_error(problematicTrackElement);
                 return { false, STR_TRACK_UNSUITABLE_FOR_TYPE_OF_TRAIN };
             }
         }
@@ -3952,7 +3955,7 @@ ResultWithMessage Ride::Test(RideStatus newStatus, bool isApplying)
         {
             if (ride_check_track_contains_banked(&trackElement, &problematicTrackElement))
             {
-                ride_scroll_to_track_error(&problematicTrackElement);
+                ride_scroll_to_track_error(problematicTrackElement);
                 return { false, STR_TRACK_UNSUITABLE_FOR_TYPE_OF_TRAIN };
             }
         }
@@ -3967,13 +3970,13 @@ ResultWithMessage Ride::Test(RideStatus newStatus, bool isApplying)
 
         if (!ride_check_station_length(&trackElement, &problematicTrackElement))
         {
-            ride_scroll_to_track_error(&problematicTrackElement);
+            ride_scroll_to_track_error(problematicTrackElement);
             return { false, STR_STATION_NOT_LONG_ENOUGH };
         }
 
         if (!ride_check_start_and_end_is_station(&trackElement))
         {
-            ride_scroll_to_track_error(&problematicTrackElement);
+            ride_scroll_to_track_error(problematicTrackElement);
             return { false, STR_RIDE_MUST_START_AND_END_WITH_STATIONS };
         }
     }
@@ -4057,7 +4060,7 @@ ResultWithMessage Ride::Open(bool isApplying)
     {
         if (ride_find_track_gap(this, &trackElement, &problematicTrackElement))
         {
-            ride_scroll_to_track_error(&problematicTrackElement);
+            ride_scroll_to_track_error(problematicTrackElement);
             return { false, STR_TRACK_IS_NOT_A_COMPLETE_CIRCUIT };
         }
     }
@@ -4067,7 +4070,7 @@ ResultWithMessage Ride::Open(bool isApplying)
         auto blockBrakeCheck = RideCheckBlockBrakes(trackElement, &problematicTrackElement);
         if (!blockBrakeCheck.Successful)
         {
-            ride_scroll_to_track_error(&problematicTrackElement);
+            ride_scroll_to_track_error(problematicTrackElement);
             return { false, blockBrakeCheck.Message };
         }
     }
@@ -4079,7 +4082,7 @@ ResultWithMessage Ride::Open(bool isApplying)
         {
             if (ride_check_track_contains_inversions(&trackElement, &problematicTrackElement))
             {
-                ride_scroll_to_track_error(&problematicTrackElement);
+                ride_scroll_to_track_error(problematicTrackElement);
                 return { false, STR_TRACK_UNSUITABLE_FOR_TYPE_OF_TRAIN };
             }
         }
@@ -4087,7 +4090,7 @@ ResultWithMessage Ride::Open(bool isApplying)
         {
             if (ride_check_track_contains_banked(&trackElement, &problematicTrackElement))
             {
-                ride_scroll_to_track_error(&problematicTrackElement);
+                ride_scroll_to_track_error(problematicTrackElement);
                 return { false, STR_TRACK_UNSUITABLE_FOR_TYPE_OF_TRAIN };
             }
         }
@@ -4102,13 +4105,13 @@ ResultWithMessage Ride::Open(bool isApplying)
 
         if (!ride_check_station_length(&trackElement, &problematicTrackElement))
         {
-            ride_scroll_to_track_error(&problematicTrackElement);
+            ride_scroll_to_track_error(problematicTrackElement);
             return { false, STR_STATION_NOT_LONG_ENOUGH };
         }
 
         if (!ride_check_start_and_end_is_station(&trackElement))
         {
-            ride_scroll_to_track_error(&problematicTrackElement);
+            ride_scroll_to_track_error(problematicTrackElement);
             return { false, STR_RIDE_MUST_START_AND_END_WITH_STATIONS };
         }
     }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2664,15 +2664,18 @@ void Ride::ChainQueues() const
  *
  *  rct2: 0x006D3319
  */
-static ResultWithMessage ride_check_block_brakes(CoordsXYE* input, CoordsXYE* output)
+static ResultWithMessage RideCheckBlockBrakes(const CoordsXYE& input, CoordsXYE* output)
 {
-    RideId rideIndex = input->element->AsTrack()->GetRideIndex();
+    if (input.element == nullptr || input.element->GetType() != TileElementType::Track)
+        return { false };
+
+    RideId rideIndex = input.element->AsTrack()->GetRideIndex();
     rct_window* w = window_find_by_class(WC_RIDE_CONSTRUCTION);
     if (w != nullptr && _rideConstructionState != RideConstructionState::State0 && _currentRideIndex == rideIndex)
         ride_construction_invalidate_current_track();
 
     track_circuit_iterator it;
-    track_circuit_iterator_begin(&it, *input);
+    track_circuit_iterator_begin(&it, input);
     while (track_circuit_iterator_next(&it))
     {
         if (it.current.element->AsTrack()->GetTrackType() == TrackElemType::BlockBrakes)
@@ -3926,7 +3929,7 @@ ResultWithMessage Ride::Test(RideStatus newStatus, bool isApplying)
 
     if (IsBlockSectioned())
     {
-        auto blockBrakeCheck = ride_check_block_brakes(&trackElement, &problematicTrackElement);
+        auto blockBrakeCheck = RideCheckBlockBrakes(trackElement, &problematicTrackElement);
         if (!blockBrakeCheck.Successful)
         {
             ride_scroll_to_track_error(&problematicTrackElement);
@@ -4061,7 +4064,7 @@ ResultWithMessage Ride::Open(bool isApplying)
 
     if (IsBlockSectioned())
     {
-        auto blockBrakeCheck = ride_check_block_brakes(&trackElement, &problematicTrackElement);
+        auto blockBrakeCheck = RideCheckBlockBrakes(trackElement, &problematicTrackElement);
         if (!blockBrakeCheck.Successful)
         {
             ride_scroll_to_track_error(&problematicTrackElement);

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -141,7 +141,7 @@ void ride_construct(Ride* ride)
         ride_find_track_gap(ride, &trackElement, &trackElement);
 
         rct_window* w = window_get_main();
-        if (w != nullptr && ride_modify(&trackElement))
+        if (w != nullptr && ride_modify(trackElement))
             window_scroll_to_location(*w, { trackElement, trackElement.element->GetBaseZ() });
     }
     else
@@ -985,9 +985,9 @@ static bool ride_modify_maze(const CoordsXYE& tileElement)
  *
  *  rct2: 0x006CC056
  */
-bool ride_modify(CoordsXYE* input)
+bool ride_modify(const CoordsXYE& input)
 {
-    auto tileElement = *input;
+    auto tileElement = input;
     if (tileElement.element == nullptr)
         return false;
 

--- a/src/openrct2/ride/RideConstruction.h
+++ b/src/openrct2/ride/RideConstruction.h
@@ -88,7 +88,7 @@ void ride_construction_set_default_next_piece();
 void ride_select_next_section();
 void ride_select_previous_section();
 
-bool ride_modify(CoordsXYE* input);
+bool ride_modify(const CoordsXYE& input);
 
 CoordsXYZD ride_get_entrance_or_exit_position_from_screen_position(const ScreenCoordsXY& screenCoords);
 


### PR DESCRIPTION
Fixes both the original NPE, as well as another one it would hit after the first (using the park uploaded with #17797 and trying to open the maze).