### PR TITLE
Fix #18134: Photo section clips through terrain

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
+- Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.
 
 0.4.2 (2022-10-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -2067,23 +2067,23 @@ void track_paint_util_onride_photo_small_paint(
     {
         case 0:
             PaintAddImageAsParent(session, imageId, { 26, 0, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, imageId, { 26, 31, height }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, imageId, { 26, 28, height - 3 }, { 1, 1, 19 });
             PaintAddImageAsParent(session, flashImageId, { 6, 0, height }, { 1, 1, 19 });
             break;
         case 1:
             PaintAddImageAsParent(session, imageId, { 0, 6, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, imageId, { 31, 6, height }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, imageId, { 28, 6, height - 3 }, { 1, 1, 19 });
             PaintAddImageAsParent(session, flashImageId, { 0, 26, height }, { 1, 1, 19 });
             break;
         case 2:
             PaintAddImageAsParent(session, imageId, { 6, 0, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, imageId, { 6, 31, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, flashImageId, { 26, 31, height }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, imageId, { 6, 28, height - 3 }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, flashImageId, { 26, 28, height - 3 }, { 1, 1, 19 });
             break;
         case 3:
             PaintAddImageAsParent(session, imageId, { 0, 26, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, imageId, { 31, 26, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, flashImageId, { 31, 6, height }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, imageId, { 28, 26, height - 3 }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, flashImageId, { 28, 6, height - 3 }, { 1, 1, 19 });
             break;
     }
 }
@@ -2105,23 +2105,23 @@ void track_paint_util_onride_photo_paint(
     {
         case 0:
             PaintAddImageAsParent(session, imageId, { 26, 0, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, imageId, { 26, 31, height }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, imageId, { 26, 28, height - 3 }, { 1, 1, 19 });
             PaintAddImageAsParent(session, flashImageId, { 6, 0, height }, { 1, 1, 19 });
             break;
         case 1:
             PaintAddImageAsParent(session, imageId, { 0, 6, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, imageId, { 31, 6, height }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, imageId, { 28, 6, height - 3 }, { 1, 1, 19 });
             PaintAddImageAsParent(session, flashImageId, { 0, 26, height }, { 1, 1, 19 });
             break;
         case 2:
             PaintAddImageAsParent(session, imageId, { 6, 0, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, imageId, { 6, 31, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, flashImageId, { 26, 31, height }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, imageId, { 6, 28, height - 3 }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, flashImageId, { 26, 28, height - 3 }, { 1, 1, 19 });
             break;
         case 3:
             PaintAddImageAsParent(session, imageId, { 0, 26, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, imageId, { 31, 26, height }, { 1, 1, 19 });
-            PaintAddImageAsParent(session, flashImageId, { 31, 6, height }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, imageId, { 28, 26, height - 3 }, { 1, 1, 19 });
+            PaintAddImageAsParent(session, flashImageId, { 28, 6, height - 3 }, { 1, 1, 19 });
             break;
     }
 }


### PR DESCRIPTION
Change the bounding box so photo section elements no longer clip through terrain. The change to the height ensures the elements still properly align to the track, and reflects the change in the `x` or `y` axis. 

I applied the fix to both types of photo sections (regular and small), since they both had the same issue.

Resolves #18134.

**Before and after from all four angles:**
![Before angle 1](https://user-images.githubusercontent.com/30838294/194108470-45c12aa9-b408-42ad-8f7c-cf48e8620414.png)
![After angle 1](https://user-images.githubusercontent.com/30838294/194108503-edfcfd2b-661d-4c91-900f-c2119767836f.png)

![Before angle 2](https://user-images.githubusercontent.com/30838294/194108477-3bf35da4-3117-4fb0-8623-dd358ddbad82.png)
![After angle 2](https://user-images.githubusercontent.com/30838294/194108514-c81f6b49-ae2f-4444-99b4-99ded529bf15.png)

![Before angle 3](https://user-images.githubusercontent.com/30838294/194108529-574486a2-7363-45de-bc8a-cae2da51bc42.png)
![After angle 3](https://user-images.githubusercontent.com/30838294/194108544-cf026911-78bb-4811-bb14-b501f3589612.png)

![Before angle 4](https://user-images.githubusercontent.com/30838294/194108568-b58c512e-9e18-4657-9d54-9792eb5faae3.png)
![After angle 4](https://user-images.githubusercontent.com/30838294/194108578-d305a3d3-ead3-4647-b20c-a9f5326c18ea.png)
