### PR TITLE
Fix #18007: Revert "Fix #17992: Virginia Reel doesn't show sloped tracks"

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2736,7 +2736,8 @@ static void WindowRideConstructionUpdateDisabledPieces(ObjectEntryIndex rideType
                 continue;
 
             // Non-default vehicle visuals do not use this system, so we have to assume it supports all the track pieces.
-            if (currentRideEntry->Cars[0].PaintStyle != VEHICLE_VISUAL_DEFAULT || rideType == RIDE_TYPE_CHAIRLIFT)
+            if (currentRideEntry->Cars[0].PaintStyle != VEHICLE_VISUAL_DEFAULT || rideType == RIDE_TYPE_CHAIRLIFT
+                || (currentRideEntry->Cars[0].flags & CAR_ENTRY_FLAG_SLIDE_SWING))
             {
                 disabledPieces.reset();
                 break;

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2723,6 +2723,12 @@ static void WindowRideConstructionUpdateDisabledPieces(ObjectEntryIndex rideType
 
         auto& objManager = OpenRCT2::GetContext()->GetObjectManager();
         auto& rideEntries = objManager.GetAllRideEntries(rideType);
+        // If there are no vehicles for this ride type, enable all the track pieces.
+        if (rideEntries.size() == 0)
+        {
+            disabledPieces.reset();
+        }
+
         for (auto rideEntryIndex : rideEntries)
         {
             const auto* currentRideEntry = get_ride_entry(rideEntryIndex);

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -42,8 +42,6 @@ static const uint8_t SpriteGroupMultiplier[EnumValue(SpriteGroupType::Count)] = 
     1, 2, 2, 2, 2, 2, 2, 10, 1, 2, 2, 2, 2, 2, 2, 2, 6, 4, 4, 4, 4, 4, 4, 4, 12, 4, 4, 4, 4, 4, 20, 3, 1,
 };
 
-static constexpr uint8_t RiverRapidsNumSpinningSprites = 8;
-
 static constexpr SpritePrecision PrecisionFromNumFrames(uint8_t numRotationFrames)
 {
     if (numRotationFrames == 0)
@@ -231,33 +229,16 @@ void RideObject::Load()
             uint32_t imageIndex = baseImageId;
             carEntry->base_image_id = baseImageId;
 
-            switch (carEntry->PaintStyle)
+            for (uint8_t spriteGroup = 0; spriteGroup < EnumValue(SpriteGroupType::Count); spriteGroup++)
             {
-                case VEHICLE_VISUAL_RIVER_RAPIDS:
-                case VEHICLE_VISUAL_VIRGINIA_REEL:
-                    // Paint code for these rides do not use sprite groups but #17909 requires them. Dummy sprite groups are
-                    // added.
-                    carEntry->SpriteGroups[EnumValue(SpriteGroupType::SlopeFlat)] = { baseImageId, SpritePrecision::Sprites1 };
-                    carEntry->SpriteGroups[EnumValue(SpriteGroupType::Slopes12)] = {
-                        baseImageId + RiverRapidsNumSpinningSprites, SpritePrecision::Sprites4
-                    };
-                    carEntry->SpriteGroups[EnumValue(SpriteGroupType::Slopes25)] = {
-                        baseImageId + RiverRapidsNumSpinningSprites + RiverRapidsNumSpinningSprites * NumOrthogonalDirections,
-                        SpritePrecision::Sprites4
-                    };
-                    break;
-                default:
-                    for (uint8_t spriteGroup = 0; spriteGroup < EnumValue(SpriteGroupType::Count); spriteGroup++)
-                    {
-                        if (carEntry->SpriteGroups[spriteGroup].Enabled())
-                        {
-                            carEntry->SpriteGroups[spriteGroup].imageId = imageIndex;
-                            const auto spriteCount = carEntry->base_num_frames
-                                * carEntry->NumRotationSprites(static_cast<SpriteGroupType>(spriteGroup))
-                                * SpriteGroupMultiplier[spriteGroup];
-                            imageIndex += spriteCount;
-                        }
-                    }
+                if (carEntry->SpriteGroups[spriteGroup].Enabled())
+                {
+                    carEntry->SpriteGroups[spriteGroup].imageId = imageIndex;
+                    const auto spriteCount = carEntry->base_num_frames
+                        * carEntry->NumRotationSprites(static_cast<SpriteGroupType>(spriteGroup))
+                        * SpriteGroupMultiplier[spriteGroup];
+                    imageIndex += spriteCount;
+                }
             }
 
             carEntry->NumCarImages = imageIndex - currentCarImagesOffset;


### PR DESCRIPTION
This reverts commit ce95b58d5e112832809337fa5d7b4a8d816be006. (#17994)

This temporary fix has only fixed building with cheats on and introduced bug #18007 sadly.

A different solution needs to be found and I believe is already being worked on.