### PR TITLE
Code Style: Remove snakes from entrances and footpaths

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -620,7 +620,7 @@ static void ViewportInteractionRemoveFootpath(TileElement* tileElement, const Co
 
     w = window_find_by_class(WindowClass::Footpath);
     if (w != nullptr)
-        footpath_provisional_update();
+        FootpathProvisionalUpdate();
 
     tileElement2 = map_get_first_element_at(mapCoords);
     if (tileElement2 == nullptr)

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -228,7 +228,7 @@ rct_window* WindowFootpathOpen()
  */
 static void WindowFootpathClose(rct_window* w)
 {
-    footpath_provisional_update();
+    FootpathProvisionalUpdate();
     viewport_set_visibility(0);
     map_invalidate_map_selection_tiles();
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
@@ -261,7 +261,7 @@ static void WindowFootpathMouseup(rct_window* w, WidgetIndex widgetIndex)
 
             _window_footpath_cost = MONEY32_UNDEFINED;
             tool_cancel();
-            footpath_provisional_update();
+            FootpathProvisionalUpdate();
             map_invalidate_map_selection_tiles();
             gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
             _footpathConstructionMode = PATH_CONSTRUCTION_MODE_LAND;
@@ -278,7 +278,7 @@ static void WindowFootpathMouseup(rct_window* w, WidgetIndex widgetIndex)
 
             _window_footpath_cost = MONEY32_UNDEFINED;
             tool_cancel();
-            footpath_provisional_update();
+            FootpathProvisionalUpdate();
             map_invalidate_map_selection_tiles();
             gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
             _footpathConstructionMode = PATH_CONSTRUCTION_MODE_BRIDGE_OR_TUNNEL_TOOL;
@@ -376,7 +376,7 @@ static void WindowFootpathDropdown(rct_window* w, WidgetIndex widgetIndex, int32
         return;
     }
 
-    footpath_provisional_update();
+    FootpathProvisionalUpdate();
     _window_footpath_cost = MONEY32_UNDEFINED;
     w->Invalidate();
 }
@@ -451,7 +451,7 @@ static void WindowFootpathUpdateProvisionalPathForBridgeMode(rct_window* w)
     // Recheck area for construction. Set by ride_construction window
     if (gProvisionalFootpath.Flags & PROVISIONAL_PATH_FLAG_2)
     {
-        footpath_provisional_remove();
+        FootpathProvisionalRemove();
         gProvisionalFootpath.Flags &= ~PROVISIONAL_PATH_FLAG_2;
     }
 
@@ -466,7 +466,7 @@ static void WindowFootpathUpdateProvisionalPathForBridgeMode(rct_window* w)
         FootpathGetNextPathInfo(&type, footpathLoc, &slope);
         auto pathConstructFlags = FootpathCreateConstructFlags(type);
 
-        _window_footpath_cost = footpath_provisional_set(type, railings, footpathLoc, slope, pathConstructFlags);
+        _window_footpath_cost = FootpathProvisionalSet(type, railings, footpathLoc, slope, pathConstructFlags);
         widget_invalidate(*w, WIDX_CONSTRUCT);
     }
 
@@ -824,7 +824,7 @@ static void WindowFootpathShowRailingsTypesDialog(rct_window* w, rct_widget* wid
  */
 static void WindowFootpathMousedownDirection(int32_t direction)
 {
-    footpath_provisional_update();
+    FootpathProvisionalUpdate();
     _footpathConstructDirection = (direction - get_current_rotation()) & 3;
     _window_footpath_cost = MONEY32_UNDEFINED;
     WindowFootpathSetEnabledAndPressedWidgets();
@@ -836,7 +836,7 @@ static void WindowFootpathMousedownDirection(int32_t direction)
  */
 static void WindowFootpathMousedownSlope(int32_t slope)
 {
-    footpath_provisional_update();
+    FootpathProvisionalUpdate();
     gFootpathConstructSlope = slope;
     _window_footpath_cost = MONEY32_UNDEFINED;
     WindowFootpathSetEnabledAndPressedWidgets();
@@ -857,7 +857,7 @@ static void WindowFootpathSetProvisionalPathAtPoint(const ScreenCoordsXY& screen
     if (info.SpriteType == ViewportInteractionItem::None || info.Element == nullptr)
     {
         gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
-        footpath_provisional_update();
+        FootpathProvisionalUpdate();
     }
     else
     {
@@ -874,7 +874,7 @@ static void WindowFootpathSetProvisionalPathAtPoint(const ScreenCoordsXY& screen
         gMapSelectPositionA = info.Loc;
         gMapSelectPositionB = info.Loc;
 
-        footpath_provisional_update();
+        FootpathProvisionalUpdate();
 
         // Set provisional path
         int32_t slope = 0;
@@ -914,7 +914,7 @@ static void WindowFootpathSetProvisionalPathAtPoint(const ScreenCoordsXY& screen
 
         auto pathType = gFootpathSelection.GetSelectedSurface();
         auto constructFlags = FootpathCreateConstructFlags(pathType);
-        _window_footpath_cost = footpath_provisional_set(
+        _window_footpath_cost = FootpathProvisionalSet(
             pathType, gFootpathSelection.Railings, { info.Loc, z }, slope, constructFlags);
         window_invalidate_by_class(WindowClass::Footpath);
     }
@@ -933,7 +933,7 @@ static void WindowFootpathSetSelectionStartBridgeAtPoint(const ScreenCoordsXY& s
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
 
-    auto mapCoords = footpath_bridge_get_info_from_pos(screenCoords, &direction, &tileElement);
+    auto mapCoords = FootpathBridgeGetInfoFromPos(screenCoords, &direction, &tileElement);
     if (mapCoords.IsNull())
     {
         return;
@@ -975,7 +975,7 @@ static void WindowFootpathPlacePathAtPoint(const ScreenCoordsXY& screenCoords)
         return;
     }
 
-    footpath_provisional_update();
+    FootpathProvisionalUpdate();
 
     const auto info = get_map_coordinates_from_pos(
         screenCoords, EnumsToFlags(ViewportInteractionItem::Terrain, ViewportInteractionItem::Footpath));
@@ -1041,7 +1041,7 @@ static void WindowFootpathStartBridgeAtPoint(const ScreenCoordsXY& screenCoords)
     int32_t z, direction;
     TileElement* tileElement;
 
-    auto mapCoords = footpath_bridge_get_info_from_pos(screenCoords, &direction, &tileElement);
+    auto mapCoords = FootpathBridgeGetInfoFromPos(screenCoords, &direction, &tileElement);
     if (mapCoords.IsNull())
     {
         return;
@@ -1096,7 +1096,7 @@ static void WindowFootpathStartBridgeAtPoint(const ScreenCoordsXY& screenCoords)
 static void WindowFootpathConstruct()
 {
     _window_footpath_cost = MONEY32_UNDEFINED;
-    footpath_provisional_update();
+    FootpathProvisionalUpdate();
 
     ObjectEntryIndex type;
     int32_t slope;
@@ -1252,7 +1252,7 @@ static void WindowFootpathRemove()
     TileElement* tileElement;
 
     _window_footpath_cost = MONEY32_UNDEFINED;
-    footpath_provisional_update();
+    FootpathProvisionalUpdate();
 
     tileElement = FootpathGetTileElementToRemove();
     if (tileElement != nullptr)

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -917,7 +917,7 @@ private:
 
         gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
 
-        auto mapCoords = footpath_get_coordinates_from_pos({ screenCoords.x, screenCoords.y + 16 }, nullptr, nullptr);
+        auto mapCoords = FootpathGetCoordinatesFromPos({ screenCoords.x, screenCoords.y + 16 }, nullptr, nullptr);
         if (!mapCoords.IsNull())
         {
             gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
@@ -958,7 +958,7 @@ private:
             return;
 
         TileElement* tileElement;
-        auto destCoords = footpath_get_coordinates_from_pos({ screenCoords.x, screenCoords.y + 16 }, nullptr, &tileElement);
+        auto destCoords = FootpathGetCoordinatesFromPos({ screenCoords.x, screenCoords.y + 16 }, nullptr, &tileElement);
 
         if (destCoords.IsNull())
             return;

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -550,7 +550,7 @@ public:
         map_invalidate_selection_rect();
         gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
         gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
-        auto mapCoords = footpath_bridge_get_info_from_pos(screenCoords, &direction, &tileElement);
+        auto mapCoords = FootpathBridgeGetInfoFromPos(screenCoords, &direction, &tileElement);
         if (mapCoords.IsNull())
             return;
 
@@ -578,7 +578,7 @@ public:
         // Verify footpath exists at location, and retrieve coordinates
         TileElement* tileElement;
         int32_t direction;
-        auto mapCoords = footpath_get_coordinates_from_pos(screenCoords, &direction, &tileElement);
+        auto mapCoords = FootpathGetCoordinatesFromPos(screenCoords, &direction, &tileElement);
         if (mapCoords.IsNull())
             return;
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -410,7 +410,7 @@ public:
                 hide_construction_rights();
                 break;
             case WIDX_BUILD_PARK_ENTRANCE:
-                park_entrance_remove_ghost();
+                ParkEntranceRemoveGhost();
                 Invalidate();
                 hide_gridlines();
                 hide_land_rights();
@@ -492,7 +492,7 @@ public:
         CoordsXYZD parkEntrancePosition = PlaceParkEntranceGetMapPosition(screenCoords);
         if (parkEntrancePosition.IsNull())
         {
-            park_entrance_remove_ghost();
+            ParkEntranceRemoveGhost();
             return;
         }
 
@@ -514,7 +514,7 @@ public:
             return;
         }
 
-        park_entrance_remove_ghost();
+        ParkEntranceRemoveGhost();
 
         auto gameAction = PlaceParkEntranceAction(parkEntrancePosition, gFootpathSelectedId);
         gameAction.SetFlags(GAME_COMMAND_FLAG_GHOST);
@@ -529,7 +529,7 @@ public:
 
     void PlaceParkEntranceToolDown(const ScreenCoordsXY& screenCoords)
     {
-        park_entrance_remove_ghost();
+        ParkEntranceRemoveGhost();
 
         CoordsXYZD parkEntrancePosition = PlaceParkEntranceGetMapPosition(screenCoords);
         if (!parkEntrancePosition.IsNull())

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -280,7 +280,7 @@ private:
 
     std::optional<CoordsXY> GetBestCoordsFromPos(const ScreenCoordsXY& pos)
     {
-        auto coords = footpath_get_coordinates_from_pos(pos, nullptr, nullptr);
+        auto coords = FootpathGetCoordinatesFromPos(pos, nullptr, nullptr);
         return coords.IsNull() ? std::nullopt : std::make_optional(coords);
     }
 };

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3363,7 +3363,7 @@ void ride_construction_toolupdate_construct(const ScreenCoordsXY& screenCoords)
                 continue;
             }
 
-            pathsByDir[i] = map_get_footpath_element(testLoc);
+            pathsByDir[i] = MapGetFootpathElement(testLoc);
 
             if (pathsByDir[i] != nullptr && (pathsByDir[i])->AsPath()->IsSloped()
                 && (pathsByDir[i])->AsPath()->GetSlopeDirection() != i)
@@ -3374,7 +3374,7 @@ void ride_construction_toolupdate_construct(const ScreenCoordsXY& screenCoords)
             // Sloped path on the level below
             if (pathsByDir[i] == nullptr)
             {
-                pathsByDir[i] = map_get_footpath_element({ *mapCoords + CoordsDirectionDelta[i], z - PATH_HEIGHT_STEP });
+                pathsByDir[i] = MapGetFootpathElement({ *mapCoords + CoordsDirectionDelta[i], z - PATH_HEIGHT_STEP });
 
                 if (pathsByDir[i] != nullptr
                     && (!(pathsByDir[i])->AsPath()->IsSloped()

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -3453,7 +3453,7 @@ void ride_construction_toolupdate_entrance_exit(const ScreenCoordsXY& screenCoor
         auto ride = get_ride(_currentRideIndex);
         if (ride != nullptr)
         {
-            _currentTrackPrice = ride_entrance_exit_place_ghost(
+            _currentTrackPrice = RideEntranceExitPlaceGhost(
                 ride, entranceOrExitCoords, entranceOrExitCoords.direction, gRideEntranceExitPlaceType, stationNum);
         }
         window_ride_construction_update_active_elements();

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -655,7 +655,7 @@ private:
 
         gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE;
 
-        auto mapCoords = footpath_get_coordinates_from_pos({ screenCoords.x, screenCoords.y + 16 }, nullptr, nullptr);
+        auto mapCoords = FootpathGetCoordinatesFromPos({ screenCoords.x, screenCoords.y + 16 }, nullptr, nullptr);
         if (!mapCoords.IsNull())
         {
             gMapSelectFlags |= MAP_SELECT_FLAG_ENABLE;
@@ -695,7 +695,7 @@ private:
 
         const auto staffEntityId = EntityId::FromUnderlying(number);
         TileElement* tileElement;
-        auto destCoords = footpath_get_coordinates_from_pos({ screenCoords.x, screenCoords.y + 16 }, nullptr, &tileElement);
+        auto destCoords = FootpathGetCoordinatesFromPos({ screenCoords.x, screenCoords.y + 16 }, nullptr, &tileElement);
 
         if (destCoords.IsNull())
             return;

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -590,7 +590,7 @@ private:
     {
         int32_t direction{};
         TileElement* tileElement{};
-        auto footpathCoords = footpath_get_coordinates_from_pos(screenCoords, &direction, &tileElement);
+        auto footpathCoords = FootpathGetCoordinatesFromPos(screenCoords, &direction, &tileElement);
         if (footpathCoords.IsNull())
             return nullptr;
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1320,7 +1320,7 @@ public:
                     {
                         // TODO: Make this work with Left/Right park entrance parts
                         ft = Formatter();
-                        ft.Add<StringId>(park_entrance_get_index({ _toolMap, tileElement->GetBaseZ() }));
+                        ft.Add<StringId>(ParkEntranceGetIndex({ _toolMap, tileElement->GetBaseZ() }));
                         DrawTextBasic(
                             &dpi, screenCoords + ScreenCoordsXY{ 0, 11 }, STR_TILE_INSPECTOR_ENTRANCE_ENTRANCE_ID, ft,
                             { colours[1] });

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -545,7 +545,7 @@ namespace Editor
         {
             int32_t direction = direction_reverse(parkEntrance.direction);
 
-            switch (footpath_is_connected_to_map_edge(parkEntrance, direction, 0))
+            switch (FootpathIsConnectedToMapEdge(parkEntrance, direction, 0))
             {
                 case FOOTPATH_SEARCH_NOT_FOUND:
                     return { false, STR_PARK_ENTRANCE_WRONG_DIRECTION_OR_NO_PATH };
@@ -554,7 +554,7 @@ namespace Editor
                     return { false, STR_PARK_ENTRANCE_PATH_INCOMPLETE_OR_COMPLEX };
                 case FOOTPATH_SEARCH_SUCCESS:
                     // Run the search again and unown the path
-                    footpath_is_connected_to_map_edge(parkEntrance, direction, (1 << 5));
+                    FootpathIsConnectedToMapEdge(parkEntrance, direction, (1 << 5));
                     break;
             }
         }

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -450,7 +450,7 @@ void game_fix_save_vars()
     fix_invalid_vehicle_sprite_sizes();
 
     // Fix gParkEntrance locations for which the tile_element no longer exists
-    fix_park_entrance_locations();
+    ParkEntranceFixLocations();
 
     UpdateConsolidatedPatrolAreas();
 }

--- a/src/openrct2/actions/FootpathAdditionPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathAdditionPlaceAction.cpp
@@ -70,7 +70,7 @@ GameActions::Result FootpathAdditionPlaceAction::Query() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_TOO_HIGH);
     }
 
-    auto tileElement = map_get_footpath_element(_loc);
+    auto tileElement = MapGetFootpathElement(_loc);
     if (tileElement == nullptr)
     {
         log_error("Could not find path element.");
@@ -145,7 +145,7 @@ GameActions::Result FootpathAdditionPlaceAction::Execute() const
     res.Position = _loc;
     res.Expenditure = ExpenditureType::Landscaping;
 
-    auto tileElement = map_get_footpath_element(_loc);
+    auto tileElement = MapGetFootpathElement(_loc);
     auto pathElement = tileElement->AsPath();
 
     if (pathElement == nullptr)
@@ -178,7 +178,7 @@ GameActions::Result FootpathAdditionPlaceAction::Execute() const
     }
     else
     {
-        footpath_interrupt_peeps(_loc);
+        FootpathInterruptPeeps(_loc);
     }
 
     if ((_pathItemType != 0 && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))

--- a/src/openrct2/actions/FootpathAdditionRemoveAction.cpp
+++ b/src/openrct2/actions/FootpathAdditionRemoveAction.cpp
@@ -64,7 +64,7 @@ GameActions::Result FootpathAdditionRemoveAction::Query() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_REMOVE_THIS, STR_TOO_HIGH);
     }
 
-    auto tileElement = map_get_footpath_element(_loc);
+    auto tileElement = MapGetFootpathElement(_loc);
     if (tileElement == nullptr)
     {
         log_warning("Could not find path element.");
@@ -91,12 +91,12 @@ GameActions::Result FootpathAdditionRemoveAction::Query() const
 
 GameActions::Result FootpathAdditionRemoveAction::Execute() const
 {
-    auto tileElement = map_get_footpath_element(_loc);
+    auto tileElement = MapGetFootpathElement(_loc);
     auto pathElement = tileElement->AsPath();
 
     if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
-        footpath_interrupt_peeps(_loc);
+        FootpathInterruptPeeps(_loc);
     }
 
     if (pathElement == nullptr)

--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -102,7 +102,7 @@ GameActions::Result FootpathPlaceAction::Query() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_BUILD_FOOTPATH_HERE, STR_NONE);
     }
 
-    footpath_provisional_remove();
+    FootpathProvisionalRemove();
     auto tileElement = map_get_footpath_element_slope(_loc, _slope);
     if (tileElement == nullptr)
     {
@@ -120,7 +120,7 @@ GameActions::Result FootpathPlaceAction::Execute() const
 
     if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
-        footpath_interrupt_peeps(_loc);
+        FootpathInterruptPeeps(_loc);
     }
 
     gFootpathGroundFlags = 0;
@@ -218,11 +218,11 @@ GameActions::Result FootpathPlaceAction::ElementUpdateExecute(PathElement* pathE
         res.Cost += 6.00_GBP;
     }
 
-    footpath_queue_chain_reset();
+    FootpathQueueChainReset();
 
     if (!(GetFlags() & GAME_COMMAND_FLAG_TRACK_DESIGN))
     {
-        footpath_remove_edges_at(_loc, reinterpret_cast<TileElement*>(pathElement));
+        FootpathRemoveEdgesAt(_loc, reinterpret_cast<TileElement*>(pathElement));
     }
 
     if (_constructFlags & PathConstructFlag::IsLegacyPathObject)
@@ -339,7 +339,7 @@ GameActions::Result FootpathPlaceAction::ElementInsertExecute(GameActions::Resul
 
     if (!(GetFlags() & (GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_GHOST)))
     {
-        footpath_remove_litter(_loc);
+        FootpathRemoveLitter(_loc);
     }
 
     res.Cost = 12.00_GBP;
@@ -428,11 +428,11 @@ GameActions::Result FootpathPlaceAction::ElementInsertExecute(GameActions::Resul
         pathElement->SetIsBroken(false);
         pathElement->SetGhost(GetFlags() & GAME_COMMAND_FLAG_GHOST);
 
-        footpath_queue_chain_reset();
+        FootpathQueueChainReset();
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_TRACK_DESIGN))
         {
-            footpath_remove_edges_at(_loc, pathElement->as<TileElement>());
+            FootpathRemoveEdgesAt(_loc, pathElement->as<TileElement>());
         }
         if ((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
@@ -492,7 +492,7 @@ void FootpathPlaceAction::RemoveIntersectingWalls(PathElement* pathElement) cons
         wall_remove_intersecting_walls({ _loc, z, z + (6 * COORDS_Z_STEP) }, direction_reverse(direction));
         wall_remove_intersecting_walls({ _loc, z, z + (6 * COORDS_Z_STEP) }, direction);
         // Removing walls may have made the pointer invalid, so find it again
-        auto tileElement = map_get_footpath_element(CoordsXYZ(_loc, z));
+        auto tileElement = MapGetFootpathElement(CoordsXYZ(_loc, z));
         if (tileElement == nullptr)
         {
             log_error("Something went wrong. Could not refind footpath.");
@@ -502,9 +502,9 @@ void FootpathPlaceAction::RemoveIntersectingWalls(PathElement* pathElement) cons
     }
 
     if (!(GetFlags() & GAME_COMMAND_FLAG_TRACK_DESIGN))
-        footpath_connect_edges(_loc, reinterpret_cast<TileElement*>(pathElement), GetFlags());
+        FootpathConnectEdges(_loc, reinterpret_cast<TileElement*>(pathElement), GetFlags());
 
-    footpath_update_queue_chains();
+    FootpathUpdateQueueChains();
     map_invalidate_tile_full(_loc);
 }
 

--- a/src/openrct2/actions/FootpathPlaceFromTrackAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceFromTrackAction.cpp
@@ -93,7 +93,7 @@ GameActions::Result FootpathPlaceFromTrackAction::Execute() const
 
     if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
-        footpath_interrupt_peeps(_loc);
+        FootpathInterruptPeeps(_loc);
     }
 
     gFootpathGroundFlags = 0;
@@ -182,7 +182,7 @@ GameActions::Result FootpathPlaceFromTrackAction::ElementInsertExecute(GameActio
 
     if (!(GetFlags() & (GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED | GAME_COMMAND_FLAG_GHOST)))
     {
-        footpath_remove_litter(_loc);
+        FootpathRemoveLitter(_loc);
     }
 
     res.Cost = 12.00_GBP;

--- a/src/openrct2/actions/FootpathRemoveAction.cpp
+++ b/src/openrct2/actions/FootpathRemoveAction.cpp
@@ -82,23 +82,23 @@ GameActions::Result FootpathRemoveAction::Execute() const
 
     if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
-        footpath_interrupt_peeps(_loc);
-        footpath_remove_litter(_loc);
+        FootpathInterruptPeeps(_loc);
+        FootpathRemoveLitter(_loc);
     }
 
     TileElement* footpathElement = GetFootpathElement();
     if (footpathElement != nullptr)
     {
-        footpath_queue_chain_reset();
+        FootpathQueueChainReset();
         auto bannerRes = RemoveBannersAtElement(_loc, footpathElement);
         if (bannerRes.Error == GameActions::Status::Ok)
         {
             res.Cost += bannerRes.Cost;
         }
-        footpath_remove_edges_at(_loc, footpathElement);
+        FootpathRemoveEdgesAt(_loc, footpathElement);
         map_invalidate_tile_full(_loc);
         tile_element_remove(footpathElement);
-        footpath_update_queue_chains();
+        FootpathUpdateQueueChains();
 
         // Remove the spawn point (if there is one in the current tile)
         gPeepSpawns.erase(
@@ -125,7 +125,7 @@ TileElement* FootpathRemoveAction::GetFootpathElement() const
 {
     bool getGhostPath = GetFlags() & GAME_COMMAND_FLAG_GHOST;
 
-    TileElement* tileElement = map_get_footpath_element(_loc);
+    TileElement* tileElement = MapGetFootpathElement(_loc);
     TileElement* footpathElement = nullptr;
     if (tileElement != nullptr)
     {

--- a/src/openrct2/actions/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/LandSetHeightAction.cpp
@@ -100,7 +100,7 @@ GameActions::Result LandSetHeightAction::Query() const
     // We need to check if there is _currently_ a level crossing on the tile.
     // For that, we need the old height, so we can't use the _height variable.
     auto oldCoords = CoordsXYZ{ _coords, surfaceElement->GetBaseZ() };
-    auto* pathElement = map_get_footpath_element(oldCoords);
+    auto* pathElement = MapGetFootpathElement(oldCoords);
     if (pathElement != nullptr && pathElement->AsPath()->IsLevelCrossing(oldCoords))
     {
         return GameActions::Result(GameActions::Status::Disallowed, STR_REMOVE_LEVEL_CROSSING_FIRST, STR_NONE);
@@ -145,7 +145,7 @@ GameActions::Result LandSetHeightAction::Execute() const
 {
     money32 cost = 0.00_GBP;
     auto surfaceHeight = tile_element_height(_coords);
-    footpath_remove_litter({ _coords, surfaceHeight });
+    FootpathRemoveLitter({ _coords, surfaceHeight });
 
     if (!gCheatsDisableClearanceChecks)
     {

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -274,7 +274,7 @@ GameActions::Result LargeSceneryPlaceAction::Execute() const
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            footpath_remove_litter({ curTile, zLow });
+            FootpathRemoveLitter({ curTile, zLow });
             if (!gCheatsDisableClearanceChecks)
             {
                 wall_remove_at({ curTile, zLow, zHigh });

--- a/src/openrct2/actions/MazePlaceTrackAction.cpp
+++ b/src/openrct2/actions/MazePlaceTrackAction.cpp
@@ -144,7 +144,7 @@ GameActions::Result MazePlaceTrackAction::Execute() const
     uint32_t flags = GetFlags();
     if (!(flags & GAME_COMMAND_FLAG_GHOST))
     {
-        footpath_remove_litter(_loc);
+        FootpathRemoveLitter(_loc);
         wall_remove_at({ _loc.ToTileStart(), _loc.z, _loc.z + 32 });
     }
 

--- a/src/openrct2/actions/MazeSetTrackAction.cpp
+++ b/src/openrct2/actions/MazeSetTrackAction.cpp
@@ -166,7 +166,7 @@ GameActions::Result MazeSetTrackAction::Execute() const
     uint32_t flags = GetFlags();
     if (!(flags & GAME_COMMAND_FLAG_GHOST))
     {
-        footpath_remove_litter(_loc);
+        FootpathRemoveLitter(_loc);
         wall_remove_at({ _loc.ToTileStart(), _loc.z, _loc.z + 32 });
     }
 

--- a/src/openrct2/actions/ParkEntranceRemoveAction.cpp
+++ b/src/openrct2/actions/ParkEntranceRemoveAction.cpp
@@ -43,7 +43,7 @@ GameActions::Result ParkEntranceRemoveAction::Query() const
     res.Position = _loc;
     res.ErrorTitle = STR_CANT_REMOVE_THIS;
 
-    auto entranceIndex = park_entrance_get_index(_loc);
+    auto entranceIndex = ParkEntranceGetIndex(_loc);
     if (!LocationValid(_loc) || entranceIndex == -1)
     {
         log_error("Could not find entrance at x = %d, y = %d, z = %d", _loc.x, _loc.y, _loc.z);
@@ -59,7 +59,7 @@ GameActions::Result ParkEntranceRemoveAction::Execute() const
     res.Position = _loc;
     res.ErrorTitle = STR_CANT_REMOVE_THIS;
 
-    auto entranceIndex = park_entrance_get_index(_loc);
+    auto entranceIndex = ParkEntranceGetIndex(_loc);
     if (entranceIndex == -1)
     {
         log_error("Could not find entrance at x = %d, y = %d, z = %d", _loc.x, _loc.y, _loc.z);

--- a/src/openrct2/actions/PlaceParkEntranceAction.cpp
+++ b/src/openrct2/actions/PlaceParkEntranceAction.cpp
@@ -157,7 +157,7 @@ GameActions::Result PlaceParkEntranceAction::Execute() const
 
         if (!entranceElement->IsGhost())
         {
-            footpath_connect_edges(entranceLoc, entranceElement->as<TileElement>(), GAME_COMMAND_FLAG_APPLY);
+            FootpathConnectEdges(entranceLoc, entranceElement->as<TileElement>(), GAME_COMMAND_FLAG_APPLY);
         }
 
         update_park_fences(entranceLoc);

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -164,7 +164,7 @@ GameActions::Result RideEntranceExitPlaceAction::Execute() const
     auto z = station.GetBaseZ();
     if (!(GetFlags() & GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED) && !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
-        footpath_remove_litter({ _loc, z });
+        FootpathRemoveLitter({ _loc, z });
         wall_remove_at_z({ _loc, z });
     }
 
@@ -205,15 +205,15 @@ GameActions::Result RideEntranceExitPlaceAction::Execute() const
         map_animation_create(MAP_ANIMATION_TYPE_RIDE_ENTRANCE, { _loc, z });
     }
 
-    footpath_queue_chain_reset();
+    FootpathQueueChainReset();
 
     if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
         MazeEntranceHedgeRemoval({ _loc, entranceElement->as<TileElement>() });
     }
 
-    footpath_connect_edges(_loc, entranceElement->as<TileElement>(), GetFlags());
-    footpath_update_queue_chains();
+    FootpathConnectEdges(_loc, entranceElement->as<TileElement>(), GetFlags());
+    FootpathUpdateQueueChains();
 
     map_invalidate_tile_full(_loc);
 

--- a/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitPlaceAction.cpp
@@ -209,7 +209,7 @@ GameActions::Result RideEntranceExitPlaceAction::Execute() const
 
     if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
-        maze_entrance_hedge_removal({ _loc, entranceElement->as<TileElement>() });
+        MazeEntranceHedgeRemoval({ _loc, entranceElement->as<TileElement>() });
     }
 
     footpath_connect_edges(_loc, entranceElement->as<TileElement>(), GetFlags());

--- a/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
@@ -140,9 +140,9 @@ GameActions::Result RideEntranceExitRemoveAction::Execute() const
     res.Position.y = _loc.y + 16;
     res.Position.z = tile_element_height(res.Position);
 
-    footpath_queue_chain_reset();
+    FootpathQueueChainReset();
     MazeEntranceHedgeReplacement({ _loc, entranceElement });
-    footpath_remove_edges_at(_loc, entranceElement);
+    FootpathRemoveEdgesAt(_loc, entranceElement);
 
     tile_element_remove(entranceElement);
 
@@ -156,7 +156,7 @@ GameActions::Result RideEntranceExitRemoveAction::Execute() const
         station.Entrance.SetNull();
     }
 
-    footpath_update_queue_chains();
+    FootpathUpdateQueueChains();
 
     map_invalidate_tile_full(_loc);
     return res;

--- a/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
+++ b/src/openrct2/actions/RideEntranceExitRemoveAction.cpp
@@ -141,7 +141,7 @@ GameActions::Result RideEntranceExitRemoveAction::Execute() const
     res.Position.z = tile_element_height(res.Position);
 
     footpath_queue_chain_reset();
-    maze_entrance_hedge_replacement({ _loc, entranceElement });
+    MazeEntranceHedgeReplacement({ _loc, entranceElement });
     footpath_remove_edges_at(_loc, entranceElement);
 
     tile_element_remove(entranceElement);

--- a/src/openrct2/actions/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.cpp
@@ -350,7 +350,7 @@ GameActions::Result SmallSceneryPlaceAction::Execute() const
 
     if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
-        footpath_remove_litter({ _loc, targetHeight });
+        FootpathRemoveLitter({ _loc, targetHeight });
         if (!gCheatsDisableClearanceChecks && (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_NO_WALLS)))
         {
             wall_remove_at({ _loc, targetHeight, targetHeight + sceneryEntry->height });

--- a/src/openrct2/actions/SurfaceSetStyleAction.cpp
+++ b/src/openrct2/actions/SurfaceSetStyleAction.cpp
@@ -198,7 +198,7 @@ GameActions::Result SurfaceSetStyleAction::Execute() const
                         surfaceElement->SetSurfaceStyle(_surfaceStyle);
 
                         map_invalidate_tile_full(coords);
-                        footpath_remove_litter({ coords, tile_element_height(coords) });
+                        FootpathRemoveLitter({ coords, tile_element_height(coords) });
                     }
                 }
             }

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -261,7 +261,7 @@ GameActions::Result TrackPlaceAction::Query() const
         // When building a level crossing, remove any pre-existing path furniture.
         if (crossingMode == CREATE_CROSSING_MODE_TRACK_OVER_PATH)
         {
-            auto footpathElement = map_get_footpath_element(mapLoc);
+            auto footpathElement = MapGetFootpathElement(mapLoc);
             if (footpathElement != nullptr && footpathElement->AsPath()->HasAddition())
             {
                 footpathElement->AsPath()->SetAddition(0);
@@ -478,7 +478,7 @@ GameActions::Result TrackPlaceAction::Execute() const
 
         if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST) && !gCheatsDisableClearanceChecks)
         {
-            footpath_remove_litter(mapLoc);
+            FootpathRemoveLitter(mapLoc);
             if (rideTypeFlags & RIDE_TYPE_FLAG_TRACK_NO_WALLS)
             {
                 wall_remove_at(mapLocWithClearance);
@@ -696,7 +696,7 @@ GameActions::Result TrackPlaceAction::Execute() const
 
         if (!gCheatsDisableClearanceChecks || !(GetFlags() & GAME_COMMAND_FLAG_GHOST))
         {
-            footpath_connect_edges(mapLoc, tileElement, GetFlags());
+            FootpathConnectEdges(mapLoc, tileElement, GetFlags());
         }
         map_invalidate_tile_full(mapLoc);
     }

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -429,10 +429,10 @@ GameActions::Result TrackRemoveAction::Execute() const
         }
 
         invalidate_test_results(ride);
-        footpath_queue_chain_reset();
+        FootpathQueueChainReset();
         if (!gCheatsDisableClearanceChecks || !(tileElement->IsGhost()))
         {
-            footpath_remove_edges_at(mapLoc, tileElement);
+            FootpathRemoveEdgesAt(mapLoc, tileElement);
         }
         tile_element_remove(tileElement);
         ride->ValidateStations();

--- a/src/openrct2/actions/WaterSetHeightAction.cpp
+++ b/src/openrct2/actions/WaterSetHeightAction.cpp
@@ -105,7 +105,7 @@ GameActions::Result WaterSetHeightAction::Execute() const
     res.Position = { _coords, _height * COORDS_Z_STEP };
 
     int32_t surfaceHeight = tile_element_height(_coords);
-    footpath_remove_litter({ _coords, surfaceHeight });
+    FootpathRemoveLitter({ _coords, surfaceHeight });
     if (!gCheatsDisableClearanceChecks)
         wall_remove_at_z({ _coords, surfaceHeight });
 

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -325,7 +325,7 @@ bool Peep::PathIsBlockedByVehicle()
 {
     auto curPos = TileCoordsXYZ(GetLocation());
     auto dstPos = TileCoordsXYZ(CoordsXYZ{ GetDestination(), NextLoc.z });
-    if ((curPos.x != dstPos.x || curPos.y != dstPos.y) && footpath_is_blocked_by_vehicle(dstPos))
+    if ((curPos.x != dstPos.x || curPos.y != dstPos.y) && FootpathIsBlockedByVehicle(dstPos))
     {
         return true;
     }

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -591,10 +591,10 @@ Direction Staff::DirectionSurface(Direction initialDirection) const
 
         direction &= 3;
 
-        if (fence_in_the_way({ NextLoc, NextLoc.z, NextLoc.z + PEEP_CLEARANCE_HEIGHT }, direction))
+        if (WallInTheWay({ NextLoc, NextLoc.z, NextLoc.z + PEEP_CLEARANCE_HEIGHT }, direction))
             continue;
 
-        if (fence_in_the_way({ NextLoc, NextLoc.z, NextLoc.z + PEEP_CLEARANCE_HEIGHT }, direction_reverse(direction)))
+        if (WallInTheWay({ NextLoc, NextLoc.z, NextLoc.z + PEEP_CLEARANCE_HEIGHT }, direction_reverse(direction)))
             continue;
 
         CoordsXY chosenTile = CoordsXY{ NextLoc } + CoordsDirectionDelta[direction];

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1013,7 +1013,7 @@ namespace OpenRCT2
                                 }
                             }
                         }
-                        UpdateParkEntranceLocations();
+                        ParkEntranceUpdateLocations();
                     }
                     else
                     {

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -185,13 +185,13 @@ static int32_t guest_surface_path_finding(Peep& peep)
     auto pathPos = CoordsXYRangedZ{ peep.NextLoc, peep.NextLoc.z, peep.NextLoc.z + PATH_CLEARANCE };
     Direction randDirection = scenario_rand() & 3;
 
-    if (!fence_in_the_way(pathPos, randDirection))
+    if (!WallInTheWay(pathPos, randDirection))
     {
         pathPos.x += CoordsDirectionDelta[randDirection].x;
         pathPos.y += CoordsDirectionDelta[randDirection].y;
         Direction backwardsDirection = direction_reverse(randDirection);
 
-        if (!fence_in_the_way(pathPos, backwardsDirection))
+        if (!WallInTheWay(pathPos, backwardsDirection))
         {
             if (!map_surface_is_blocked(pathPos))
             {
@@ -210,13 +210,13 @@ static int32_t guest_surface_path_finding(Peep& peep)
 
     pathPos.x = peep.NextLoc.x;
     pathPos.y = peep.NextLoc.y;
-    if (!fence_in_the_way(pathPos, randDirection))
+    if (!WallInTheWay(pathPos, randDirection))
     {
         pathPos.x += CoordsDirectionDelta[randDirection].x;
         pathPos.y += CoordsDirectionDelta[randDirection].y;
         Direction backwardsDirection = direction_reverse(randDirection);
 
-        if (!fence_in_the_way(pathPos, backwardsDirection))
+        if (!WallInTheWay(pathPos, backwardsDirection))
         {
             if (!map_surface_is_blocked(pathPos))
             {
@@ -230,13 +230,13 @@ static int32_t guest_surface_path_finding(Peep& peep)
 
     pathPos.x = peep.NextLoc.x;
     pathPos.y = peep.NextLoc.y;
-    if (!fence_in_the_way(pathPos, randDirection))
+    if (!WallInTheWay(pathPos, randDirection))
     {
         pathPos.x += CoordsDirectionDelta[randDirection].x;
         pathPos.y += CoordsDirectionDelta[randDirection].y;
         Direction backwardsDirection = direction_reverse(randDirection);
 
-        if (!fence_in_the_way(pathPos, backwardsDirection))
+        if (!WallInTheWay(pathPos, backwardsDirection))
         {
             if (!map_surface_is_blocked(pathPos))
             {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2544,11 +2544,11 @@ namespace RCT1
                     exitElement->SetEntranceType(ENTRANCE_TYPE_RIDE_EXIT);
 
                     // Trigger footpath update
-                    footpath_queue_chain_reset();
-                    footpath_connect_edges(
+                    FootpathQueueChainReset();
+                    FootpathConnectEdges(
                         entranceCoords.ToCoordsXY(), reinterpret_cast<TileElement*>(entranceElement),
                         GAME_COMMAND_FLAG_APPLY | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED);
-                    footpath_update_queue_chains();
+                    FootpathUpdateQueueChains();
                 }
             }
         }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3010,7 +3010,7 @@ static void ride_set_maze_entrance_exit_points(Ride* ride)
             if (tileElement->GetBaseZ() != entranceExitMapPos.z)
                 continue;
 
-            maze_entrance_hedge_removal({ entranceExitMapPos, tileElement });
+            MazeEntranceHedgeRemoval({ entranceExitMapPos, tileElement });
         } while (!(tileElement++)->IsLastForTile());
     }
 }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -2639,7 +2639,7 @@ static ResultWithMessage ride_check_for_entrance_exit(RideId rideIndex)
 }
 
 /**
- * Calls footpath_chain_ride_queue for all entrances of the ride
+ * Calls FootpathChainRideQueue for all entrances of the ride
  *  rct2: 0x006B5952
  */
 void Ride::ChainQueues() const
@@ -2664,8 +2664,7 @@ void Ride::ChainQueues() const
                     continue;
 
                 int32_t direction = tileElement->GetDirection();
-                footpath_chain_ride_queue(
-                    id, GetStationIndex(&station), mapLocation, tileElement, direction_reverse(direction));
+                FootpathChainRideQueue(id, GetStationIndex(&station), mapLocation, tileElement, direction_reverse(direction));
             } while (!(tileElement++)->IsLastForTile());
         }
     }

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1057,7 +1057,7 @@ bool track_block_get_previous_from_zero(
 void ride_get_start_of_track(CoordsXYE* output);
 
 void window_ride_construction_update_active_elements();
-money32 ride_entrance_exit_place_ghost(
+money32 RideEntranceExitPlaceGhost(
     Ride* ride, const CoordsXY& entranceExitCoords, Direction direction, int32_t placeType, StationIndex stationNum);
 
 ResultWithMessage ride_are_all_possible_entrances_and_exits_built(Ride* ride);

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -352,7 +352,7 @@ void ride_clear_blocked_tiles(Ride* ride)
                     continue;
 
                 // Unblock footpath element that is at same position
-                auto* footpathElement = map_get_footpath_element(
+                auto* footpathElement = MapGetFootpathElement(
                     TileCoordsXYZ{ tilePos, trackElement->base_height }.ToCoordsXYZ());
 
                 if (footpathElement == nullptr)
@@ -1572,10 +1572,10 @@ void Ride::ValidateStations()
             // remove the ride entrance and clean up if necessary
             if (shouldRemove)
             {
-                footpath_queue_chain_reset();
+                FootpathQueueChainReset();
                 MazeEntranceHedgeReplacement({ location, tileElement });
-                footpath_remove_edges_at(location, tileElement);
-                footpath_update_queue_chains();
+                FootpathRemoveEdgesAt(location, tileElement);
+                FootpathUpdateQueueChains();
                 map_invalidate_tile_full(location);
                 tile_element_remove(tileElement);
                 tileElement--;

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -534,7 +534,7 @@ void ride_construction_remove_ghosts()
 {
     if (_currentTrackSelectionFlags & TRACK_SELECTION_FLAG_ENTRANCE_OR_EXIT)
     {
-        ride_entrance_exit_remove_ghost();
+        RideEntranceExitRemoveGhost();
         _currentTrackSelectionFlags &= ~TRACK_SELECTION_FLAG_ENTRANCE_OR_EXIT;
     }
     if (_currentTrackSelectionFlags & TRACK_SELECTION_FLAG_TRACK)
@@ -1573,7 +1573,7 @@ void Ride::ValidateStations()
             if (shouldRemove)
             {
                 footpath_queue_chain_reset();
-                maze_entrance_hedge_replacement({ location, tileElement });
+                MazeEntranceHedgeReplacement({ location, tileElement });
                 footpath_remove_edges_at(location, tileElement);
                 footpath_update_queue_chains();
                 map_invalidate_tile_full(location);

--- a/src/openrct2/ride/RideConstruction.h
+++ b/src/openrct2/ride/RideConstruction.h
@@ -72,8 +72,8 @@ extern uint8_t gRideEntranceExitPlaceDirection;
 std::optional<CoordsXYZ> GetTrackElementOriginAndApplyChanges(
     const CoordsXYZD& location, track_type_t type, uint16_t extra_params, TileElement** output_element, uint16_t flags);
 
-void ride_entrance_exit_place_provisional_ghost();
-void ride_entrance_exit_remove_ghost();
+void RideEntranceExitPlaceProvisionalGhost();
+void RideEntranceExitRemoveGhost();
 void ride_restore_provisional_track_piece();
 void ride_remove_provisional_track_piece();
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -1259,8 +1259,8 @@ static GameActions::Result TrackDesignPlaceSceneryElement(
 
                 if (tds.PlaceOperation == PTD_OPERATION_PLACE)
                 {
-                    footpath_queue_chain_reset();
-                    footpath_remove_edges_at(mapCoord, reinterpret_cast<TileElement*>(pathElement));
+                    FootpathQueueChainReset();
+                    FootpathRemoveEdgesAt(mapCoord, reinterpret_cast<TileElement*>(pathElement));
                 }
 
                 flags = GAME_COMMAND_FLAG_APPLY;
@@ -1280,8 +1280,8 @@ static GameActions::Result TrackDesignPlaceSceneryElement(
 
                 if (tds.PlaceOperation == PTD_OPERATION_PLACE)
                 {
-                    footpath_connect_edges(mapCoord, reinterpret_cast<TileElement*>(pathElement), flags);
-                    footpath_update_queue_chains();
+                    FootpathConnectEdges(mapCoord, reinterpret_cast<TileElement*>(pathElement), flags);
+                    FootpathUpdateQueueChains();
                 }
 
                 return GameActions::Result();

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -54,7 +54,7 @@ static money32 RideEntranceExitPlaceGhost(
  *
  *  rct2: 0x00666F9E
  */
-void park_entrance_remove_ghost()
+void ParkEntranceRemoveGhost()
 {
     if (gParkEntranceGhostExists)
     {
@@ -65,7 +65,7 @@ void park_entrance_remove_ghost()
     }
 }
 
-int32_t park_entrance_get_index(const CoordsXYZ& entrancePos)
+int32_t ParkEntranceGetIndex(const CoordsXYZ& entrancePos)
 {
     int32_t i = 0;
     for (const auto& entrance : gParkEntrances)
@@ -79,12 +79,12 @@ int32_t park_entrance_get_index(const CoordsXYZ& entrancePos)
     return -1;
 }
 
-void reset_park_entrance()
+void PartEntranceReset()
 {
     gParkEntrances.clear();
 }
 
-void ride_entrance_exit_place_provisional_ghost()
+void RideEntranceExitPlaceProvisionalGhost()
 {
     if (_currentTrackSelectionFlags & TRACK_SELECTION_FLAG_ENTRANCE_OR_EXIT)
     {
@@ -94,7 +94,7 @@ void ride_entrance_exit_place_provisional_ghost()
     }
 }
 
-void ride_entrance_exit_remove_ghost()
+void RideEntranceExitRemoveGhost()
 {
     if (_currentTrackSelectionFlags & TRACK_SELECTION_FLAG_ENTRANCE_OR_EXIT)
     {
@@ -111,7 +111,7 @@ void ride_entrance_exit_remove_ghost()
  *
  *  rct2: 0x006CA28C
  */
-money32 ride_entrance_exit_place_ghost(
+money32 RideEntranceExitPlaceGhost(
     Ride* ride, const CoordsXY& entranceExitCoords, Direction direction, int32_t placeType, StationIndex stationNum)
 {
     ride_construction_remove_ghosts();
@@ -132,7 +132,7 @@ money32 ride_entrance_exit_place_ghost(
  * Replaces the outer hedge walls for an entrance placement removal.
  *  rct2: 0x00666D6F
  */
-void maze_entrance_hedge_replacement(const CoordsXYE& entrance)
+void MazeEntranceHedgeReplacement(const CoordsXYE& entrance)
 {
     int32_t direction = entrance.element->GetDirection();
     auto hedgePos = entrance + CoordsDirectionDelta[direction];
@@ -169,7 +169,7 @@ void maze_entrance_hedge_replacement(const CoordsXYE& entrance)
  * Removes the hedge walls for an entrance placement.
  *  rct2: 0x00666CBE
  */
-void maze_entrance_hedge_removal(const CoordsXYE& entrance)
+void MazeEntranceHedgeRemoval(const CoordsXYE& entrance)
 {
     int32_t direction = entrance.element->GetDirection();
     auto hedgePos = entrance + CoordsDirectionDelta[direction];
@@ -208,7 +208,7 @@ void maze_entrance_hedge_removal(const CoordsXYE& entrance)
     } while (!(tileElement++)->IsLastForTile());
 }
 
-void fix_park_entrance_locations(void)
+void ParkEntranceFixLocations(void)
 {
     // Fix gParkEntrance locations for which the tile_element no longer exists
     gParkEntrances.erase(
@@ -218,7 +218,7 @@ void fix_park_entrance_locations(void)
         gParkEntrances.end());
 }
 
-void UpdateParkEntranceLocations()
+void ParkEntranceUpdateLocations()
 {
     gParkEntrances.clear();
     tile_element_iterator it;

--- a/src/openrct2/world/Entrance.cpp
+++ b/src/openrct2/world/Entrance.cpp
@@ -79,7 +79,7 @@ int32_t ParkEntranceGetIndex(const CoordsXYZ& entrancePos)
     return -1;
 }
 
-void PartEntranceReset()
+void ParkEntranceReset()
 {
     gParkEntrances.clear();
 }

--- a/src/openrct2/world/Entrance.h
+++ b/src/openrct2/world/Entrance.h
@@ -55,11 +55,11 @@ extern std::vector<CoordsXYZD> gParkEntrances;
 extern CoordsXYZD gRideEntranceExitGhostPosition;
 extern StationIndex gRideEntranceExitGhostStationIndex;
 
-void park_entrance_remove_ghost();
+void ParkEntranceRemoveGhost();
 
-void reset_park_entrance();
-void maze_entrance_hedge_replacement(const CoordsXYE& entrance);
-void maze_entrance_hedge_removal(const CoordsXYE& entrance);
+void PartEntranceReset();
+void MazeEntranceHedgeReplacement(const CoordsXYE& entrance);
+void MazeEntranceHedgeRemoval(const CoordsXYE& entrance);
 
-void fix_park_entrance_locations();
-void UpdateParkEntranceLocations();
+void ParkEntranceFixLocations();
+void ParkEntranceUpdateLocations();

--- a/src/openrct2/world/Entrance.h
+++ b/src/openrct2/world/Entrance.h
@@ -57,7 +57,7 @@ extern StationIndex gRideEntranceExitGhostStationIndex;
 
 void ParkEntranceRemoveGhost();
 
-void PartEntranceReset();
+void ParkEntranceReset();
 void MazeEntranceHedgeReplacement(const CoordsXYE& entrance);
 void MazeEntranceHedgeRemoval(const CoordsXYE& entrance);
 

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -44,7 +44,7 @@
 #include <iterator>
 
 using namespace OpenRCT2::TrackMetaData;
-void footpath_update_queue_entrance_banner(const CoordsXY& footpathPos, TileElement* tileElement);
+void FootpathUpdateQueueEntranceBanner(const CoordsXY& footpathPos, TileElement* tileElement);
 
 FootpathSelection gFootpathSelection;
 ProvisionalFootpath gProvisionalFootpath;
@@ -116,7 +116,7 @@ static bool entrance_has_direction(const EntranceElement& entranceElement, int32
     return entranceElement.GetDirections() & (1 << (direction & 3));
 }
 
-TileElement* map_get_footpath_element(const CoordsXYZ& coords)
+TileElement* MapGetFootpathElement(const CoordsXYZ& coords)
 {
     TileElement* tileElement = map_get_first_element_at(coords);
     do
@@ -134,13 +134,13 @@ TileElement* map_get_footpath_element(const CoordsXYZ& coords)
  *
  *  rct2: 0x006A76FF
  */
-money32 footpath_provisional_set(
+money32 FootpathProvisionalSet(
     ObjectEntryIndex type, ObjectEntryIndex railingsType, const CoordsXYZ& footpathLoc, int32_t slope,
     PathConstructFlags constructFlags)
 {
     money32 cost;
 
-    footpath_provisional_remove();
+    FootpathProvisionalRemove();
 
     auto footpathPlaceAction = FootpathPlaceAction(footpathLoc, slope, type, railingsType, INVALID_DIRECTION, constructFlags);
     footpathPlaceAction.SetFlags(GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED);
@@ -196,7 +196,7 @@ money32 footpath_provisional_set(
  *
  *  rct2: 0x006A77FF
  */
-void footpath_provisional_remove()
+void FootpathProvisionalRemove()
 {
     if (gProvisionalFootpath.Flags & PROVISIONAL_PATH_FLAG_1)
     {
@@ -212,7 +212,7 @@ void footpath_provisional_remove()
  *
  *  rct2: 0x006A7831
  */
-void footpath_provisional_update()
+void FootpathProvisionalUpdate()
 {
     if (gProvisionalFootpath.Flags & PROVISIONAL_PATH_FLAG_SHOW_ARROW)
     {
@@ -221,7 +221,7 @@ void footpath_provisional_update()
         gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_ARROW;
         map_invalidate_tile_full(gFootpathConstructFromPosition);
     }
-    footpath_provisional_remove();
+    FootpathProvisionalRemove();
 }
 
 /**
@@ -238,7 +238,7 @@ void footpath_provisional_update()
  *      direction: ecx
  *      tileElement: edx
  */
-CoordsXY footpath_get_coordinates_from_pos(const ScreenCoordsXY& screenCoords, int32_t* direction, TileElement** tileElement)
+CoordsXY FootpathGetCoordinatesFromPos(const ScreenCoordsXY& screenCoords, int32_t* direction, TileElement** tileElement)
 {
     rct_window* window = window_find_from_point(screenCoords);
     if (window == nullptr || window->viewport == nullptr)
@@ -335,7 +335,7 @@ CoordsXY footpath_get_coordinates_from_pos(const ScreenCoordsXY& screenCoords, i
  * direction: cl
  * tileElement: edx
  */
-CoordsXY footpath_bridge_get_info_from_pos(const ScreenCoordsXY& screenCoords, int32_t* direction, TileElement** tileElement)
+CoordsXY FootpathBridgeGetInfoFromPos(const ScreenCoordsXY& screenCoords, int32_t* direction, TileElement** tileElement)
 {
     // First check if we point at an entrance or exit. In that case, we would want the path coming from the entrance/exit.
     rct_window* window = window_find_from_point(screenCoords);
@@ -380,14 +380,14 @@ CoordsXY footpath_bridge_get_info_from_pos(const ScreenCoordsXY& screenCoords, i
     }
 
     // We point at something else
-    return footpath_get_coordinates_from_pos(screenCoords, direction, tileElement);
+    return FootpathGetCoordinatesFromPos(screenCoords, direction, tileElement);
 }
 
 /**
  *
  *  rct2: 0x00673883
  */
-void footpath_remove_litter(const CoordsXYZ& footpathPos)
+void FootpathRemoveLitter(const CoordsXYZ& footpathPos)
 {
     std::vector<Litter*> removals;
     for (auto litter : EntityTileList<Litter>(footpathPos))
@@ -409,7 +409,7 @@ void footpath_remove_litter(const CoordsXYZ& footpathPos)
  *
  *  rct2: 0x0069A48B
  */
-void footpath_interrupt_peeps(const CoordsXYZ& footpathPos)
+void FootpathInterruptPeeps(const CoordsXYZ& footpathPos)
 {
     auto quad = EntityTileList<Peep>(footpathPos);
     for (auto peep : quad)
@@ -436,7 +436,7 @@ void footpath_interrupt_peeps(const CoordsXYZ& footpathPos)
  *
  *  rct2: 0x006E59DC
  */
-bool fence_in_the_way(const CoordsXYRangedZ& fencePos, int32_t direction)
+bool WallInTheWay(const CoordsXYRangedZ& fencePos, int32_t direction)
 {
     TileElement* tileElement;
 
@@ -461,7 +461,7 @@ bool fence_in_the_way(const CoordsXYRangedZ& fencePos, int32_t direction)
     return false;
 }
 
-static PathElement* footpath_connect_corners_get_neighbour(const CoordsXYZ& footpathPos, int32_t requireEdges)
+static PathElement* FootpathConnectCornersGetNeighbour(const CoordsXYZ& footpathPos, int32_t requireEdges)
 {
     if (!map_is_location_valid(footpathPos))
     {
@@ -497,7 +497,7 @@ static PathElement* footpath_connect_corners_get_neighbour(const CoordsXYZ& foot
  *
  *  rct2: 0x006A70EB
  */
-static void footpath_connect_corners(const CoordsXY& footpathPos, PathElement* initialTileElement)
+static void FootpathConnectCorners(const CoordsXY& footpathPos, PathElement* initialTileElement)
 {
     using PathElementCoordsPair = std::pair<PathElement*, CoordsXY>;
     std::array<PathElementCoordsPair, 4> tileElements;
@@ -515,7 +515,7 @@ static void footpath_connect_corners(const CoordsXY& footpathPos, PathElement* i
         auto currentPos = footpathPos + CoordsDirectionDelta[direction];
 
         std::get<1>(tileElements) = {
-            footpath_connect_corners_get_neighbour({ currentPos, z }, (1 << direction_reverse(direction))), currentPos
+            FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << direction_reverse(direction))), currentPos
         };
         if (std::get<1>(tileElements).first == nullptr)
             continue;
@@ -523,7 +523,7 @@ static void footpath_connect_corners(const CoordsXY& footpathPos, PathElement* i
         direction = direction_next(direction);
         currentPos += CoordsDirectionDelta[direction];
         std::get<2>(tileElements) = {
-            footpath_connect_corners_get_neighbour({ currentPos, z }, (1 << direction_reverse(direction))), currentPos
+            FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << direction_reverse(direction))), currentPos
         };
         if (std::get<2>(tileElements).first == nullptr)
             continue;
@@ -532,12 +532,12 @@ static void footpath_connect_corners(const CoordsXY& footpathPos, PathElement* i
         currentPos += CoordsDirectionDelta[direction];
         // First check link to previous tile
         std::get<3>(tileElements) = {
-            footpath_connect_corners_get_neighbour({ currentPos, z }, (1 << direction_reverse(direction))), currentPos
+            FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << direction_reverse(direction))), currentPos
         };
         if (std::get<3>(tileElements).first == nullptr)
             continue;
         // Second check link to initial tile
-        std::get<3>(tileElements) = { footpath_connect_corners_get_neighbour({ currentPos, z }, (1 << ((direction + 1) & 3))),
+        std::get<3>(tileElements) = { FootpathConnectCornersGetNeighbour({ currentPos, z }, (1 << ((direction + 1) & 3))),
                                       currentPos };
         if (std::get<3>(tileElements).first == nullptr)
             continue;
@@ -580,7 +580,7 @@ struct rct_neighbour_list
     size_t count;
 };
 
-static int32_t rct_neighbour_compare(const void* a, const void* b)
+static int32_t FootpathNeighbourCompare(const void* a, const void* b)
 {
     uint8_t va = (static_cast<const rct_neighbour*>(a))->order;
     uint8_t vb = (static_cast<const rct_neighbour*>(b))->order;
@@ -598,12 +598,12 @@ static int32_t rct_neighbour_compare(const void* a, const void* b)
     return 0;
 }
 
-static void neighbour_list_init(rct_neighbour_list* neighbourList)
+static void FootpathNeighbourListInit(rct_neighbour_list* neighbourList)
 {
     neighbourList->count = 0;
 }
 
-static void neighbour_list_push(
+static void FootpathNeighbourListPush(
     rct_neighbour_list* neighbourList, int32_t order, int32_t direction, RideId rideIndex, ::StationIndex entrance_index)
 {
     Guard::Assert(neighbourList->count < std::size(neighbourList->items));
@@ -614,7 +614,7 @@ static void neighbour_list_push(
     neighbourList->count++;
 }
 
-static bool neighbour_list_pop(rct_neighbour_list* neighbourList, rct_neighbour* outNeighbour)
+static bool FootpathNeighbourListPop(rct_neighbour_list* neighbourList, rct_neighbour* outNeighbour)
 {
     if (neighbourList->count == 0)
         return false;
@@ -626,7 +626,7 @@ static bool neighbour_list_pop(rct_neighbour_list* neighbourList, rct_neighbour*
     return true;
 }
 
-static void neighbour_list_remove(rct_neighbour_list* neighbourList, size_t index)
+static void FootpathNeighbourListRemove(rct_neighbour_list* neighbourList, size_t index)
 {
     Guard::ArgumentInRange<size_t>(index, 0, neighbourList->count - 1);
     int32_t itemsRemaining = static_cast<int32_t>(neighbourList->count - index) - 1;
@@ -637,12 +637,12 @@ static void neighbour_list_remove(rct_neighbour_list* neighbourList, size_t inde
     neighbourList->count--;
 }
 
-static void neighbour_list_sort(rct_neighbour_list* neighbourList)
+static void FoopathNeighbourListSort(rct_neighbour_list* neighbourList)
 {
-    qsort(neighbourList->items, neighbourList->count, sizeof(rct_neighbour), rct_neighbour_compare);
+    qsort(neighbourList->items, neighbourList->count, sizeof(rct_neighbour), FootpathNeighbourCompare);
 }
 
-static TileElement* footpath_get_element(const CoordsXYRangedZ& footpathPos, int32_t direction)
+static TileElement* FootpathGetElement(const CoordsXYRangedZ& footpathPos, int32_t direction)
 {
     TileElement* tileElement = map_get_first_element_at(footpathPos);
     if (tileElement == nullptr)
@@ -680,7 +680,7 @@ static TileElement* footpath_get_element(const CoordsXYRangedZ& footpathPos, int
 /**
  * Attempt to connect a newly disconnected queue tile to the specified path tile
  */
-static bool footpath_reconnect_queue_to_path(
+static bool FootpathReconnectQueueToPath(
     const CoordsXY& footpathPos, TileElement* tileElement, int32_t action, int32_t direction)
 {
     if (((tileElement->AsPath()->GetEdges() & (1 << direction)) == 0) ^ (action < 0))
@@ -690,16 +690,16 @@ static bool footpath_reconnect_queue_to_path(
 
     if (action < 0)
     {
-        if (fence_in_the_way({ footpathPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, direction))
+        if (WallInTheWay({ footpathPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, direction))
             return false;
 
-        if (fence_in_the_way(
+        if (WallInTheWay(
                 { targetQueuePos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, direction_reverse(direction)))
             return false;
     }
 
     int32_t z = tileElement->GetBaseZ();
-    TileElement* targetFootpathElement = footpath_get_element({ targetQueuePos, z - LAND_HEIGHT_STEP, z }, direction);
+    TileElement* targetFootpathElement = FootpathGetElement({ targetQueuePos, z - LAND_HEIGHT_STEP, z }, direction);
     if (targetFootpathElement != nullptr && !targetFootpathElement->AsPath()->IsQueue())
     {
         auto targetQueueElement = targetFootpathElement->AsPath();
@@ -723,7 +723,7 @@ static bool footpath_reconnect_queue_to_path(
     return false;
 }
 
-static bool footpath_disconnect_queue_from_path(const CoordsXY& footpathPos, TileElement* tileElement, int32_t action)
+static bool FootpathDisconnectQueueFromPath(const CoordsXY& footpathPos, TileElement* tileElement, int32_t action)
 {
     if (!tileElement->AsPath()->IsQueue())
         return false;
@@ -738,7 +738,7 @@ static bool footpath_disconnect_queue_from_path(const CoordsXY& footpathPos, Til
     if (action < 0)
     {
         uint8_t direction = tileElement->AsPath()->GetSlopeDirection();
-        if (footpath_reconnect_queue_to_path(footpathPos, tileElement, action, direction))
+        if (FootpathReconnectQueueToPath(footpathPos, tileElement, action, direction))
             return true;
     }
 
@@ -746,7 +746,7 @@ static bool footpath_disconnect_queue_from_path(const CoordsXY& footpathPos, Til
     {
         if ((action < 0) && (direction == tileElement->AsPath()->GetSlopeDirection()))
             continue;
-        if (footpath_reconnect_queue_to_path(footpathPos, tileElement, action, direction))
+        if (FootpathReconnectQueueToPath(footpathPos, tileElement, action, direction))
             return true;
     }
 
@@ -776,8 +776,7 @@ static void loc_6A6F1F(
 {
     if (query)
     {
-        if (fence_in_the_way(
-                { targetPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, direction_reverse(direction)))
+        if (WallInTheWay({ targetPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() }, direction_reverse(direction)))
         {
             return;
         }
@@ -785,7 +784,7 @@ static void loc_6A6F1F(
         {
             if (connected_path_count[tileElement->AsPath()->GetEdges()] < 2)
             {
-                neighbour_list_push(
+                FootpathNeighbourListPush(
                     neighbourList, 4, direction, tileElement->AsPath()->GetRideIndex(),
                     tileElement->AsPath()->GetStationIndex());
             }
@@ -793,9 +792,9 @@ static void loc_6A6F1F(
             {
                 if ((initialTileElement)->GetType() == TileElementType::Path && initialTileElement->AsPath()->IsQueue())
                 {
-                    if (footpath_disconnect_queue_from_path(targetPos, tileElement, 0))
+                    if (FootpathDisconnectQueueFromPath(targetPos, tileElement, 0))
                     {
-                        neighbour_list_push(
+                        FootpathNeighbourListPush(
                             neighbourList, 3, direction, tileElement->AsPath()->GetRideIndex(),
                             tileElement->AsPath()->GetStationIndex());
                     }
@@ -804,21 +803,21 @@ static void loc_6A6F1F(
         }
         else
         {
-            neighbour_list_push(neighbourList, 2, direction, RideId::GetNull(), StationIndex::GetNull());
+            FootpathNeighbourListPush(neighbourList, 2, direction, RideId::GetNull(), StationIndex::GetNull());
         }
     }
     else
     {
-        footpath_disconnect_queue_from_path(targetPos, tileElement, 1 + ((flags >> 6) & 1));
+        FootpathDisconnectQueueFromPath(targetPos, tileElement, 1 + ((flags >> 6) & 1));
         tileElement->AsPath()->SetEdges(tileElement->AsPath()->GetEdges() | (1 << direction_reverse(direction)));
         if (tileElement->AsPath()->IsQueue())
         {
-            footpath_queue_chain_push(tileElement->AsPath()->GetRideIndex());
+            FootpathQueueChainPush(tileElement->AsPath()->GetRideIndex());
         }
     }
     if (!(flags & (GAME_COMMAND_FLAG_GHOST | GAME_COMMAND_FLAG_ALLOW_DURING_PAUSED)))
     {
-        footpath_interrupt_peeps({ targetPos, tileElement->GetBaseZ() });
+        FootpathInterruptPeeps({ targetPos, tileElement->GetBaseZ() });
     }
     map_invalidate_element(targetPos, tileElement);
     loc_6A6FD2(initialTileElementPos, direction, initialTileElement, query);
@@ -833,7 +832,7 @@ static void loc_6A6D7E(
     {
         if (query)
         {
-            neighbour_list_push(neighbourList, 7, direction, RideId::GetNull(), StationIndex::GetNull());
+            FootpathNeighbourListPush(neighbourList, 7, direction, RideId::GetNull(), StationIndex::GetNull());
         }
         loc_6A6FD2(initialTileElementPos, direction, initialTileElement, query);
     }
@@ -899,7 +898,7 @@ static void loc_6A6D7E(
                         }
                         if (query)
                         {
-                            neighbour_list_push(
+                            FootpathNeighbourListPush(
                                 neighbourList, 1, direction, tileElement->AsTrack()->GetRideIndex(), StationIndex::GetNull());
                         }
                         loc_6A6FD2(initialTileElementPos, direction, initialTileElement, query);
@@ -914,7 +913,7 @@ static void loc_6A6D7E(
                         {
                             if (query)
                             {
-                                neighbour_list_push(
+                                FootpathNeighbourListPush(
                                     neighbourList, 8, direction, tileElement->AsEntrance()->GetRideIndex(),
                                     tileElement->AsEntrance()->GetStationIndex());
                             }
@@ -922,7 +921,7 @@ static void loc_6A6D7E(
                             {
                                 if (tileElement->AsEntrance()->GetEntranceType() != ENTRANCE_TYPE_PARK_ENTRANCE)
                                 {
-                                    footpath_queue_chain_push(tileElement->AsEntrance()->GetRideIndex());
+                                    FootpathQueueChainPush(tileElement->AsEntrance()->GetRideIndex());
                                 }
                             }
                             loc_6A6FD2(initialTileElementPos, direction, initialTileElement, query);
@@ -944,7 +943,7 @@ static void loc_6A6C85(
     const CoordsXYE& tileElementPos, int32_t direction, int32_t flags, bool query, rct_neighbour_list* neighbourList)
 {
     if (query
-        && fence_in_the_way(
+        && WallInTheWay(
             { tileElementPos, tileElementPos.element->GetBaseZ(), tileElementPos.element->GetClearanceZ() }, direction))
         return;
 
@@ -1007,22 +1006,22 @@ static void loc_6A6C85(
  *
  *  rct2: 0x006A6C66
  */
-void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElement, int32_t flags)
+void FootpathConnectEdges(const CoordsXY& footpathPos, TileElement* tileElement, int32_t flags)
 {
     rct_neighbour_list neighbourList;
     rct_neighbour neighbour;
 
-    footpath_update_queue_chains();
+    FootpathUpdateQueueChains();
 
-    neighbour_list_init(&neighbourList);
+    FootpathNeighbourListInit(&neighbourList);
 
-    footpath_update_queue_entrance_banner(footpathPos, tileElement);
+    FootpathUpdateQueueEntranceBanner(footpathPos, tileElement);
     for (Direction direction : ALL_DIRECTIONS)
     {
         loc_6A6C85({ footpathPos, tileElement }, direction, flags, true, &neighbourList);
     }
 
-    neighbour_list_sort(&neighbourList);
+    FoopathNeighbourListSort(&neighbourList);
 
     if (tileElement->GetType() == TileElementType::Path && tileElement->AsPath()->IsQueue())
     {
@@ -1039,13 +1038,13 @@ void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElemen
                 }
                 else if (rideIndex != neighbourList.items[i].ride_index)
                 {
-                    neighbour_list_remove(&neighbourList, i);
+                    FootpathNeighbourListRemove(&neighbourList, i);
                 }
                 else if (
                     rideIndex == neighbourList.items[i].ride_index && entranceIndex != neighbourList.items[i].entrance_index
                     && !neighbourList.items[i].entrance_index.IsNull())
                 {
-                    neighbour_list_remove(&neighbourList, i);
+                    FootpathNeighbourListRemove(&neighbourList, i);
                 }
             }
         }
@@ -1053,14 +1052,14 @@ void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElemen
         neighbourList.count = std::min<size_t>(neighbourList.count, 2);
     }
 
-    while (neighbour_list_pop(&neighbourList, &neighbour))
+    while (FootpathNeighbourListPop(&neighbourList, &neighbour))
     {
         loc_6A6C85({ footpathPos, tileElement }, neighbour.direction, flags, false, nullptr);
     }
 
     if (tileElement->GetType() == TileElementType::Path)
     {
-        footpath_connect_corners(footpathPos, tileElement->AsPath());
+        FootpathConnectCorners(footpathPos, tileElement->AsPath());
     }
 }
 
@@ -1068,7 +1067,7 @@ void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElemen
  *
  *  rct2: 0x006A742F
  */
-void footpath_chain_ride_queue(
+void FootpathChainRideQueue(
     RideId rideIndex, StationIndex entranceIndex, const CoordsXY& initialFootpathPos, TileElement* const initialTileElement,
     int32_t direction)
 {
@@ -1189,7 +1188,7 @@ void footpath_chain_ride_queue(
     }
 }
 
-void footpath_queue_chain_reset()
+void FootpathQueueChainReset()
 {
     _footpathQueueChainNext = _footpathQueueChain;
 }
@@ -1198,7 +1197,7 @@ void footpath_queue_chain_reset()
  *
  *  rct2: 0x006A76E9
  */
-void footpath_queue_chain_push(RideId rideIndex)
+void FootpathQueueChainPush(RideId rideIndex)
 {
     if (!rideIndex.IsNull())
     {
@@ -1214,7 +1213,7 @@ void footpath_queue_chain_push(RideId rideIndex)
  *
  *  rct2: 0x006A759F
  */
-void footpath_update_queue_chains()
+void FootpathUpdateQueueChains()
 {
     for (auto* queueChainPtr = _footpathQueueChain; queueChainPtr < _footpathQueueChainNext; queueChainPtr++)
     {
@@ -1241,7 +1240,7 @@ void footpath_update_queue_chains()
                         continue;
 
                     Direction direction = direction_reverse(tileElement->GetDirection());
-                    footpath_chain_ride_queue(
+                    FootpathChainRideQueue(
                         rideIndex, ride->GetStationIndex(&station), station.Entrance.ToCoordsXY(), tileElement, direction);
                 } while (!(tileElement++)->IsLastForTile());
             }
@@ -1253,7 +1252,7 @@ void footpath_update_queue_chains()
  *
  *  rct2: 0x0069ADBD
  */
-static void footpath_fix_ownership(const CoordsXY& mapPos)
+static void FootpathFixOwnership(const CoordsXY& mapPos)
 {
     const auto* surfaceElement = map_get_surface_element_at(mapPos);
     uint16_t ownership;
@@ -1287,7 +1286,7 @@ static void footpath_fix_ownership(const CoordsXY& mapPos)
     GameActions::Execute(&landSetRightsAction);
 }
 
-static bool get_next_direction(int32_t edges, int32_t* direction)
+static bool GetNextDirection(int32_t edges, int32_t* direction)
 {
     int32_t index = bitscanforward(edges);
     if (index == -1)
@@ -1304,7 +1303,7 @@ static bool get_next_direction(int32_t edges, int32_t* direction)
  *              (1 << 5): Unown
  *              (1 << 7): Ignore no entry signs
  */
-static int32_t footpath_is_connected_to_map_edge_helper(CoordsXYZ footpathPos, int32_t direction, int32_t flags)
+static int32_t FootpathIsConnectedToMapEdgeHelper(CoordsXYZ footpathPos, int32_t direction, int32_t flags)
 {
     int32_t returnVal = FOOTPATH_SEARCH_INCOMPLETE;
 
@@ -1419,7 +1418,7 @@ static int32_t footpath_is_connected_to_map_edge_helper(CoordsXYZ footpathPos, i
 
             // Unown the footpath if needed
             if (flags & FOOTPATH_CONNECTED_MAP_EDGE_UNOWN)
-                footpath_fix_ownership(targetPos);
+                FootpathFixOwnership(targetPos);
 
             edges = tileElement->AsPath()->GetEdges();
             currentTile.direction = direction_reverse(currentTile.direction);
@@ -1443,7 +1442,7 @@ static int32_t footpath_is_connected_to_map_edge_helper(CoordsXYZ footpathPos, i
             targetPos.z = tileElement->GetBaseZ();
             edges &= ~(1 << currentTile.direction);
 
-            if (!get_next_direction(edges, &currentTile.direction))
+            if (!GetNextDirection(edges, &currentTile.direction))
                 break;
 
             edges &= ~(1 << currentTile.direction);
@@ -1487,7 +1486,7 @@ static int32_t footpath_is_connected_to_map_edge_helper(CoordsXYZ footpathPos, i
                     currentTile.footpathPos = targetPos;
                     currentTile.distanceFromJunction = 0;
                     CaptureCurrentTileState(currentTile);
-                } while (get_next_direction(edges, &currentTile.direction));
+                } while (GetNextDirection(edges, &currentTile.direction));
             }
             break;
         } while (!(tileElement++)->IsLastForTile());
@@ -1502,10 +1501,10 @@ static int32_t footpath_is_connected_to_map_edge_helper(CoordsXYZ footpathPos, i
 }
 
 // TODO: Use GAME_COMMAND_FLAGS
-int32_t footpath_is_connected_to_map_edge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags)
+int32_t FootpathIsConnectedToMapEdge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags)
 {
     flags |= FOOTPATH_CONNECTED_MAP_EDGE_IGNORE_QUEUES;
-    return footpath_is_connected_to_map_edge_helper(footpathPos, direction, flags);
+    return FootpathIsConnectedToMapEdgeHelper(footpathPos, direction, flags);
 }
 
 bool PathElement::IsSloped() const
@@ -1781,7 +1780,7 @@ void PathElement::SetShouldDrawPathOverSupports(bool on)
  *  clears the wide footpath flag for all footpaths
  *  at location
  */
-static void footpath_clear_wide(const CoordsXY& footpathPos)
+static void FootpathClearWide(const CoordsXY& footpathPos)
 {
     TileElement* tileElement = map_get_first_element_at(footpathPos);
     if (tileElement == nullptr)
@@ -1800,7 +1799,7 @@ static void footpath_clear_wide(const CoordsXY& footpathPos)
  *  returns footpath element if it can be made wide
  *  returns NULL if it can not be made wide
  */
-static TileElement* footpath_can_be_wide(const CoordsXYZ& footpathPos)
+static TileElement* FootpathCanBeWide(const CoordsXYZ& footpathPos)
 {
     TileElement* tileElement = map_get_first_element_at(footpathPos);
     if (tileElement == nullptr)
@@ -1825,12 +1824,12 @@ static TileElement* footpath_can_be_wide(const CoordsXYZ& footpathPos)
  *
  *  rct2: 0x006A87BB
  */
-void footpath_update_path_wide_flags(const CoordsXY& footpathPos)
+void FootpathUpdatePathWideFlags(const CoordsXY& footpathPos)
 {
     if (map_is_location_at_edge(footpathPos))
         return;
 
-    footpath_clear_wide(footpathPos);
+    FootpathClearWide(footpathPos);
     /* Rather than clearing the wide flag of the following tiles and
      * checking the state of them later, leave them intact and assume
      * they were cleared. Consequently only the wide flag for this single
@@ -1842,11 +1841,11 @@ void footpath_update_path_wide_flags(const CoordsXY& footpathPos)
      * Note: indexes 3, 4, 5 are reset in the current call;
      *       index 2 is reset in the previous call. */
     // x += 0x20;
-    // footpath_clear_wide(x, y);
+    // FootpathClearWide(x, y);
     // y += 0x20;
-    // footpath_clear_wide(x, y);
+    // FootpathClearWide(x, y);
     // x -= 0x20;
-    // footpath_clear_wide(x, y);
+    // FootpathClearWide(x, y);
     // y -= 0x20;
 
     TileElement* tileElement = map_get_first_element_at(footpathPos);
@@ -1875,7 +1874,7 @@ void footpath_update_path_wide_flags(const CoordsXY& footpathPos)
         for (int32_t direction = 0; direction < 8; ++direction)
         {
             auto footpathLoc = CoordsXYZ(footpathPos + CoordsDirectionDelta[direction], height);
-            pathList[direction] = footpath_can_be_wide(footpathLoc);
+            pathList[direction] = FootpathCanBeWide(footpathLoc);
         }
 
         uint8_t pathConnections = 0;
@@ -2021,7 +2020,7 @@ void footpath_update_path_wide_flags(const CoordsXY& footpathPos)
     } while (!(tileElement++)->IsLastForTile());
 }
 
-bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position)
+bool FootpathIsBlockedByVehicle(const TileCoordsXYZ& position)
 {
     auto pathElement = MapGetFirstTileElementWithBaseHeightBetween<PathElement>({ position, position.z + PATH_HEIGHT_STEP });
     return pathElement != nullptr && pathElement->IsBlockedByVehicle();
@@ -2031,19 +2030,19 @@ bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position)
  *
  *  rct2: 0x006A7642
  */
-void footpath_update_queue_entrance_banner(const CoordsXY& footpathPos, TileElement* tileElement)
+void FootpathUpdateQueueEntranceBanner(const CoordsXY& footpathPos, TileElement* tileElement)
 {
     const auto elementType = tileElement->GetType();
     if (elementType == TileElementType::Path)
     {
         if (tileElement->AsPath()->IsQueue())
         {
-            footpath_queue_chain_push(tileElement->AsPath()->GetRideIndex());
+            FootpathQueueChainPush(tileElement->AsPath()->GetRideIndex());
             for (int32_t direction = 0; direction < 4; direction++)
             {
                 if (tileElement->AsPath()->GetEdges() & (1 << direction))
                 {
-                    footpath_chain_ride_queue(
+                    FootpathChainRideQueue(
                         RideId::GetNull(), StationIndex::FromUnderlying(0), footpathPos, tileElement, direction);
                 }
             }
@@ -2054,8 +2053,8 @@ void footpath_update_queue_entrance_banner(const CoordsXY& footpathPos, TileElem
     {
         if (tileElement->AsEntrance()->GetEntranceType() == ENTRANCE_TYPE_RIDE_ENTRANCE)
         {
-            footpath_queue_chain_push(tileElement->AsEntrance()->GetRideIndex());
-            footpath_chain_ride_queue(
+            FootpathQueueChainPush(tileElement->AsEntrance()->GetRideIndex());
+            FootpathChainRideQueue(
                 RideId::GetNull(), StationIndex::FromUnderlying(0), footpathPos, tileElement,
                 direction_reverse(tileElement->GetDirection()));
         }
@@ -2066,12 +2065,12 @@ void footpath_update_queue_entrance_banner(const CoordsXY& footpathPos, TileElem
  *
  *  rct2: 0x006A6B7F
  */
-static void footpath_remove_edges_towards_here(
+static void FootpathRemoveEdgesTowardsHere(
     const CoordsXYZ& footpathPos, int32_t direction, TileElement* tileElement, bool isQueue)
 {
     if (tileElement->AsPath()->IsQueue())
     {
-        footpath_queue_chain_push(tileElement->AsPath()->GetRideIndex());
+        FootpathQueueChainPush(tileElement->AsPath()->GetRideIndex());
     }
 
     auto d = direction_reverse(direction);
@@ -2083,7 +2082,7 @@ static void footpath_remove_edges_towards_here(
     map_invalidate_tile({ footpathPos, tileElement->GetBaseZ(), tileElement->GetClearanceZ() });
 
     if (isQueue)
-        footpath_disconnect_queue_from_path(footpathPos, tileElement, -1);
+        FootpathDisconnectQueueFromPath(footpathPos, tileElement, -1);
 
     Direction shiftedDirection = (direction + 1) & 3;
     auto targetFootPathPos = CoordsXYZ{ CoordsXY{ footpathPos } + CoordsDirectionDelta[shiftedDirection], footpathPos.z };
@@ -2112,7 +2111,7 @@ static void footpath_remove_edges_towards_here(
  *
  *  rct2: 0x006A6B14
  */
-static void footpath_remove_edges_towards(const CoordsXYRangedZ& footPathPos, int32_t direction, bool isQueue)
+static void FootpathRemoveEdgesTowards(const CoordsXYRangedZ& footPathPos, int32_t direction, bool isQueue)
 {
     if (!map_is_location_valid(footPathPos))
     {
@@ -2135,7 +2134,7 @@ static void footpath_remove_edges_towards(const CoordsXYRangedZ& footPathPos, in
                 if (slope != direction)
                     break;
             }
-            footpath_remove_edges_towards_here({ footPathPos, footPathPos.clearanceZ }, direction, tileElement, isQueue);
+            FootpathRemoveEdgesTowardsHere({ footPathPos, footPathPos.clearanceZ }, direction, tileElement, isQueue);
             break;
         }
 
@@ -2148,7 +2147,7 @@ static void footpath_remove_edges_towards(const CoordsXYRangedZ& footPathPos, in
             if (slope != direction)
                 break;
 
-            footpath_remove_edges_towards_here({ footPathPos, footPathPos.clearanceZ }, direction, tileElement, isQueue);
+            FootpathRemoveEdgesTowardsHere({ footPathPos, footPathPos.clearanceZ }, direction, tileElement, isQueue);
             break;
         }
     } while (!(tileElement++)->IsLastForTile());
@@ -2156,7 +2155,7 @@ static void footpath_remove_edges_towards(const CoordsXYRangedZ& footPathPos, in
 
 // Returns true when there is an element at the given coordinates that want to connect to a path with the given direction (ride
 // entrances and exits, shops, paths).
-bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, const TileElement* const elementToBeRemoved)
+bool TileElementWantsPathConnectionTowards(const TileCoordsXYZD& coords, const TileElement* const elementToBeRemoved)
 {
     TileElement* tileElement = map_get_first_element_at(coords);
     if (tileElement == nullptr)
@@ -2229,7 +2228,7 @@ bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, co
 }
 
 // fix up the corners around the given path element that gets removed
-static void footpath_fix_corners_around(const TileCoordsXY& footpathPos, TileElement* pathElement)
+static void FootpathFixCornersAround(const TileCoordsXY& footpathPos, TileElement* pathElement)
 {
     // A mask for the paths' corners of each possible neighbour
     static constexpr uint8_t cornersTouchingTile[3][3] = {
@@ -2277,7 +2276,7 @@ static void footpath_fix_corners_around(const TileCoordsXY& footpathPos, TileEle
  * @param x x-coordinate in units (not tiles)
  * @param y y-coordinate in units (not tiles)
  */
-void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElement)
+void FootpathRemoveEdgesAt(const CoordsXY& footpathPos, TileElement* tileElement)
 {
     if (tileElement->GetType() == TileElementType::Track)
     {
@@ -2290,7 +2289,7 @@ void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElem
             return;
     }
 
-    footpath_update_queue_entrance_banner(footpathPos, tileElement);
+    FootpathUpdateQueueEntranceBanner(footpathPos, tileElement);
 
     bool fixCorners = false;
     for (uint8_t direction = 0; direction < 4; direction++)
@@ -2313,11 +2312,11 @@ void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElem
         // When clearance checks were disabled a neighbouring path can be connected to both the path-ghost and to something
         // else, so before removing edges from neighbouring paths we have to make sure there is nothing else they are connected
         // to.
-        if (!tile_element_wants_path_connection_towards({ TileCoordsXY{ footpathPos }, z1, direction }, tileElement))
+        if (!TileElementWantsPathConnectionTowards({ TileCoordsXY{ footpathPos }, z1, direction }, tileElement))
         {
             bool isQueue = tileElement->GetType() == TileElementType::Path ? tileElement->AsPath()->IsQueue() : false;
             int32_t z0 = z1 - 2;
-            footpath_remove_edges_towards(
+            FootpathRemoveEdgesTowards(
                 { footpathPos + CoordsDirectionDelta[direction], z0 * COORDS_Z_STEP, z1 * COORDS_Z_STEP }, direction, isQueue);
         }
         else
@@ -2331,7 +2330,7 @@ void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElem
     if (fixCorners && tileElement->IsGhost())
     {
         auto tileFootpathPos = TileCoordsXY{ footpathPos };
-        footpath_fix_corners_around(tileFootpathPos, tileElement);
+        FootpathFixCornersAround(tileFootpathPos, tileElement);
     }
 
     if (tileElement->GetType() == TileElementType::Path)

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -231,31 +231,31 @@ extern const CoordsXY DirectionOffsets[NumOrthogonalDirections];
 extern const CoordsXY BinUseOffsets[NumOrthogonalDirections];
 extern const CoordsXY BenchUseOffsets[NumOrthogonalDirections * 2];
 
-TileElement* map_get_footpath_element(const CoordsXYZ& coords);
-void footpath_interrupt_peeps(const CoordsXYZ& footpathPos);
-money32 footpath_provisional_set(
+TileElement* MapGetFootpathElement(const CoordsXYZ& coords);
+void FootpathInterruptPeeps(const CoordsXYZ& footpathPos);
+money32 FootpathProvisionalSet(
     ObjectEntryIndex type, ObjectEntryIndex railingsType, const CoordsXYZ& footpathLoc, int32_t slope,
     PathConstructFlags constructFlags);
-void footpath_provisional_remove();
-void footpath_provisional_update();
-CoordsXY footpath_get_coordinates_from_pos(const ScreenCoordsXY& screenCoords, int32_t* direction, TileElement** tileElement);
-CoordsXY footpath_bridge_get_info_from_pos(const ScreenCoordsXY& screenCoords, int32_t* direction, TileElement** tileElement);
-void footpath_remove_litter(const CoordsXYZ& footpathPos);
-void footpath_connect_edges(const CoordsXY& footpathPos, TileElement* tileElement, int32_t flags);
-void footpath_update_queue_chains();
-bool fence_in_the_way(const CoordsXYRangedZ& fencePos, int32_t direction);
-void footpath_chain_ride_queue(
+void FootpathProvisionalRemove();
+void FootpathProvisionalUpdate();
+CoordsXY FootpathGetCoordinatesFromPos(const ScreenCoordsXY& screenCoords, int32_t* direction, TileElement** tileElement);
+CoordsXY FootpathBridgeGetInfoFromPos(const ScreenCoordsXY& screenCoords, int32_t* direction, TileElement** tileElement);
+void FootpathRemoveLitter(const CoordsXYZ& footpathPos);
+void FootpathConnectEdges(const CoordsXY& footpathPos, TileElement* tileElement, int32_t flags);
+void FootpathUpdateQueueChains();
+bool WallInTheWay(const CoordsXYRangedZ& fencePos, int32_t direction);
+void FootpathChainRideQueue(
     RideId rideIndex, StationIndex entranceIndex, const CoordsXY& footpathPos, TileElement* tileElement, int32_t direction);
-void footpath_update_path_wide_flags(const CoordsXY& footpathPos);
-bool footpath_is_blocked_by_vehicle(const TileCoordsXYZ& position);
+void FootpathUpdatePathWideFlags(const CoordsXY& footpathPos);
+bool FootpathIsBlockedByVehicle(const TileCoordsXYZ& position);
 
-int32_t footpath_is_connected_to_map_edge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags);
-void footpath_remove_edges_at(const CoordsXY& footpathPos, TileElement* tileElement);
+int32_t FootpathIsConnectedToMapEdge(const CoordsXYZ& footpathPos, int32_t direction, int32_t flags);
+void FootpathRemoveEdgesAt(const CoordsXY& footpathPos, TileElement* tileElement);
 
 bool FootpathSelectDefault();
 const FootpathObject* GetLegacyFootpathEntry(ObjectEntryIndex entryIndex);
 const FootpathSurfaceObject* GetPathSurfaceEntry(ObjectEntryIndex entryIndex);
 const FootpathRailingsObject* GetPathRailingsEntry(ObjectEntryIndex entryIndex);
 
-void footpath_queue_chain_reset();
-void footpath_queue_chain_push(RideId rideIndex);
+void FootpathQueueChainReset();
+void FootpathQueueChainPush(RideId rideIndex);

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -731,7 +731,7 @@ void map_update_path_wide_flags()
     auto y = gWidePathTileLoopPosition.y;
     for (int32_t i = 0; i < 128; i++)
     {
-        footpath_update_path_wide_flags({ x, y });
+        FootpathUpdatePathWideFlags({ x, y });
 
         // Next x, y tile
         x += COORDS_XY_STEP;
@@ -1119,8 +1119,8 @@ void map_remove_all_rides()
                     break;
                 [[fallthrough]];
             case TileElementType::Track:
-                footpath_queue_chain_reset();
-                footpath_remove_edges_at(TileCoordsXY{ it.x, it.y }.ToCoordsXY(), it.element);
+                FootpathQueueChainReset();
+                FootpathRemoveEdgesAt(TileCoordsXY{ it.x, it.y }.ToCoordsXY(), it.element);
                 tile_element_remove(it.element);
                 tile_element_iterator_restart_for_tile(&it);
                 break;
@@ -1350,7 +1350,7 @@ void map_remove_provisional_elements()
 
     if (gProvisionalFootpath.Flags & PROVISIONAL_PATH_FLAG_1)
     {
-        footpath_provisional_remove();
+        FootpathProvisionalRemove();
         gProvisionalFootpath.Flags |= PROVISIONAL_PATH_FLAG_1;
     }
     if (window_find_by_class(WindowClass::RideConstruction) != nullptr)
@@ -1374,7 +1374,7 @@ void map_restore_provisional_elements()
     if (gProvisionalFootpath.Flags & PROVISIONAL_PATH_FLAG_1)
     {
         gProvisionalFootpath.Flags &= ~PROVISIONAL_PATH_FLAG_1;
-        footpath_provisional_set(
+        FootpathProvisionalSet(
             gProvisionalFootpath.SurfaceIndex, gProvisionalFootpath.RailingsIndex, gProvisionalFootpath.Position,
             gProvisionalFootpath.Slope, gProvisionalFootpath.ConstructFlags);
     }

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -1356,7 +1356,7 @@ void map_remove_provisional_elements()
     if (window_find_by_class(WindowClass::RideConstruction) != nullptr)
     {
         ride_remove_provisional_track_piece();
-        ride_entrance_exit_remove_ghost();
+        RideEntranceExitRemoveGhost();
     }
     // This is in non performant so only make network games suffer for it
     // non networked games do not need this as its to prevent desyncs.
@@ -1381,7 +1381,7 @@ void map_restore_provisional_elements()
     if (window_find_by_class(WindowClass::RideConstruction) != nullptr)
     {
         ride_restore_provisional_track_piece();
-        ride_entrance_exit_place_provisional_ghost();
+        RideEntranceExitPlaceProvisionalGhost();
     }
     // This is in non performant so only make network games suffer for it
     // non networked games do not need this as its to prevent desyncs.

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -227,7 +227,7 @@ void tile_element_iterator_restart_for_tile(tile_element_iterator* it);
 void map_update_tiles();
 int32_t map_get_highest_z(const CoordsXY& loc);
 
-bool tile_element_wants_path_connection_towards(const TileCoordsXYZD& coords, const TileElement* const elementToBeRemoved);
+bool TileElementWantsPathConnectionTowards(const TileCoordsXYZD& coords, const TileElement* const elementToBeRemoved);
 
 void map_remove_out_of_range_elements();
 void map_extend_boundary_surface_x();

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -278,7 +278,7 @@ void Park::Initialise()
     gParkEntranceFee = 10.00_GBP;
 
     gPeepSpawns.clear();
-    PartEntranceReset();
+    ParkEntranceReset();
 
     gResearchPriorities = EnumsToFlags(
         ResearchCategory::Transport, ResearchCategory::Gentle, ResearchCategory::Rollercoaster, ResearchCategory::Thrill,

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -278,7 +278,7 @@ void Park::Initialise()
     gParkEntranceFee = 10.00_GBP;
 
     gPeepSpawns.clear();
-    reset_park_entrance();
+    PartEntranceReset();
 
     gResearchPriorities = EnumsToFlags(
         ResearchCategory::Transport, ResearchCategory::Gentle, ResearchCategory::Rollercoaster, ResearchCategory::Thrill,

--- a/src/openrct2/world/Park.h
+++ b/src/openrct2/world/Park.h
@@ -121,7 +121,7 @@ void update_park_fences_around_tile(const CoordsXY& coords);
 uint8_t calculate_guest_initial_happiness(uint8_t percentage);
 
 void park_set_open(bool open);
-int32_t park_entrance_get_index(const CoordsXYZ& entrancePos);
+int32_t ParkEntranceGetIndex(const CoordsXYZ& entrancePos);
 money16 park_get_entrance_fee();
 
 bool park_ride_prices_unlocked();

--- a/test/tests/Pathfinding.cpp
+++ b/test/tests/Pathfinding.cpp
@@ -118,7 +118,7 @@ protected:
 
             // Check that the peep is still on a footpath. Use next_z instead of pos->z here because pos->z will change
             // when the peep is halfway up a slope, but next_z will not change until they move to the next tile.
-            EXPECT_NE(map_get_footpath_element({ pos->ToCoordsXY(), peep->NextLoc.z }), nullptr);
+            EXPECT_NE(MapGetFootpathElement({ pos->ToCoordsXY(), peep->NextLoc.z }), nullptr);
         }
 
         // Clean up the peep, because we're reusing this loaded context for all tests.

--- a/test/tests/TileElements.cpp
+++ b/test/tests/TileElements.cpp
@@ -59,31 +59,31 @@ uint8_t TileElementWantsFootpathConnection::_gScreenFlags;
 TEST_F(TileElementWantsFootpathConnection, FlatPath)
 {
     // Flat paths want to connect to other paths in any direction
-    const TileElement* const pathElement = map_get_footpath_element(TileCoordsXYZ{ 19, 18, 14 }.ToCoordsXYZ());
+    const TileElement* const pathElement = MapGetFootpathElement(TileCoordsXYZ{ 19, 18, 14 }.ToCoordsXYZ());
     ASSERT_NE(pathElement, nullptr);
-    EXPECT_TRUE(tile_element_wants_path_connection_towards({ 19, 18, 14, 0 }, nullptr));
-    EXPECT_TRUE(tile_element_wants_path_connection_towards({ 19, 18, 14, 1 }, nullptr));
-    EXPECT_TRUE(tile_element_wants_path_connection_towards({ 19, 18, 14, 2 }, nullptr));
-    EXPECT_TRUE(tile_element_wants_path_connection_towards({ 19, 18, 14, 3 }, nullptr));
+    EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 19, 18, 14, 0 }, nullptr));
+    EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 19, 18, 14, 1 }, nullptr));
+    EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 19, 18, 14, 2 }, nullptr));
+    EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 19, 18, 14, 3 }, nullptr));
     SUCCEED();
 }
 
 TEST_F(TileElementWantsFootpathConnection, SlopedPath)
 {
     // Sloped paths only want to connect in two directions, of which is one at a higher offset
-    const TileElement* const slopedPathElement = map_get_footpath_element(TileCoordsXYZ{ 18, 18, 14 }.ToCoordsXYZ());
+    const TileElement* const slopedPathElement = MapGetFootpathElement(TileCoordsXYZ{ 18, 18, 14 }.ToCoordsXYZ());
     ASSERT_NE(slopedPathElement, nullptr);
     ASSERT_TRUE(slopedPathElement->AsPath()->IsSloped());
     // Bottom and top of sloped path want a path connection
-    EXPECT_TRUE(tile_element_wants_path_connection_towards({ 18, 18, 14, 2 }, nullptr));
-    EXPECT_TRUE(tile_element_wants_path_connection_towards({ 18, 18, 16, 0 }, nullptr));
+    EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 18, 18, 14, 2 }, nullptr));
+    EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 18, 18, 16, 0 }, nullptr));
     // Other directions at both heights do not want a connection
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 18, 14, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 18, 14, 1 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 18, 14, 3 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 18, 16, 1 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 18, 16, 2 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 18, 16, 3 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 18, 14, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 18, 14, 1 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 18, 14, 3 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 18, 16, 1 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 18, 16, 2 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 18, 16, 3 }, nullptr));
     SUCCEED();
 }
 
@@ -93,10 +93,10 @@ TEST_F(TileElementWantsFootpathConnection, Stall)
     auto tileCoords = TileCoordsXYZ{ 19, 15, 14 };
     const TrackElement* const stallElement = map_get_track_element_at(tileCoords.ToCoordsXYZ());
     ASSERT_NE(stallElement, nullptr);
-    EXPECT_TRUE(tile_element_wants_path_connection_towards({ 19, 15, 14, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 15, 14, 1 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 15, 14, 2 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 15, 14, 3 }, nullptr));
+    EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 19, 15, 14, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 15, 14, 1 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 15, 14, 2 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 15, 14, 3 }, nullptr));
     SUCCEED();
 }
 
@@ -106,10 +106,10 @@ TEST_F(TileElementWantsFootpathConnection, RideEntrance)
     const EntranceElement* const entranceElement = map_get_ride_entrance_element_at(
         TileCoordsXYZ{ 18, 8, 14 }.ToCoordsXYZ(), false);
     ASSERT_NE(entranceElement, nullptr);
-    EXPECT_TRUE(tile_element_wants_path_connection_towards({ 18, 8, 14, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 8, 14, 1 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 8, 14, 2 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 8, 14, 3 }, nullptr));
+    EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 18, 8, 14, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 8, 14, 1 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 8, 14, 2 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 8, 14, 3 }, nullptr));
     SUCCEED();
 }
 
@@ -118,34 +118,34 @@ TEST_F(TileElementWantsFootpathConnection, RideExit)
     // The exit has been rotated; it wants a path connection in direction 1, but not 0 like the entrance
     const EntranceElement* const exitElement = map_get_ride_exit_element_at(TileCoordsXYZ{ 18, 10, 14 }.ToCoordsXYZ(), false);
     ASSERT_NE(exitElement, nullptr);
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 10, 14, 0 }, nullptr));
-    EXPECT_TRUE(tile_element_wants_path_connection_towards({ 18, 10, 14, 1 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 10, 14, 2 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 10, 14, 3 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 10, 14, 0 }, nullptr));
+    EXPECT_TRUE(TileElementWantsPathConnectionTowards({ 18, 10, 14, 1 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 10, 14, 2 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 10, 14, 3 }, nullptr));
     SUCCEED();
 }
 
 TEST_F(TileElementWantsFootpathConnection, DifferentHeight)
 {
     // Test at different heights, all of these should fail
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 18, 4, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 18, 4, 1 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 18, 4, 2 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 18, 4, 3 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 18, 4, 2 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 18, 6, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 15, 4, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 8, 4, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 10, 4, 1 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 18, 24, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 18, 24, 1 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 18, 24, 2 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 18, 24, 3 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 18, 24, 2 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 18, 26, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 19, 15, 24, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 8, 24, 0 }, nullptr));
-    EXPECT_FALSE(tile_element_wants_path_connection_towards({ 18, 10, 24, 1 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 18, 4, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 18, 4, 1 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 18, 4, 2 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 18, 4, 3 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 18, 4, 2 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 18, 6, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 15, 4, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 8, 4, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 10, 4, 1 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 18, 24, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 18, 24, 1 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 18, 24, 2 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 18, 24, 3 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 18, 24, 2 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 18, 26, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 19, 15, 24, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 8, 24, 0 }, nullptr));
+    EXPECT_FALSE(TileElementWantsPathConnectionTowards({ 18, 10, 24, 1 }, nullptr));
     SUCCEED();
 }
 
@@ -153,13 +153,13 @@ TEST_F(TileElementWantsFootpathConnection, MapEdge)
 {
     // Paths at the map edge should have edge flags turned on when placed in scenario editor
     // This tile is a single, unconnected footpath on the map edge - on load, GetEdges() returns 0
-    TileElement* pathElement = map_get_footpath_element(TileCoordsXYZ{ 1, 4, 14 }.ToCoordsXYZ());
+    TileElement* pathElement = MapGetFootpathElement(TileCoordsXYZ{ 1, 4, 14 }.ToCoordsXYZ());
 
     // Enable flag to simulate enabling the scenario editor
     gScreenFlags |= SCREEN_FLAGS_SCENARIO_EDITOR;
 
     // Calculate the connected edges and set the appropriate edge flags
-    footpath_connect_edges({ 16, 64 }, pathElement, 0);
+    FootpathConnectEdges({ 16, 64 }, pathElement, 0);
     auto edges = pathElement->AsPath()->GetEdges();
 
     // The tiles alongside in the Y direction are both on the map edge so should be marked as an edge


### PR DESCRIPTION
This will help reduce the chance of peeps stepping on snakes by removing them from the codebase. 

Also unified some of the naming of things.

Future refactor thinking: There is a wall function in the footpath header. All these ghost placement functions should be moved to ui.