### PR TITLE
Fix #18032: non-interactive widgets produce sound

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -68,6 +68,7 @@
 - Fix: [#18009] Visual glitch with litter at edge of sloped path.
 - Fix: [#18026] Park rating drops to 0 with more than 32k guests, total ride excitement or intensity.
 - Fix: [#18051] Visual glitch with Mine Ride's large unbanked turn.
+- Fix: [#18032] All non-interactive widgets (labels, groupboxes) produce sound when clicked.
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -1051,7 +1051,27 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, W
         case WindowWidgetType::Scroll:
             InputScrollBegin(*w, widgetIndex, screenCoords);
             break;
-        default:
+        case WindowWidgetType::Empty:
+        case WindowWidgetType::LabelCentred:
+        case WindowWidgetType::Label:
+        case WindowWidgetType::Groupbox:
+        case WindowWidgetType::Placeholder:
+        case WindowWidgetType::Last:
+            // Non-interactive widget type
+            break;
+        case WindowWidgetType::ImgBtn:
+        case WindowWidgetType::ColourBtn:
+        case WindowWidgetType::TrnBtn:
+        case WindowWidgetType::Tab:
+        case WindowWidgetType::FlatBtn:
+        case WindowWidgetType::Button:
+        case WindowWidgetType::TableHeader:
+        case WindowWidgetType::Spinner:
+        case WindowWidgetType::DropdownMenu:
+        case WindowWidgetType::CloseBox:
+        case WindowWidgetType::Checkbox:
+        case WindowWidgetType::TextBox:
+        case WindowWidgetType::Custom:
             if (!WidgetIsDisabled(*w, widgetIndex))
             {
                 OpenRCT2::Audio::Play(OpenRCT2::Audio::SoundId::Click1, 0, w->windowPos.x + widget.midX());


### PR DESCRIPTION
This bug was introduced here: https://github.com/OpenRCT2/OpenRCT2/pull/16643

Instead of reintroducing some array of interactive widgets - that then have to be managed for each window - I opted for simply checking the widget type instead.

With this change, all widget types are listed explicitly instead of handling `default`, to prevents this same issue from appearing in case new widget types are added (and likely generates a warning on our CI if one is missing, although I have not verified this).