### PR TITLE
Fix BoundBox order

### DIFF
--- a/src/openrct2/paint/Boundbox.h
+++ b/src/openrct2/paint/Boundbox.h
@@ -15,26 +15,26 @@
 
 struct BoundBoxXY
 {
-    CoordsXY length{};
     CoordsXY offset{};
+    CoordsXY length{};
 
     constexpr BoundBoxXY() = default;
-    constexpr BoundBoxXY(CoordsXY _length, CoordsXY _offset)
-        : length(_length)
-        , offset(_offset)
+    constexpr BoundBoxXY(CoordsXY _offset, CoordsXY _length)
+        : offset(_offset)
+        , length(_length)
     {
     }
 };
 
 struct BoundBoxXYZ
 {
-    CoordsXYZ length{};
     CoordsXYZ offset{};
+    CoordsXYZ length{};
 
     constexpr BoundBoxXYZ() = default;
-    constexpr BoundBoxXYZ(CoordsXYZ _length, CoordsXYZ _offset)
-        : length(_length)
-        , offset(_offset)
+    constexpr BoundBoxXYZ(CoordsXYZ _offset, CoordsXYZ _length)
+        : offset(_offset)
+        , length(_length)
     {
     }
 };


### PR DESCRIPTION
Mistake I made in https://github.com/OpenRCT2/OpenRCT2/pull/16156. All calls/tables using these constructors already assume offset is first and length is second, but I forgot to fix this file.