### PR TITLE
Hotfix B&M inline twist issue

### DIFF
--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
@@ -12498,22 +12498,22 @@ static void bolliger_mabillard_track_left_twist_down_to_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27430, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27436, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27429, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27435, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height - 5, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12609,22 +12609,22 @@ static void bolliger_mabillard_track_right_twist_down_to_up(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27442, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27448, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27441, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27447, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height - 5, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12780,22 +12780,22 @@ static void bolliger_mabillard_track_left_twist_up_to_down(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27429, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27435, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27430, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27436, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height - 5, session.TrackColours[SCHEME_SUPPORTS]);
@@ -12891,22 +12891,22 @@ static void bolliger_mabillard_track_right_twist_up_to_down(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27441, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27447, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27442, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 27448, { 0, 6, height - 5 }, { 32, 20, 3 },
-                        { 0, 0, height + 8 });
+                        { 0, 0, height + 6 });
                     break;
             }
             metal_a_supports_paint_setup(session, supportType, 4, 0, height - 5, session.TrackColours[SCHEME_SUPPORTS]);


### PR DESCRIPTION
This is a Hotfix for something I overlooked while making #17312.

![image](https://user-images.githubusercontent.com/1516893/184680895-bafc3b82-688a-4ccf-bbd5-b510437d21ed.png)


I have fixed the same issue for the flying inline in #17782. Please let me know if I need to bring that over to this PR.