### PR TITLE
Fix #17974: Setting tabIndex of custom window does not work

### DIFF
--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -1191,7 +1191,7 @@ namespace OpenRCT2::Ui::Windows
         if (w->classification == WindowClass::Custom && w->custom_info != nullptr)
         {
             auto& customInfo = GetInfo(w);
-            if (tabIndex >= WIDX_TAB_0 && tabIndex < static_cast<WidgetIndex>(WIDX_TAB_0 + customInfo.Desc.Tabs.size()))
+            if (tabIndex >= 0 && tabIndex < static_cast<int32_t>(customInfo.Desc.Tabs.size()))
             {
                 static_cast<CustomWindow*>(w)->ChangeTab(tabIndex);
             }


### PR DESCRIPTION
No edit of the changelog, since this fixes a very recent commit.