### PR TITLE
Show cursor when using inverted mouse dragging

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#18214] Competition scenarios have received their own section.
 - Improved: [#18250] Added modern style file and folder pickers on Windows.
 - Improved: [#18422] Allow adding images to music objects.
+- Change: [#17998] Show cursor when using inverted mouse dragging.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.
 - Change: [#18381] Convert custom invisible paths to the built-in ones.
 - Fix: [#14312] Research ride type message incorrect.

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -526,7 +526,10 @@ static void InputViewportDragBegin(rct_window& w)
     _ticksSinceDragStart = 0;
     auto cursorPosition = context_get_cursor_position();
     gInputDragLast = cursorPosition;
-    context_hide_cursor();
+    if (!gConfigGeneral.InvertViewportDrag)
+    {
+        context_hide_cursor();
+    }
 
     window_unfollow_sprite(w);
     // gInputFlags |= INPUT_FLAG_5;
@@ -581,7 +584,7 @@ static void InputViewportDragContinue()
         }
     }
 
-    if (cursorState->touch)
+    if (cursorState->touch || gConfigGeneral.InvertViewportDrag)
     {
         gInputDragLast = newDragCoords;
     }


### PR DESCRIPTION
I add this because many modern management game has grab and drag control, which in my opinion has better user experience than hiding cursor.
 
![openrct2](https://user-images.githubusercontent.com/1791353/189485997-b6f50080-e6a6-4475-914c-f1d39dc7a936.gif)

![image](https://user-images.githubusercontent.com/1791353/189486784-78dbf591-dbba-4e83-8230-8544d06da6f8.png)

this option is disable when user does not enable invert right mouse dragging (because it look weird). So I add little indent in option menu.

The phrase I use in menu and tooltip might need changes, but I can't come up with some things better.
