### PR TITLE
fix visual glitch with supports

### DIFF
--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -2225,7 +2225,7 @@ void PaintTrack(paint_session& session, Direction direction, int32_t height, con
             0, ride->track_colour[trackColourScheme].main, ride->track_colour[trackColourScheme].additional);
         session.TrackColours[SCHEME_SUPPORTS] = ImageId(0, ride->track_colour[trackColourScheme].supports);
         session.TrackColours[SCHEME_MISC] = ImageId(0, COLOUR_BLACK);
-        session.TrackColours[SCHEME_3] = ImageId(0, COLOUR_YELLOW);
+        session.TrackColours[SCHEME_3] = ImageId(0, COLOUR_DARK_BROWN);
         if (trackElement.IsHighlighted())
         {
             session.TrackColours[SCHEME_TRACK] = HighlightMarker;


### PR DESCRIPTION
maze and shops get their original support colors instead of yellow
![Github_Park_2022-09-29_04-09-30](https://user-images.githubusercontent.com/94884086/192997703-4a9d0239-d37d-4c0e-ac09-6555d10f50b4.png)
thank you to meehoi