### PR TITLE
Fix dirty blocks regression

### DIFF
--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1940,7 +1940,7 @@ void viewport_invalidate(const rct_viewport* viewport, const ScreenRect& screenR
         topLeft = { viewport->zoom.ApplyInversedTo(topLeft.x), viewport->zoom.ApplyInversedTo(topLeft.y) };
         topLeft += viewport->pos;
 
-        bottomRight = { std::max(bottomRight.x, viewportRight), std::max(bottomRight.y, viewportBottom) };
+        bottomRight = { std::min(bottomRight.x, viewportRight), std::min(bottomRight.y, viewportBottom) };
         bottomRight -= viewport->viewPos;
         bottomRight = { viewport->zoom.ApplyInversedTo(bottomRight.x), viewport->zoom.ApplyInversedTo(bottomRight.y) };
         bottomRight += viewport->pos;


### PR DESCRIPTION
git.exe bisect good
cec8447c6f55aac6ef2f39b7c5a5a99a6ea41e69 is the first bad commit
commit cec8447c6f55aac6ef2f39b7c5a5a99a6ea41e69
Author: Sijmen <me@vijf.life>
Date:   Wed Oct 27 05:13:38 2021 +0200

Refactor Viewport.cpp to use ScreenRect (#15790)

src/openrct2-ui/windows/EditorMain.cpp   |   2 +-
src/openrct2-ui/windows/Main.cpp         |   2 +-
src/openrct2/cmdline/BenchSpriteSort.cpp |   2 +-
src/openrct2/interface/Screenshot.cpp    |   2 +-
src/openrct2/interface/Viewport.cpp      | 117 ++++++++++++++-----------------
src/openrct2/interface/Viewport.h        |   8 +--
src/openrct2/interface/Window.cpp        |   2 +-
src/openrct2/ride/TrackDesign.cpp        |  15 +---
src/openrct2/world/Map.cpp               |   6 +-
src/openrct2/world/Sprite.cpp            |   2 +-
10 files changed, 70 insertions(+), 88 deletions(-)

Success (797 ms @ 9/3/2022 6:05:38 PM)