### PR TITLE
Add railway crossing behaviour for staff

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Feature: [#17821] [Plugin] Add API for track subpositions and vehicle subposition.
 - Feature: [#17877] Add three real-life flying roller coaster colour schemes.
 - Feature: [#17900] Add “Classic Wooden Coaster” with shallow banked turns.
+- Feature: [#18057] Staff members now wait for passing or stalled vehicles before crossing railway tracks.
 - Feature: [objects#198] Add additional pirate roofs.
 - Feature: [objects#205] Add additional glass roofs.
 - Feature: [objects#209] Add the Steel Roller Coaster train and 2-across Inverted Train from RollerCoaster Tycoon 1.

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5299,16 +5299,10 @@ void Guest::UpdateWalking()
         }
     }
 
-    // Check if vehicle is blocking the destination tile
-    auto curPos = TileCoordsXYZ(GetLocation());
-    auto dstPos = TileCoordsXYZ(CoordsXYZ{ GetDestination(), NextLoc.z });
-    if (curPos.x != dstPos.x || curPos.y != dstPos.y)
+    if (PathIsBlockedByVehicle())
     {
-        if (footpath_is_blocked_by_vehicle(dstPos))
-        {
-            // Wait for vehicle to pass
-            return;
-        }
+        // Wait for vehicle to pass
+        return;
     }
 
     uint8_t pathingResult;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -321,6 +321,18 @@ bool Peep::CheckForPath()
     return false;
 }
 
+bool Peep::PathIsBlockedByVehicle()
+{
+    auto curPos = TileCoordsXYZ(GetLocation());
+    auto dstPos = TileCoordsXYZ(CoordsXYZ{ GetDestination(), NextLoc.z });
+    if ((curPos.x != dstPos.x || curPos.y != dstPos.y) && footpath_is_blocked_by_vehicle(dstPos))
+    {
+        return true;
+    }
+
+    return false;
+}
+
 PeepActionSpriteType Peep::GetActionSpriteType()
 {
     if (IsActionInterruptable())

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -412,6 +412,7 @@ public: // Peep
     // TODO: Make these private again when done refactoring
 public: // Peep
     [[nodiscard]] bool CheckForPath();
+    bool PathIsBlockedByVehicle();
     void PerformNextAction(uint8_t& pathing_result);
     void PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result);
     [[nodiscard]] int32_t GetZOnSlope(int32_t tile_x, int32_t tile_y);

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -862,6 +862,14 @@ bool Staff::DoMiscPathFinding()
     return false;
 }
 
+bool Staff::IsMechanicHeadingToFixRideBlockingPath()
+{
+    auto trackElement = map_get_track_element_at(CoordsXYZ{ GetDestination(), NextLoc.z });
+    auto ride = get_ride(trackElement->GetRideIndex());
+    return AssignedStaffType == StaffType::Mechanic && ride->id == CurrentRide
+        && ride->breakdown_reason == BREAKDOWN_SAFETY_CUT_OUT;
+}
+
 /**
  *
  *  rct2: 0x006C086D
@@ -1323,6 +1331,9 @@ void Staff::UpdateHeadingToInspect()
         if (!CheckForPath())
             return;
 
+        if (PathIsBlockedByVehicle() && !IsMechanicHeadingToFixRideBlockingPath())
+            return;
+
         uint8_t pathingResult;
         TileElement* rideEntranceExitElement;
         PerformNextAction(pathingResult, rideEntranceExitElement);
@@ -1426,6 +1437,9 @@ void Staff::UpdateAnswering()
         }
 
         if (!CheckForPath())
+            return;
+
+        if (PathIsBlockedByVehicle() && !IsMechanicHeadingToFixRideBlockingPath())
             return;
 
         uint8_t pathingResult;
@@ -1758,6 +1772,9 @@ void Staff::UpdateStaff(uint32_t stepsToTake)
 void Staff::UpdatePatrolling()
 {
     if (!CheckForPath())
+        return;
+
+    if (PathIsBlockedByVehicle() && !IsMechanicHeadingToFixRideBlockingPath())
         return;
 
     uint8_t pathingResult;

--- a/src/openrct2/entity/Staff.h
+++ b/src/openrct2/entity/Staff.h
@@ -94,6 +94,7 @@ private:
     bool DoMechanicPathFinding();
     bool DoEntertainerPathFinding();
     bool DoMiscPathFinding();
+    bool IsMechanicHeadingToFixRideBlockingPath();
 
     Direction HandymanDirectionRandSurface(uint8_t validDirections) const;
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "16"
+#define NETWORK_STREAM_VERSION "17"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Staff could cross railways no matter the situation, for example with an incoming train or a stalled train at the crossing. They would just phase right through. 

This PR adds railway crossing behaviour to staff members as well. It's based on PR #6998, which some of its logic extracted to the `Peep` base class. The only difference being: if a mechanic is heading to fix the ride with the stalled train, the mechanic can go through. This prevents the mechanic (and other guests/stuff) becoming forever stuck.

**Before:**
You can see all staff members going right through the stalled train at the railway crossing.
![Before](https://user-images.githubusercontent.com/30838294/191012698-334ba562-c2ad-409d-8956-74478668ad0b.gif)

**After:**
Only the mechanic heading to fix the stalled right will pass through. Other staff members will wait for the crossing to clear, like the guests.
![After](https://user-images.githubusercontent.com/30838294/191012727-296bfe83-1add-4585-b487-bbbba16fd46b.gif)
