### PR TITLE
Fix #17992: Virginia Reel doesn't show sloped tracks

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2729,6 +2729,13 @@ static void WindowRideConstructionUpdateDisabledPieces(ObjectEntryIndex rideType
             if (currentRideEntry == nullptr)
                 continue;
 
+            // Non-default vehicle visuals do not use this system, so we have to assume it supports all the track pieces.
+            if (currentRideEntry->Cars[0].PaintStyle != VEHICLE_VISUAL_DEFAULT || rideType == RIDE_TYPE_CHAIRLIFT)
+            {
+                disabledPieces.reset();
+                break;
+            }
+
             // Any pieces that this ride entry supports must be taken out of the array.
             auto supportedPieces = ride_entry_get_supported_track_pieces(currentRideEntry);
             disabledPieces &= supportedPieces.flip();


### PR DESCRIPTION
This is a bit of a temporary solution, fixing the issue while also not throwing out the baby with the bathwater.