### PR TITLE
Implement #17806: Warn user if fallback images used

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3620,6 +3620,9 @@ STR_6511    :Zero G Roll (right)
 STR_6512    :Large Zero G Roll (left)
 STR_6513    :Large Zero G Roll (right)
 STR_6514    :Invalid height!
+STR_6515    :Fallback images will be used
+STR_6516    :Object uses RollerCoaster Tycoon 1 sprites. Fallback images will be used.
+STR_6517    :Park has objects that use RollerCoaster Tycoon 1 sprites. Fallback images will be used.
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3620,7 +3620,7 @@ STR_6511    :Zero G Roll (right)
 STR_6512    :Large Zero G Roll (left)
 STR_6513    :Large Zero G Roll (right)
 STR_6514    :Invalid height!
-STR_6515    :{BLACK}RCT1 not linked; fallback sprites will be used.
+STR_6515    :{BLACK}RCT1 not linked - fallback images will be used.
 STR_6516    :One or more objects added require RCT1 linked for proper display. Fallback images will be used.
 STR_6517    :One or more objects in this park require RCT1 linked for proper display. Fallback images will be used.
 

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3620,7 +3620,7 @@ STR_6511    :Zero G Roll (right)
 STR_6512    :Large Zero G Roll (left)
 STR_6513    :Large Zero G Roll (right)
 STR_6514    :Invalid height!
-STR_6515    :Fallback images will be used
+STR_6515    :RCT1 not linked. Fallback images will be used
 STR_6516    :One or more objects added require RCT1 linked for proper display. Fallback images will be used.
 STR_6517    :One or more objects in this park require RCT1 linked for proper display. Fallback images will be used.
 

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3620,7 +3620,7 @@ STR_6511    :Zero G Roll (right)
 STR_6512    :Large Zero G Roll (left)
 STR_6513    :Large Zero G Roll (right)
 STR_6514    :Invalid height!
-STR_6515    :RCT1 not linked. Fallback images will be used
+STR_6515    :Object uses RCT1 sprites, which is currently not linked. Fallback sprites will be used.
 STR_6516    :One or more objects added require RCT1 linked for proper display. Fallback images will be used.
 STR_6517    :One or more objects in this park require RCT1 linked for proper display. Fallback images will be used.
 

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3621,8 +3621,8 @@ STR_6512    :Large Zero G Roll (left)
 STR_6513    :Large Zero G Roll (right)
 STR_6514    :Invalid height!
 STR_6515    :Fallback images will be used
-STR_6516    :Object uses RCT1 sprites. Fallback images will be used.
-STR_6517    :One or more objects in this park requires RCT1 linked for proper display. Fallback images will be used.
+STR_6516    :One or more objects added require RCT1 linked for proper display. Fallback images will be used.
+STR_6517    :One or more objects in this park require RCT1 linked for proper display. Fallback images will be used.
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3620,7 +3620,7 @@ STR_6511    :Zero G Roll (right)
 STR_6512    :Large Zero G Roll (left)
 STR_6513    :Large Zero G Roll (right)
 STR_6514    :Invalid height!
-STR_6515    :Object uses RCT1 sprites, which is currently not linked. Fallback sprites will be used.
+STR_6515    :RCT1 not linked; fallback sprites will be used.
 STR_6516    :One or more objects added require RCT1 linked for proper display. Fallback images will be used.
 STR_6517    :One or more objects in this park require RCT1 linked for proper display. Fallback images will be used.
 

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3621,8 +3621,8 @@ STR_6512    :Large Zero G Roll (left)
 STR_6513    :Large Zero G Roll (right)
 STR_6514    :Invalid height!
 STR_6515    :Fallback images will be used
-STR_6516    :Object uses RollerCoaster Tycoon 1 sprites. Fallback images will be used.
-STR_6517    :Park has objects that use RollerCoaster Tycoon 1 sprites. Fallback images will be used.
+STR_6516    :Object uses RCT1 sprites. Fallback images will be used.
+STR_6517    :One or more objects in this park requires RCT1 linked for proper display. Fallback images will be used.
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3620,7 +3620,7 @@ STR_6511    :Zero G Roll (right)
 STR_6512    :Large Zero G Roll (left)
 STR_6513    :Large Zero G Roll (right)
 STR_6514    :Invalid height!
-STR_6515    :RCT1 not linked; fallback sprites will be used.
+STR_6515    :{BLACK}RCT1 not linked; fallback sprites will be used.
 STR_6516    :One or more objects added require RCT1 linked for proper display. Fallback images will be used.
 STR_6517    :One or more objects in this park require RCT1 linked for proper display. Fallback images will be used.
 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,7 +14,7 @@
 - Improved: [#16840] Add support for rectangular heightmaps.
 - Improved: [#17575] You can now search for Authors in Object Selection.
 - Improved: [#17868] [Plugin] You can now change active tab of a custom window programmatically.
-- Improved: [#17928] Added error message when using RCT1 objects without RCT1 linked.
+- Improved: [#17928] Added warning when using RCT1 objects without RCT1 linked.
 - Change: [#9104] Calculate maze support costs.
 - Change: [#17319] Giant screenshots are now cropped to the horizontal view-clipping selection.
 - Change: [#17499] Update error text when using vehicle incompatible with TD6 and add error when using incompatible track elements.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Improved: [#16840] Add support for rectangular heightmaps.
 - Improved: [#17575] You can now search for Authors in Object Selection.
 - Improved: [#17868] [Plugin] You can now change active tab of a custom window programmatically.
+- Improved: [#17928] Added error message when using RCT1 objects without RCT1 linked.
 - Change: [#9104] Calculate maze support costs.
 - Change: [#17319] Giant screenshots are now cropped to the horizontal view-clipping selection.
 - Change: [#17499] Update error text when using vehicle incompatible with TD6 and add error when using incompatible track elements.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -13,8 +13,8 @@
 - Improved: [#15358] Park and scenario names can now contain up to 128 characters.
 - Improved: [#16840] Add support for rectangular heightmaps.
 - Improved: [#17575] You can now search for Authors in Object Selection.
+- Improved: [#17806] Added warning when using RCT1 objects without RCT1 linked.
 - Improved: [#17868] [Plugin] You can now change active tab of a custom window programmatically.
-- Improved: [#17928] Added warning when using RCT1 objects without RCT1 linked.
 - Change: [#9104] Calculate maze support costs.
 - Change: [#17319] Giant screenshots are now cropped to the horizontal view-clipping selection.
 - Change: [#17499] Update error text when using vehicle incompatible with TD6 and add error when using incompatible track elements.

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1566,6 +1566,7 @@ void EditorLoadSelectedObjects()
     auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
     int32_t numItems = static_cast<int32_t>(object_repository_get_items_count());
     const ObjectRepositoryItem* items = object_repository_get_items();
+    bool showFallbackWarning = false;
     for (int32_t i = 0; i < numItems; i++)
     {
         if (_objectSelectionFlags[i] & ObjectSelectionFlags::Selected)
@@ -1596,6 +1597,10 @@ void EditorLoadSelectedObjects()
                     {
                         research_insert_scenery_group_entry(entryIndex, true);
                     }
+                    if (loadedObject->UsesFallbackImages())
+                    {
+                        showFallbackWarning = true;
+                    }
                 }
             }
         }
@@ -1605,4 +1610,6 @@ void EditorLoadSelectedObjects()
         // Reloads the default cyan water palette if no palette was selected.
         load_palette();
     }
+    if (showFallbackWarning)
+        context_show_error(STR_OBJECT_SELECTION_FALLBACK_IMAGES_WARNING, STR_EMPTY, Formatter::Common());
 }

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1261,7 +1261,7 @@ private:
         // Draw fallback image warning
         if (_loadedObject && _loadedObject->UsesFallbackImages())
         {
-            DrawTextBasic(dpi, screenPos, STR_OBJECT_USES_FALLBACK_IMAGES, {}, { COLOUR_SATURATED_RED, TextAlignment::RIGHT });
+            DrawTextBasic(dpi, screenPos, STR_OBJECT_USES_FALLBACK_IMAGES, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
         }
         screenPos.y += LIST_ROW_HEIGHT;
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1256,7 +1256,15 @@ private:
     void DrawDebugData(rct_drawpixelinfo* dpi)
     {
         ObjectListItem* listItem = &_listItems[selected_list_item];
-        auto screenPos = windowPos + ScreenCoordsXY{ width - 5, height - (LIST_ROW_HEIGHT * 5) };
+        auto screenPos = windowPos + ScreenCoordsXY{ width - 5, height - (LIST_ROW_HEIGHT * 6) };
+
+        // Draw fallback image warning
+        if (_loadedObject && _loadedObject->UsesFallbackImages())
+        {
+            DrawTextBasic(dpi, screenPos, STR_OBJECT_USES_FALLBACK_IMAGES, {}, { COLOUR_SATURATED_RED, TextAlignment::RIGHT });
+        }
+        screenPos.y += LIST_ROW_HEIGHT;
+
         // Draw ride type.
         if (GetSelectedObjectType() == ObjectType::Ride)
         {

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -694,6 +694,14 @@ namespace OpenRCT2
                     ft.Add<uint32_t>(result.TargetVersion);
                     windowManager->ShowError(STR_WARNING_PARK_VERSION_TITLE, STR_WARNING_PARK_VERSION_MESSAGE, ft);
                 }
+
+                if (GetObjectUsesFallbackImages())
+                {
+                    Console::Error::WriteLine("Park has objects which require RCT1 linked. Fallback images will be used.");
+                    auto windowManager = _uiContext->GetWindowManager();
+                    windowManager->ShowError(STR_PARK_USES_FALLBACK_IMAGES_WARNING, STR_EMPTY, Formatter());
+                }
+
                 return true;
             }
             catch (const ObjectLoadException& e)
@@ -777,6 +785,25 @@ namespace OpenRCT2
         }
 
     private:
+        bool GetObjectUsesFallbackImages()
+        {
+            ObjectList objectList;
+            for (auto objectType : ObjectTypes)
+            {
+                auto maxObjectsOfType = static_cast<ObjectEntryIndex>(object_entry_group_counts[EnumValue(objectType)]);
+                for (ObjectEntryIndex i = 0; i < maxObjectsOfType; i++)
+                {
+                    auto obj = _objectManager->GetLoadedObject(objectType, i);
+                    if (obj != nullptr)
+                    {
+                        if (obj->UsesFallbackImages())
+                            return true;
+                    }
+                }
+            }
+            return false;
+        }
+
         std::string GetOrPromptRCT2Path()
         {
             auto result = std::string();

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -694,7 +694,7 @@ namespace OpenRCT2
                     ft.Add<uint32_t>(result.TargetVersion);
                     windowManager->ShowError(STR_WARNING_PARK_VERSION_TITLE, STR_WARNING_PARK_VERSION_MESSAGE, ft);
                 }
-                else if (GetObjectUsesFallbackImages())
+                else if (HasObjectsThatUseFallbackImages())
                 {
                     Console::Error::WriteLine("Park has objects which require RCT1 linked. Fallback images will be used.");
                     auto windowManager = _uiContext->GetWindowManager();
@@ -784,7 +784,7 @@ namespace OpenRCT2
         }
 
     private:
-        bool GetObjectUsesFallbackImages()
+        bool HasObjectsThatUseFallbackImages()
         {
             for (auto objectType : ObjectTypes)
             {

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -694,8 +694,7 @@ namespace OpenRCT2
                     ft.Add<uint32_t>(result.TargetVersion);
                     windowManager->ShowError(STR_WARNING_PARK_VERSION_TITLE, STR_WARNING_PARK_VERSION_MESSAGE, ft);
                 }
-
-                if (GetObjectUsesFallbackImages())
+                else if (GetObjectUsesFallbackImages())
                 {
                     Console::Error::WriteLine("Park has objects which require RCT1 linked. Fallback images will be used.");
                     auto windowManager = _uiContext->GetWindowManager();
@@ -787,7 +786,6 @@ namespace OpenRCT2
     private:
         bool GetObjectUsesFallbackImages()
         {
-            ObjectList objectList;
             for (auto objectType : ObjectTypes)
             {
                 auto maxObjectsOfType = static_cast<ObjectEntryIndex>(object_entry_group_counts[EnumValue(objectType)]);

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3901,6 +3901,10 @@ enum : uint16_t
 
     STR_INVALID_HEIGHT = 6514,
 
+    STR_OBJECT_USES_FALLBACK_IMAGES = 6515,
+    STR_OBJECT_SELECTION_FALLBACK_IMAGES_WARNING = 6516,
+    STR_PARK_USES_FALLBACK_IMAGES_WARNING = 6517,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
Warns user on the object debug info, when closing the object selection window after selecting objects, and when opening a park.

![openrct2_2022-08-28_17-36-55](https://user-images.githubusercontent.com/3454156/187124971-53af4b1a-48a9-4083-a672-5007d0b5e312.png)
![openrct2_2022-08-28_21-42-50](https://user-images.githubusercontent.com/3454156/187124973-618f542d-833f-4a37-b4a7-37d160c56e22.png)