### PR TITLE
Rename more instances of “vehicle” to “train”

### DIFF
--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -455,7 +455,7 @@ public:
 
                 auto ride = vehicle->GetRide();
                 auto viewVehicleIndex = w->ride.view - 1;
-                if (ride == nullptr || viewVehicleIndex < 0 || viewVehicleIndex >= ride->num_vehicles)
+                if (ride == nullptr || viewVehicleIndex < 0 || viewVehicleIndex >= ride->NumTrains)
                     return;
 
                 if (vehicle->sprite_index != ride->vehicles[viewVehicleIndex])

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1200,7 +1200,7 @@ rct_window* WindowRideMainOpen(Ride* ride)
         w->ride.var_482 = -1;
         w->ride.view = 0;
     }
-    else if (w->ride.view >= (1 + ride->num_vehicles + ride->num_stations))
+    else if (w->ride.view >= (1 + ride->NumTrains + ride->num_stations))
     {
         w->ride.view = 0;
     }
@@ -1268,7 +1268,7 @@ static rct_window* WindowRideOpenStation(Ride* ride, StationIndex stationIndex)
         }
     }
 
-    w->ride.view = 1 + ride->num_vehicles + stationIndex.ToUnderlying();
+    w->ride.view = 1 + ride->NumTrains + stationIndex.ToUnderlying();
     WindowRideInitViewport(w);
 
     return w;
@@ -1486,7 +1486,7 @@ static std::optional<StationIndex> GetStationIndexFromViewSelection(const rct_wi
     if (ride == nullptr)
         return std::nullopt;
 
-    int32_t viewSelectionIndex = w.ride.view - 1 - ride->num_vehicles;
+    int32_t viewSelectionIndex = w.ride.view - 1 - ride->NumTrains;
     if (viewSelectionIndex < 0)
     {
         return std::nullopt;
@@ -1520,7 +1520,7 @@ static void WindowRideInitViewport(rct_window* w)
 
     std::optional<Focus> focus;
 
-    if (viewSelectionIndex >= 0 && viewSelectionIndex < ride->num_vehicles && ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
+    if (viewSelectionIndex >= 0 && viewSelectionIndex < ride->NumTrains && ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
     {
         auto vehId = ride->vehicles[viewSelectionIndex];
         rct_ride_entry* ride_entry = ride->GetRideEntry();
@@ -1541,7 +1541,7 @@ static void WindowRideInitViewport(rct_window* w)
             focus = Focus(vehId);
         }
     }
-    else if (viewSelectionIndex >= ride->num_vehicles && viewSelectionIndex < (ride->num_vehicles + ride->num_stations))
+    else if (viewSelectionIndex >= ride->NumTrains && viewSelectionIndex < (ride->NumTrains + ride->num_stations))
     {
         auto stationIndex = GetStationIndexFromViewSelection(*w);
         if (stationIndex)
@@ -1746,7 +1746,7 @@ static void WindowRideShowViewDropdown(rct_window* w, rct_widget* widget)
     if (!ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_NO_VEHICLES))
     {
         numItems += ride->num_stations;
-        numItems += ride->num_vehicles;
+        numItems += ride->NumTrains;
     }
 
     WindowDropdownShowTextCustomWidth(
@@ -1762,7 +1762,7 @@ static void WindowRideShowViewDropdown(rct_window* w, rct_widget* widget)
 
     // Vehicles
     int32_t name = GetRideComponentName(rtd.NameConvention.vehicle).number;
-    for (int32_t i = 1; i <= ride->num_vehicles; i++)
+    for (int32_t i = 1; i <= ride->NumTrains; i++)
     {
         gDropdownItems[currentItem].Format = STR_DROPDOWN_MENU_LABEL;
         gDropdownItems[currentItem].Args = name | (currentItem << 16);
@@ -1781,7 +1781,7 @@ static void WindowRideShowViewDropdown(rct_window* w, rct_widget* widget)
     // Set highlighted item
     if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK))
     {
-        for (int32_t i = 0; i < ride->num_vehicles; i++)
+        for (int32_t i = 0; i < ride->NumTrains; i++)
         {
             // The +1 is to skip 'Overall view'
             Dropdown::SetDisabled(i + 1, true);
@@ -1963,8 +1963,7 @@ static void WindowRideShowLocateDropdown(rct_window* w, rct_widget* widget)
     WindowDropdownShowText(
         { w->windowPos.x + widget->left, w->windowPos.y + widget->top }, widget->height() + 1, w->colours[1], 0, 2);
     gDropdownDefaultIndex = 0;
-    if (!ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_TRACK) || w->ride.view == 0
-        || w->ride.view > ride->num_vehicles)
+    if (!ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_TRACK) || w->ride.view == 0 || w->ride.view > ride->NumTrains)
     {
         // Disable if we're a flat ride, 'overall view' is selected or a station is selected
         Dropdown::SetDisabled(1, true);
@@ -1980,7 +1979,7 @@ static void WindowRideMainFollowRide(rct_window* w)
         {
             if (w->ride.view > 0)
             {
-                if (w->ride.view <= ride->num_vehicles)
+                if (w->ride.view <= ride->NumTrains)
                 {
                     Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[w->ride.view - 1]);
                     if (vehicle != nullptr)
@@ -2133,10 +2132,10 @@ static void WindowRideMainDropdown(rct_window* w, WidgetIndex widgetIndex, int32
                 auto ride = get_ride(w->rideId);
                 if (ride != nullptr)
                 {
-                    if (dropdownIndex != 0 && dropdownIndex <= ride->num_vehicles
+                    if (dropdownIndex != 0 && dropdownIndex <= ride->NumTrains
                         && !(ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK))
                     {
-                        dropdownIndex = ride->num_vehicles + 1;
+                        dropdownIndex = ride->NumTrains + 1;
                     }
                     if (dropdownIndex >= gDropdownNumItems)
                     {
@@ -2236,7 +2235,7 @@ static void WindowRideMainUpdate(rct_window* w)
             if (w->ride.view == 0)
                 return;
 
-            if (w->ride.view <= ride->num_vehicles)
+            if (w->ride.view <= ride->NumTrains)
             {
                 Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[w->ride.view - 1]);
                 if (vehicle == nullptr
@@ -2552,7 +2551,7 @@ static StringId WindowRideGetStatus(rct_window* w, Formatter& ft)
     auto ride = get_ride(w->rideId);
     if (w->ride.view == 0)
         return WindowRideGetStatusOverallView(w, ft);
-    if (ride != nullptr && w->ride.view <= ride->num_vehicles)
+    if (ride != nullptr && w->ride.view <= ride->NumTrains)
         return WindowRideGetStatusVehicle(w, ft);
     if (ride != nullptr && ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN)
         return WindowRideGetStatusOverallView(w, ft);
@@ -2586,10 +2585,10 @@ static void WindowRideMainPaint(rct_window* w, rct_drawpixelinfo* dpi)
     auto ft = Formatter();
     if (w->ride.view != 0)
     {
-        if (w->ride.view > ride->num_vehicles)
+        if (w->ride.view > ride->NumTrains)
         {
             ft.Add<StringId>(GetRideComponentName(ride->GetRideTypeDescriptor().NameConvention.station).number);
-            ft.Add<uint16_t>(w->ride.view - ride->num_vehicles);
+            ft.Add<uint16_t>(w->ride.view - ride->NumTrains);
         }
         else
         {
@@ -2671,12 +2670,12 @@ static void WindowRideVehicleMousedown(rct_window* w, WidgetIndex widgetIndex, r
             WindowRideShowVehicleTypeDropdown(w, &w->widgets[widgetIndex]);
             break;
         case WIDX_VEHICLE_TRAINS_INCREASE:
-            if (ride->num_vehicles < OpenRCT2::Limits::MaxTrainsPerRide)
-                ride->SetNumVehicles(ride->num_vehicles + 1);
+            if (ride->NumTrains < OpenRCT2::Limits::MaxTrainsPerRide)
+                ride->SetNumTrains(ride->NumTrains + 1);
             break;
         case WIDX_VEHICLE_TRAINS_DECREASE:
-            if (ride->num_vehicles > 1)
-                ride->SetNumVehicles(ride->num_vehicles - 1);
+            if (ride->NumTrains > 1)
+                ride->SetNumTrains(ride->NumTrains - 1);
             break;
         case WIDX_VEHICLE_CARS_PER_TRAIN_INCREASE:
             if (ride->num_cars_per_train < OpenRCT2::Limits::MaxCarsPerTrain)
@@ -2842,12 +2841,12 @@ static void WindowRideVehicleInvalidate(rct_window* w)
     ft.Add<uint16_t>(carsPerTrain);
     RideComponentType vehicleType = ride->GetRideTypeDescriptor().NameConvention.vehicle;
     stringId = GetRideComponentName(vehicleType).count;
-    if (ride->num_vehicles > 1)
+    if (ride->NumTrains > 1)
     {
         stringId = GetRideComponentName(vehicleType).count_plural;
     }
     ft.Add<StringId>(stringId);
-    ft.Add<uint16_t>(ride->num_vehicles);
+    ft.Add<uint16_t>(ride->NumTrains);
 
     ft.Increment(8);
 
@@ -2957,14 +2956,14 @@ static void WindowRideVehicleScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, 
     gfx_fill_rect(dpi, { { dpi->x, dpi->y }, { dpi->x + dpi->width, dpi->y + dpi->height } }, PALETTE_INDEX_12);
 
     rct_widget* widget = &window_ride_vehicle_widgets[WIDX_VEHICLE_TRAINS_PREVIEW];
-    int32_t startX = std::max(2, (widget->width() - ((ride->num_vehicles - 1) * 36)) / 2 - 25);
+    int32_t startX = std::max(2, (widget->width() - ((ride->NumTrains - 1) * 36)) / 2 - 25);
     int32_t startY = widget->height() - 4;
 
     CarEntry* carEntry = &rideEntry->Cars[ride_entry_get_vehicle_at_position(ride->subtype, ride->num_cars_per_train, 0)];
     startY += carEntry->tab_height;
 
     // For each train
-    for (int32_t i = 0; i < ride->num_vehicles; i++)
+    for (int32_t i = 0; i < ride->NumTrains; i++)
     {
         VehicleDrawInfo trainCarImages[OpenRCT2::Limits::MaxCarsPerTrain];
         VehicleDrawInfo* nextSpriteToDraw = trainCarImages;
@@ -3530,7 +3529,7 @@ static void WindowRideOperatingInvalidate(rct_window* w)
 
     // Leave if another vehicle arrives at station
     if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_LEAVE_WHEN_ANOTHER_VEHICLE_ARRIVES_AT_STATION)
-        && ride->num_vehicles > 1 && !ride->IsBlockSectioned())
+        && ride->NumTrains > 1 && !ride->IsBlockSectioned())
     {
         window_ride_operating_widgets[WIDX_LEAVE_WHEN_ANOTHER_ARRIVES_CHECKBOX].type = WindowWidgetType::Checkbox;
         window_ride_operating_widgets[WIDX_LEAVE_WHEN_ANOTHER_ARRIVES_CHECKBOX].tooltip
@@ -3874,7 +3873,7 @@ static void WindowRideMaintenanceMousedown(rct_window* w, WidgetIndex widgetInde
                 {
                     if (i == BREAKDOWN_BRAKES_FAILURE && ride->IsBlockSectioned())
                     {
-                        if (ride->num_vehicles != 1)
+                        if (ride->NumTrains != 1)
                             continue;
                     }
                     gDropdownItems[num_items].Format = STR_DROPDOWN_MENU_LABEL;
@@ -3902,7 +3901,7 @@ static void WindowRideMaintenanceMousedown(rct_window* w, WidgetIndex widgetInde
                         {
                             if (i == BREAKDOWN_BRAKES_FAILURE && ride->IsBlockSectioned())
                             {
-                                if (ride->num_vehicles != 1)
+                                if (ride->NumTrains != 1)
                                     continue;
                             }
                             if (i == breakdownReason)
@@ -3958,7 +3957,7 @@ static void WindowRideMaintenanceDropdown(rct_window* w, WidgetIndex widgetIndex
                     case BREAKDOWN_SAFETY_CUT_OUT:
                         if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK))
                             break;
-                        for (int32_t i = 0; i < ride->num_vehicles; ++i)
+                        for (int32_t i = 0; i < ride->NumTrains; ++i)
                         {
                             for (vehicle = GetEntity<Vehicle>(ride->vehicles[i]); vehicle != nullptr;
                                  vehicle = GetEntity<Vehicle>(vehicle->next_vehicle_on_train))
@@ -4017,7 +4016,7 @@ static void WindowRideMaintenanceDropdown(rct_window* w, WidgetIndex widgetIndex
                     {
                         if (i == BREAKDOWN_BRAKES_FAILURE && ride->IsBlockSectioned())
                         {
-                            if (ride->num_vehicles != 1)
+                            if (ride->NumTrains != 1)
                                 continue;
                         }
                         if (num_items == dropdownIndex)
@@ -4438,7 +4437,7 @@ static void WindowRideColourMousedown(rct_window* w, WidgetIndex widgetIndex, rc
             Dropdown::SetChecked(ride->colour_scheme_type & 3, true);
             break;
         case WIDX_VEHICLE_COLOUR_INDEX_DROPDOWN:
-            numItems = ride->num_vehicles;
+            numItems = ride->NumTrains;
             if ((ride->colour_scheme_type & 3) != VEHICLE_COLOUR_SCHEME_PER_TRAIN)
                 numItems = ride->num_cars_per_train;
 
@@ -4809,7 +4808,7 @@ static void WindowRideColourInvalidate(rct_window* w)
 
         // Vehicle colour scheme type
         if (!ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_VEHICLE_IS_INTEGRAL)
-            && (ride->num_cars_per_train | ride->num_vehicles) > 1)
+            && (ride->num_cars_per_train | ride->NumTrains) > 1)
         {
             window_ride_colour_widgets[WIDX_VEHICLE_COLOUR_SCHEME].type = WindowWidgetType::DropdownMenu;
             window_ride_colour_widgets[WIDX_VEHICLE_COLOUR_SCHEME_DROPDOWN].type = WindowWidgetType::Button;

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -153,22 +153,22 @@ GameActions::Result RideCreateAction::Execute() const
     ride->lifecycle_flags = 0;
     ride->vehicle_change_timeout = 0;
     ride->num_stations = 0;
-    ride->num_vehicles = 1;
+    ride->NumTrains = 1;
     if (gCheatsDisableTrainLengthLimit)
     {
         // Reduce amount of proposed trains to prevent 32 trains from always spawning when limits are disabled
         if (rideEntry->cars_per_flat_ride == NoFlatRideCars)
         {
-            ride->proposed_num_vehicles = 12;
+            ride->ProposedNumTrains = 12;
         }
         else
         {
-            ride->proposed_num_vehicles = rideEntry->cars_per_flat_ride;
+            ride->ProposedNumTrains = rideEntry->cars_per_flat_ride;
         }
     }
     else
     {
-        ride->proposed_num_vehicles = 32;
+        ride->ProposedNumTrains = 32;
     }
     ride->max_trains = OpenRCT2::Limits::MaxTrainsPerRide;
     ride->num_cars_per_train = 1;

--- a/src/openrct2/actions/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/RideSetVehicleAction.cpp
@@ -137,7 +137,7 @@ GameActions::Result RideSetVehicleAction::Execute() const
             ride->RemovePeeps();
             ride->vehicle_change_timeout = 100;
 
-            ride->proposed_num_vehicles = _value;
+            ride->ProposedNumTrains = _value;
             break;
         case RideSetVehicleType::NumCarsPerTrain:
         {

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2533,7 +2533,7 @@ bool Guest::FindVehicleToEnter(Ride* ride, std::vector<uint8_t>& car_array)
         if (ride->lifecycle_flags & RIDE_LIFECYCLE_PASS_STATION_NO_STOPPING)
             return false;
 
-        for (int32_t i = 0; i < ride->num_vehicles; ++i)
+        for (int32_t i = 0; i < ride->NumTrains; ++i)
         {
             Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[i]);
             if (vehicle == nullptr)
@@ -3931,7 +3931,7 @@ void Guest::UpdateRideFreeVehicleCheck()
     {
         vehicle->mini_golf_flags &= ~MiniGolfFlag::Flag5;
 
-        for (size_t i = 0; i < ride->num_vehicles; ++i)
+        for (size_t i = 0; i < ride->NumTrains; ++i)
         {
             Vehicle* train = GetEntity<Vehicle>(ride->vehicles[i]);
             if (train == nullptr)

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -272,7 +272,7 @@ static int32_t cc_rides(InteractiveConsole& console, const arguments_t& argv)
                     }
                     else
                     {
-                        for (int32_t i = 0; i < ride->num_vehicles; ++i)
+                        for (int32_t i = 0; i < ride->NumTrains; ++i)
                         {
                             for (Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[i]); vehicle != nullptr;
                                  vehicle = GetEntity<Vehicle>(vehicle->next_vehicle_on_train))

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1220,9 +1220,9 @@ namespace OpenRCT2
                     cs.ReadWrite(ride.overall_view.y);
 
                     // Vehicles
-                    cs.ReadWrite(ride.num_vehicles);
+                    cs.ReadWrite(ride.NumTrains);
                     cs.ReadWrite(ride.num_cars_per_train);
-                    cs.ReadWrite(ride.proposed_num_vehicles);
+                    cs.ReadWrite(ride.ProposedNumTrains);
                     cs.ReadWrite(ride.proposed_num_cars_per_train);
                     cs.ReadWrite(ride.max_trains);
                     if (version < 0x5)

--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -155,9 +155,9 @@ namespace RCT1
         uint16_t vehicles[Limits::MaxTrainsPerRide];             // 0x05E
         uint8_t depart_flags;                                    // 0x076
         uint8_t num_stations;                                    // 0x077
-        uint8_t num_trains;                                      // 0x078
+        uint8_t NumTrains;                                       // 0x078
         uint8_t num_cars_per_train;                              // 0x079
-        uint8_t proposed_num_vehicles;                           // 0x07A
+        uint8_t ProposedNumTrains;                               // 0x07A
         uint8_t proposed_num_cars_per_train;                     // 0x07B
         uint8_t max_trains;                                      // 0x07C
         uint8_t min_max_cars_per_train;                          // 0x07D

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -903,9 +903,9 @@ namespace RCT1
                 dst->vehicles[i] = EntityId::GetNull();
             }
 
-            dst->num_vehicles = src->num_trains;
+            dst->NumTrains = src->NumTrains;
             dst->num_cars_per_train = src->num_cars_per_train + rideEntry->zero_cars;
-            dst->proposed_num_vehicles = src->num_trains;
+            dst->ProposedNumTrains = src->NumTrains;
             dst->max_trains = src->max_trains;
             dst->proposed_num_cars_per_train = src->num_cars_per_train + rideEntry->zero_cars;
             dst->special_track_elements = src->special_track_elements;

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -108,9 +108,9 @@ namespace RCT2
 
         // Not sure if these should be uint or sint.
         uint8_t num_stations;                // 0x0C7
-        uint8_t num_vehicles;                // 0x0C8
+        uint8_t NumTrains;                   // 0x0C8
         uint8_t num_cars_per_train;          // 0x0C9
-        uint8_t proposed_num_vehicles;       // 0x0CA
+        uint8_t ProposedNumTrains;           // 0x0CA
         uint8_t proposed_num_cars_per_train; // 0x0CB
         uint8_t max_trains;                  // 0x0CC
         uint8_t min_max_cars_per_train;      // 0x0CD

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -822,9 +822,9 @@ namespace RCT2
             dst->depart_flags = src->depart_flags;
 
             dst->num_stations = src->num_stations;
-            dst->num_vehicles = src->num_vehicles;
+            dst->NumTrains = src->NumTrains;
             dst->num_cars_per_train = src->num_cars_per_train;
-            dst->proposed_num_vehicles = src->proposed_num_vehicles;
+            dst->ProposedNumTrains = src->ProposedNumTrains;
             dst->proposed_num_cars_per_train = src->proposed_num_cars_per_train;
             dst->max_trains = src->max_trains;
             dst->MinCarsPerTrain = src->GetMinCarsPerTrain();

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -880,7 +880,7 @@ bool Ride::CanHaveMultipleCircuits() const
     }
 
     // Must have no more than one vehicle and one station
-    if (num_vehicles > 1 || num_stations > 1)
+    if (NumTrains > 1 || num_stations > 1)
         return false;
 
     return true;
@@ -1440,7 +1440,7 @@ static int32_t ride_get_new_breakdown_problem(Ride* ride)
     // However if this is the case, brake failure should be taken out the equation, otherwise block brake
     // rides have a lower probability to break down due to a random implementation reason.
     if (ride->IsBlockSectioned())
-        if (ride->num_vehicles != 1)
+        if (ride->NumTrains != 1)
             return -1;
 
     // If brakes failure is disabled, also take it out of the equation (see above comment why)
@@ -1468,10 +1468,10 @@ bool Ride::CanBreakDown() const
 static void choose_random_train_to_breakdown_safe(Ride* ride)
 {
     // Prevent integer division by zero in case of hacked ride.
-    if (ride->num_vehicles == 0)
+    if (ride->NumTrains == 0)
         return;
 
-    ride->broken_vehicle = scenario_rand() % ride->num_vehicles;
+    ride->broken_vehicle = scenario_rand() % ride->NumTrains;
 
     // Prevent crash caused by accessing SPRITE_INDEX_NULL on hacked rides.
     // This should probably be cleaned up on import instead.
@@ -2043,7 +2043,7 @@ void ride_measurements_update()
             else
             {
                 // For each vehicle
-                for (int32_t j = 0; j < ride.num_vehicles; j++)
+                for (int32_t j = 0; j < ride.NumTrains; j++)
                 {
                     auto vehicleSpriteIdx = ride.vehicles[j];
                     auto vehicle = GetEntity<Vehicle>(vehicleSpriteIdx);
@@ -3350,7 +3350,7 @@ static bool vehicle_create_trains(RideId rideIndex, const CoordsXYZ& trainsPos, 
     int32_t remainingDistance = 0;
     bool allTrainsCreated = true;
 
-    for (int32_t vehicleIndex = 0; vehicleIndex < ride->num_vehicles; vehicleIndex++)
+    for (int32_t vehicleIndex = 0; vehicleIndex < ride->NumTrains; vehicleIndex++)
     {
         if (ride->IsBlockSectioned())
         {
@@ -3474,7 +3474,7 @@ ResultWithMessage Ride::CreateVehicles(const CoordsXYE& element, bool isApplying
     }
 
     // Check if there are enough free sprite slots for all the vehicles
-    int32_t totalCars = num_vehicles * num_cars_per_train;
+    int32_t totalCars = NumTrains * num_cars_per_train;
     if (totalCars > count_free_misc_sprite_slots())
     {
         return { false, STR_UNABLE_TO_CREATE_ENOUGH_VEHICLES };
@@ -3527,7 +3527,7 @@ ResultWithMessage Ride::CreateVehicles(const CoordsXYE& element, bool isApplying
         }
         else
         {
-            for (int32_t i = 0; i < num_vehicles; i++)
+            for (int32_t i = 0; i < NumTrains; i++)
             {
                 Vehicle* vehicle = GetEntity<Vehicle>(vehicles[i]);
                 if (vehicle == nullptr)
@@ -3558,7 +3558,7 @@ ResultWithMessage Ride::CreateVehicles(const CoordsXYE& element, bool isApplying
  */
 void Ride::MoveTrainsToBlockBrakes(TrackElement* firstBlock)
 {
-    for (int32_t i = 0; i < num_vehicles; i++)
+    for (int32_t i = 0; i < NumTrains; i++)
     {
         auto train = GetEntity<Vehicle>(vehicles[i]);
         if (train == nullptr)
@@ -4729,7 +4729,7 @@ void invalidate_test_results(Ride* ride)
     ride->lifecycle_flags &= ~RIDE_LIFECYCLE_TEST_IN_PROGRESS;
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
     {
-        for (int32_t i = 0; i < ride->num_vehicles; i++)
+        for (int32_t i = 0; i < ride->NumTrains; i++)
         {
             Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[i]);
             if (vehicle != nullptr)
@@ -4757,7 +4757,7 @@ void ride_fix_breakdown(Ride* ride, int32_t reliabilityIncreaseFactor)
 
     if (ride->lifecycle_flags & RIDE_LIFECYCLE_ON_TRACK)
     {
-        for (int32_t i = 0; i < ride->num_vehicles; i++)
+        for (int32_t i = 0; i < ride->NumTrains; i++)
         {
             for (Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[i]); vehicle != nullptr;
                  vehicle = GetEntity<Vehicle>(vehicle->next_vehicle_on_train))
@@ -5115,7 +5115,7 @@ void Ride::UpdateMaxVehicles()
         return;
     }
     CarEntry* carEntry;
-    uint8_t numCarsPerTrain, numVehicles;
+    uint8_t numCarsPerTrain, numTrains;
     int32_t maxNumTrains;
 
     if (rideEntry->cars_per_flat_ride == NoFlatRideCars)
@@ -5245,13 +5245,13 @@ void Ride::UpdateMaxVehicles()
     {
         maxNumTrains = OpenRCT2::Limits::MaxTrainsPerRide;
     }
-    numVehicles = std::min(proposed_num_vehicles, static_cast<uint8_t>(maxNumTrains));
+    numTrains = std::min(ProposedNumTrains, static_cast<uint8_t>(maxNumTrains));
 
     // Refresh new current num vehicles / num cars per vehicle
-    if (numVehicles != num_vehicles || numCarsPerTrain != num_cars_per_train)
+    if (numTrains != NumTrains || numCarsPerTrain != num_cars_per_train)
     {
         num_cars_per_train = numCarsPerTrain;
-        num_vehicles = numVehicles;
+        NumTrains = numTrains;
         window_invalidate_by_number(WindowClass::Ride, id.ToUnderlying());
     }
 }
@@ -5271,9 +5271,9 @@ void Ride::SetRideEntry(ObjectEntryIndex entryIndex)
     GameActions::Execute(&rideSetVehicleAction);
 }
 
-void Ride::SetNumVehicles(int32_t numVehicles)
+void Ride::SetNumTrains(int32_t numTrains)
 {
-    auto rideSetVehicleAction = RideSetVehicleAction(id, RideSetVehicleType::NumTrains, numVehicles);
+    auto rideSetVehicleAction = RideSetVehicleAction(id, RideSetVehicleType::NumTrains, numTrains);
     GameActions::Execute(&rideSetVehicleAction);
 }
 

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -128,9 +128,9 @@ struct Ride
     EntityId vehicles[OpenRCT2::Limits::MaxTrainsPerRide + 1]; // Points to the first car in the train
     uint8_t depart_flags;
     uint8_t num_stations;
-    uint8_t num_vehicles;
+    uint8_t NumTrains;
     uint8_t num_cars_per_train;
-    uint8_t proposed_num_vehicles;
+    uint8_t ProposedNumTrains;
     uint8_t proposed_num_cars_per_train;
     uint8_t max_trains;
     uint8_t MinCarsPerTrain;
@@ -319,7 +319,7 @@ public:
     void SetToDefaultInspectionInterval();
     void SetRideEntry(ObjectEntryIndex entryIndex);
 
-    void SetNumVehicles(int32_t numVehicles);
+    void SetNumTrains(int32_t numTrains);
     void SetNumCarsPerVehicle(int32_t numCarsPerVehicle);
     void UpdateMaxVehicles();
     void UpdateNumberOfCircuits();

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -911,7 +911,7 @@ static uint16_t ride_compute_upkeep(RideRatingUpdateState& state, Ride* ride)
     // various variables set on the ride itself.
 
     // https://gist.github.com/kevinburke/e19b803cd2769d96c540
-    upkeep += ride->GetRideTypeDescriptor().UpkeepCosts.CostPerTrain * ride->num_vehicles;
+    upkeep += ride->GetRideTypeDescriptor().UpkeepCosts.CostPerTrain * ride->NumTrains;
     upkeep += ride->GetRideTypeDescriptor().UpkeepCosts.CostPerCar * ride->num_cars_per_train;
 
     // slight upkeep boosts for some rides - 5 for mini railway, 10 for log
@@ -2580,7 +2580,7 @@ void ride_ratings_calculate_go_karts(Ride* ride, RideRatingUpdateState& state)
     ride_ratings_set(&ratings, RIDE_RATING(1, 42), RIDE_RATING(1, 73), RIDE_RATING(0, 40));
     ride_ratings_apply_length(&ratings, ride, 700, 32768);
 
-    if (ride->mode == RideMode::Race && ride->num_vehicles >= 4)
+    if (ride->mode == RideMode::Race && ride->NumTrains >= 4)
     {
         ride_ratings_add(&ratings, RIDE_RATING(1, 40), RIDE_RATING(0, 50), 0);
 
@@ -2684,14 +2684,14 @@ void ride_ratings_calculate_dodgems(Ride* ride, RideRatingUpdateState& state)
     RatingTuple ratings;
     ride_ratings_set(&ratings, RIDE_RATING(1, 30), RIDE_RATING(0, 50), RIDE_RATING(0, 35));
 
-    if (ride->num_vehicles >= 4)
+    if (ride->NumTrains >= 4)
     {
         ride_ratings_add(&ratings, RIDE_RATING(0, 40), 0, 0);
     }
 
     ride_ratings_add(&ratings, ride->operation_option, ride->operation_option / 2, 0);
 
-    if (ride->num_vehicles >= 4)
+    if (ride->NumTrains >= 4)
     {
         ride_ratings_add(&ratings, RIDE_RATING(0, 40), 0, 0);
     }
@@ -3844,14 +3844,14 @@ void ride_ratings_calculate_flying_saucers(Ride* ride, RideRatingUpdateState& st
         /* .nausea =     */ RIDE_RATING(0, 39),
     };
 
-    if (ride->num_vehicles >= 4)
+    if (ride->NumTrains >= 4)
     {
         ride_ratings_add(&ratings, RIDE_RATING(0, 40), 0, 0);
     }
 
     ride_ratings_add(&ratings, ride->time_limit, ride->time_limit / 2, 0);
 
-    if (ride->num_vehicles >= 4)
+    if (ride->NumTrains >= 4)
     {
         ride_ratings_add(&ratings, RIDE_RATING(0, 40), 0, 0);
     }

--- a/src/openrct2/ride/Station.cpp
+++ b/src/openrct2/ride/Station.cpp
@@ -102,7 +102,7 @@ static void ride_update_station_dodgems(Ride* ride, StationIndex stationIndex)
     {
         int32_t dx = ride->time_limit * 32;
         int32_t dh = (dx >> 8) & 0xFF;
-        for (size_t i = 0; i < ride->num_vehicles; i++)
+        for (size_t i = 0; i < ride->NumTrains; i++)
         {
             Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[i]);
             if (vehicle == nullptr)
@@ -123,7 +123,7 @@ static void ride_update_station_dodgems(Ride* ride, StationIndex stationIndex)
     else
     {
         // Check if all vehicles are ready to go
-        for (size_t i = 0; i < ride->num_vehicles; i++)
+        for (size_t i = 0; i < ride->NumTrains; i++)
         {
             Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[i]);
             if (vehicle == nullptr)
@@ -199,7 +199,7 @@ static void ride_update_station_race(Ride* ride, StationIndex stationIndex)
     {
         int32_t numLaps = ride->NumLaps;
 
-        for (size_t i = 0; i < ride->num_vehicles; i++)
+        for (size_t i = 0; i < ride->NumTrains; i++)
         {
             Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[i]);
             if (vehicle == nullptr)
@@ -235,7 +235,7 @@ static void ride_update_station_race(Ride* ride, StationIndex stationIndex)
     else
     {
         // Check if all vehicles are ready to go
-        for (size_t i = 0; i < ride->num_vehicles; i++)
+        for (size_t i = 0; i < ride->NumTrains; i++)
         {
             Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[i]);
             if (vehicle == nullptr)
@@ -272,7 +272,7 @@ static void ride_update_station_race(Ride* ride, StationIndex stationIndex)
  */
 static void ride_race_init_vehicle_speeds(Ride* ride)
 {
-    for (size_t i = 0; i < ride->num_vehicles; i++)
+    for (size_t i = 0; i < ride->NumTrains; i++)
     {
         Vehicle* vehicle = GetEntity<Vehicle>(ride->vehicles[i]);
         if (vehicle == nullptr)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -124,7 +124,7 @@ StringId TrackDesign::CreateTrackDesign(TrackDesignState& tds, const Ride& ride)
     }
 
     depart_flags = ride.depart_flags;
-    number_of_trains = ride.num_vehicles;
+    number_of_trains = ride.NumTrains;
     number_of_cars_per_train = ride.num_cars_per_train;
     min_waiting_time = ride.min_waiting_time;
     max_waiting_time = ride.max_waiting_time;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2139,7 +2139,7 @@ static std::optional<uint32_t> ride_get_train_index_from_vehicle(Ride* ride, Ent
     while (ride->vehicles[trainIndex] != spriteIndex)
     {
         trainIndex++;
-        if (trainIndex >= ride->num_vehicles)
+        if (trainIndex >= ride->NumTrains)
         {
             // This should really return nullopt, but doing so
             // would break some hacked parks that hide track by setting tracked rides'
@@ -2663,7 +2663,7 @@ static bool try_add_synchronised_station(const CoordsXYZ& coords)
     }
 
     // Look for a vehicle on this station waiting to depart.
-    for (int32_t i = 0; i < ride->num_vehicles; i++)
+    for (int32_t i = 0; i < ride->NumTrains; i++)
     {
         auto* vehicle = GetEntity<Vehicle>(ride->vehicles[i]);
         if (vehicle == nullptr)
@@ -2801,7 +2801,7 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
                         auto curRide = get_ride(rideId);
                         if (curRide != nullptr)
                         {
-                            for (int32_t i = 0; i < curRide->num_vehicles; i++)
+                            for (int32_t i = 0; i < curRide->NumTrains; i++)
                             {
                                 Vehicle* v = GetEntity<Vehicle>(curRide->vehicles[i]);
                                 if (v == nullptr)
@@ -2839,7 +2839,7 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
                     int32_t numTrainsAtStation = 0;
                     int32_t numTravelingTrains = 0;
                     auto currentStation = sv->stationIndex;
-                    for (int32_t i = 0; i < sv_ride->num_vehicles; i++)
+                    for (int32_t i = 0; i < sv_ride->NumTrains; i++)
                     {
                         auto* otherVehicle = GetEntity<Vehicle>(sv_ride->vehicles[i]);
                         if (otherVehicle == nullptr)
@@ -2864,9 +2864,9 @@ static bool ride_station_can_depart_synchronised(const Ride& ride, StationIndex 
                     }
 
                     int32_t totalTrains = numTrainsAtStation + numTravelingTrains;
-                    if (totalTrains != sv_ride->num_vehicles || numTravelingTrains >= sv_ride->num_vehicles / 2)
+                    if (totalTrains != sv_ride->NumTrains || numTravelingTrains >= sv_ride->NumTrains / 2)
                     {
-                        // if (numArrivingTrains > 0 || numTravelingTrains >= sv_ride->num_vehicles / 2) {
+                        // if (numArrivingTrains > 0 || numTravelingTrains >= sv_ride->NumTrains / 2) {
                         /* Sync condition: If there are trains arriving at the
                          * station or half or more of the ride trains are
                          * travelling, this station must be sync-ed before the
@@ -3411,7 +3411,7 @@ void Vehicle::CheckIfMissing()
         ft.Add<StringId>(GetRideComponentName(GetRideTypeDescriptor(curRide->type).NameConvention.vehicle).number);
 
         uint8_t vehicleIndex = 0;
-        for (; vehicleIndex < curRide->num_vehicles; ++vehicleIndex)
+        for (; vehicleIndex < curRide->NumTrains; ++vehicleIndex)
             if (curRide->vehicles[vehicleIndex] == sprite_index)
                 break;
 

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -38,7 +38,7 @@ static void paint_space_rings_structure(
 {
     uint32_t vehicleIndex = (segment - direction) & 0x3;
 
-    if (ride.num_stations == 0 || vehicleIndex < ride.num_vehicles)
+    if (ride.num_stations == 0 || vehicleIndex < ride.NumTrains)
     {
         rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
 

--- a/src/openrct2/scripting/bindings/ride/ScRide.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScRide.cpp
@@ -192,7 +192,7 @@ namespace OpenRCT2::Scripting
         auto ride = GetRide();
         if (ride != nullptr)
         {
-            std::for_each(std::begin(ride->vehicles), std::begin(ride->vehicles) + ride->num_vehicles, [&](auto& veh) {
+            std::for_each(std::begin(ride->vehicles), std::begin(ride->vehicles) + ride->NumTrains, [&](auto& veh) {
                 result.push_back(veh.ToUnderlying());
             });
         }


### PR DESCRIPTION
Another PR to disambiguate better between “train” and “car”.