### PR TITLE
Fix #17053: Crash when trying to open files under 4 bytes in length

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -39,6 +39,7 @@
 - Fix: [#15328] Wooden Roller Coaster incorrectly draws a railing on the first station piece (original bug).
 - Fix: [#16392] Scenery on sloped surface is placed at wrong height.
 - Fix: [#16476] The game sometimes crashes when demolishing a maze.
+- Fix: [#17053] Crash when trying to open files under 4 bytes in length.
 - Fix: [#17312] (Flying) Inline Twist appearing under the surface when placed on ground level.
 - Fix: [#17339] Distorted visuals when changing scaling factor between integer numbers in OpenGL rendering mode.
 - Fix: [#17394] Six-seater Hyper-Twister Trains focuses ride window camera on Car 2 rather than Car 1 (original bug).

--- a/src/openrct2/util/SawyerCoding.cpp
+++ b/src/openrct2/util/SawyerCoding.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <stdexcept>
 
 static size_t decode_chunk_rle(const uint8_t* src_buffer, uint8_t* dst_buffer, size_t length);
 static size_t decode_chunk_rle_with_size(const uint8_t* src_buffer, uint8_t* dst_buffer, size_t length, size_t dstSize);
@@ -152,6 +153,9 @@ size_t sawyercoding_encode_td6(const uint8_t* src, uint8_t* dst, size_t length)
 /* Based off of rct2: 0x006770C1 */
 int32_t sawyercoding_validate_track_checksum(const uint8_t* src, size_t length)
 {
+    if (length < 4)
+        return 0;
+
     uint32_t file_checksum = *(reinterpret_cast<const uint32_t*>(&src[length - 4]));
 
     uint32_t checksum = 0;
@@ -384,6 +388,11 @@ static void encode_chunk_rotate(uint8_t* buffer, size_t length)
 
 int32_t sawyercoding_detect_file_type(const uint8_t* src, size_t length)
 {
+    if (length < 4)
+    {
+        throw std::length_error("Stream is (nearly) empty!");
+    }
+
     size_t i;
 
     // Currently can't detect TD4, as the checksum is the same as SC4 (need alternative method)


### PR DESCRIPTION
This is responsible for a *lot* of crash reports.