### PR TITLE
Fix visual glitch with litter at sloped path

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -65,6 +65,7 @@
 - Fix: [#17959] Areas marked for dirty drawing are too large.
 - Fix: [#17966] Reversed steel trains do not properly import from S4.
 - Fix: [#18008] Steeplechase S-bends has multiple gaps visible in the tracks.
+- Fix: [#18009] Visual glitch with litter at edge of sloped path.
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -188,5 +188,5 @@ void Litter::Paint(paint_session& session, int32_t imageDirection) const
 
     // In the following call to PaintAddImageAsParent, we add 4 (instead of 2) to the
     // bound_box_offset_z to make sure litter is drawn on top of railways
-    PaintAddImageAsParent(session, image_id, { 0, 0, z }, { 4, 4, -1 }, { -4, -4, z + 4 });
+    PaintAddImageAsParent(session, image_id, { 0, 0, z }, { 5, 5, -1 }, { -4, -4, z + 4 });
 }


### PR DESCRIPTION
Litter just at the edge of a sloped path (both up or down) wasn't properly drawn. Slightly manipulating the bounding box fixes this issue. 

### Upwards slope (before and after)
![Before up](https://user-images.githubusercontent.com/30838294/189533298-ed75315c-8b93-425d-9105-9e57dbfb855a.png)
![After up](https://user-images.githubusercontent.com/30838294/189533323-0e4f784b-7e37-47c6-9fbb-005ee8eda216.png)

### Downwards slope (before and after)
![Before down](https://user-images.githubusercontent.com/30838294/189533329-e42af95f-c01a-4025-b4e1-4c0bfbbab536.png)
![After down](https://user-images.githubusercontent.com/30838294/189533331-a9ebf18e-4e29-402d-81bc-f6ccf55b7b46.png)

