### PR TITLE
Allow selecting the RCTC folder

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3494,7 +3494,7 @@ STR_6386    :Blizzard
 STR_6387    :Can’t lower element here…
 STR_6388    :Can’t raise element here…
 STR_6389    :Invalid clearance
-STR_6390    :OpenRCT2 needs files from the original RollerCoaster Tycoon 2 in order to work. Please select the directory where you installed RollerCoaster Tycoon 2.
+STR_6390    :OpenRCT2 needs files from the original RollerCoaster Tycoon 2 or RollerCoaster Tycoon Classic in order to work. Please select the directory where you installed RollerCoaster Tycoon 2 or RollerCoaster Tycoon Classic.
 STR_6391    :Please select your RCT2 directory
 STR_6392    :Could not find {STRING} at this path.
 STR_6393    :Objective Selection
@@ -3503,9 +3503,9 @@ STR_6395    :Maintenance
 STR_6396    :Disable screensaver and monitor power saving
 STR_6397    :If checked, screensaver and other monitor power saving features will be inhibited while OpenRCT2 is running.
 STR_6398    :File contains unsupported ride types. Please update to a newer version of OpenRCT2.
-STR_6399    :OpenRCT2 needs files from the original RollerCoaster Tycoon 2 in order to work. Please set the “game_path” variable in config.ini to the directory where you installed RollerCoaster Tycoon 2, then restart OpenRCT2.
+STR_6399    :OpenRCT2 needs files from the original RollerCoaster Tycoon 2 or RollerCoaster Tycoon Classic in order to work. Please set the “game_path” variable in config.ini to the directory where you installed RollerCoaster Tycoon 2 or RollerCoaster Tycoon Classic, then restart OpenRCT2.
 STR_6400    :I have the GOG offline installer for RollerCoaster Tycoon 2 downloaded, but it is not installed
-STR_6401    :I have RollerCoaster Tycoon 2 installed already
+STR_6401    :I have RollerCoaster Tycoon 2 or RollerCoaster Tycoon Classic installed already
 STR_6402    :OpenRCT2 Data Setup
 STR_6403    :Select which applies best to you
 STR_6404    :Please select the GOG RollerCoaster Tycoon 2 installer.

--- a/distribution/linux/openrct2.appdata.xml
+++ b/distribution/linux/openrct2.appdata.xml
@@ -30,7 +30,7 @@
       <li>Auto-saving and giant screenshots.</li>
     </ul>
     <p>
-      Original RollerCoaster Tycoon 2 game files are required in order to play OpenRCT2.
+      Original RollerCoaster Tycoon 2 or RollerCoaster Tycoon Classic game files are required in order to play OpenRCT2.
     </p>
   </description>
   <screenshots>

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -219,6 +219,7 @@ const char* PlatformEnvironment::DirectoryNamesRCT2[] = {
     nullptr,       // SHADER
     nullptr,       // THEME
     "Tracks",      // TRACK
+    nullptr,       // SOURCE
 };
 
 const u8string PlatformEnvironment::DirectoryNamesOpenRCT2[] = {
@@ -241,6 +242,7 @@ const u8string PlatformEnvironment::DirectoryNamesOpenRCT2[] = {
     u8"replay",     // REPLAY
     u8"desyncs",    // DESYNCS
     u8"crash",      // CRASH
+    u8"rct2",       // RCT2_SOURCE
 };
 
 const u8string PlatformEnvironment::FileNames[] = {

--- a/src/openrct2/PlatformEnvironment.h
+++ b/src/openrct2/PlatformEnvironment.h
@@ -51,6 +51,7 @@ namespace OpenRCT2
         REPLAY,      // Contains recorded replays.
         LOG_DESYNCS, // Contains desync reports.
         CRASH,       // Contains crash dumps.
+        RCT2_SOURCE, // Extracted RCT2 files.
     };
 
     enum class PATHID

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -706,6 +706,17 @@ namespace Config
             }
         }
 
+        //        static constexpr u8string_view rctcSearchLocations[] = {
+        //        };
+        //
+        //        for (const auto& location : searchLocations)
+        //        {
+        //            if (Platform::RCTCDataExists(location))
+        //            {
+        //                return Platform::CopyRCTCData(location);
+        //            }
+        //        }
+
         auto steamPath = Platform::GetSteamPath();
         if (!steamPath.empty())
         {
@@ -888,8 +899,8 @@ bool config_find_or_browse_install_directory()
                         return false;
                     }
 
-                    const std::string dest = Path::Combine(
-                        GetContext()->GetPlatformEnvironment()->GetDirectoryPath(DIRBASE::CONFIG), "rct2");
+                    const std::string dest = GetContext()->GetPlatformEnvironment()->GetDirectoryPath(
+                        DIRBASE::CONFIG, DIRID::RCT2_SOURCE);
 
                     while (true)
                     {
@@ -919,6 +930,11 @@ bool config_find_or_browse_install_directory()
 
                 if (Platform::OriginalGameDataExists(installPath))
                 {
+                    return true;
+                }
+                else if (Platform::RCTCDataExists(installPath))
+                {
+                    gConfigGeneral.rct2_path = Platform::CopyRCTCData(installPath);
                     return true;
                 }
 

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -88,6 +88,8 @@ namespace Platform
     float GetDefaultScale();
 
     bool OriginalGameDataExists(std::string_view path);
+    bool RCTCDataExists(u8string_view path);
+    u8string CopyRCTCData(u8string_view sourceDir);
 
     std::string GetUsername();
 

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -15,8 +15,10 @@
 
 #include "../Context.h"
 #include "../Game.h"
+#include "../PlatformEnvironment.h"
 #include "../config/Config.h"
 #include "../core/File.h"
+#include "../core/FileIndex.hpp"
 #include "../core/Path.hpp"
 #include "../localisation/Localisation.h"
 #include "Platform.h"
@@ -31,6 +33,9 @@ static constexpr std::array _prohibitedCharacters = { '<', '>', '*', '\\', ':', 
 #else
 static constexpr std::array _prohibitedCharacters = { '/' };
 #endif
+
+using OpenRCT2::DIRBASE;
+using OpenRCT2::DIRID;
 
 namespace Platform
 {
@@ -98,6 +103,71 @@ namespace Platform
     {
         std::string combinedPath = Path::ResolveCasing(Path::Combine(path, u8"Data", u8"g1.dat"));
         return File::Exists(combinedPath);
+    }
+
+    bool RCTCDataExists(u8string_view path)
+    {
+        u8string combinedPath = Path::ResolveCasing(Path::Combine(path, u8"Assets", u8"g1.dat"));
+        return File::Exists(combinedPath);
+    }
+
+    u8string CopyRCTCData(u8string_view sourceDir)
+    {
+        const auto assetDir = Path::Combine(sourceDir, "Assets");
+        auto env = OpenRCT2::GetContext()->GetPlatformEnvironment();
+        const auto targetDir = env->GetDirectoryPath(DIRBASE::CONFIG, DIRID::RCT2_SOURCE);
+        env->SetBasePath(DIRBASE::RCT2, targetDir);
+
+        struct AssetGroup
+        {
+            u8string Pattern;
+            DIRID TargetSubdir;
+            u8string NewExtension;
+        };
+
+        AssetGroup assetGroups[] = {
+            { "*.pob", DIRID::OBJECT, "dat" },
+            { "*.td6", DIRID::TRACK, "" },
+            { "*.ogg", DIRID::DATA, "" },
+            { "*.sea", DIRID::SCENARIO, "sc6" },
+        };
+
+        for (const auto& assetGroup : assetGroups)
+        {
+            auto targetSubdir = env->GetDirectoryPath(DIRBASE::RCT2, assetGroup.TargetSubdir);
+            EnsureDirectoryExists(targetSubdir);
+            auto objDataPattern = Path::Combine(assetDir, assetGroup.Pattern);
+            auto scanner = Path::ScanDirectory(objDataPattern, true);
+            while (scanner->Next())
+            {
+                auto path = std::string(scanner->GetPath());
+                auto newFilename = u8string(scanner->GetPathRelative());
+                if (!assetGroup.NewExtension.empty())
+                {
+                    newFilename = newFilename.substr(0, newFilename.length() - 3) + assetGroup.NewExtension;
+                }
+
+                if (assetGroup.Pattern == "*.sea")
+                {
+                    auto data = DecryptSea(fs::u8path(path));
+                    File::WriteAllBytes(Path::Combine(targetSubdir, newFilename), data.data(), data.size());
+                }
+                else
+                {
+                    File::Copy(path, Path::Combine(targetSubdir, newFilename), true);
+                }
+            }
+        }
+
+        File::Copy(
+            Path::Combine(assetDir, "g1.dat"), Path::Combine(env->GetDirectoryPath(DIRBASE::RCT2, DIRID::DATA), "g1.dat"),
+            true);
+
+        // Needs to be on for the RCTC scenarios to load.
+        gConfigGeneral.allow_loading_with_incorrect_checksum = true;
+        config_save_default();
+
+        return targetDir;
     }
 
     std::string SanitiseFilename(std::string_view originalName)


### PR DESCRIPTION
This will copy all the files and apply fixes along the way. This has the advantage of making it slightly quicker (as decoding of .sea files only has to take place once, and because we avoid several if/else checks to handle two very different folder structures), as well as keeping the code to handle the different folder structure of RCTC mostly contained to a single place.