### PR TITLE
Allow building of rides and placing of staff in Scenario Editor's Landscape Editor mode.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -15,6 +15,7 @@
 - Feature: [objects#198] Add additional pirate roofs.
 - Feature: [objects#205] Add additional glass roofs.
 - Feature: [objects#209] Add the Steel Roller Coaster train and 2-across Inverted Train from RollerCoaster Tycoon 1.
+- Feature: [#00000] Allow building of rides in Landscape Editor mode in Scenario Editor
 - Improved: [#15358] Park and scenario names can now contain up to 128 characters.
 - Improved: [#15589] Numpad Enter can now be used to close text input.
 - Improved: [#16819] Don’t prompt to “Save game as” when saving a loaded saved game (excepting autosaves).

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -265,7 +265,7 @@ static void ShortcutBuildNewRide()
     if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
         return;
 
-    if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR))
+    if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gEditorStep == EditorStep::LandscapeEditor)
     {
         if (!(gScreenFlags & (SCREEN_FLAGS_TRACK_DESIGNER | SCREEN_FLAGS_TRACK_MANAGER)))
         {

--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -63,7 +63,11 @@ InteractionInfo ViewportInteractionGetItemLeft(const ScreenCoordsXY& screenCoord
 {
     InteractionInfo info{};
     // No click input for scenario editor or track manager
-    if (gScreenFlags & (SCREEN_FLAGS_SCENARIO_EDITOR | SCREEN_FLAGS_TRACK_MANAGER))
+    if (gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER)
+        return info;
+
+    // No click input in scenario editor if not in landscape designer
+    if ((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && gEditorStep != EditorStep::LandscapeEditor)
         return info;
 
     //
@@ -251,6 +255,10 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
     if (gScreenFlags & (SCREEN_FLAGS_TITLE_DEMO | SCREEN_FLAGS_TRACK_MANAGER))
         return info;
 
+    // No click input in editor unless in landscape mode
+    if ((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && gEditorStep != EditorStep::LandscapeEditor)
+        return info;
+
     //
     if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) && gEditorStep != EditorStep::RollercoasterDesigner)
         return info;
@@ -265,7 +273,7 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
         case ViewportInteractionItem::Entity:
         {
             auto sprite = info.Entity;
-            if ((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || sprite->Type != EntityType::Vehicle)
+            if (sprite->Type != EntityType::Vehicle)
             {
                 info.SpriteType = ViewportInteractionItem::None;
                 return info;
@@ -289,11 +297,6 @@ InteractionInfo ViewportInteractionGetItemRight(const ScreenCoordsXY& screenCoor
         }
         case ViewportInteractionItem::Ride:
         {
-            if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
-            {
-                info.SpriteType = ViewportInteractionItem::None;
-                return info;
-            }
             if (tileElement->GetType() == TileElementType::Path)
             {
                 info.SpriteType = ViewportInteractionItem::None;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -733,9 +733,7 @@ static void WindowTopToolbarInvalidate(rct_window* w)
     if (gScreenFlags & SCREEN_FLAGS_EDITOR)
     {
         window_top_toolbar_widgets[WIDX_PARK].type = WindowWidgetType::Empty;
-        window_top_toolbar_widgets[WIDX_STAFF].type = WindowWidgetType::Empty;
         window_top_toolbar_widgets[WIDX_GUESTS].type = WindowWidgetType::Empty;
-        window_top_toolbar_widgets[WIDX_FINANCES].type = WindowWidgetType::Empty;
         window_top_toolbar_widgets[WIDX_RESEARCH].type = WindowWidgetType::Empty;
         window_top_toolbar_widgets[WIDX_NEWS].type = WindowWidgetType::Empty;
         window_top_toolbar_widgets[WIDX_NETWORK].type = WindowWidgetType::Empty;
@@ -744,17 +742,16 @@ static void WindowTopToolbarInvalidate(rct_window* w)
         {
             window_top_toolbar_widgets[WIDX_LAND].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_WATER].type = WindowWidgetType::Empty;
-        }
-
-        if (gEditorStep != EditorStep::RollercoasterDesigner)
-        {
-            window_top_toolbar_widgets[WIDX_RIDES].type = WindowWidgetType::Empty;
-            window_top_toolbar_widgets[WIDX_CONSTRUCT_RIDE].type = WindowWidgetType::Empty;
-            window_top_toolbar_widgets[WIDX_FASTFORWARD].type = WindowWidgetType::Empty;
+            window_top_toolbar_widgets[WIDX_FINANCES].type = WindowWidgetType::Empty;
+            window_top_toolbar_widgets[WIDX_STAFF].type = WindowWidgetType::Empty;
         }
 
         if (gEditorStep != EditorStep::LandscapeEditor && gEditorStep != EditorStep::RollercoasterDesigner)
         {
+            window_top_toolbar_widgets[WIDX_RIDES].type = WindowWidgetType::Empty;
+            window_top_toolbar_widgets[WIDX_CONSTRUCT_RIDE].type = WindowWidgetType::Empty;
+            window_top_toolbar_widgets[WIDX_FASTFORWARD].type = WindowWidgetType::Empty;
+
             window_top_toolbar_widgets[WIDX_MAP].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_SCENERY].type = WindowWidgetType::Empty;
             window_top_toolbar_widgets[WIDX_PATH].type = WindowWidgetType::Empty;

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -946,28 +946,6 @@ void Ride::UpdateAll()
 {
     PROFILED_FUNCTION();
 
-    // Remove all rides if scenario editor
-    if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
-    {
-        switch (gEditorStep)
-        {
-            case EditorStep::ObjectSelection:
-            case EditorStep::LandscapeEditor:
-            case EditorStep::InventionsListSetUp:
-                for (auto& ride : GetRideManager())
-                    ride.Delete();
-                break;
-            case EditorStep::OptionsSelection:
-            case EditorStep::ObjectiveSelection:
-            case EditorStep::SaveScenario:
-            case EditorStep::RollercoasterDesigner:
-            case EditorStep::DesignsManager:
-            case EditorStep::Invalid:
-                break;
-        }
-        return;
-    }
-
     window_update_viewport_ride_music();
 
     // Update rides
@@ -2026,9 +2004,6 @@ static void ride_measurement_update(Ride& ride, RideMeasurement& measurement)
 void ride_measurements_update()
 {
     PROFILED_FUNCTION();
-
-    if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
-        return;
 
     // For each ride measurement
     for (auto& ride : GetRideManager())

--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -269,7 +269,7 @@ namespace OpenRCT2::RideAudio
      */
     void UpdateMusicChannels()
     {
-        if ((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) != 0 || (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) != 0)
+        if ((gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) != 0)
             return;
 
         // TODO Allow circus music (CSS24) to play if ride music is disabled (that should be sound)
@@ -396,7 +396,7 @@ namespace OpenRCT2::RideAudio
      */
     void UpdateMusicInstance(Ride& ride, const CoordsXYZ& rideCoords, uint16_t sampleRate)
     {
-        if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gGameSoundsOff && g_music_tracking_viewport != nullptr)
+        if (!gGameSoundsOff && g_music_tracking_viewport != nullptr)
         {
             auto rotatedCoords = translate_3d_to_2d_with_z(get_current_rotation(), rideCoords);
             auto viewport = g_music_tracking_viewport;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -121,9 +121,6 @@ void ride_ratings_update_all()
 {
     PROFILED_FUNCTION();
 
-    if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
-        return;
-
     // NOTE: Until the new save format only one ride can be updated at once.
     // The SV6 format can store only a single state.
     ride_ratings_update_state(gRideRatingUpdateState);

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -783,7 +783,7 @@ template<typename T> int32_t Train<T>::Mass()
 
 bool Vehicle::SoundCanPlay() const
 {
-    if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
+    if ((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && gEditorStep != EditorStep::LandscapeEditor)
         return false;
 
     if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) && gEditorStep != EditorStep::RollercoasterDesigner)
@@ -1234,7 +1234,7 @@ void vehicle_update_all()
 {
     PROFILED_FUNCTION();
 
-    if (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
+    if ((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && gEditorStep != EditorStep::LandscapeEditor)
         return;
 
     if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) && gEditorStep != EditorStep::RollercoasterDesigner)


### PR DESCRIPTION
Pretty much does as you would expect it to do. It allows you to hire staff and build rides in the Scenario Editor while in the Landscape Editor mode. 

No netcode changes should be required.