### PR TITLE
Fix #17897: Guest can get stuck on construction rights outside the park

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -46,6 +46,7 @@
 - Fix: [#17788] Guests could leave queue if another guest rejoins it from the entrance building.
 - Fix: [#17834] Finance window becomes blank after 4096 years.
 - Fix: [#17816] Option to pause game when Steam Overlay is active is not greyed out when using the OpenGL renderer.
+- Fix: [#17897] Guest can get stuck on tiles with construction rights outside the park.
 - Fix: [#17905] The chain button in the map window is enabled for rectangular maps when (re)opened.
 - Fix: [#17931] The in-game command ‘count_objects’ crashes the game.
 

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -797,8 +797,7 @@ bool map_is_location_owned(const CoordsXYZ& loc)
 
             if (surfaceElement->GetOwnership() & OWNERSHIP_CONSTRUCTION_RIGHTS_OWNED)
             {
-                if (loc.z < surfaceElement->GetBaseZ()
-                    || loc.z >= surfaceElement->GetBaseZ() + ConstructionRightsClearanceSmall)
+                if (loc.z < surfaceElement->GetBaseZ() || loc.z >= surfaceElement->GetBaseZ() + ConstructionRightsClearanceBig)
                     return true;
             }
         }


### PR DESCRIPTION
Caused by a refactor mistake in https://github.com/OpenRCT2/OpenRCT2/commit/f0777e54186a79a5ae44a097ed1fb3b165f1af35.

**Do not squash merge!**