### PR TITLE
Fix park rating overflow with over 32k guests, ride excitement or intensity

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -66,6 +66,7 @@
 - Fix: [#17966] Reversed steel trains do not properly import from S4.
 - Fix: [#18008] Steeplechase S-bends has multiple gaps visible in the tracks.
 - Fix: [#18009] Visual glitch with litter at edge of sloped path.
+- Fix: [#18026] Park rating drops to 0 with more than 32k guests, total ride excitement or intensity.
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -379,7 +379,7 @@ int32_t Park::CalculateParkRating() const
     // Guests
     {
         // -150 to +3 based on a range of guests from 0 to 2000
-        result -= 150 - (std::min<int16_t>(2000, gNumGuestsInPark) / 13);
+        result -= 150 - (std::min<int32_t>(2000, gNumGuestsInPark) / 13);
 
         // Find the number of happy peeps and the number of peeps who can't find the park exit
         uint32_t happyGuestCount = 0;
@@ -459,8 +459,8 @@ int32_t Park::CalculateParkRating() const
             result += 100 - averageExcitement - averageIntensity;
         }
 
-        totalRideExcitement = std::min<int16_t>(1000, totalRideExcitement);
-        totalRideIntensity = std::min<int16_t>(1000, totalRideIntensity);
+        totalRideExcitement = std::min<int32_t>(1000, totalRideExcitement);
+        totalRideIntensity = std::min<int32_t>(1000, totalRideIntensity);
         result -= 200 - ((totalRideExcitement + totalRideIntensity) / 10);
     }
 


### PR DESCRIPTION
Hey all, a few days ago I got a report from a user who issued a bug report where my ParkRatingPlugin was reporting a different park rating than the game (Basssiiie/OpenRCT2-ParkRatingInspector#20). It turns out that his park has more than 32k guests and this caused an overflow in the park rating calculation This overflow then drops the rating to negative values (clamped to 0 ingame), despite the park not having any issues that affect the rating negatively.

This PR aims to fix that issue by using the correct integer types for a few `std:min` calls in the calculation function. This should also fix other potential overflows from total ride excitement and intensity, which were capped in the same way. (The attached park is about 65% of the way to overflowing the excitement as well.)

Screenshot of the current situation:
![image](https://user-images.githubusercontent.com/20048660/190222658-c1038583-8cf6-4343-9cad-c2d668a3d20a.png)

Screenshot of the fix:
![image](https://user-images.githubusercontent.com/20048660/190222935-1e31f003-059c-4f4f-abe5-fb7df77453ca.png)

The park from the report, with this specific issue.
[WrongRating.zip](https://github.com/OpenRCT2/OpenRCT2/files/9568588/WrongRating.zip)

Thank you for your time!
