### PR TITLE
Fix Steeplechase S-bends bounding boxes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -64,7 +64,7 @@
 - Fix: [#17866] [Plugin] Wrong Soft Guest Cap at start of new game
 - Fix: [#17959] Areas marked for dirty drawing are too large.
 - Fix: [#17966] Reversed steel trains do not properly import from S4.
-- Fix: [#18008] Steeplechase S-bends had multiple 'gaps' visible in the tracks.
+- Fix: [#18008] Steeplechase S-bends has multiple gaps visible in the tracks.
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -64,6 +64,7 @@
 - Fix: [#17866] [Plugin] Wrong Soft Guest Cap at start of new game
 - Fix: [#17959] Areas marked for dirty drawing are too large.
 - Fix: [#17966] Reversed steel trains do not properly import from S4.
+- Fix: [#18008] Steeplechase S-bends had multiple 'gaps' visible in the tracks.
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -543,25 +543,25 @@ static void steeplechase_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28665, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28665, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28672, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28672, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28668, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28668, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28669, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28669, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height - 2, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -579,23 +579,23 @@ static void steeplechase_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28666, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28666, { 0, 0, height }, { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28671, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28671, { 0, 0, height }, { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28667, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28667, { 0, 6, height }, { 33, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28670, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28670, { 0, 6, height }, { 33, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -610,21 +610,21 @@ static void steeplechase_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28667, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28667, { 0, 6, height }, { 33, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28670, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28670, { 0, 6, height }, { 33, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28666, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28666, { 0, 0, height }, { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28671, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28671, { 0, 0, height }, { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -641,25 +641,25 @@ static void steeplechase_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28668, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28668, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28669, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28669, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height - 2, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28665, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28665, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28672, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28672, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -692,25 +692,25 @@ static void steeplechase_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28661, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28661, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28676, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28676, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28664, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28664, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28673, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28673, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -728,23 +728,23 @@ static void steeplechase_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28662, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28662, { 0, 6, height }, { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 8, 0, height - 2, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28675, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28675, { 0, 6, height }, { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28663, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28663, { 0, 0, height }, { 33, 26, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28674, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28674, { 0, 0, height }, { 33, 26, 3 });
                     break;
             }
             paint_util_set_segment_support_height(
@@ -759,21 +759,21 @@ static void steeplechase_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28663, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28663, { 0, 0, height }, { 33, 26, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28674, { 0, 0, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28674, { 0, 0, height }, { 33, 26, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28662, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28662, { 0, 6, height }, { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 8, 0, height - 2, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28675, { 0, 6, height }, { 32, 26, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28675, { 0, 6, height }, { 33, 26, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -790,25 +790,25 @@ static void steeplechase_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28664, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28664, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28673, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28673, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28661, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28661, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, session.TrackColours[SCHEME_TRACK] | 28676, { 0, 6, height }, { 32, 20, 3 });
+                        session, direction, session.TrackColours[SCHEME_TRACK] | 28676, { 0, 6, height }, { 33, 20, 3 });
                     metal_a_supports_paint_setup(
                         session, METAL_SUPPORTS_STICK_ALT, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;


### PR DESCRIPTION
When placed directly on land or water, the S-bends had multiple 'gaps' visible in the tracks. Minor adjustment of the bounding boxes resolves these issues. This applies to both S-bends (left and right).

### Angle 1 before and after
![Before 1](https://user-images.githubusercontent.com/30838294/189528784-c8038c7e-fb2c-4d5a-b4e6-427007c68320.png)
![After 1](https://user-images.githubusercontent.com/30838294/189528792-0869ef23-8d9e-4827-83bf-8b674526a3eb.png)

### Angle 2 before and after
It's a bit hidden behind the red track, but still visible.
![Before 2](https://user-images.githubusercontent.com/30838294/189528818-52c57a1b-b12a-40a9-beb7-f25711fbf5d7.png)
![After 2](https://user-images.githubusercontent.com/30838294/189528825-aaaea410-965a-4761-91a5-501965ead580.png)

### Angle 3 before and after
![Before 3](https://user-images.githubusercontent.com/30838294/189528828-e716b1a5-56f6-4663-933f-c010230bb6b3.png)
![After 3](https://user-images.githubusercontent.com/30838294/189528830-ad58032c-a50c-4403-939f-ada0b814518c.png)

### Angle 4 before and after
![Before 4](https://user-images.githubusercontent.com/30838294/189528836-70d4e90a-73f4-4ace-9ec6-7de614723dc2.png)

![After 4](https://user-images.githubusercontent.com/30838294/189528838-439d370c-0d24-44b5-a00c-eed10cf480e0.png)
