### PR TITLE
Fix FileWatcher

### DIFF
--- a/src/openrct2/core/FileWatcher.h
+++ b/src/openrct2/core/FileWatcher.h
@@ -9,12 +9,16 @@
 
 #pragma once
 
+#include "String.hpp"
+
 #include <functional>
 #include <string>
 #include <thread>
 #include <vector>
 
 #ifdef _WIN32
+#    include "FileSystem.hpp"
+
 typedef void* HANDLE;
 #endif
 
@@ -26,7 +30,7 @@ class FileWatcher
 private:
     std::thread _watchThread;
 #if defined(_WIN32)
-    std::string _path;
+    fs::path _path;
     HANDLE _directoryHandle{};
 #elif defined(__linux__)
     struct FileDescriptor
@@ -53,9 +57,9 @@ private:
 #endif
 
 public:
-    std::function<void(const std::string& path)> OnFileChanged;
+    std::function<void(u8string_view path)> OnFileChanged;
 
-    FileWatcher(const std::string& directoryPath);
+    FileWatcher(u8string_view directoryPath);
     ~FileWatcher();
 
 private:

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -771,8 +771,8 @@ void ScriptEngine::SetupHotReloading()
         if (Path::DirectoryExists(base))
         {
             _pluginFileWatcher = std::make_unique<FileWatcher>(base);
-            _pluginFileWatcher->OnFileChanged = [this](const std::string& path) {
-                std::lock_guard<std::mutex> guard(_changedPluginFilesMutex);
+            _pluginFileWatcher->OnFileChanged = [this](u8string_view path) {
+                std::lock_guard guard(_changedPluginFilesMutex);
                 _changedPluginFiles.emplace(path);
             };
             _hotReloadingInitialised = true;
@@ -799,10 +799,10 @@ void ScriptEngine::DoAutoReloadPluginCheck()
 
 void ScriptEngine::AutoReloadPlugins()
 {
-    if (_changedPluginFiles.size() > 0)
+    if (!_changedPluginFiles.empty())
     {
-        std::lock_guard<std::mutex> guard(_changedPluginFilesMutex);
-        for (auto& path : _changedPluginFiles)
+        std::lock_guard guard(_changedPluginFilesMutex);
+        for (const auto& path : _changedPluginFiles)
         {
             auto findResult = std::find_if(_plugins.begin(), _plugins.end(), [&path](const std::shared_ptr<Plugin>& plugin) {
                 return Path::Equals(path, plugin->GetPath());


### PR DESCRIPTION
This PR fixes several issues with FileWatcher, some of them Windows-only:

Windows-only:
* Fixed Unicode path issues.
* Fixed file sharing issues (the watcher handle actually prevented modifications of the watched directory, making the entire ordeal rather pointless).
* Guarded the code against `ReadDirectoryChangesW` returning 0 bytes while also returning `true`, as the docs specifically state it's possible.

General:
* Simplified the watcher thread creation semantics and made it join **before** closing watcher handles, just to be sure.
* Made `ScriptEngine::AutoReloadPlugins()` take a mutex earlier as checking if the container is not empty while not holding a mutex is probably a bad idea too.
* More `string_view` goodness

It's nitpicks so I don't think they're worth mentioning in the changelog, the only user-observable issue was the sharing issue anyway.