### PR TITLE
Fix guests stopping dead in tracks at crossings

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#18094] Underground shops & facilities don't show when adjacent to non-underground path (original bug).
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 - Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.
+- Fix: [#18245] Guests stopping dead in their tracks at railway crossings.
 - Fix: [#18257] Guests ‘waiting’ on extended railway crossings.
 - Fix: [#18354] Overwrite alert does not show when save name has different casing on Windows.
 - Fix: [#18379] Tunnel entrances for underground Mini Golf Hole E are not rendered correctly.

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5293,6 +5293,8 @@ void Guest::UpdateWalking()
     if (ShouldWaitForLevelCrossing())
     {
         // Wait for vehicle to pass
+        UpdateWaitingAtCrossing();
+
         return;
     }
 
@@ -5443,6 +5445,44 @@ void Guest::UpdateWalking()
     {
         InsertNewThought(PeepThoughtType::Scenery);
     }
+}
+
+void Guest::UpdateWaitingAtCrossing()
+{
+    if (!IsActionInterruptable())
+    {
+        UpdateAction();
+        Invalidate();
+        if (!IsActionWalking())
+            return;
+    }
+
+    Action = PeepActionType::Idle;
+    NextActionSpriteType = PeepActionSpriteType::WatchRide;
+    SwitchNextActionSpriteType();
+
+    if (HasFoodOrDrink())
+    {
+        if ((scenario_rand() & 0xFFFF) <= 1310)
+        {
+            Action = PeepActionType::EatFood;
+            ActionFrame = 0;
+            ActionSpriteImageOffset = 0;
+        }
+
+        UpdateCurrentActionSpriteType();
+
+        return;
+    }
+
+    if ((scenario_rand() & 0xFFFF) <= 64)
+    {
+        Action = PeepActionType::Wave2;
+        ActionFrame = 0;
+        ActionSpriteImageOffset = 0;
+    }
+
+    UpdateCurrentActionSpriteType();
 }
 
 /**

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -382,6 +382,7 @@ private:
     void UpdateRide();
     void UpdateOnRide(){}; // TODO
     void UpdateWalking();
+    void UpdateWaitingAtCrossing();
     void UpdateQueuing();
     void UpdateSitting();
     void UpdateEnteringPark();

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "5"
+#define NETWORK_STREAM_VERSION "6"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
When guests have to stop for a railway crossing, they stop dead in their tracks - right at the frame at which stop walking. This could look a tad weird at times.

Now, guests will assume a natural idle waiting position. If they have food or a drink, they will continue consuming it from time to time. And occasionally, guests might even wave at the train passing by!

**Demo before:**
![Stop dead in tracks](https://user-images.githubusercontent.com/30838294/194636415-fc5030ae-c261-445d-833e-d6044cf0e3d9.gif)

**Demo after:**
![Idling](https://user-images.githubusercontent.com/30838294/194636468-82021971-8dd3-49a6-bcc6-1f451522b0dc.gif)

Guests will also continue consuming food or drinks:
![Drinking](https://user-images.githubusercontent.com/30838294/194636503-80ff70e1-0c98-42b9-956b-e03be82e2c94.gif)

And if you're very lucky,  a guest might just wave at the train passing by!
![Waving](https://user-images.githubusercontent.com/30838294/194636545-61222be2-2fd8-4ab3-ac93-0ce77135e828.gif)
