### PR TITLE
Fix visual glitch with Mine Ride's large turn

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -67,6 +67,7 @@
 - Fix: [#18008] Steeplechase S-bends has multiple gaps visible in the tracks.
 - Fix: [#18009] Visual glitch with litter at edge of sloped path.
 - Fix: [#18026] Park rating drops to 0 with more than 32k guests, total ride excitement or intensity.
+- Fix: [#18051] Visual glitch with Mine Ride's large unbanked turn.
 
 0.4.1 (2022-07-04)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/coaster/MineRide.cpp
+++ b/src/openrct2/ride/coaster/MineRide.cpp
@@ -373,7 +373,7 @@ static void mine_ride_track_left_quarter_turn_5(
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK] | 19430, { 0, 0, height }, { 16, 16, 3 },
-                        { 16, 16, height });
+                        { 6, 6, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(


### PR DESCRIPTION
At two spots in a large unbanked turn, the mine ride trains would glitch. Adjusting the bounding box of those turns fixes this issue.

**Before:**
![Right turn before](https://user-images.githubusercontent.com/30838294/190920811-8b11631e-e80b-4821-aeb4-537d7a3150ce.gif)
**After:**
![Right turn after](https://user-images.githubusercontent.com/30838294/190920813-f907bfac-2432-4812-8694-a2e4edaae32b.gif)
