### PR TITLE
Expand api coverage (parksetparameter, parksetresearchfunding, scenariosetsetting, staffsetcolour, staffsetcostume, staffsetname, staffsetorders)

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -98,6 +98,7 @@ The following people are not part of the development team, but have been contrib
 * Andrew Pratt (andrewpratt64) - Added api hook for vehicle crashes, api function to get entities on a tile
 * Karst van Galen Last (AuraSpecs) - Misc.
 * (8street) - Misc.
+* Austin Burk (sudofox) - API improvements
 
 ## Bug fixes
 * (KirilAngelov)

--- a/src/openrct2/actions/ParkSetParameterAction.cpp
+++ b/src/openrct2/actions/ParkSetParameterAction.cpp
@@ -20,6 +20,12 @@ ParkSetParameterAction::ParkSetParameterAction(ParkParameter parameter, uint64_t
 {
 }
 
+void ParkSetParameterAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("parameter", _parameter);
+    visitor.Visit("value", _value);
+}
+
 uint16_t ParkSetParameterAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/ParkSetParameterAction.h
+++ b/src/openrct2/actions/ParkSetParameterAction.h
@@ -36,6 +36,8 @@ public:
     ParkSetParameterAction() = default;
     ParkSetParameterAction(ParkParameter parameter, uint64_t value = 0);
 
+    void AcceptParameters(GameActionParameterVisitor& visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser& stream) override;

--- a/src/openrct2/actions/ParkSetResearchFundingAction.cpp
+++ b/src/openrct2/actions/ParkSetResearchFundingAction.cpp
@@ -23,6 +23,12 @@ ParkSetResearchFundingAction::ParkSetResearchFundingAction(uint32_t priorities, 
 {
 }
 
+void ParkSetResearchFundingAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("priorities", _priorities);
+    visitor.Visit("fundingAmount", _fundingAmount);
+}
+
 uint16_t ParkSetResearchFundingAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/ParkSetResearchFundingAction.h
+++ b/src/openrct2/actions/ParkSetResearchFundingAction.h
@@ -22,6 +22,8 @@ public:
     ParkSetResearchFundingAction() = default;
     ParkSetResearchFundingAction(uint32_t priorities, uint8_t fundingAmount);
 
+    void AcceptParameters(GameActionParameterVisitor& visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser& stream) override;

--- a/src/openrct2/actions/ScenarioSetSettingAction.cpp
+++ b/src/openrct2/actions/ScenarioSetSettingAction.cpp
@@ -26,6 +26,12 @@ void ScenarioSetSettingAction::Serialise(DataSerialiser& stream)
     stream << DS_TAG(_setting) << DS_TAG(_value);
 }
 
+void ScenarioSetSettingAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("setting", _setting);
+    visitor.Visit("value", _value);
+}
+
 GameActions::Result ScenarioSetSettingAction::Query() const
 {
     if (_setting >= ScenarioSetSetting::Count)

--- a/src/openrct2/actions/ScenarioSetSettingAction.h
+++ b/src/openrct2/actions/ScenarioSetSettingAction.h
@@ -52,6 +52,8 @@ public:
     {
     }
 
+    void AcceptParameters(GameActionParameterVisitor& visitor) override;
+
     uint16_t GetActionFlags() const override
     {
         return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/StaffSetColourAction.cpp
+++ b/src/openrct2/actions/StaffSetColourAction.cpp
@@ -25,6 +25,12 @@ StaffSetColourAction::StaffSetColourAction(StaffType staffType, uint8_t colour)
 {
 }
 
+void StaffSetColourAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("staffType", _staffType);
+    visitor.Visit("colour", _colour);
+}
+
 uint16_t StaffSetColourAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/StaffSetColourAction.h
+++ b/src/openrct2/actions/StaffSetColourAction.h
@@ -21,6 +21,8 @@ public:
     StaffSetColourAction() = default;
     StaffSetColourAction(StaffType staffType, uint8_t colour);
 
+    void AcceptParameters(GameActionParameterVisitor& visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser& stream) override;

--- a/src/openrct2/actions/StaffSetCostumeAction.cpp
+++ b/src/openrct2/actions/StaffSetCostumeAction.cpp
@@ -42,6 +42,12 @@ StaffSetCostumeAction::StaffSetCostumeAction(EntityId spriteIndex, EntertainerCo
 {
 }
 
+void StaffSetCostumeAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("staff", _spriteIndex);
+    visitor.Visit("costume", _costume);
+}
+
 uint16_t StaffSetCostumeAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/StaffSetCostumeAction.h
+++ b/src/openrct2/actions/StaffSetCostumeAction.h
@@ -22,6 +22,8 @@ public:
     StaffSetCostumeAction() = default;
     StaffSetCostumeAction(EntityId spriteIndex, EntertainerCostume costume);
 
+    void AcceptParameters(GameActionParameterVisitor& visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser& stream) override;

--- a/src/openrct2/actions/StaffSetNameAction.cpp
+++ b/src/openrct2/actions/StaffSetNameAction.cpp
@@ -27,6 +27,12 @@ StaffSetNameAction::StaffSetNameAction(EntityId spriteIndex, const std::string& 
 {
 }
 
+void StaffSetNameAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("staff", _spriteIndex);
+    visitor.Visit("name", _name);
+}
+
 uint16_t StaffSetNameAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/StaffSetNameAction.h
+++ b/src/openrct2/actions/StaffSetNameAction.h
@@ -21,6 +21,8 @@ public:
     StaffSetNameAction() = default;
     StaffSetNameAction(EntityId spriteIndex, const std::string& name);
 
+    void AcceptParameters(GameActionParameterVisitor& visitor) override;
+
     uint16_t GetActionFlags() const override;
     void Serialise(DataSerialiser& stream) override;
     GameActions::Result Query() const override;

--- a/src/openrct2/actions/StaffSetOrdersAction.cpp
+++ b/src/openrct2/actions/StaffSetOrdersAction.cpp
@@ -23,6 +23,12 @@ StaffSetOrdersAction::StaffSetOrdersAction(EntityId spriteIndex, uint8_t ordersI
 {
 }
 
+void StaffSetOrdersAction::AcceptParameters(GameActionParameterVisitor& visitor)
+{
+    visitor.Visit("staff", _spriteIndex);
+    visitor.Visit("orders", _ordersId);
+}
+
 uint16_t StaffSetOrdersAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags() | GameActions::Flags::AllowWhilePaused;

--- a/src/openrct2/actions/StaffSetOrdersAction.h
+++ b/src/openrct2/actions/StaffSetOrdersAction.h
@@ -21,6 +21,8 @@ public:
     StaffSetOrdersAction() = default;
     StaffSetOrdersAction(EntityId spriteIndex, uint8_t ordersId);
 
+    void AcceptParameters(GameActionParameterVisitor& visitor) override;
+
     uint16_t GetActionFlags() const override;
 
     void Serialise(DataSerialiser& stream) override;


### PR DESCRIPTION
# Foreword

This is my first contribution. Please scrutinize it, especially for api param names. I tried to follow existing convention as much as I could.

This PR adds support to the API for a variety of methods. I would've added more, but I was struggling to figure out the correct syntax for some of them -- I'll keep working on them if/when this gets accepted.

## `staffsetorders`

Example usage (assuming that the first staff member is a handyman) water gardens, empty trash bins:

```js
context.executeAction("staffsetorders", { "staff": map.getAllEntities("staff")[0].id, "orders": 6 })
```

## `staffsetname`

Example: Set first staff member's name to Foo Bar

```js
context.executeAction("staffsetname", { "staff": map.getAllEntities("staff")[0].id, "name": "Foo Bar" })
```

## `staffsetcolour`

Example: Set handyman uniforms to orange

```js
context.executeAction("staffsetcolour", { "staffType": 0, "colour": 20 })
```

## `parksetresearchfunding`

Example usage (maximum funding on rollercoasters and thrill rides):

```js
context.executeAction("parksetresearchfunding", { "priorities": 12, "fundingAmount": 3 })
```

## `parksetparameter`

Example usages (note that the value doesn't matter for close/open park):

```js
context.executeAction("parksetparameter", { "parameter": 0, "value": 0 }) // close the park
context.executeAction("parksetparameter", { "parameter": 1, "value": 0 }) // open the park
context.executeAction("parksetparameter", { "parameter": 2, "value": 12345 }) // set the flags (uint64_t bitmask) for "Same price for item across park"
```

## `staffsetcostume`

Example usage (changes costume of first entertainer):

```js
context.executeAction("staffsetcostume", { "staff": map.getAllEntities("staff").filter(function(staff) { return staff.staffType == "entertainer" })[0].id, "costume": 0 })
```

## `scenariosetsetting`

Example call (changes ParkChargeMethod to "Free park entry, pay for ride":
```js
context.executeAction("scenariosetsetting", { "setting": 14, "value": 1 })
```

