### PR TITLE
Fix #17816: Game shows the ability to pause game when Steam Overlay is enabled even though OpenGL renderer has no such ability

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -43,6 +43,7 @@
 - Fix: [#17784] Colour preset RNG is biased (original bug).
 - Fix: [#17788] Guests could leave queue if another guest rejoins it from the entrance building.
 - Fix: [#17834] Finance window becomes blank after 4096 years.
+- Fix: [#17816] Option to pause game when Steam Overlay is active is not greyed out when using the OpenGL renderer.
 - Fix: [#17905] The chain button in the map window is enabled for rectangular maps when (re)opened.
 - Fix: [#17931] The in-game command ‘count_objects’ crashes the game.
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -877,8 +877,8 @@ private:
             disabled_widgets &= ~(1ULL << WIDX_RESOLUTION_LABEL);
         }
 
-        // Disable Steam Overlay checkbox when using software rendering.
-        if (gConfigGeneral.drawing_engine == DrawingEngine::Software)
+        // Disable Steam Overlay checkbox when using software or OpenGL rendering.
+        if (gConfigGeneral.drawing_engine == DrawingEngine::Software || gConfigGeneral.drawing_engine == DrawingEngine::OpenGL)
         {
             disabled_widgets |= (1ULL << WIDX_STEAM_OVERLAY_PAUSE);
         }


### PR DESCRIPTION
#17816

Issue: When using the OpenGL hardware rendering option, the check to enable pause when Steam Overlay appears is enabled. This option, however, does nothing when using the OpenGL hardware rendering option.

Fix: Add a check so that the option is grayed out when using OpenGL hardware rendering.
