### PR TITLE
Fix #10535: Guests getting stuck at specific level crossings.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -29,6 +29,7 @@
 - Change: [#17762] Use vertical tabs in the New Game dialog.
 - Fix: [#5141] Headless server is counted as a player.
 - Fix: [#7466] Coaster track not drawn at tunnel exit.
+- Fix: [#10535] Guests getting stuck at specific level crossings.
 - Fix: [#14337] Guest blocking ride entrance after ride price changed to be unaffordable.
 - Fix: [#15328] Wooden Roller Coaster incorrectly draws a railing on the first station piece (original bug).
 - Fix: [#16392] Scenery on sloped surface is placed at wrong height.

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -9258,17 +9258,17 @@ void Vehicle::UpdateCrossings() const
     uint8_t freeCount = travellingForwards ? 3 : 1;
     while (freeCount-- > 0)
     {
-        if (travellingForwards && track_block_get_previous(xyElement, &output))
-        {
-            xyElement.x = output.begin_x;
-            xyElement.y = output.begin_y;
-            xyElement.element = output.begin_element;
-        }
-
         auto* pathElement = map_get_path_element_at(TileCoordsXYZ(CoordsXYZ{ xyElement, xyElement.element->GetBaseZ() }));
         if (pathElement != nullptr)
         {
             pathElement->SetIsBlockedByVehicle(false);
+        }
+
+        if (travellingForwards && freeCount > 0 && track_block_get_previous(xyElement, &output))
+        {
+            xyElement.x = output.begin_x;
+            xyElement.y = output.begin_y;
+            xyElement.element = output.begin_element;
         }
     }
 }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -9250,29 +9250,25 @@ void Vehicle::UpdateCrossings() const
 
     xyElement = { backVehicle->TrackLocation,
                   map_get_track_element_at_of_type_seq(backVehicle->TrackLocation, backVehicle->GetTrackType(), 0) };
-    curZ = backVehicle->TrackLocation.z;
-
-    if (xyElement.element != nullptr)
+    if (xyElement.element == nullptr)
     {
-        uint8_t freeCount = travellingForwards ? 3 : 1;
+        return;
+    }
 
-        while (freeCount-- > 0)
+    uint8_t freeCount = travellingForwards ? 3 : 1;
+    while (freeCount-- > 0)
+    {
+        if (travellingForwards && track_block_get_previous(xyElement, &output))
         {
-            if (travellingForwards)
-            {
-                if (track_block_get_previous(xyElement, &output))
-                {
-                    xyElement.x = output.begin_x;
-                    xyElement.y = output.begin_y;
-                    xyElement.element = output.begin_element;
-                }
-            }
+            xyElement.x = output.begin_x;
+            xyElement.y = output.begin_y;
+            xyElement.element = output.begin_element;
+        }
 
-            auto* pathElement = map_get_path_element_at(TileCoordsXYZ(CoordsXYZ{ xyElement, xyElement.element->GetBaseZ() }));
-            if (pathElement != nullptr)
-            {
-                pathElement->SetIsBlockedByVehicle(false);
-            }
+        auto* pathElement = map_get_path_element_at(TileCoordsXYZ(CoordsXYZ{ xyElement, xyElement.element->GetBaseZ() }));
+        if (pathElement != nullptr)
+        {
+            pathElement->SetIsBlockedByVehicle(false);
         }
     }
 }


### PR DESCRIPTION
Guest could get stuck at specific level crossing because the location of the back vehicle itself wasn't included when removing the 'blocked by vehicle' flags on footpath. This usually isn't necessary but on specific tile / track combinations, certain bits of footpath could be missed otherwise. The flag wouldn't ever be cleared there, leading to stuck guests. 

I also did some minor code reformatting to prevent some unnecessary nested if's, which I did in a separate commit so it's easier to review. 

Resolves #10535, also resolves #14340.

**Demo 1:**
Note this change doesn't lead to guests going to soon through the freed pathway, and it works for both the blocked guests at the previously continuously blocked crossing(left) and crossing which worked properly before too (right).
![Demo](https://user-images.githubusercontent.com/30838294/191899830-bccdb1a7-3aa2-49f4-b88e-547f2b2c6c85.gif)

**Demo 2:**
Also still works as expected on extended tracks on footpath.
![Demo2](https://user-images.githubusercontent.com/30838294/191899854-99705b0e-636a-4e55-8a17-98be2369a3aa.gif)

I also tested it shuttle mode and everything seems to still work fine too.