### PR TITLE
Disable track elements if no train supports them

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -18,6 +18,7 @@
 - Improved: [#17575] You can now search for Authors in Object Selection.
 - Improved: [#17806] Added warning when using RCT1 objects without RCT1 linked.
 - Improved: [#17868] [Plugin] You can now change active tab of a custom window programmatically.
+- Improved: [#17909] Track elements that are not supported by any train are now hidden by default.
 - Improved: [#17924] Improved performance when loading JSON object images from a .DAT file.
 - Change: [#9104] Calculate maze support costs.
 - Change: [#17319] Giant screenshots are now cropped to the horizontal view-clipping selection.

--- a/src/openrct2/ride/RideData.cpp
+++ b/src/openrct2/ride/RideData.cpp
@@ -384,6 +384,7 @@ bool RideTypeDescriptor::SupportsRideMode(RideMode rideMode) const
 }
 
 static RideTrackGroup _enabledRidePieces = {};
+static RideTrackGroup _disabledRidePieces = {};
 
 bool IsTrackEnabled(int32_t trackFlagIndex)
 {
@@ -393,4 +394,14 @@ bool IsTrackEnabled(int32_t trackFlagIndex)
 void UpdateEnabledRidePieces(ride_type_t rideType)
 {
     GetRideTypeDescriptor(rideType).GetAvailableTrackPieces(_enabledRidePieces);
+
+    if (!gCheatsEnableAllDrawableTrackPieces)
+    {
+        _enabledRidePieces &= ~_disabledRidePieces;
+    }
+}
+
+void UpdateDisabledRidePieces(const RideTrackGroup& res)
+{
+    _disabledRidePieces = res;
 }

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -467,3 +467,4 @@ constexpr bool RideTypeIsValid(ObjectEntryIndex rideType)
 
 bool IsTrackEnabled(int32_t trackFlagIndex);
 void UpdateEnabledRidePieces(ride_type_t rideType);
+void UpdateDisabledRidePieces(const RideTrackGroup& res);


### PR DESCRIPTION
This can be useful in several situations:
- In RCT1 scenarios, or when playing with ported RCT1 vehicles, it will disable elements like banked turns
- We can add extra elements to existing coaster types by default, even if no RCT2 train supports them.

Example in an RCT1 scenario, with a ported vehicle that does not support banked turns:
![afbeelding](https://user-images.githubusercontent.com/1478678/187040307-4c0e5f2d-fd08-4fc0-a6ce-255058748cd5.png)
