### PR TITLE
Change how _lastTrackDesignCountRideType and _lastTrackDesignCount are handled

### DIFF
--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -429,6 +429,13 @@ public:
         }
 
         new_ride.HighlightedRide = item;
+
+        if (item.Type != _lastTrackDesignCountRideType.Type || item.EntryIndex != _lastTrackDesignCountRideType.EntryIndex)
+        {
+            _lastTrackDesignCountRideType = item;
+            _lastTrackDesignCount = GetNumTrackDesigns(item);
+        }
+
         Invalidate();
     }
 
@@ -848,11 +855,7 @@ private:
         }
 
         ft = Formatter();
-        if (item.Type != _lastTrackDesignCountRideType.Type || item.EntryIndex != _lastTrackDesignCountRideType.EntryIndex)
-        {
-            _lastTrackDesignCountRideType = item;
-            _lastTrackDesignCount = GetNumTrackDesigns(item);
-        }
+
         ft.Add<int32_t>(_lastTrackDesignCount);
 
         StringId designCountStringId;


### PR DESCRIPTION
May fix: #17843

Issue: ``_lastTrackDesignCountRideType`` and ``_lastTrackDesignCount`` are handled on draw, while draw routine should not be mutating a field that is used for user interaction.

Fix: Move adjustment of ``_lastTrackDesignCountRideType`` and ``_lastTrackDesignCount`` from draw routine to OnScrollMouseOver, as this is where the variable new_ride.HighlightedRide is set, which is the variable that is used to set ``_lastTrackDesignCountRideType`` and ``_lastTrackDesignCount``.