### PR TITLE
Create category for DLC and BYO scenarios

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3623,6 +3623,7 @@ STR_6515    :{BLACK}RCT1 not linked - fallback images will be used.
 STR_6516    :One or more objects added require RCT1 linked for proper display. Fallback images will be used.
 STR_6517    :One or more objects in this park require RCT1 linked for proper display. Fallback images will be used.
 STR_6518    :{BLACK}Hover over a scenario to view its description and objective. Click it to start playing.
+STR_6519    :Extras
 
 #############
 # Scenarios #

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2408,7 +2408,7 @@ declare global {
     interface ScenarioFile {
         id: number;
         category: "beginner" | "challenging" | "expert" | "real" | "other" | "dlc" | "build_your_own";
-        sourceGame: "rct1" | "rct1_aa" | "rct1_ll" | "rct2" | "rct2_ww" | "rct2_tt" | "real" | "other";
+        sourceGame: "rct1" | "rct1_aa" | "rct1_ll" | "rct2" | "rct2_ww" | "rct2_tt" | "real" | "extras" | "other";
         path: string;
         internalName: string;
         name: string;

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -58,6 +58,7 @@ namespace OpenRCT2::Scripting
         { "rct2_ww", ScenarioSource::RCT2_WW },
         { "rct2_tt", ScenarioSource::RCT2_TT },
         { "real", ScenarioSource::Real },
+        { "extras", ScenarioSource::Extras },
         { "other", ScenarioSource::Other },
     });
 

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -35,7 +35,7 @@ static constexpr const int32_t TabHeight = 34;
 static constexpr const int32_t WidgetsStart = 17;
 static constexpr const int32_t TabsStart = WidgetsStart;
 #define INITIAL_NUM_UNLOCKED_SCENARIOS 5
-constexpr const uint8_t NumTabs = 8;
+constexpr const uint8_t NumTabs = 9;
 
 // clang-format off
 enum class ListItemType : uint8_t
@@ -76,6 +76,7 @@ enum {
     WIDX_TAB6,
     WIDX_TAB7,
     WIDX_TAB8,
+    WIDX_TAB9,
     WIDX_SCENARIOLIST
 };
 
@@ -90,6 +91,7 @@ static rct_widget window_scenarioselect_widgets[] = {
     MakeRemapWidget({  3, TabsStart + (TabHeight * 5) }, { TabWidth,  TabHeight}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB),   // tab 6
     MakeRemapWidget({  3, TabsStart + (TabHeight * 6) }, { TabWidth,  TabHeight}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB),   // tab 7
     MakeRemapWidget({  3, TabsStart + (TabHeight * 7) }, { TabWidth,  TabHeight}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB),   // tab 8
+    MakeRemapWidget({  3, TabsStart + (TabHeight * 8) }, { TabWidth,  TabHeight}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_G2_SIDEWAYS_TAB),   // tab 9
     MakeWidget     ({  TabWidth + 3, WidgetsStart + 1 }, { WW - SidebarWidth, 276 }, WindowWidgetType::Scroll, WindowColour::Secondary, SCROLL_VERTICAL), // level list
     WIDGETS_END,
 };
@@ -102,6 +104,7 @@ static constexpr const StringId ScenarioOriginStringIds[] = {
     STR_SCENARIO_CATEGORY_RCT2_WW,
     STR_SCENARIO_CATEGORY_RCT2_TT,
     STR_SCENARIO_CATEGORY_REAL_PARKS,
+    STR_SCENARIO_CATEGORY_EXTRAS_PARKS,
     STR_SCENARIO_CATEGORY_OTHER_PARKS,
 };
 
@@ -264,7 +267,7 @@ static void WindowScenarioselectMouseup(rct_window* w, WidgetIndex widgetIndex)
 
 static void WindowScenarioselectMousedown(rct_window* w, WidgetIndex widgetIndex, rct_widget* widget)
 {
-    if (widgetIndex >= WIDX_TAB1 && widgetIndex <= WIDX_TAB8)
+    if (widgetIndex >= WIDX_TAB1 && widgetIndex <= WIDX_TAB9)
     {
         w->selected_tab = widgetIndex - 4;
         w->highlighted_scenario = nullptr;
@@ -405,7 +408,7 @@ static void WindowScenarioselectInvalidate(rct_window* w)
 {
     w->pressed_widgets &= ~(
         (1ULL << WIDX_CLOSE) | (1ULL << WIDX_TAB1) | (1ULL << WIDX_TAB2) | (1ULL << WIDX_TAB3) | (1ULL << WIDX_TAB4)
-        | (1ULL << WIDX_TAB5) | (1ULL << WIDX_TAB6) | (1ULL << WIDX_TAB7) | (1ULL << WIDX_TAB8));
+        | (1ULL << WIDX_TAB5) | (1ULL << WIDX_TAB6) | (1ULL << WIDX_TAB7) | (1ULL << WIDX_TAB8) | (1ULL << WIDX_TAB9));
 
     w->pressed_widgets |= 1LL << (w->selected_tab + WIDX_TAB1);
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3905,6 +3905,8 @@ enum : uint16_t
 
     STR_SCENARIO_HOVER_HINT = 6518,
 
+    STR_SCENARIO_CATEGORY_EXTRAS_PARKS = 6519,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -126,7 +126,7 @@ class ScenarioFileIndex final : public FileIndex<scenario_index_entry>
 {
 private:
     static constexpr uint32_t MAGIC_NUMBER = 0x58444953; // SIDX
-    static constexpr uint16_t VERSION = 5;
+    static constexpr uint16_t VERSION = 6;
     static constexpr auto PATTERN = "*.sc4;*.sc6;*.sea;*.park";
 
 public:

--- a/src/openrct2/scenario/ScenarioRepository.h
+++ b/src/openrct2/scenario/ScenarioRepository.h
@@ -33,6 +33,7 @@ enum class ScenarioSource : uint8_t
     RCT2_WW,
     RCT2_TT,
     Real,
+    Extras,
     Other
 };
 

--- a/src/openrct2/scenario/ScenarioSources.cpp
+++ b/src/openrct2/scenario/ScenarioSources.cpp
@@ -287,7 +287,7 @@ namespace ScenarioSources
     };
 
     // Other parks
-    static constexpr const ScenarioTitleDescriptor ScenarioTitlesOtherParks[] =
+    static constexpr const ScenarioTitleDescriptor ScenarioTitlesExtrasParks[] =
     {
         { SC_FORT_ANACHRONISM,                          "Fort Anachronism",                                 SCENARIO_CATEGORY_DLC            },
         { SC_PCPLAYER,                                  "PC Player",                                        SCENARIO_CATEGORY_DLC            },
@@ -327,7 +327,7 @@ namespace ScenarioSources
         DEFINE_SCENARIO_TITLE_DESC_GROUP(ScenarioTitlesRCT2WW),
         DEFINE_SCENARIO_TITLE_DESC_GROUP(ScenarioTitlesRCT2TT),
         DEFINE_SCENARIO_TITLE_DESC_GROUP(ScenarioTitlesRealParks),
-        DEFINE_SCENARIO_TITLE_DESC_GROUP(ScenarioTitlesOtherParks),
+        DEFINE_SCENARIO_TITLE_DESC_GROUP(ScenarioTitlesExtrasParks),
     };
     // clang-format on
 


### PR DESCRIPTION
Makes the “Other tab” less crowded.

![afbeelding](https://user-images.githubusercontent.com/1478678/192066354-b800cb95-922a-472a-b79b-f871fb5181bc.png)
