### PR TITLE
Fixed bug #17844

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -195,6 +195,7 @@ The following people are not part of the development team, but have been contrib
 * Hoby R. (hobyr)
 * Huu Kim Nguyen (CoderUndefined)
 * Henry Cheng (jazzysoggy)
+* Dan Stevens (MajeureX)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "6"
+#define NETWORK_STREAM_VERSION "7"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -743,33 +743,33 @@ static void ride_ratings_calculate(RideRatingUpdateState& state, Ride* ride)
     // https://github.com/OpenRCT2/OpenRCT2/issues/17844
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED)
     {
-    auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
-    if (hookEngine.HasSubscriptions(HOOK_TYPE::RIDE_RATINGS_CALCULATE))
-    {
-        auto ctx = GetContext()->GetScriptEngine().GetContext();
-        auto originalExcitement = ride->excitement;
-        auto originalIntensity = ride->intensity;
-        auto originalNausea = ride->nausea;
+        auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
+        if (hookEngine.HasSubscriptions(HOOK_TYPE::RIDE_RATINGS_CALCULATE))
+        {
+            auto ctx = GetContext()->GetScriptEngine().GetContext();
+            auto originalExcitement = ride->excitement;
+            auto originalIntensity = ride->intensity;
+            auto originalNausea = ride->nausea;
 
-        // Create event args object
-        auto obj = DukObject(ctx);
-        obj.Set("rideId", ride->id.ToUnderlying());
-        obj.Set("excitement", originalExcitement);
-        obj.Set("intensity", originalIntensity);
-        obj.Set("nausea", originalNausea);
+            // Create event args object
+            auto obj = DukObject(ctx);
+            obj.Set("rideId", ride->id.ToUnderlying());
+            obj.Set("excitement", originalExcitement);
+            obj.Set("intensity", originalIntensity);
+            obj.Set("nausea", originalNausea);
 
-        // Call the subscriptions
-        auto e = obj.Take();
-        hookEngine.Call(HOOK_TYPE::RIDE_RATINGS_CALCULATE, e, true);
+            // Call the subscriptions
+            auto e = obj.Take();
+            hookEngine.Call(HOOK_TYPE::RIDE_RATINGS_CALCULATE, e, true);
 
-        auto scriptExcitement = AsOrDefault(e["excitement"], static_cast<int32_t>(originalExcitement));
-        auto scriptIntensity = AsOrDefault(e["intensity"], static_cast<int32_t>(originalIntensity));
-        auto scriptNausea = AsOrDefault(e["nausea"], static_cast<int32_t>(originalNausea));
+            auto scriptExcitement = AsOrDefault(e["excitement"], static_cast<int32_t>(originalExcitement));
+            auto scriptIntensity = AsOrDefault(e["intensity"], static_cast<int32_t>(originalIntensity));
+            auto scriptNausea = AsOrDefault(e["nausea"], static_cast<int32_t>(originalNausea));
 
-        ride->excitement = std::clamp<int32_t>(scriptExcitement, 0, INT16_MAX);
-        ride->intensity = std::clamp<int32_t>(scriptIntensity, 0, INT16_MAX);
-        ride->nausea = std::clamp<int32_t>(scriptNausea, 0, INT16_MAX);
-    }
+            ride->excitement = std::clamp<int32_t>(scriptExcitement, 0, INT16_MAX);
+            ride->intensity = std::clamp<int32_t>(scriptIntensity, 0, INT16_MAX);
+            ride->nausea = std::clamp<int32_t>(scriptNausea, 0, INT16_MAX);
+        }
     }
 #endif
 }

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -739,6 +739,10 @@ static void ride_ratings_calculate(RideRatingUpdateState& state, Ride* ride)
 #endif
 
 #ifdef ENABLE_SCRIPTING
+    // Only call the 'ride.ratings.calculate' API hook if testing of the ride is complete
+    // https://github.com/OpenRCT2/OpenRCT2/issues/17844
+    if (ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED)
+    {
     auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();
     if (hookEngine.HasSubscriptions(HOOK_TYPE::RIDE_RATINGS_CALCULATE))
     {
@@ -765,6 +769,7 @@ static void ride_ratings_calculate(RideRatingUpdateState& state, Ride* ride)
         ride->excitement = std::clamp<int32_t>(scriptExcitement, 0, INT16_MAX);
         ride->intensity = std::clamp<int32_t>(scriptIntensity, 0, INT16_MAX);
         ride->nausea = std::clamp<int32_t>(scriptNausea, 0, INT16_MAX);
+    }
     }
 #endif
 }

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -740,7 +740,6 @@ static void ride_ratings_calculate(RideRatingUpdateState& state, Ride* ride)
 
 #ifdef ENABLE_SCRIPTING
     // Only call the 'ride.ratings.calculate' API hook if testing of the ride is complete
-    // https://github.com/OpenRCT2/OpenRCT2/issues/17844
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_TESTED)
     {
         auto& hookEngine = GetContext()->GetScriptEngine().GetHookEngine();


### PR DESCRIPTION
The 'ride.ratings.calculate' API hook is now called for a ride only after its rating calculations are complete (RIDE_LIFECYCLE_TESTED lifecycle_flag is set)

https://github.com/OpenRCT2/OpenRCT2/issues/17844