### PR TITLE
Fix #17854 : Items in Invention List sometimes end up in the wrong place after moving

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -521,6 +521,13 @@ public:
         _selectedResearchItem = nullptr;
         Invalidate();
 
+        uint32_t beforeItemRawValue = 0;
+        if (beforeItem != nullptr)
+            beforeItemRawValue = beforeItem->rawValue;
+
+        if (item.rawValue == beforeItemRawValue)
+            return;
+
         ResearchRemove(item);
 
         auto& researchList = isInvented ? gResearchItemsInvented : gResearchItemsUninvented;
@@ -528,7 +535,7 @@ public:
         {
             for (size_t i = 0; i < researchList.size(); i++)
             {
-                if (researchList[i] == *beforeItem)
+                if (researchList[i].rawValue == beforeItemRawValue)
                 {
                     researchList.insert((researchList.begin() + i), item);
                     return;


### PR DESCRIPTION
After removing item from the Invention & Uninvention list, **beforeItem** gets mutated to the next item automatically.

By comparing rawValue of beforeItem in the list, problem goes away.

Before #17854
![185287381-eaf3c056-2e1e-46b7-bccc-0c7b627a7661](https://user-images.githubusercontent.com/12020398/194640611-0ae68256-f064-4e60-8fb3-0a370f42920a.gif)

After
![Animation](https://user-images.githubusercontent.com/12020398/194640553-39b2fdff-d88d-4811-a75c-97ae3a1e209a.gif)
