### PR TITLE
refactor Park::CalculateSuggestedMaxGuests

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -51,6 +51,7 @@
 - Fix: [#17897] Guest can get stuck on tiles with construction rights outside the park.
 - Fix: [#17905] The chain button in the map window is enabled for rectangular maps when (re)opened.
 - Fix: [#17931] The in-game command ‘count_objects’ crashes the game.
+- Fix: [#17865] With difficult guest generation, tested but unopened rides still contribute to the guest cap.
 - Fix: [#17866] [Plugin] Wrong Soft Guest Cap at start of new game
 
 0.4.1 (2022-07-04)

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -570,6 +570,8 @@ uint32_t Park::CalculateSuggestedMaxGuests() const
         suggestedMaxGuests = std::min<uint32_t>(suggestedMaxGuests, 1000);
         for (auto& ride : GetRideManager())
         {
+            if (ride.status != RideStatus::Open)
+                continue;
             if (ride.lifecycle_flags & RIDE_LIFECYCLE_CRASHED)
                 continue;
             if (ride.lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -549,8 +549,8 @@ money16 Park::CalculateTotalRideValueForMoney() const
 uint32_t Park::CalculateSuggestedMaxGuests() const
 {
     uint32_t suggestedMaxGuests = 0;
+    uint32_t difficultGenerationBonus = 0;
 
-    // TODO combine the two ride loops
     for (auto& ride : GetRideManager())
     {
         if (ride.status != RideStatus::Open)
@@ -562,20 +562,10 @@ uint32_t Park::CalculateSuggestedMaxGuests() const
 
         // Add guest score for ride type
         suggestedMaxGuests += ride.GetRideTypeDescriptor().BonusValue;
-    }
 
-    // If difficult guest generation, extra guests are available for good rides
-    if (gParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
-    {
-        suggestedMaxGuests = std::min<uint32_t>(suggestedMaxGuests, 1000);
-        for (auto& ride : GetRideManager())
+        // If difficult guest generation, extra guests are available for good rides
+        if (gParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
         {
-            if (ride.status != RideStatus::Open)
-                continue;
-            if (ride.lifecycle_flags & RIDE_LIFECYCLE_CRASHED)
-                continue;
-            if (ride.lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
-                continue;
             if (!(ride.lifecycle_flags & RIDE_LIFECYCLE_TESTED))
                 continue;
             if (!ride.GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_TRACK))
@@ -588,8 +578,14 @@ uint32_t Park::CalculateSuggestedMaxGuests() const
                 continue;
 
             // Bonus guests for good ride
-            suggestedMaxGuests += ride.GetRideTypeDescriptor().BonusValue * 2;
+            difficultGenerationBonus += ride.GetRideTypeDescriptor().BonusValue * 2;
         }
+    }
+
+    if (gParkFlags & PARK_FLAGS_DIFFICULT_GUEST_GENERATION)
+    {
+        suggestedMaxGuests = std::min<uint32_t>(suggestedMaxGuests, 1000);
+        suggestedMaxGuests += difficultGenerationBonus;
     }
 
     suggestedMaxGuests = std::min<uint32_t>(suggestedMaxGuests, 65535);


### PR DESCRIPTION
Combines two loops into one.
Also fixes #17865. (With difficult guest generation, tested but unopened rides still contribute to the guest cap.)
