### PR TITLE
Fix guests 'waiting' on extended railway crossings

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Fix: [#18064] Unable to dismiss notification messages.
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 - Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.
+- Fix: [#18257] Guests ‘waiting’ on extended railway crossings.
 - Improved: [#18192, #18214] Tycoon Park has been added Extras tab, Competition scenarios have received their own section.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.
 

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5289,7 +5289,7 @@ void Guest::UpdateWalking()
         }
     }
 
-    if (PathIsBlockedByVehicle())
+    if (ShouldWaitForLevelCrossing())
     {
         // Wait for vehicle to pass
         return;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -324,6 +324,12 @@ bool Peep::CheckForPath()
 bool Peep::PathIsBlockedByVehicle()
 {
     auto curPos = TileCoordsXYZ(GetLocation());
+    if (FootpathIsBlockedByVehicle(curPos))
+    {
+        // If current position is blocked, try to get out of the way
+        return false;
+    }
+
     auto dstPos = TileCoordsXYZ(CoordsXYZ{ GetDestination(), NextLoc.z });
     if ((curPos.x != dstPos.x || curPos.y != dstPos.y) && FootpathIsBlockedByVehicle(dstPos))
     {

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -321,7 +321,7 @@ bool Peep::CheckForPath()
     return false;
 }
 
-bool Peep::PathIsBlockedByVehicle()
+bool Peep::ShouldWaitForLevelCrossing()
 {
     auto curPos = TileCoordsXYZ(GetLocation());
     if (FootpathIsBlockedByVehicle(curPos))

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -412,7 +412,7 @@ public: // Peep
     // TODO: Make these private again when done refactoring
 public: // Peep
     [[nodiscard]] bool CheckForPath();
-    bool PathIsBlockedByVehicle();
+    bool ShouldWaitForLevelCrossing();
     bool IsOnLevelCrossing();
     void PerformNextAction(uint8_t& pathing_result);
     void PerformNextAction(uint8_t& pathing_result, TileElement*& tile_result);

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1338,7 +1338,7 @@ void Staff::UpdateHeadingToInspect()
         if (!CheckForPath())
             return;
 
-        if (PathIsBlockedByVehicle() && !IsMechanicHeadingToFixRideBlockingPath())
+        if (ShouldWaitForLevelCrossing() && !IsMechanicHeadingToFixRideBlockingPath())
             return;
 
         uint8_t pathingResult;
@@ -1446,7 +1446,7 @@ void Staff::UpdateAnswering()
         if (!CheckForPath())
             return;
 
-        if (PathIsBlockedByVehicle() && !IsMechanicHeadingToFixRideBlockingPath())
+        if (ShouldWaitForLevelCrossing() && !IsMechanicHeadingToFixRideBlockingPath())
             return;
 
         uint8_t pathingResult;
@@ -1781,7 +1781,7 @@ void Staff::UpdatePatrolling()
     if (!CheckForPath())
         return;
 
-    if (PathIsBlockedByVehicle() && !IsMechanicHeadingToFixRideBlockingPath())
+    if (ShouldWaitForLevelCrossing() && !IsMechanicHeadingToFixRideBlockingPath())
         return;
 
     uint8_t pathingResult;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -42,7 +42,7 @@
 // This string specifies which version of network stream current build uses.
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 
 static Peep* _pickup_peep = nullptr;


### PR DESCRIPTION
On extended railway crossings, guests would stop to 'wait' for the passing train, which would then phase right through them. This change at least allows guests a chance to get to a safe place.

**Before**:
Guests would stop dead in their tracks, accepting their fate.
![Accepting faith](https://user-images.githubusercontent.com/30838294/194725483-56cc5eef-8788-42b1-bf16-e8c5d106539c.gif)

**After:**
Guests will at least try to reach a safe place. This lucky peep manages to do just that!
![Railway escape](https://user-images.githubusercontent.com/30838294/194725461-99b0964b-ed63-4f03-a5f5-3785407ac55d.gif)

Of course, guests heading towards to incoming train will simply continue walking (right through it). And not every guest will get to a safe place in time. But I think this is at least better than the current situation where every guest would stop dead in their tracks. 