### PR TITLE
Use ride_type_t instead of uint8_t in more places

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1404,7 +1404,7 @@ private:
     {
         if (item->Type == ObjectType::Ride)
         {
-            uint8_t rideType = 0;
+            ride_type_t rideType = 0;
             for (int32_t i = 0; i < RCT2::ObjectLimits::MaxRideTypesPerRideEntry; i++)
             {
                 if (item->RideInfo.RideType[i] != RIDE_TYPE_NULL)
@@ -1500,10 +1500,10 @@ private:
             ;
 
         rct_ride_entry* ride_entry = get_ride_entry(entry_index);
-        uint8_t ride_type = ride_entry_get_first_non_null_ride_type(ride_entry);
+        auto rideType = ride_entry_get_first_non_null_ride_type(ride_entry);
 
         auto intent = Intent(WC_TRACK_DESIGN_LIST);
-        intent.putExtra(INTENT_EXTRA_RIDE_TYPE, ride_type);
+        intent.putExtra(INTENT_EXTRA_RIDE_TYPE, rideType);
         intent.putExtra(INTENT_EXTRA_RIDE_ENTRY_INDEX, entry_index);
         context_open_intent(&intent);
     }
@@ -1539,7 +1539,7 @@ static StringId GetRideTypeStringId(const ObjectRepositoryItem* item)
     StringId result = STR_NONE;
     for (int32_t i = 0; i < RCT2::ObjectLimits::MaxRideTypesPerRideEntry; i++)
     {
-        uint8_t rideType = item->RideInfo.RideType[i];
+        auto rideType = item->RideInfo.RideType[i];
         if (rideType != RIDE_TYPE_NULL)
         {
             result = GetRideTypeDescriptor(rideType).Naming.Name;
@@ -1580,7 +1580,7 @@ void EditorLoadSelectedObjects()
                     if (objectType == ObjectType::Ride)
                     {
                         rct_ride_entry* rideEntry = get_ride_entry(entryIndex);
-                        uint8_t rideType = ride_entry_get_first_non_null_ride_type(rideEntry);
+                        auto rideType = ride_entry_get_first_non_null_ride_type(rideEntry);
                         ResearchCategory category = static_cast<ResearchCategory>(GetRideTypeDescriptor(rideType).Category);
                         research_insert_ride_entry(rideType, entryIndex, category, true);
                     }

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -52,7 +52,7 @@ static constexpr const int32_t GroupByTrackTypeWidth = 172;
  * The order of ride types shown in the new ride window so that the order stays consistent across games and rides of the same
  * type are kept together.
  */
-static constexpr const char RideTypeViewOrder[] = {
+static constexpr const ride_type_t RideTypeViewOrder[] = {
     // Transport rides
     RIDE_TYPE_MINIATURE_RAILWAY,
     RIDE_TYPE_MONORAIL,
@@ -602,7 +602,7 @@ private:
         // For each ride type in the view order list
         for (int32_t i = 0; i < static_cast<int32_t>(std::size(RideTypeViewOrder)); i++)
         {
-            uint8_t rideType = RideTypeViewOrder[i];
+            auto rideType = RideTypeViewOrder[i];
             if (rideType == RIDE_TYPE_NULL)
                 continue;
 
@@ -616,7 +616,7 @@ private:
         nextListItem->EntryIndex = OBJECT_ENTRY_INDEX_NULL;
     }
 
-    RideSelection* IterateOverRideType(uint8_t rideType, RideSelection* nextListItem, RideSelection* listEnd)
+    RideSelection* IterateOverRideType(ride_type_t rideType, RideSelection* nextListItem, RideSelection* listEnd)
     {
         bool buttonForRideTypeCreated = false;
         bool allowDrawingOverLastButton = false;
@@ -984,7 +984,7 @@ void WindowNewRideFocus(RideSelection rideItem)
     }
 
     rct_ride_entry* rideEntry = get_ride_entry(rideItem.EntryIndex);
-    uint8_t rideTypeIndex = ride_entry_get_first_non_null_ride_type(rideEntry);
+    auto rideTypeIndex = ride_entry_get_first_non_null_ride_type(rideEntry);
 
     w->SetPage(GetRideTypeDescriptor(rideTypeIndex).Category);
 }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -841,7 +841,7 @@ static constexpr auto RIDE_G_FORCES_RED_LATERAL = FIXED_2DP(2, 80);
 // Used for sorting the ride type cheat dropdown.
 struct RideTypeLabel
 {
-    uint8_t ride_type_id;
+    ride_type_t ride_type_id;
     StringId label_id;
     const char* label_string;
 };
@@ -1868,7 +1868,7 @@ static void WindowRideShowOpenDropdown(rct_window* w, rct_widget* widget)
     gDropdownDefaultIndex = info.DefaultIndex;
 }
 
-static StringId GetRideTypeNameForDropdown(uint8_t rideType)
+static StringId GetRideTypeNameForDropdown(ride_type_t rideType)
 {
     switch (rideType)
     {

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -103,7 +103,7 @@ static void setup_track_designer_objects()
         {
             *selectionFlags |= ObjectSelectionFlags::Flag6;
 
-            for (uint8_t rideType : item->RideInfo.RideType)
+            for (auto rideType : item->RideInfo.RideType)
             {
                 if (rideType != RIDE_TYPE_NULL)
                 {

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -586,7 +586,7 @@ GameActions::Result WallPlaceAction::WallCheckObstruction(
 }
 
 bool WallPlaceAction::TrackIsAllowedWallEdges(
-    uint8_t rideType, track_type_t trackType, uint8_t trackSequence, uint8_t direction)
+    ride_type_t rideType, track_type_t trackType, uint8_t trackSequence, uint8_t direction)
 {
     if (!GetRideTypeDescriptor(rideType).HasFlag(RIDE_TYPE_FLAG_TRACK_NO_WALLS))
     {

--- a/src/openrct2/actions/WallPlaceAction.h
+++ b/src/openrct2/actions/WallPlaceAction.h
@@ -62,5 +62,5 @@ private:
      * Gets whether the given track type can have a wall placed on the edge of the given direction.
      * Some thin tracks for example are allowed to have walls either side of the track, but wider tracks can not.
      */
-    static bool TrackIsAllowedWallEdges(uint8_t rideType, track_type_t trackType, uint8_t trackSequence, uint8_t direction);
+    static bool TrackIsAllowedWallEdges(ride_type_t rideType, track_type_t trackType, uint8_t trackSequence, uint8_t direction);
 };

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -3229,11 +3229,11 @@ static void PeepHeadForNearestRideWithFlags(Guest* peep, bool considerOnlyCloseR
  * such as "I'm hungry" after visiting a food shop.
  * Works for Thirst/Hungry/Low Money/Toilet
  */
-void Guest::StopPurchaseThought(uint8_t ride_type)
+void Guest::StopPurchaseThought(ride_type_t rideType)
 {
     auto thoughtType = PeepThoughtType::Hungry;
 
-    const auto& rtd = GetRideTypeDescriptor(ride_type);
+    const auto& rtd = GetRideTypeDescriptor(rideType);
     if (!rtd.HasFlag(RIDE_TYPE_FLAG_SELLS_FOOD))
     {
         thoughtType = PeepThoughtType::Thirsty;

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -331,7 +331,7 @@ public:
     void OnExitRide(Ride* ride);
     void UpdateSpriteType();
     bool HeadingForRideOrParkExit() const;
-    void StopPurchaseThought(uint8_t ride_type);
+    void StopPurchaseThought(ride_type_t rideType);
     void TryGetUpFromSitting();
     bool ShouldRideWhileRaining(const Ride& ride);
     void ChoseNotToGoOnRide(Ride* ride, bool peepAtRide, bool updateLastRide);

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1227,13 +1227,12 @@ static int32_t cc_load_object(InteractiveConsole& console, const arguments_t& ar
         {
             // Automatically research the ride so it's supported by the game.
             rct_ride_entry* rideEntry;
-            int32_t rideType;
 
             rideEntry = get_ride_entry(groupIndex);
 
             for (int32_t j = 0; j < RCT2::ObjectLimits::MaxRideTypesPerRideEntry; j++)
             {
-                rideType = rideEntry->ride_type[j];
+                auto rideType = rideEntry->ride_type[j];
                 if (rideType != RIDE_TYPE_NULL)
                 {
                     ResearchCategory category = GetRideTypeDescriptor(rideType).GetResearchCategory();

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -199,7 +199,7 @@ void research_finish_item(ResearchItem* researchItem)
     if (researchItem->type == Research::EntryType::Ride)
     {
         // Ride
-        uint32_t base_ride_type = researchItem->baseRideType;
+        auto base_ride_type = researchItem->baseRideType;
         ObjectEntryIndex rideEntryIndex = researchItem->entryIndex;
         rct_ride_entry* rideEntry = get_ride_entry(rideEntryIndex);
 
@@ -505,7 +505,7 @@ void research_populate_list_random()
     }
 }
 
-bool research_insert_ride_entry(uint8_t rideType, ObjectEntryIndex entryIndex, ResearchCategory category, bool researched)
+bool research_insert_ride_entry(ride_type_t rideType, ObjectEntryIndex entryIndex, ResearchCategory category, bool researched)
 {
     if (rideType != RIDE_TYPE_NULL && entryIndex != OBJECT_ENTRY_INDEX_NULL)
     {

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -133,7 +133,7 @@ void research_finish_item(ResearchItem* researchItem);
 void research_insert(ResearchItem&& item, bool researched);
 void ResearchRemove(const ResearchItem& researchItem);
 
-bool research_insert_ride_entry(uint8_t rideType, ObjectEntryIndex entryIndex, ResearchCategory category, bool researched);
+bool research_insert_ride_entry(ride_type_t rideType, ObjectEntryIndex entryIndex, ResearchCategory category, bool researched);
 void research_insert_ride_entry(ObjectEntryIndex entryIndex, bool researched);
 bool research_insert_scenery_group_entry(ObjectEntryIndex entryIndex, bool researched);
 

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -155,7 +155,7 @@ std::optional<uint8_t> MusicObject::GetOriginalStyleId() const
     return _originalStyleId;
 }
 
-bool MusicObject::SupportsRideType(uint8_t rideType)
+bool MusicObject::SupportsRideType(ride_type_t rideType)
 {
     if (_rideTypes.size() == 0)
     {

--- a/src/openrct2/object/MusicObject.h
+++ b/src/openrct2/object/MusicObject.h
@@ -57,7 +57,7 @@ public:
     void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
 
     std::optional<uint8_t> GetOriginalStyleId() const;
-    bool SupportsRideType(uint8_t rideType);
+    bool SupportsRideType(ride_type_t rideType);
     size_t GetTrackCount() const;
     const MusicObjectTrack* GetTrack(size_t trackIndex) const;
     constexpr MusicNiceFactor GetNiceFactor() const

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -26,6 +26,7 @@
 using ObjectEntryIndex = uint16_t;
 constexpr const ObjectEntryIndex OBJECT_ENTRY_INDEX_NULL = std::numeric_limits<ObjectEntryIndex>::max();
 struct ObjectRepositoryItem;
+using ride_type_t = uint16_t;
 
 // First 0xF of rct_object_entry->flags
 enum class ObjectType : uint8_t
@@ -167,12 +168,13 @@ struct rct_object_entry_group
 assert_struct_size(rct_object_entry_group, 8);
 #endif
 
+#pragma pack(pop)
+
 struct rct_ride_filters
 {
     uint8_t category[2];
-    uint8_t ride_type;
+    ride_type_t ride_type;
 };
-assert_struct_size(rct_ride_filters, 3);
 
 struct rct_object_filters
 {
@@ -181,8 +183,6 @@ struct rct_object_filters
         rct_ride_filters ride;
     };
 };
-assert_struct_size(rct_object_filters, 3);
-#pragma pack(pop)
 
 enum class ObjectGeneration : uint8_t
 {

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -283,7 +283,7 @@ public:
         }
     }
 
-    const std::vector<ObjectEntryIndex>& GetAllRideEntries(uint8_t rideType) override
+    const std::vector<ObjectEntryIndex>& GetAllRideEntries(ride_type_t rideType) override
     {
         if (rideType >= RIDE_TYPE_COUNT)
         {

--- a/src/openrct2/object/ObjectManager.h
+++ b/src/openrct2/object/ObjectManager.h
@@ -44,7 +44,7 @@ struct IObjectManager
     virtual void ResetObjects() abstract;
 
     virtual std::vector<const ObjectRepositoryItem*> GetPackableObjects() abstract;
-    virtual const std::vector<ObjectEntryIndex>& GetAllRideEntries(uint8_t rideType) abstract;
+    virtual const std::vector<ObjectEntryIndex>& GetAllRideEntries(ride_type_t rideType) abstract;
 };
 
 [[nodiscard]] std::unique_ptr<IObjectManager> CreateObjectManager(IObjectRepository& objectRepository);

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -79,7 +79,7 @@ class ObjectFileIndex final : public FileIndex<ObjectRepositoryItem>
 {
 private:
     static constexpr uint32_t MAGIC_NUMBER = 0x5844494F; // OIDX
-    static constexpr uint16_t VERSION = 28;
+    static constexpr uint16_t VERSION = 29;
     static constexpr auto PATTERN = "*.dat;*.pob;*.json;*.parkobj";
 
     IObjectRepository& _objectRepository;

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -50,7 +50,7 @@ struct ObjectRepositoryItem
     {
         uint8_t RideFlags;
         uint8_t RideCategory[RCT2::ObjectLimits::MaxCategoriesPerRide];
-        uint8_t RideType[RCT2::ObjectLimits::MaxRideTypesPerRideEntry];
+        ride_type_t RideType[RCT2::ObjectLimits::MaxRideTypesPerRideEntry];
     } RideInfo;
     struct
     {

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -861,12 +861,12 @@ std::vector<VehicleColour> RideObject::ReadJsonColourConfiguration(json_t& jColo
     return config;
 }
 
-bool RideObject::IsRideTypeShopOrFacility(uint8_t rideType)
+bool RideObject::IsRideTypeShopOrFacility(ride_type_t rideType)
 {
     return GetRideTypeDescriptor(rideType).HasFlag(RIDE_TYPE_FLAG_IS_SHOP_OR_FACILITY);
 }
 
-uint8_t RideObject::ParseRideType(const std::string& s)
+ride_type_t RideObject::ParseRideType(const std::string& s)
 {
     auto result = std::find_if(
         std::begin(RideTypeDescriptors), std::end(RideTypeDescriptors), [s](const auto& rtd) { return rtd.Name == s; });

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -44,7 +44,7 @@ public:
 
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 
-    static uint8_t ParseRideType(const std::string& s);
+    static ride_type_t ParseRideType(const std::string& s);
 
 private:
     void ReadLegacyCar(IReadObjectContext* context, OpenRCT2::IStream* stream, CarEntry* car);
@@ -58,7 +58,7 @@ private:
     static uint8_t CalculateNumVerticalFrames(const CarEntry* carEntry);
     static uint8_t CalculateNumHorizontalFrames(const CarEntry* carEntry);
 
-    static bool IsRideTypeShopOrFacility(uint8_t rideType);
+    static bool IsRideTypeShopOrFacility(ride_type_t rideType);
     static uint8_t ParseRideCategory(const std::string& s);
     static ShopItem ParseShopItem(const std::string& s);
     static colour_t ParseColour(const std::string& s);

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -1275,7 +1275,7 @@ namespace RCT1
         RCT1_PATH_SUPPORT_TYPE_BAMBOO,
     };
 
-    track_type_t RCT1TrackTypeToOpenRCT2(RCT12TrackType origTrackType, uint8_t rideType);
+    track_type_t RCT1TrackTypeToOpenRCT2(RCT12TrackType origTrackType, ride_type_t rideType);
 } // namespace RCT1
 
 void load_from_sv4(const char* path);

--- a/src/openrct2/rct1/Tables.cpp
+++ b/src/openrct2/rct1/Tables.cpp
@@ -1412,7 +1412,7 @@ namespace RCT1
     }
     // clang-format on
 
-    track_type_t RCT1TrackTypeToOpenRCT2(RCT12TrackType origTrackType, uint8_t rideType)
+    track_type_t RCT1TrackTypeToOpenRCT2(RCT12TrackType origTrackType, ride_type_t rideType)
     {
         if (GetRideTypeDescriptor(rideType).HasFlag(RIDE_TYPE_FLAG_FLAT_RIDE))
             return RCT12FlatTrackTypeToOpenRCT2(origTrackType);

--- a/src/openrct2/rct2/RCT2.cpp
+++ b/src/openrct2/rct2/RCT2.cpp
@@ -138,14 +138,14 @@ namespace RCT2
         min_max_cars_per_train |= newValue & 0x0F;
     }
 
-    bool RCT2TrackTypeIsBooster(uint8_t rideType, uint16_t trackType)
+    bool RCT2TrackTypeIsBooster(ride_type_t rideType, uint16_t trackType)
     {
         // Boosters share their ID with the Spinning Control track.
         return rideType != RIDE_TYPE_SPINNING_WILD_MOUSE && rideType != RIDE_TYPE_STEEL_WILD_MOUSE
             && trackType == TrackElemType::Booster;
     }
 
-    track_type_t RCT2TrackTypeToOpenRCT2(RCT12TrackType origTrackType, uint8_t rideType, bool convertFlat)
+    track_type_t RCT2TrackTypeToOpenRCT2(RCT12TrackType origTrackType, ride_type_t rideType, bool convertFlat)
     {
         if (convertFlat && GetRideTypeDescriptor(rideType).HasFlag(RIDE_TYPE_FLAG_FLAT_RIDE))
             return RCT12FlatTrackTypeToOpenRCT2(origTrackType);

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -1033,10 +1033,10 @@ namespace RCT2
 #pragma pack(pop)
 
     ObjectEntryIndex RCT2RideTypeToOpenRCT2RideType(uint8_t rct2RideType, const rct_ride_entry* rideEntry);
-    bool RCT2TrackTypeIsBooster(uint8_t rideType, uint16_t trackType);
+    bool RCT2TrackTypeIsBooster(ride_type_t rideType, uint16_t trackType);
     bool RCT2RideTypeNeedsConversion(uint8_t rct2RideType);
     uint8_t OpenRCT2RideTypeToRCT2RideType(ObjectEntryIndex openrct2Type);
-    track_type_t RCT2TrackTypeToOpenRCT2(RCT12TrackType origTrackType, uint8_t rideType, bool convertFlat);
+    track_type_t RCT2TrackTypeToOpenRCT2(RCT12TrackType origTrackType, ride_type_t rideType, bool convertFlat);
     RCT12TrackType OpenRCT2TrackTypeToRCT2(track_type_t origTrackType);
 
     /**

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4203,11 +4203,11 @@ RideMode Ride::GetDefaultMode() const
     return GetRideTypeDescriptor().DefaultMode;
 }
 
-static bool RideTypeWithTrackColoursExists(uint8_t ride_type, const TrackColour& colours)
+static bool RideTypeWithTrackColoursExists(ride_type_t rideType, const TrackColour& colours)
 {
     for (auto& ride : GetRideManager())
     {
-        if (ride.type != ride_type)
+        if (ride.type != rideType)
             continue;
         if (ride.track_colour[0].main != colours.main)
             continue;
@@ -4240,7 +4240,7 @@ bool Ride::NameExists(std::string_view name, RideId excludeRideId)
     return false;
 }
 
-int32_t ride_get_random_colour_preset_index(uint8_t rideType)
+int32_t ride_get_random_colour_preset_index(ride_type_t rideType)
 {
     if (rideType >= std::size(RideTypeDescriptors))
     {
@@ -4332,7 +4332,7 @@ void Ride::SetNameToDefault()
 /**
  * This will return the name of the ride, as seen in the New Ride window.
  */
-RideNaming get_ride_naming(const uint8_t rideType, rct_ride_entry* rideEntry)
+RideNaming get_ride_naming(const ride_type_t rideType, rct_ride_entry* rideEntry)
 {
     if (!GetRideTypeDescriptor(rideType).HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
     {
@@ -5511,7 +5511,7 @@ bool ride_has_ratings(const Ride* ride)
  *  Searches for a non-null ride type in a ride entry.
  *  If none is found, it will still return RIDE_TYPE_NULL.
  */
-uint8_t ride_entry_get_first_non_null_ride_type(const rct_ride_entry* rideEntry)
+ride_type_t ride_entry_get_first_non_null_ride_type(const rct_ride_entry* rideEntry)
 {
     for (uint8_t i = 0; i < RCT2::ObjectLimits::MaxRideTypesPerRideEntry; i++)
     {
@@ -5523,7 +5523,7 @@ uint8_t ride_entry_get_first_non_null_ride_type(const rct_ride_entry* rideEntry)
     return RIDE_TYPE_NULL;
 }
 
-int32_t get_booster_speed(uint8_t rideType, int32_t rawSpeed)
+int32_t get_booster_speed(ride_type_t rideType, int32_t rawSpeed)
 {
     int8_t shiftFactor = GetRideTypeDescriptor(rideType).OperatingSettings.BoosterSpeedFactor;
     if (shiftFactor == 0)

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -113,7 +113,7 @@ enum class RideStatus : uint8_t;
 struct Ride
 {
     RideId id = RideId::GetNull();
-    uint8_t type = RIDE_TYPE_NULL;
+    ride_type_t type = RIDE_TYPE_NULL;
     // pointer to static info. for example, wild mouse type is 0x36, subtype is
     // 0x4c.
     ObjectEntryIndex subtype;
@@ -1025,7 +1025,7 @@ void ride_prepare_breakdown(Ride* ride, int32_t breakdownReason);
 TileElement* ride_get_station_start_track_element(const Ride* ride, StationIndex stationIndex);
 TileElement* ride_get_station_exit_element(const CoordsXYZ& elementPos);
 int32_t ride_get_refund_price(const Ride* ride);
-int32_t ride_get_random_colour_preset_index(uint8_t ride_type);
+int32_t ride_get_random_colour_preset_index(ride_type_t rideType);
 money32 ride_get_common_price(Ride* forRide);
 
 void ride_clear_for_construction(Ride* ride);
@@ -1091,8 +1091,8 @@ bool ride_has_adjacent_station(Ride* ride);
 bool ride_has_station_shelter(Ride* ride);
 bool ride_has_ratings(const Ride* ride);
 
-uint8_t ride_entry_get_first_non_null_ride_type(const rct_ride_entry* rideEntry);
-int32_t get_booster_speed(uint8_t rideType, int32_t rawSpeed);
+ride_type_t ride_entry_get_first_non_null_ride_type(const rct_ride_entry* rideEntry);
+int32_t get_booster_speed(ride_type_t rideType, int32_t rawSpeed);
 void fix_invalid_vehicle_sprite_sizes();
 bool ride_entry_has_category(const rct_ride_entry* rideEntry, uint8_t category);
 

--- a/src/openrct2/ride/RideEntry.h
+++ b/src/openrct2/ride/RideEntry.h
@@ -11,6 +11,7 @@
 
 #include "../rct2/DATLimits.h"
 #include "RideColour.h"
+#include "RideTypes.h"
 #include "ShopItem.h"
 #include "VehicleColour.h"
 #include "VehicleEntry.h"
@@ -47,7 +48,7 @@ struct rct_ride_entry
     // The first three images are previews. They correspond to the ride_type[] array.
     uint32_t images_offset;
     uint32_t flags;
-    uint8_t ride_type[RCT2::ObjectLimits::MaxRideTypesPerRideEntry];
+    ride_type_t ride_type[RCT2::ObjectLimits::MaxRideTypesPerRideEntry];
     uint8_t min_cars_in_train;
     uint8_t max_cars_in_train;
     uint8_t cars_per_flat_ride;
@@ -88,4 +89,4 @@ struct rct_ride_entry
 };
 
 void set_vehicle_type_image_max_sizes(CarEntry* vehicle_type, int32_t num_images);
-RideNaming get_ride_naming(const uint8_t rideType, rct_ride_entry* rideEntry);
+RideNaming get_ride_naming(const ride_type_t rideType, rct_ride_entry* rideEntry);

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -4471,7 +4471,7 @@ void ride_ratings_calculate_alpine_coaster(Ride* ride, RideRatingUpdateState& st
 
 #pragma region Ride rating calculation function table
 
-ride_ratings_calculation ride_ratings_get_calculate_func(uint8_t rideType)
+ride_ratings_calculation ride_ratings_get_calculate_func(ride_type_t rideType)
 {
     return GetRideTypeDescriptor(rideType).RatingsCalculationFunction;
 }

--- a/src/openrct2/ride/RideRatings.h
+++ b/src/openrct2/ride/RideRatings.h
@@ -60,7 +60,7 @@ void ride_ratings_update_ride(const Ride& ride);
 void ride_ratings_update_all();
 
 using ride_ratings_calculation = void (*)(Ride* ride, RideRatingUpdateState& state);
-ride_ratings_calculation ride_ratings_get_calculate_func(uint8_t rideType);
+ride_ratings_calculation ride_ratings_get_calculate_func(ride_type_t rideType);
 
 void ride_ratings_calculate_spiral_roller_coaster(Ride* ride, RideRatingUpdateState& state);
 void ride_ratings_calculate_stand_up_roller_coaster(Ride* ride, RideRatingUpdateState& state);

--- a/src/openrct2/ride/RideTypes.h
+++ b/src/openrct2/ride/RideTypes.h
@@ -25,7 +25,7 @@ using ride_type_t = uint16_t;
  */
 struct RideSelection
 {
-    uint8_t Type;
+    ride_type_t Type;
     ObjectEntryIndex EntryIndex;
 
     bool operator==(const RideSelection& other) const

--- a/src/openrct2/ride/TrackDesignRepository.cpp
+++ b/src/openrct2/ride/TrackDesignRepository.cpp
@@ -35,7 +35,7 @@ struct TrackRepositoryItem
 {
     std::string Name;
     std::string Path;
-    uint8_t RideType = RIDE_TYPE_NULL;
+    ride_type_t RideType = RIDE_TYPE_NULL;
     std::string ObjectEntry;
     uint32_t Flags = 0;
 };
@@ -57,7 +57,7 @@ class TrackDesignFileIndex final : public FileIndex<TrackRepositoryItem>
 {
 private:
     static constexpr uint32_t MAGIC_NUMBER = 0x58444954; // TIDX
-    static constexpr uint16_t VERSION = 4;
+    static constexpr uint16_t VERSION = 5;
     static constexpr auto PATTERN = "*.td4;*.td6";
 
 public:
@@ -136,7 +136,7 @@ public:
      * @param entry The entry name to count the track list of. Leave empty to count track list for the non-separated types (e.g.
      * Hyper-Twister, Car Ride)
      */
-    size_t GetCountForObjectEntry(uint8_t rideType, const std::string& entry) const override
+    size_t GetCountForObjectEntry(ride_type_t rideType, const std::string& entry) const override
     {
         size_t count = 0;
         const auto& repo = GetContext()->GetObjectRepository();
@@ -170,7 +170,7 @@ public:
      * @param entry The entry name to build a track list for. Leave empty to build track list for the non-separated types (e.g.
      * Hyper-Twister, Car Ride)
      */
-    std::vector<TrackDesignFileRef> GetItemsForObjectEntry(uint8_t rideType, const std::string& entry) const override
+    std::vector<TrackDesignFileRef> GetItemsForObjectEntry(ride_type_t rideType, const std::string& entry) const override
     {
         std::vector<TrackDesignFileRef> refs;
         const auto& repo = GetContext()->GetObjectRepository();

--- a/src/openrct2/ride/TrackDesignRepository.h
+++ b/src/openrct2/ride/TrackDesignRepository.h
@@ -11,6 +11,7 @@
 
 #include "../common.h"
 #include "../core/String.hpp"
+#include "RideTypes.h"
 
 #include <memory>
 #include <string>
@@ -32,9 +33,9 @@ struct ITrackDesignRepository
     virtual ~ITrackDesignRepository() = default;
 
     [[nodiscard]] virtual size_t GetCount() const abstract;
-    [[nodiscard]] virtual size_t GetCountForObjectEntry(uint8_t rideType, const std::string& entry) const abstract;
+    [[nodiscard]] virtual size_t GetCountForObjectEntry(ride_type_t rideType, const std::string& entry) const abstract;
     [[nodiscard]] virtual std::vector<TrackDesignFileRef> GetItemsForObjectEntry(
-        uint8_t rideType, const std::string& entry) const abstract;
+        ride_type_t rideType, const std::string& entry) const abstract;
 
     virtual void Scan(int32_t language) abstract;
     virtual bool Delete(const std::string& path) abstract;


### PR DESCRIPTION
Part of preparation for making ride types into objects.