### PR TITLE
Fix [#17544, #17754]: Visual glitches in Invention List window

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#17535] Multiplayer desync when placing rides with scenery.
 - Fix: [#17541] Station style not correctly saved to TD6.
 - Fix: [#17542] Stalls will autorotate towards paths outside the park.
+- Fix: [#17544, #17754] Visual glitches in Invention List window.
 - Fix: [#17553] Crash when moving invention list items to empty list.
 - Fix: [#17571] All researched tracked rides show up as new vehicles in .park scenarios.
 - Fix: [#17600] Notifications are not properly cleared when loading a park.

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -414,7 +414,7 @@ public:
             const auto clipHeight = bkWidget.height() - 1;
             if (clip_drawpixelinfo(&clipDPI, &dpi, screenPos, clipWidth, clipHeight))
             {
-                object->DrawPreview(&clipDPI, clipWidth, height);
+                object->DrawPreview(&clipDPI, clipWidth, clipHeight);
             }
         }
 

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -509,6 +509,12 @@ public:
         return item == _selectedResearchItem;
     }
 
+    // hack to fix #17544: OnScrollMouseOver never gets called while dragging
+    void SetSelectedResearchItem(ResearchItem* item)
+    {
+        _selectedResearchItem = item;
+    }
+
     void MoveResearchItem(const ResearchItem& item, ResearchItem* beforeItem, bool isInvented)
     {
         _selectedResearchItem = nullptr;
@@ -597,6 +603,7 @@ public:
             auto* research = res.has_value() ? res->research : nullptr;
             if (!inventionListWindow->IsResearchItemSelected(research))
             {
+                inventionListWindow->SetSelectedResearchItem(research);
                 inventionListWindow->Invalidate();
             }
         }


### PR DESCRIPTION
Although I bundled these two into a single PR, I consider the second one to be hacky and I'll gladly roll it back if you agree. I did it this way because, as far as I can tell, the issue lies in how `OnScrollMouseOver` does not get called while an item is being held, and I didn't get to figure out why.

I came across two more bugs here that I didn't find an open issue for:

1. The window that holds the dragged item's name appears to ~be shorter than necessary~ snap horizontally to something, leaving chunks of text behind like dirty pixels

![1194](https://user-images.githubusercontent.com/25644992/184756206-00b89cd1-1daa-4fbf-9508-18e014bcefd3.png)

It predates this PR, but wasn't visible because the full window was being invalidated every frame so long as the dragged item was being held away from its original location. Seems minor enough (9c6a1dd94 imitates the old behaviour), but I'd rather not do that.

2. When dragging an item to a lower position within the same list, or even the bottom half of its current position, it ends up one place lower than expected. The above screenshot leads to this result:

![1195](https://user-images.githubusercontent.com/25644992/184757019-ee7372e3-45b4-41dd-998c-bb44473acb6e.png)

This also predates the recent window class refactor #17486.

I'll open issues for these, unless you're fine with guiding me towards a proper fix within this PR.