### PR TITLE
Remove Scream 8 from coasters and add all other screams to nonwooden coasters

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "19"
+#define NETWORK_STREAM_VERSION "20"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -78,14 +78,17 @@ Vehicle* _vehicleFrontVehicle;
 CoordsXYZ _vehicleCurPosition;
 
 static constexpr const OpenRCT2::Audio::SoundId _screamSet0[] = {
-    OpenRCT2::Audio::SoundId::Scream8,
-    OpenRCT2::Audio::SoundId::Scream1,
+    OpenRCT2::Audio::SoundId::Scream3, OpenRCT2::Audio::SoundId::Scream1, OpenRCT2::Audio::SoundId::Scream5,
+    OpenRCT2::Audio::SoundId::Scream6, OpenRCT2::Audio::SoundId::Scream7, OpenRCT2::Audio::SoundId::Scream2,
+    OpenRCT2::Audio::SoundId::Scream4,
 };
+
 static constexpr const OpenRCT2::Audio::SoundId _screamSet1Wooden[] = {
     OpenRCT2::Audio::SoundId::Scream3, OpenRCT2::Audio::SoundId::Scream1, OpenRCT2::Audio::SoundId::Scream5,
     OpenRCT2::Audio::SoundId::Scream6, OpenRCT2::Audio::SoundId::Scream7, OpenRCT2::Audio::SoundId::Scream2,
     OpenRCT2::Audio::SoundId::Scream4,
 };
+
 static constexpr const OpenRCT2::Audio::SoundId _screamSet2[] = {
     OpenRCT2::Audio::SoundId::Scream1,
     OpenRCT2::Audio::SoundId::Scream6,


### PR DESCRIPTION
this will add wooden screams to all coasters and remove scream 8 from nonwooden coasters, as discussed in other PRs but not implemented