### PR TITLE
Fix #17889: Peeps don't stop at level railway crossings if approached from downhill 

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -70,6 +70,7 @@
 - Fix: [#17931] The in-game command ‘count_objects’ crashes the game.
 - Fix: [#17865] With difficult guest generation, tested but unopened rides still contribute to the guest cap.
 - Fix: [#17866] [Plugin] Wrong Soft Guest Cap at start of new game.
+- Fix: [#17889] Peeps don't stop at level railway crossings if approached from downhill.
 - Fix: [#17980] Queue lines of track designs mess up existing queue lines if dragged through them.
 - Fix: [#17959] Areas marked for dirty drawing are too large.
 - Fix: [#17963] Some marketing campaigns can’t be started after Finances window tab has been on Research.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,7 +17,7 @@
 - Feature: [objects#209] Add the Steel Roller Coaster train and 2-across Inverted Train from RollerCoaster Tycoon 1.
 - Improved: [#15358] Park and scenario names can now contain up to 128 characters.
 - Improved: [#15589] Numpad Enter can now be used to close text input.
-- Improved: [#16819] Don't prompt to “Save game as” when saving a loaded saved game (excepting autosaves).
+- Improved: [#16819] Don’t prompt to “Save game as” when saving a loaded saved game (excepting autosaves).
 - Improved: [#16840] Add support for rectangular heightmaps.
 - Improved: [#17575] You can now search for Authors in Object Selection.
 - Improved: [#17806] Added warning when using RCT1 objects without RCT1 linked.
@@ -70,7 +70,7 @@
 - Fix: [#17931] The in-game command ‘count_objects’ crashes the game.
 - Fix: [#17865] With difficult guest generation, tested but unopened rides still contribute to the guest cap.
 - Fix: [#17866] [Plugin] Wrong Soft Guest Cap at start of new game.
-- Fix: [#17889] Peeps don't stop at level railway crossings if approached from downhill.
+- Fix: [#17889] Peeps don’t stop at level railway crossings if approached from downhill.
 - Fix: [#17980] Queue lines of track designs mess up existing queue lines if dragged through them.
 - Fix: [#17959] Areas marked for dirty drawing are too large.
 - Fix: [#17963] Some marketing campaigns can’t be started after Finances window tab has been on Research.
@@ -82,7 +82,7 @@
 - Fix: [#18026] Park rating drops to 0 with more than 32k guests, total ride excitement or intensity.
 - Fix: [#18032] All non-interactive widgets (labels, groupboxes) produce sound when clicked.
 - Fix: [#18035] Favourited servers don’t get their online status updated.
-- Fix: [#18051] Visual glitch with Mine Ride's large unbanked turn (original bug).
+- Fix: [#18051] Visual glitch with Mine Ride’s large unbanked turn (original bug).
 - Fix: [#18059] [Plugin] Width and height of custom window not changeable via script.
 
 0.4.1 (2022-07-04)
@@ -107,7 +107,7 @@
 - Removed: [#16864] Title sequence editor (replaced by plug-in).
 - Removed: [#16911, #17411] Residual support for pre-Vista Windows systems.
 - Fix: [#13997] Placing a track design interferes with other players building a ride.
-- Fix: [#15787] When deselecting "Show banner text in upper case", the banners remain upper case for 10 seconds.
+- Fix: [#15787] When deselecting “Show banner text in upper case”, the banners remain upper case for 10 seconds.
 - Fix: [#16539] CustomListView header not clickable when listview is scrolled.
 - Fix: [#16799] Browsing “Up” in the Load Save window shows no files, only folders.
 - Fix: [#16934] Park size displayed incorrectly in Park window.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "20"
+#define NETWORK_STREAM_VERSION "21"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -2023,7 +2023,7 @@ void footpath_update_path_wide_flags(const CoordsXY& footpathPos)
 
 bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position)
 {
-    auto pathElement = map_get_path_element_at(position);
+    auto pathElement = map_get_first_path_element_at_or_up_from_z(position);
     return pathElement != nullptr && pathElement->IsBlockedByVehicle();
 }
 

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -2023,7 +2023,7 @@ void footpath_update_path_wide_flags(const CoordsXY& footpathPos)
 
 bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position)
 {
-    auto pathElement = map_get_first_path_element_at_or_up_from_z(position);
+    auto pathElement = MapGetFirstPathElementWithBaseHeightBetween({ position, position.z + PATH_HEIGHT_STEP });
     return pathElement != nullptr && pathElement->IsBlockedByVehicle();
 }
 

--- a/src/openrct2/world/Location.hpp
+++ b/src/openrct2/world/Location.hpp
@@ -489,6 +489,34 @@ struct TileCoordsXYZ : public TileCoordsXY
     }
 };
 
+struct TileCoordsXYRangedZ : public TileCoordsXY
+{
+    int32_t baseZ{};
+    int32_t clearanceZ{};
+
+    constexpr TileCoordsXYRangedZ() = default;
+    constexpr TileCoordsXYRangedZ(int32_t _x, int32_t _y, int32_t _baseZ, int32_t _clearanceZ)
+        : TileCoordsXY(_x, _y)
+        , baseZ(_baseZ)
+        , clearanceZ(_clearanceZ)
+    {
+    }
+
+    constexpr TileCoordsXYRangedZ(const TileCoordsXY& _c, int32_t _baseZ, int32_t _clearanceZ)
+        : TileCoordsXY(_c)
+        , baseZ(_baseZ)
+        , clearanceZ(_clearanceZ)
+    {
+    }
+
+    constexpr TileCoordsXYRangedZ(const TileCoordsXYZ& _c, int32_t _clearanceZ)
+        : TileCoordsXY(_c)
+        , baseZ(_c.z)
+        , clearanceZ(_clearanceZ)
+    {
+    }
+};
+
 /**
  * Cardinal directions are represented by the Direction type. It has four
  * possible values:

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -401,13 +401,13 @@ PathElement* map_get_path_element_at(const TileCoordsXYZ& loc)
     return nullptr;
 }
 
-PathElement* map_get_first_path_element_at_or_up_from_z(const TileCoordsXYZ& loc)
+PathElement* MapGetFirstPathElementWithBaseHeightBetween(const TileCoordsXYRangedZ& loc)
 {
     for (auto* element : TileElementsView<PathElement>(loc.ToCoordsXY()))
     {
         if (element->IsGhost())
             continue;
-        if (element->base_height >= loc.z)
+        if (element->base_height >= loc.baseZ && element->base_height <= loc.clearanceZ)
             return element;
     }
     return nullptr;

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -401,6 +401,18 @@ PathElement* map_get_path_element_at(const TileCoordsXYZ& loc)
     return nullptr;
 }
 
+PathElement* map_get_first_path_element_at_or_up_from_z(const TileCoordsXYZ& loc)
+{
+    for (auto* element : TileElementsView<PathElement>(loc.ToCoordsXY()))
+    {
+        if (element->IsGhost())
+            continue;
+        if (element->base_height >= loc.z)
+            return element;
+    }
+    return nullptr;
+}
+
 BannerElement* map_get_banner_element_at(const CoordsXYZ& bannerPos, uint8_t position)
 {
     const auto bannerTilePos = TileCoordsXYZ{ bannerPos };

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -169,6 +169,7 @@ int32_t map_height_from_slope(const CoordsXY& coords, int32_t slopeDirection, bo
 BannerElement* map_get_banner_element_at(const CoordsXYZ& bannerPos, uint8_t direction);
 SurfaceElement* map_get_surface_element_at(const CoordsXY& coords);
 PathElement* map_get_path_element_at(const TileCoordsXYZ& loc);
+PathElement* map_get_first_path_element_at_or_up_from_z(const TileCoordsXYZ& loc);
 WallElement* map_get_wall_element_at(const CoordsXYZD& wallCoords);
 WallElement* map_get_wall_element_at(const CoordsXYRangedZ& coords);
 SmallSceneryElement* map_get_small_scenery_element_at(const CoordsXYZ& sceneryCoords, int32_t type, uint8_t quadrant);

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -169,7 +169,7 @@ int32_t map_height_from_slope(const CoordsXY& coords, int32_t slopeDirection, bo
 BannerElement* map_get_banner_element_at(const CoordsXYZ& bannerPos, uint8_t direction);
 SurfaceElement* map_get_surface_element_at(const CoordsXY& coords);
 PathElement* map_get_path_element_at(const TileCoordsXYZ& loc);
-PathElement* map_get_first_path_element_at_or_up_from_z(const TileCoordsXYZ& loc);
+PathElement* MapGetFirstPathElementWithBaseHeightBetween(const TileCoordsXYRangedZ& loc);
 WallElement* map_get_wall_element_at(const CoordsXYZD& wallCoords);
 WallElement* map_get_wall_element_at(const CoordsXYRangedZ& coords);
 SmallSceneryElement* map_get_small_scenery_element_at(const CoordsXYZ& sceneryCoords, int32_t type, uint8_t quadrant);


### PR DESCRIPTION
If peeps approached a railway crossing from downhill, they would not stop for a passing train. This was because the exact destination z is determined too late. To always get the correct path, get the first footpath at or above the previous z index.

_This is a replacement for PR #18101, where I tried moving the logic deeper into the pathfinding logic. That caused undesired side effects and doesn't seem/feel like the right way to go._

Resolves #17889.