### PR TITLE
Fix #17889: Peeps don't stop at level railway crossings if approached from downhill

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -67,6 +67,7 @@
 - Fix: [#17931] The in-game command ‘count_objects’ crashes the game.
 - Fix: [#17865] With difficult guest generation, tested but unopened rides still contribute to the guest cap.
 - Fix: [#17866] [Plugin] Wrong Soft Guest Cap at start of new game.
+- Fix: [#17889] Peeps don't stop at level railway crossings if approached from downhill.
 - Fix: [#17980] Queue lines of track designs mess up existing queue lines if dragged through them.
 - Fix: [#17959] Areas marked for dirty drawing are too large.
 - Fix: [#17963] Some marketing campaigns can’t be started after Finances window tab has been on Research.

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5299,12 +5299,6 @@ void Guest::UpdateWalking()
         }
     }
 
-    if (PathIsBlockedByVehicle())
-    {
-        // Wait for vehicle to pass
-        return;
-    }
-
     uint8_t pathingResult;
     PerformNextAction(pathingResult);
     if (!(pathingResult & PATHING_DESTINATION_REACHED))

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -412,7 +412,6 @@ public: // Peep
     // TODO: Make these private again when done refactoring
 public: // Peep
     [[nodiscard]] bool CheckForPath();
-    bool PathIsBlockedByVehicle();
     void PerformNextAction(uint8_t& pathing_result);
     void PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result);
     [[nodiscard]] int32_t GetZOnSlope(int32_t tile_x, int32_t tile_y);

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -862,12 +862,17 @@ bool Staff::DoMiscPathFinding()
     return false;
 }
 
-bool Staff::IsMechanicHeadingToFixRideBlockingPath()
+bool Staff::IsMechanicHeadingToFixRideBlockingPath(const CoordsXYZ& nextPos)
 {
-    auto trackElement = map_get_track_element_at(CoordsXYZ{ GetDestination(), NextLoc.z });
+    if (!IsMechanic())
+        return false;
+
+    auto trackElement = map_get_track_element_at(nextPos);
+    if (trackElement == nullptr)
+        return false;
+
     auto ride = get_ride(trackElement->GetRideIndex());
-    return AssignedStaffType == StaffType::Mechanic && ride->id == CurrentRide
-        && ride->breakdown_reason == BREAKDOWN_SAFETY_CUT_OUT;
+    return ride != nullptr && ride->id == CurrentRide && ride->breakdown_reason == BREAKDOWN_SAFETY_CUT_OUT;
 }
 
 /**
@@ -1331,9 +1336,6 @@ void Staff::UpdateHeadingToInspect()
         if (!CheckForPath())
             return;
 
-        if (PathIsBlockedByVehicle() && !IsMechanicHeadingToFixRideBlockingPath())
-            return;
-
         uint8_t pathingResult;
         TileElement* rideEntranceExitElement;
         PerformNextAction(pathingResult, rideEntranceExitElement);
@@ -1437,9 +1439,6 @@ void Staff::UpdateAnswering()
         }
 
         if (!CheckForPath())
-            return;
-
-        if (PathIsBlockedByVehicle() && !IsMechanicHeadingToFixRideBlockingPath())
             return;
 
         uint8_t pathingResult;
@@ -1772,9 +1771,6 @@ void Staff::UpdateStaff(uint32_t stepsToTake)
 void Staff::UpdatePatrolling()
 {
     if (!CheckForPath())
-        return;
-
-    if (PathIsBlockedByVehicle() && !IsMechanicHeadingToFixRideBlockingPath())
         return;
 
     uint8_t pathingResult;

--- a/src/openrct2/entity/Staff.h
+++ b/src/openrct2/entity/Staff.h
@@ -67,6 +67,8 @@ public:
     bool HasPatrolArea() const;
     void SetPatrolArea(const std::vector<TileCoordsXY>& area);
 
+    bool IsMechanicHeadingToFixRideBlockingPath(const CoordsXYZ& nextPos);
+
 private:
     void UpdatePatrolling();
     void UpdateMowing();
@@ -94,7 +96,6 @@ private:
     bool DoMechanicPathFinding();
     bool DoEntertainerPathFinding();
     bool DoMiscPathFinding();
-    bool IsMechanicHeadingToFixRideBlockingPath();
 
     Direction HandymanDirectionRandSurface(uint8_t validDirections) const;
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "17"
+#define NETWORK_STREAM_VERSION "18"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -9266,6 +9266,16 @@ void Vehicle::UpdateCrossings() const
             xyElement.y = output.begin_y;
             xyElement.element = output.begin_element;
         }
+        else if (!travellingForwards)
+        {
+            CoordsXYE next;
+            if (track_block_get_next(&xyElement, &next, &curZ, &direction))
+            {
+                xyElement.x = next.x;
+                xyElement.y = next.y;
+                xyElement.element = next.element;
+            }
+        }
 
         auto* pathElement = map_get_path_element_at(TileCoordsXYZ(CoordsXYZ{ xyElement, xyElement.element->GetBaseZ() }));
         if (pathElement != nullptr)

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -2021,9 +2021,9 @@ void footpath_update_path_wide_flags(const CoordsXY& footpathPos)
     } while (!(tileElement++)->IsLastForTile());
 }
 
-bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position)
+bool footpath_is_blocked_by_vehicle(const TileElement* tileElement)
 {
-    auto pathElement = map_get_path_element_at(position);
+    auto pathElement = tileElement->AsPath();
     return pathElement != nullptr && pathElement->IsBlockedByVehicle();
 }
 

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -247,7 +247,7 @@ bool fence_in_the_way(const CoordsXYRangedZ& fencePos, int32_t direction);
 void footpath_chain_ride_queue(
     RideId rideIndex, StationIndex entranceIndex, const CoordsXY& footpathPos, TileElement* tileElement, int32_t direction);
 void footpath_update_path_wide_flags(const CoordsXY& footpathPos);
-bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position);
+bool footpath_is_blocked_by_vehicle(const TileElement* tileElement);
 
 int32_t footpath_is_connected_to_map_edge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags);
 void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElement);


### PR DESCRIPTION
If peeps approached a railway crossing from downhill, they would not stop for a passing train. This was because the destination z wasn't up-to-date.

Moving the logic to the generic peep_footpath_move_forward method, where the new target destination is determined, resolves this issue. It also prevents some code duplication in the 'Guest' and 'Peep' classes.

_Note: this change ended in guests starting to walk too soon at a railway crossing, making them phase through the final part of the train. So, I reverted my earlier change where the final part of the train was also included in tile elements to unblock._

_Instead, ensure UpdateCrossings is called every time -> even when there is no new track progress. This prevents certain tiles from becoming blocked forever. Also ensured most code from that method won't be run anymore if the ride type doesn't support level crossings anyway._

_For trains going backwards in shuttle mode, update the logic so the next tile is selected to prevent guests starting to walk too soon in that way too._

Resolves #17889.

### Demo
Guests will now stop for railway crossings when they're approached from an upwards sloped path. Note that the mechanic will also stop.

![Guests](https://user-images.githubusercontent.com/30838294/192141913-89d47f61-ec79-481c-9189-3f3d6ab5715e.gif)

Staff members will also still stop for railway crossings at upwards sloped paths, except mechanics who are on the way to fix the ride that's blocking the track.
![Staff](https://user-images.githubusercontent.com/30838294/192136827-13891a8e-073a-45ff-821e-4678a141a2e3.gif)
