### PR TITLE
Fix #17973: Path items overlay parts of the land

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -68,6 +68,7 @@
 - Fix: [#17959] Areas marked for dirty drawing are too large.
 - Fix: [#17963] Some marketing campaigns can’t be started after Finances window tab has been on Research.
 - Fix: [#17966] Reversed steel trains do not properly import from S4.
+- Fix: [#17973] Bins and lamps overlay parts of the land.
 - Fix: [#18008] Steeplechase S-bends has multiple gaps visible in the tracks.
 - Fix: [#18009] Visual glitch with litter at edge of sloped path.
 - Fix: [#18025] Fix land ownership in Six Holland, Six Flags Magic Mountain, North America - Grand Canyon and Asia - Great Wall of China Tourism Enhancement scenarios. 

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -68,7 +68,7 @@
 - Fix: [#17959] Areas marked for dirty drawing are too large.
 - Fix: [#17963] Some marketing campaigns can’t be started after Finances window tab has been on Research.
 - Fix: [#17966] Reversed steel trains do not properly import from S4.
-- Fix: [#17973] Bins and lamps overlay parts of the land.
+- Fix: [#17973] Bins and lamps overlay parts of the land (original bug).
 - Fix: [#18008] Steeplechase S-bends has multiple gaps visible in the tracks.
 - Fix: [#18009] Visual glitch with litter at edge of sloped path.
 - Fix: [#18025] Fix land ownership in Six Holland, Six Flags Magic Mountain, North America - Grand Canyon and Asia - Great Wall of China Tourism Enhancement scenarios. 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -150,25 +150,25 @@ static void path_bit_lights_paint(
     {
         auto imageIndex = GetFootpathLampImage(pathBitEntry, EDGE_NE, isBroken);
         PaintAddImageAsParent(
-            session, imageTemplate.WithIndex(imageIndex), { 2, 16, height }, { 1, 1, 23 }, { 3, 16, height + 2 });
+            session, imageTemplate.WithIndex(imageIndex), { 2, 16, height }, { 0, 16, 23 }, { 6, 8, height + 2 });
     }
     if (!(edges & EDGE_SE))
     {
         auto imageIndex = GetFootpathLampImage(pathBitEntry, EDGE_SE, isBroken);
         PaintAddImageAsParent(
-            session, imageTemplate.WithIndex(imageIndex), { 16, 30, height }, { 1, 0, 23 }, { 16, 29, height + 2 });
+            session, imageTemplate.WithIndex(imageIndex), { 16, 30, height }, { 16, 0, 23 }, { 8, 23, height + 2 });
     }
     if (!(edges & EDGE_SW))
     {
         auto imageIndex = GetFootpathLampImage(pathBitEntry, EDGE_SW, isBroken);
         PaintAddImageAsParent(
-            session, imageTemplate.WithIndex(imageIndex), { 30, 16, height }, { 0, 1, 23 }, { 29, 16, height + 2 });
+            session, imageTemplate.WithIndex(imageIndex), { 30, 16, height }, { 0, 16, 23 }, { 23, 8, height + 2 });
     }
     if (!(edges & EDGE_NW))
     {
         auto imageIndex = GetFootpathLampImage(pathBitEntry, EDGE_NW, isBroken);
         PaintAddImageAsParent(
-            session, imageTemplate.WithIndex(imageIndex), { 16, 2, height }, { 1, 1, 23 }, { 16, 3, height + 2 });
+            session, imageTemplate.WithIndex(imageIndex), { 16, 2, height }, { 16, 0, 23 }, { 8, 6, height + 2 });
     }
 }
 
@@ -206,7 +206,7 @@ static void path_bit_bins_paint(
         auto imageIndex = GetFootpathBinImage(pathBitEntry, EDGE_NE, binsAreVandalised, binIsFull);
         if (!highlightPathIssues || binIsFull || binsAreVandalised)
             PaintAddImageAsParent(
-                session, imageTemplate.WithIndex(imageIndex), { 7, 16, height }, { 1, 1, 7 }, { 7, 16, height + 2 });
+                session, imageTemplate.WithIndex(imageIndex), { 7, 16, height }, { 0, 16, 7 }, { 6, 8, height + 2 });
     }
     if (!(edges & EDGE_SE))
     {
@@ -214,25 +214,23 @@ static void path_bit_bins_paint(
         auto imageIndex = GetFootpathBinImage(pathBitEntry, EDGE_SE, binsAreVandalised, binIsFull);
         if (!highlightPathIssues || binIsFull || binsAreVandalised)
             PaintAddImageAsParent(
-                session, imageTemplate.WithIndex(imageIndex), { 16, 25, height }, { 1, 1, 7 }, { 16, 25, height + 2 });
+                session, imageTemplate.WithIndex(imageIndex), { 16, 25, height }, { 16, 0, 7 }, { 8, 23, height + 2 });
     }
-
     if (!(edges & EDGE_SW))
     {
         auto binIsFull = IsBinFull(session, pathElement, EDGE_SW);
         auto imageIndex = GetFootpathBinImage(pathBitEntry, EDGE_SW, binsAreVandalised, binIsFull);
         if (!highlightPathIssues || binIsFull || binsAreVandalised)
             PaintAddImageAsParent(
-                session, imageTemplate.WithIndex(imageIndex), { 25, 16, height }, { 1, 1, 7 }, { 25, 16, height + 2 });
+                session, imageTemplate.WithIndex(imageIndex), { 25, 16, height }, { 0, 16, 7 }, { 23, 8, height + 2 });
     }
-
     if (!(edges & EDGE_NW))
     {
         auto binIsFull = IsBinFull(session, pathElement, EDGE_NW);
         auto imageIndex = GetFootpathBinImage(pathBitEntry, EDGE_NW, binsAreVandalised, binIsFull);
         if (!highlightPathIssues || binIsFull || binsAreVandalised)
             PaintAddImageAsParent(
-                session, imageTemplate.WithIndex(imageIndex), { 16, 7, height }, { 1, 1, 7 }, { 16, 7, height + 2 });
+                session, imageTemplate.WithIndex(imageIndex), { 16, 7, height }, { 16, 0, 7 }, { 8, 6, height + 2 });
     }
 }
 
@@ -278,10 +276,10 @@ static void path_bit_jumping_fountains_paint(
         return;
 
     auto imageId = imageTemplate.WithIndex(pathBitEntry.image);
-    PaintAddImageAsParent(session, imageId.WithIndexOffset(1), { 0, 0, height }, { 1, 1, 2 }, { 3, 3, height + 2 });
-    PaintAddImageAsParent(session, imageId.WithIndexOffset(2), { 0, 0, height }, { 1, 1, 2 }, { 3, 29, height + 2 });
-    PaintAddImageAsParent(session, imageId.WithIndexOffset(3), { 0, 0, height }, { 1, 1, 2 }, { 29, 29, height + 2 });
-    PaintAddImageAsParent(session, imageId.WithIndexOffset(4), { 0, 0, height }, { 1, 1, 2 }, { 29, 3, height + 2 });
+    PaintAddImageAsParent(session, imageId.WithIndexOffset(1), { 0, 0, height }, { 1, 1, 2 }, { 6, 8, height + 2 });
+    PaintAddImageAsParent(session, imageId.WithIndexOffset(2), { 0, 0, height }, { 1, 1, 2 }, { 8, 23, height + 2 });
+    PaintAddImageAsParent(session, imageId.WithIndexOffset(3), { 0, 0, height }, { 1, 1, 2 }, { 23, 8, height + 2 });
+    PaintAddImageAsParent(session, imageId.WithIndexOffset(4), { 0, 0, height }, { 1, 1, 2 }, { 8, 6, height + 2 });
 }
 
 /**


### PR DESCRIPTION
Adjust the bounding box and the bounding box offset of path items (bins, lamps and jumping fountains). Their previous small sizes caused clipping issues with certain parts of sloped land. Tested on all kinds of land (including sloped) with different kinds of surrounding terrain.

Resolves #17973. Also resolves #5064, of which 17973 was apparently a duplicate.

![Bins 1](https://user-images.githubusercontent.com/30838294/188708018-5596aba4-932e-439b-8602-734e72005055.png)
![Bins 2](https://user-images.githubusercontent.com/30838294/188708062-29e38455-47e0-4424-b0f3-c2a6b372de26.png)
![Lamps 1](https://user-images.githubusercontent.com/30838294/188708068-5ce92cff-08af-4475-89e6-80bb8977f5c9.png)
![Lamps 2](https://user-images.githubusercontent.com/30838294/188708073-a9a02c73-9fb6-4aac-99c0-2207162ebcb8.png)
