### PR TITLE
[Plugin] Widget tooltips can now be read and changed.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Improved: [#17909] Track elements that are not supported by any train are now hidden by default.
 - Improved: [#17924] Improved performance when loading JSON object images from a .DAT file.
 - Improved: [#17955] Modifying ratings via in-game console is now multiplayer-safe and also freezes the ratings.
+- Improved: [#18177] [Plugin] Widget tooltips can now be read and changed.
 - Change: [#9104] Calculate maze support costs.
 - Change: [#17319] Giant screenshots are now cropped to the horizontal view-clipping selection.
 - Change: [#17499] Update error text when using vehicle incompatible with TD6 and add error when using incompatible track elements.
@@ -79,7 +80,7 @@
 - Fix: [#17973] Bins and lamps overlay parts of the land (original bug).
 - Fix: [#18008] Steeplechase S-bends has multiple gaps visible in the tracks (original bug).
 - Fix: [#18009] Visual glitch with litter at edge of sloped path.
-- Fix: [#18025] Fix land ownership in Six Holland, Six Flags Magic Mountain, North America - Grand Canyon and Asia - Great Wall of China Tourism Enhancement scenarios. 
+- Fix: [#18025] Fix land ownership in Six Holland, Six Flags Magic Mountain, North America - Grand Canyon and Asia - Great Wall of China Tourism Enhancement scenarios.
 - Fix: [#18026] Park rating drops to 0 with more than 32k guests, total ride excitement or intensity.
 - Fix: [#18032] All non-interactive widgets (labels, groupboxes) produce sound when clicked.
 - Fix: [#18035] Favourited servers don’t get their online status updated.

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -963,11 +963,8 @@ namespace OpenRCT2::Ui::Windows
             widget.bottom = desc.Y + desc.Height - 1;
             widget.content = std::numeric_limits<uint32_t>::max();
             widget.tooltip = STR_NONE;
-            if (!desc.Tooltip.empty())
-            {
-                widget.sztooltip = const_cast<utf8*>(desc.Tooltip.c_str());
-                widget.flags |= WIDGET_FLAGS::TOOLTIP_IS_STRING;
-            }
+            widget.sztooltip = const_cast<utf8*>(desc.Tooltip.c_str());
+            widget.flags |= WIDGET_FLAGS::TOOLTIP_IS_STRING;
             if (desc.IsDisabled)
                 widget.flags |= WIDGET_FLAGS::IS_DISABLED;
             if (!desc.IsVisible)
@@ -1402,6 +1399,33 @@ namespace OpenRCT2::Ui::Windows
             if (customWidgetInfo != nullptr)
             {
                 customWidgetInfo->Name = std::string(name);
+            }
+        }
+    }
+
+    std::string GetWidgetTooltip(rct_window* w, WidgetIndex widgetIndex)
+    {
+        if (w->custom_info != nullptr)
+        {
+            const auto& customInfo = GetInfo(w);
+            auto customWidgetInfo = customInfo.GetCustomWidgetDesc(w, widgetIndex);
+            if (customWidgetInfo != nullptr)
+            {
+                return customWidgetInfo->Tooltip;
+            }
+        }
+        return {};
+    }
+
+    void SetWidgetTooltip(rct_window* w, WidgetIndex widgetIndex, std::string_view tooltip)
+    {
+        if (w->custom_info != nullptr)
+        {
+            auto& customInfo = GetInfo(w);
+            auto customWidgetInfo = customInfo.GetCustomWidgetDesc(w, widgetIndex);
+            if (customWidgetInfo != nullptr)
+            {
+                customWidgetInfo->Tooltip = std::string(tooltip);
             }
         }
     }

--- a/src/openrct2-ui/scripting/CustomWindow.h
+++ b/src/openrct2-ui/scripting/CustomWindow.h
@@ -35,6 +35,8 @@ namespace OpenRCT2::Ui::Windows
     std::optional<WidgetIndex> FindWidgetIndexByName(rct_window* w, std::string_view name);
     std::string GetWidgetName(rct_window* w, WidgetIndex widgetIndex);
     void SetWidgetName(rct_window* w, WidgetIndex widgetIndex, std::string_view name);
+    std::string GetWidgetTooltip(rct_window* w, WidgetIndex widgetIndex);
+    void SetWidgetTooltip(rct_window* w, WidgetIndex widgetIndex, std::string_view tooltip);
     CustomListView* GetCustomListView(rct_window* w, WidgetIndex widgetIndex);
     int32_t GetWidgetMaxLength(rct_window* w, WidgetIndex widgetIndex);
     void SetWidgetMaxLength(rct_window* w, WidgetIndex widgetIndex, int32_t value);

--- a/src/openrct2-ui/scripting/ScWidget.hpp
+++ b/src/openrct2-ui/scripting/ScWidget.hpp
@@ -291,6 +291,24 @@ namespace OpenRCT2::Scripting
             }
         }
 
+        std::string tooltip_get() const
+        {
+            auto w = GetWindow();
+            if (w != nullptr && IsCustomWindow())
+            {
+                return OpenRCT2::Ui::Windows::GetWidgetTooltip(w, _widgetIndex);
+            }
+            return {};
+        }
+        void tooltip_set(const std::string& value)
+        {
+            auto w = GetWindow();
+            if (w != nullptr && IsCustomWindow())
+            {
+                OpenRCT2::Ui::Windows::SetWidgetTooltip(w, _widgetIndex, value);
+            }
+        }
+
         bool isDisabled_get() const
         {
             auto w = GetWindow();

--- a/src/openrct2-ui/scripting/UiExtensions.cpp
+++ b/src/openrct2-ui/scripting/UiExtensions.cpp
@@ -76,6 +76,7 @@ void ScWidget::Register(duk_context* ctx)
     dukglue_register_property(ctx, &ScWidget::y_get, &ScWidget::y_set, "y");
     dukglue_register_property(ctx, &ScWidget::width_get, &ScWidget::width_set, "width");
     dukglue_register_property(ctx, &ScWidget::height_get, &ScWidget::height_set, "height");
+    dukglue_register_property(ctx, &ScWidget::tooltip_get, &ScWidget::tooltip_set, "tooltip");
     dukglue_register_property(ctx, &ScWidget::isDisabled_get, &ScWidget::isDisabled_set, "isDisabled");
     dukglue_register_property(ctx, &ScWidget::isVisible_get, &ScWidget::isVisible_set, "isVisible");
 }

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -116,9 +116,13 @@ void WindowTooltipOpen(rct_window* widgetWindow, WidgetIndex widgetIndex, const 
     OpenRCT2String result;
     if (widget->flags & WIDGET_FLAGS::TOOLTIP_IS_STRING)
     {
+        auto tooltipString = widget->sztooltip;
+        if (*tooltipString == 0)
+            return;
+
         result.str = STR_STRING_TOOLTIP;
         result.args = Formatter();
-        result.args.Add<const char*>(widget->sztooltip);
+        result.args.Add<const char*>(tooltipString);
 
         gTooltipWidget.window_classification = widgetWindow->classification;
         gTooltipWidget.window_number = widgetWindow->number;

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -46,7 +46,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 61;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 62;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;


### PR DESCRIPTION
This PR adds the ability to read and change widget tooltips of custom windows.

The check if the tooltip is empty was moved to `WindowTooltipOpen`. Otherwise it would be neccessary to have two checks: When a widget is created and when the tooltip is updated.