### PR TITLE
Fix #18174: Height marks on land do not appear

### DIFF
--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1088,11 +1088,11 @@ void PaintSurface(paint_session& session, uint8_t direction, uint16_t height, co
         int32_t surfaceHeight = tile_element_height({ x + 16, y + 16 });
         int32_t dx = surfaceHeight + 3;
 
-        int32_t image_id = (SPR_HEIGHT_MARKER_BASE + dx / 16) | 0x20780000;
+        int32_t image_id = (SPR_HEIGHT_MARKER_BASE + dx / 16);
         image_id += get_height_marker_offset();
         image_id -= gMapBaseZ;
 
-        PaintAddImageAsParent(session, ImageId(image_id), { 16, 16, surfaceHeight }, { 1, 1, 0 });
+        PaintAddImageAsParent(session, ImageId(image_id, COLOUR_OLIVE_GREEN), { 16, 16, surfaceHeight }, { 1, 1, 0 });
     }
 
     bool has_surface = false;


### PR DESCRIPTION
Image from my fixes (Left: 0.4.1 release, Right: My fix)
![Screenshot 2022-10-03 195022](https://user-images.githubusercontent.com/1791353/193581830-d208b01b-bf25-4182-92f6-a2655c35b31d.png)

Unit label:
![Screenshot 2022-10-03 195241](https://user-images.githubusercontent.com/1791353/193581845-984ac5d1-cec3-4dcd-91be-92095745ab70.png)


Fix #18174