### PR TITLE
Fix: Ghosts element not ignored when assessing scenery or fountains

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -57,7 +57,7 @@ The following people are not part of the development team, but have been contrib
 * Inseok Lee (dlunch) - Load save files from command line
 * Jørn Lomax (jvlomax) - Configuration parser
 * Alexander Overvoorde (Overv) - OpenGL improvements, Steam overlay detection, various bugfixes.
-* (eezstreet) - Add finances button to toolbar
+* (eezstreet) - Add finances button to toolbar, various bugfixes.
 * Hielke Morsink (Broxzier) - Tile inspector, heightmap loader, misc.
 * Joe Minor Jr (wolfreak99) - Various cheats, bugfixes, new About and Changelog windows.
 * Thomas den Hollander (ThomasdenH) - Dithering in sprite importer, invert viewport dragging, park rating cheats misc.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.3 (in development)
 ------------------------------------------------------------------------
 - Fix: [#14312] Research ride type message incorrect.
+- Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 
 0.4.2 (2022-10-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2924,6 +2924,11 @@ static PeepThoughtType peep_assess_surroundings(int16_t centre_x, int16_t centre
             {
                 Ride* ride;
 
+                if (tileElement->IsGhost())
+                {
+                    continue;
+                }
+
                 switch (tileElement->GetType())
                 {
                     case TileElementType::Path:

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
Previously, if you had 39 pieces of scenery placed, and a ghost is present, it would count that ghost as the 40th piece of scenery, thus causing guests to think "Great scenery!"