### PR TITLE
Remove format string in server name from Discord rich presence

### DIFF
--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -7,9 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "openrct2/localisation/Formatting.h"
 #ifdef __ENABLE_DISCORD__
-
 #    include "DiscordService.h"
 
 #    include "../Context.h"
@@ -17,6 +15,7 @@
 #    include "../OpenRCT2.h"
 #    include "../core/Console.hpp"
 #    include "../core/String.hpp"
+#    include "../localisation/Formatting.h"
 #    include "../localisation/Localisation.h"
 #    include "../world/Park.h"
 #    include "network.h"
@@ -100,7 +99,6 @@ void DiscordService::RefreshPresence() const
             }
             else
             {
-                
                 OpenRCT2::FmtString fmtServerName(network_get_server_name());
                 std::string serverName;
                 for (const auto& token : fmtServerName)

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include "openrct2/localisation/Formatting.h"
 #ifdef __ENABLE_DISCORD__
 
 #    include "DiscordService.h"
@@ -99,7 +100,24 @@ void DiscordService::RefreshPresence() const
             }
             else
             {
-                state = String::ToStd(network_get_server_name());
+                
+                OpenRCT2::FmtString fmtServerName(network_get_server_name());
+                std::string serverName;
+                for (const auto& token : fmtServerName)
+                {
+                    if (token.IsLiteral())
+                    {
+                        serverName += token.text;
+                    }
+                    else if (token.IsCodepoint())
+                    {
+                        auto codepoint = token.GetCodepoint();
+                        char buffer[8]{};
+                        utf8_write_codepoint(buffer, codepoint);
+                        serverName += buffer;
+                    }
+                }
+                state = serverName;
 
                 // NOTE: the party size is displayed next to state
                 discordPresence.partyId = network_get_server_name();


### PR DESCRIPTION
As I said in [this comment](https://github.com/OpenRCT2/OpenRCT2/issues/18109#issuecomment-1261769987) `FmtString::WithoutFormatTokens` removes `{}` from escape string and I don't want to modify it. So I add directly to `DiscordService`. But tell me if you want me to modify `FmtString::WithoutFormatTokens` instead.

Fix #18109