### PR TITLE
Fix #17853: Invention name tears while being dragged

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,6 +1,7 @@
 0.4.3 (in development)
 ------------------------------------------------------------------------
 - Fix: [#14312] Research ride type message incorrect.
+- Fix: [#17853] Invention name tears while being dragged.
 - Fix: [#18064] Unable to dismiss notification messages.
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 - Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -655,9 +655,9 @@ public:
             const auto rideEntry = get_ride_entry(researchItem.entryIndex);
             const StringId rideTypeName = get_ride_naming(researchItem.baseRideType, rideEntry).Name;
             Formatter ft;
-            ft.Add<StringId>(stringId);
             ft.Add<StringId>(rideTypeName);
-            format_string(buffer, 256, STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME, &ft);
+            ft.Add<StringId>(stringId);
+            format_string(buffer, 256, STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME_DRAG, &ft);
         }
         else
         {


### PR DESCRIPTION
DragWindow only invalidates when there is a selectedResearchItem. The cutting off on the label happens when the cursor is on the same Y or on the horizontal separator.

Before #17853 

![185285900-ab61de91-f3c4-4b9b-bde6-d27c6e49da4e](https://user-images.githubusercontent.com/12020398/194590106-9b2f2fbc-59ba-497e-8b31-6157ecd98fd6.gif)

After 

![5](https://user-images.githubusercontent.com/12020398/194692128-254ddb30-6e4e-456b-aac1-d1b19dcc7216.gif)
