### PR TITLE
Fix #17664: Ride music channel data leaks when stopping inactive music

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -58,6 +58,7 @@
 - Fix: [#17600] Notifications are not properly cleared when loading a park.
 - Fix: [#17605] Crash when opening parks which have had objects removed externally.
 - Fix: [#17639, 17735] When building upside down, the special elements list contains many items twice (original bug).
+- Fix: [#17664] Unable to save after an extended period of time due to inactive ride music data leaking.
 - Fix: [#17703] (undefined string) when building on invalid height.
 - Fix: [#17776] “Other Parks” tab uses separate lists for SC4/SC6 and .park scenarios.
 - Fix: [#17784] Colour preset RNG is biased (original bug).

--- a/src/openrct2/ride/RideAudio.cpp
+++ b/src/openrct2/ride/RideAudio.cpp
@@ -77,6 +77,8 @@ namespace OpenRCT2::RideAudio
 
         RideMusicChannel& operator=(RideMusicChannel&& src) noexcept
         {
+            using std::swap;
+
             RideId = src.RideId;
             TrackIndex = src.TrackIndex;
 
@@ -85,15 +87,8 @@ namespace OpenRCT2::RideAudio
             Pan = src.Pan;
             Frequency = src.Frequency;
 
-            if (Channel != nullptr)
-            {
-                Channel->Stop();
-            }
-            Channel = src.Channel;
-            src.Channel = nullptr;
-
-            Source = src.Source;
-            src.Source = nullptr;
+            swap(Channel, src.Channel);
+            swap(Source, src.Source);
 
             return *this;
         }
@@ -103,12 +98,10 @@ namespace OpenRCT2::RideAudio
             if (Channel != nullptr)
             {
                 Channel->Stop();
-                Channel = nullptr;
-                if (Source != nullptr)
-                {
-                    Source->Release();
-                    Source = nullptr;
-                }
+            }
+            if (Source != nullptr)
+            {
+                Source->Release();
             }
         }
 


### PR DESCRIPTION
Fixes a resource leak in `RideMusicChannel`'s move operator that caused the music source data to stick around. This kept the music file handles open while opening new handles the next time a new channel was created. The limit of open handles is still relatively low, at least on Windows (512), and so moving the camera enough times to start and stop enough ride music sources would eventually lead to the handles pool running out, leading to effects such as:
* Music not playing (can't open files for read)
* **Inability to save** (can't open files for write)

To make the move operator truly `noexcept`, instead of releasing sources in the function body I opted for a swap idiom, letting the moved-from object's destructor deal with it. I have verified **all** uses of `RideMusicChannel` against wrong assumptions, and they all deal with the moved-from object properly.

Fixes #17664.