### PR TITLE
[Plugin] Implement plugin getters for track and vehicle subpositions

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,7 +6,7 @@
 - Feature: [#16662] Show a warning message when g2.dat is mismatched.
 - Feature: [#17107] Ride operating settings can be set via text input.
 - Feature: [#17638] Added Zero G rolls, medium loops and large corkscrews to the Hybrid and Single-Rail coasters.
-- Feature: [#17821] [Plugin] Add API for track subposition length and vehicle subposition.
+- Feature: [#17821] [Plugin] Add API for track subpositions and vehicle subposition.
 - Feature: [#17877] Add three real-life flying roller coaster colour schemes.
 - Feature: [#17900] Add “Classic Wooden Coaster” with shallow banked turns.
 - Feature: [#6570, #10860, #17929] Fully support RollerCoaster Tycoon Classic as a RCT2 base install path.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Feature: [#16662] Show a warning message when g2.dat is mismatched.
 - Feature: [#17107] Ride operating settings can be set via text input.
 - Feature: [#17638] Added Zero G rolls, medium loops and large corkscrews to the Hybrid and Single-Rail coasters.
+- Feature: [#17821] [Plugin] Add API for track subposition length and vehicle subposition.
 - Feature: [#17877] Add three real-life flying roller coaster colour schemes.
 - Feature: [#17900] Add “Classic Wooden Coaster” with shallow banked turns.
 - Feature: [#6570, #10860, #17929] Fully support RollerCoaster Tycoon Classic as a RCT2 base install path.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -884,7 +884,7 @@ declare global {
         readonly imageId: number;
         readonly spriteNumImages: number;
     }
-     
+
     /**
      * Represents the sprite groups of a vehicle
      */
@@ -915,7 +915,7 @@ declare global {
         readonly restraintAnimation?: SpriteGroup;
         readonly curvedLiftHill?: SpriteGroup;
     }
-     
+
     /**
      * Represents a defined vehicle within a Ride object definition.
      */
@@ -1244,11 +1244,17 @@ declare global {
          * Gets a list of the elements that make up the track segment.
          */
         readonly elements: TrackSegmentElement[];
-		
+
 		/**
          * Gets a length of the subpositions list for this track segment.
          */
         getSubpositionLength(subpositionType: number, direction: Direction): number;
+
+		/**
+         * Gets all of the subpositions for this track segment. These subpositions are used for the
+         * pathing of vehicles when moving along the track.
+         */
+        getSubpositions(subpositionType: number, direction: Direction): TrackSubposition[];
     }
 
     enum TrackSlope {
@@ -1268,7 +1274,16 @@ declare global {
         UpsideDown = 15
     }
 
-    interface TrackSegmentElement extends CoordsXYZ {
+    interface TrackSegmentElement extends Readonly<CoordsXYZ> {
+    }
+
+    /**
+     * A single subposition on a track piece. These subpositions are used for the pathing of vehicles
+     * when moving along the track.
+     */
+    interface TrackSubposition extends Readonly<CoordsXYZD> {
+        readonly angle: TrackSlope;
+        readonly banking: TrackBanking;
     }
 
     interface TrackIterator {
@@ -1473,7 +1488,7 @@ declare global {
         readonly remainingDistance: number;
 
         /**
-         * The type of subposition coordinates that this vehicle is using to find its 
+         * The type of subposition coordinates that this vehicle is using to find its
 		 * position on the track.
          */
         readonly subposition: number;

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -107,7 +107,7 @@ declare global {
      * The direction is between 0 and 3.
      */
     interface CoordsXYZD extends CoordsXYZ {
-        direction: number;
+        direction: Direction;
     }
 
     /**
@@ -1244,6 +1244,11 @@ declare global {
          * Gets a list of the elements that make up the track segment.
          */
         readonly elements: TrackSegmentElement[];
+		
+		/**
+         * Gets a length of the subpositions list for this track segment.
+         */
+        getSubpositionLength(subpositionType: number, direction: Direction): number;
     }
 
     enum TrackSlope {
@@ -1466,6 +1471,12 @@ declare global {
          * The currently projected remaining distance the car will travel.
          */
         readonly remainingDistance: number;
+
+        /**
+         * The type of subposition coordinates that this vehicle is using to find its 
+		 * position on the track.
+         */
+        readonly subposition: number;
 
         /**
          * List of guest IDs ordered by seat.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1245,12 +1245,12 @@ declare global {
          */
         readonly elements: TrackSegmentElement[];
 
-		/**
+        /**
          * Gets a length of the subpositions list for this track segment.
          */
         getSubpositionLength(subpositionType: number, direction: Direction): number;
 
-		/**
+        /**
          * Gets all of the subpositions for this track segment. These subpositions are used for the
          * pathing of vehicles when moving along the track.
          */
@@ -1281,9 +1281,10 @@ declare global {
      * A single subposition on a track piece. These subpositions are used for the pathing of vehicles
      * when moving along the track.
      */
-    interface TrackSubposition extends Readonly<CoordsXYZD> {
-        readonly angle: TrackSlope;
-        readonly banking: TrackBanking;
+    interface TrackSubposition extends Readonly<CoordsXYZ> {
+        readonly yaw: number;
+        readonly pitch: TrackSlope;
+        readonly roll: TrackBanking;
     }
 
     interface TrackIterator {
@@ -1489,7 +1490,7 @@ declare global {
 
         /**
          * The type of subposition coordinates that this vehicle is using to find its
-		 * position on the track.
+         * position on the track.
          */
         readonly subposition: number;
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -664,7 +664,7 @@ const rct_vehicle_info* Vehicle::GetMoveInfo() const
     return vehicle_get_move_info(TrackSubposition, GetTrackType(), GetTrackDirection(), track_progress);
 }
 
-static uint16_t vehicle_get_move_info_size(VehicleTrackSubposition trackSubposition, track_type_t type, uint8_t direction)
+uint16_t vehicle_get_move_info_size(VehicleTrackSubposition trackSubposition, track_type_t type, uint8_t direction)
 {
     uint16_t typeAndDirection = (type << 2) | (direction & 3);
 

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -526,6 +526,7 @@ enum
 Vehicle* try_get_vehicle(EntityId spriteIndex);
 void vehicle_update_all();
 void vehicle_sounds_update();
+uint16_t vehicle_get_move_info_size(VehicleTrackSubposition trackSubposition, track_type_t type, uint8_t direction);
 
 void RideUpdateMeasurementsSpecialElements_Default(Ride* ride, const track_type_t trackType);
 void RideUpdateMeasurementsSpecialElements_MiniGolf(Ride* ride, const track_type_t trackType);

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 58;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 59;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.cpp
@@ -75,6 +75,7 @@ namespace OpenRCT2::Scripting
         dukglue_register_property(ctx, &ScVehicle::trackLocation_get, &ScVehicle::trackLocation_set, "trackLocation");
         dukglue_register_property(ctx, &ScVehicle::trackProgress_get, nullptr, "trackProgress");
         dukglue_register_property(ctx, &ScVehicle::remainingDistance_get, nullptr, "remainingDistance");
+        dukglue_register_property(ctx, &ScVehicle::subposition_get, nullptr, "subposition");
         dukglue_register_property(
             ctx, &ScVehicle::poweredAcceleration_get, &ScVehicle::poweredAcceleration_set, "poweredAcceleration");
         dukglue_register_property(ctx, &ScVehicle::poweredMaxSpeed_get, &ScVehicle::poweredMaxSpeed_set, "poweredMaxSpeed");
@@ -384,6 +385,12 @@ namespace OpenRCT2::Scripting
     {
         auto vehicle = GetVehicle();
         return vehicle != nullptr ? vehicle->remaining_distance : 0;
+    }
+
+    uint8_t ScVehicle::subposition_get() const
+    {
+        auto vehicle = GetVehicle();
+        return vehicle != nullptr ? static_cast<uint8_t>(vehicle->TrackSubposition) : 0;
     }
 
     uint8_t ScVehicle::poweredAcceleration_get() const

--- a/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
+++ b/src/openrct2/scripting/bindings/entity/ScVehicle.hpp
@@ -77,6 +77,8 @@ namespace OpenRCT2::Scripting
 
         int32_t remainingDistance_get() const;
 
+        uint8_t subposition_get() const;
+
         uint8_t poweredAcceleration_get() const;
         void poweredAcceleration_set(uint8_t value);
 

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -13,6 +13,7 @@
 
 #    include "../../../Context.h"
 #    include "../../../ride/TrackData.h"
+#    include "../../../ride/Vehicle.h"
 #    include "../../ScriptEngine.h"
 
 using namespace OpenRCT2::Scripting;
@@ -35,6 +36,7 @@ void ScTrackSegment::Register(duk_context* ctx)
     dukglue_register_property(ctx, &ScTrackSegment::endZ_get, nullptr, "endZ");
     dukglue_register_property(ctx, &ScTrackSegment::endDirection_get, nullptr, "endDirection");
     dukglue_register_property(ctx, &ScTrackSegment::length_get, nullptr, "length");
+    dukglue_register_method(ctx, &ScTrackSegment::getSubpositionLength, "getSubpositionLength");
 }
 
 int32_t ScTrackSegment::type_get() const
@@ -139,6 +141,11 @@ DukValue ScTrackSegment::elements_get() const
     }
 
     return DukValue::take_from_stack(ctx);
+}
+
+uint16_t ScTrackSegment::getSubpositionLength(uint8_t trackSubposition, uint8_t direction) const
+{
+    return vehicle_get_move_info_size(static_cast<VehicleTrackSubposition>(trackSubposition), _type, direction);
 }
 
 #endif

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -37,6 +37,7 @@ void ScTrackSegment::Register(duk_context* ctx)
     dukglue_register_property(ctx, &ScTrackSegment::endDirection_get, nullptr, "endDirection");
     dukglue_register_property(ctx, &ScTrackSegment::length_get, nullptr, "length");
     dukglue_register_method(ctx, &ScTrackSegment::getSubpositionLength, "getSubpositionLength");
+    dukglue_register_method(ctx, &ScTrackSegment::getSubpositions, "getSubpositions");
 }
 
 int32_t ScTrackSegment::type_get() const
@@ -146,6 +147,22 @@ DukValue ScTrackSegment::elements_get() const
 uint16_t ScTrackSegment::getSubpositionLength(uint8_t trackSubposition, uint8_t direction) const
 {
     return vehicle_get_move_info_size(static_cast<VehicleTrackSubposition>(trackSubposition), _type, direction);
+}
+
+std::vector<DukValue> ScTrackSegment::getSubpositions(uint8_t trackSubposition, uint8_t direction) const
+{
+    const auto ctx = GetContext()->GetScriptEngine().GetContext();
+    const uint16_t size = getSubpositionLength(trackSubposition, direction);
+    const uint16_t typeAndDirection = (_type << 2) | (direction & 3);
+
+    std::vector<DukValue> result;
+
+    for (auto idx = 0; idx < size; idx++)
+    {
+        result.push_back(ToDuk<rct_vehicle_info>(
+            ctx, gTrackVehicleInfo[static_cast<uint8_t>(trackSubposition)][typeAndDirection]->info[idx]));
+    }
+    return result;
 }
 
 #endif

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -25,9 +25,9 @@ namespace OpenRCT2::Scripting
         dukSubposition.Set("x", value.x);
         dukSubposition.Set("y", value.y);
         dukSubposition.Set("z", value.z);
-        dukSubposition.Set("direction", value.direction);
-        dukSubposition.Set("angle", value.Pitch);
-        dukSubposition.Set("banking", value.bank_rotation);
+        dukSubposition.Set("yaw", value.direction);
+        dukSubposition.Set("pitch", value.Pitch);
+        dukSubposition.Set("roll", value.bank_rotation);
         return dukSubposition.Take();
     }
 

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -44,6 +44,7 @@ namespace OpenRCT2::Scripting
         int32_t endBank_get() const;
         int32_t length_get() const;
         DukValue elements_get() const;
+        uint16_t getSubpositionLength(uint8_t trackSubposition, uint8_t direction) const;
     };
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -19,6 +19,18 @@
 
 namespace OpenRCT2::Scripting
 {
+    template<> inline DukValue ToDuk(duk_context* ctx, const rct_vehicle_info& value)
+    {
+        DukObject dukSubposition(ctx);
+        dukSubposition.Set("x", value.x);
+        dukSubposition.Set("y", value.y);
+        dukSubposition.Set("z", value.z);
+        dukSubposition.Set("direction", value.direction);
+        dukSubposition.Set("angle", value.Pitch);
+        dukSubposition.Set("banking", value.bank_rotation);
+        return dukSubposition.Take();
+    }
+
     class ScTrackSegment
     {
     private:
@@ -45,6 +57,7 @@ namespace OpenRCT2::Scripting
         int32_t length_get() const;
         DukValue elements_get() const;
         uint16_t getSubpositionLength(uint8_t trackSubposition, uint8_t direction) const;
+        std::vector<DukValue> getSubpositions(uint8_t trackSubposition, uint8_t direction) const;
     };
 
 } // namespace OpenRCT2::Scripting


### PR DESCRIPTION
Hey all,

I've been experimenting with the track iterator implemented in #16975 and I've been trying to use it to calculate `trackProgress`-distance between two vehicles. For this I need to know how long track pieces can be, and while there is [`TrackSegment.length`](https://github.com/OpenRCT2/OpenRCT2/blob/121afbe1d0eb1ff526b223468fc887bf8919e954/distribution/openrct2.d.ts#L1241), this is just an arbitrary number for each track piece and not an exact upper bound for `trackProgress`.

Thus, hereby a PR that exposes this upper bound, the subposition coordinates, and a new property for `Car` to get which subposition it is currently using.

- I wasn't sure about exposing `vehicle_get_move_info_size()` in the header file, but it seemed better than copy/pasting the contents. But if you have a better suggestion, I'd love to hear it.
- The `TrackSubposition` properties `angle` and `banking` are called that way to be consistent with the properties already present in `TrackSegment`.
- I also changed the type of `CoordsXYZD.direction` to be more compatible with all other uses of `Direction`. (This affects just the Typescript side, and thus is not a breaking change.)

Thank you for your time!