### PR TITLE
More ImageId cleanup

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -108,9 +108,9 @@ public:
     void DrawSpriteRawMasked(
         rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId& maskImage, const ImageId& colourImage) override;
     void DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, uint8_t colour) override;
-    void DrawGlyph(rct_drawpixelinfo* dpi, uint32_t image, int32_t x, int32_t y, const PaletteMap& palette) override;
+    void DrawGlyph(rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, const PaletteMap& palette) override;
     void DrawBitmap(
-        rct_drawpixelinfo* dpi, uint32_t image, const void* pixels, int32_t width, int32_t height, int32_t x,
+        rct_drawpixelinfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
         int32_t y) override;
 
     void FlushCommandBuffers();
@@ -852,17 +852,18 @@ void OpenGLDrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawGlyph(rct_drawpixelinfo* dpi, uint32_t image, int32_t x, int32_t y, const PaletteMap& palette)
+void OpenGLDrawingContext::DrawGlyph(
+    rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, const PaletteMap& palette)
 {
     CalculcateClipping(dpi);
 
-    auto g1Element = gfx_get_g1_element(image & 0x7FFFF);
+    auto g1Element = gfx_get_g1_element(image);
     if (g1Element == nullptr)
     {
         return;
     }
 
-    const auto texture = _textureCache->GetOrLoadGlyphTexture(ImageId::FromUInt32(image), palette);
+    const auto texture = _textureCache->GetOrLoadGlyphTexture(image, palette);
 
     int32_t left = x + g1Element->x_offset;
     int32_t top = y + g1Element->y_offset;
@@ -908,7 +909,7 @@ void OpenGLDrawingContext::DrawGlyph(rct_drawpixelinfo* dpi, uint32_t image, int
 }
 
 void OpenGLDrawingContext::DrawBitmap(
-    rct_drawpixelinfo* dpi, uint32_t image, const void* pixels, int32_t width, int32_t height, int32_t x, int32_t y)
+    rct_drawpixelinfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x, int32_t y)
 {
     CalculcateClipping(dpi);
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -1187,7 +1187,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex
     }
 }
 
-uint32_t GetColourButtonImage(colour_t colour)
+ImageId GetColourButtonImage(colour_t colour)
 {
-    return SPRITE_ID_PALETTE_COLOUR_1(colour) | IMAGE_TYPE_TRANSPARENT | SPR_PALETTE_BTN;
+    return ImageId(SPR_PALETTE_BTN).WithTransparency(colour);
 }

--- a/src/openrct2-ui/interface/Widget.h
+++ b/src/openrct2-ui/interface/Widget.h
@@ -9,7 +9,8 @@
 
 #pragma once
 
+#include <openrct2/drawing/ImageId.hpp>
 #include <openrct2/interface/Widget.h>
 
-uint32_t GetColourButtonImage(colour_t colour);
+ImageId GetColourButtonImage(colour_t colour);
 rct_widget* GetWidgetByIndex(const rct_window& w, WidgetIndex widgetIndex);

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -1003,7 +1003,7 @@ namespace OpenRCT2::Ui::Windows
             else if (desc.Type == "colourpicker")
             {
                 widget.type = WindowWidgetType::ColourBtn;
-                widget.image = GetColourButtonImage(desc.Colour);
+                widget.image = GetColourButtonImage(desc.Colour).ToUInt32();
                 widgetList.push_back(widget);
             }
             else if (desc.Type == "custom")
@@ -1238,7 +1238,7 @@ namespace OpenRCT2::Ui::Windows
                 if (lastColour != colour && colour < COLOUR_COUNT)
                 {
                     customWidgetInfo->Colour = colour;
-                    widget.image = GetColourButtonImage(colour);
+                    widget.image = GetColourButtonImage(colour).ToUInt32();
                     widget_invalidate(*w, widgetIndex);
 
                     std::vector<DukValue> args;

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -465,12 +465,12 @@ static void WindowGameBottomToolbarDrawParkRating(
     bar_width = (factor * 114) / 255;
     gfx_fill_rect_inset(
         dpi, { coords + ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 114, 9 } }, w->colours[1], INSET_RECT_F_30);
-    if (!(colour & IMAGE_TYPE_REMAP_2_PLUS) || game_is_paused() || (gCurrentRealTimeTicks & 8))
+    if (!(colour & BAR_BLINK) || game_is_paused() || (gCurrentRealTimeTicks & 8))
     {
         if (bar_width > 2)
         {
             gfx_fill_rect_inset(
-                dpi, { coords + ScreenCoordsXY{ 2, 2 }, coords + ScreenCoordsXY{ bar_width - 1, 8 } }, colour & 0x7FFFFFFF, 0);
+                dpi, { coords + ScreenCoordsXY{ 2, 2 }, coords + ScreenCoordsXY{ bar_width - 1, 8 } }, colour, 0);
         }
     }
 

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -649,9 +649,8 @@ private:
         // Tab 1 image
         auto i = (_selectedTab == TabId::Individual ? _tabAnimationIndex & ~3 : 0);
         i += GetPeepAnimation(PeepSpriteType::Normal).base_image + 1;
-        i |= 0xA1600000;
         gfx_draw_sprite(
-            &dpi, ImageId::FromUInt32(i),
+            &dpi, ImageId(i, COLOUR_GREY, COLOUR_DARK_OLIVE_GREEN),
             windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].midX(), widgets[WIDX_TAB_1].bottom - 6 });
 
         // Tab 2 image

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -258,11 +258,9 @@ public:
                             }
                         }
 
-                        uint32_t image_id = GetPeepAnimation(spriteType).base_image;
-                        image_id += 0xA0000001;
-                        image_id |= (peep->TshirtColour << 19) | (peep->TrousersColour << 24);
-
-                        gfx_draw_sprite(&cliped_dpi, ImageId::FromUInt32(image_id), clipCoords);
+                        ImageIndex imageId = GetPeepAnimation(spriteType).base_image + 1;
+                        auto image = ImageId(imageId, peep->TshirtColour, peep->TrousersColour);
+                        gfx_draw_sprite(&cliped_dpi, image, clipCoords);
                         break;
                     }
                     case News::ItemType::Money:

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1003,12 +1003,11 @@ static void WindowRideDrawTabCustomer(rct_drawpixelinfo* dpi, rct_window* w)
         if (w->page == WINDOW_RIDE_PAGE_CUSTOMER)
             spriteIndex = w->picked_peep_frame & ~3;
 
-        spriteIndex += GetPeepAnimation(PeepSpriteType::Normal).base_image;
-        spriteIndex += 1;
-        spriteIndex |= 0xA9E00000;
+        spriteIndex += GetPeepAnimation(PeepSpriteType::Normal).base_image + 1;
 
         gfx_draw_sprite(
-            dpi, ImageId::FromUInt32(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.midX(), widget.bottom - 6 });
+            dpi, ImageId(spriteIndex, COLOUR_BRIGHT_RED, COLOUR_TEAL),
+            w->windowPos + ScreenCoordsXY{ widget.midX(), widget.bottom - 6 });
     }
 }
 
@@ -4218,11 +4217,6 @@ static void WindowRideMaintenancePaint(rct_window* w, rct_drawpixelinfo* dpi)
 
 #pragma region Colour
 
-static uint32_t WindowRideGetColourButtonImage(int32_t colour)
-{
-    return IMAGE_TYPE_TRANSPARENT | SPRITE_ID_PALETTE_COLOUR_1(colour) | SPR_PALETTE_BTN;
-}
-
 static int32_t WindowRideHasTrackColour(Ride* ride, int32_t trackColour)
 {
     // Get station flags (shops don't have them)
@@ -4676,7 +4670,7 @@ static void WindowRideColourInvalidate(rct_window* w)
     if (WindowRideHasTrackColour(ride, 0))
     {
         window_ride_colour_widgets[WIDX_TRACK_MAIN_COLOUR].type = WindowWidgetType::ColourBtn;
-        window_ride_colour_widgets[WIDX_TRACK_MAIN_COLOUR].image = WindowRideGetColourButtonImage(trackColour.main);
+        window_ride_colour_widgets[WIDX_TRACK_MAIN_COLOUR].image = GetColourButtonImage(trackColour.main).ToUInt32();
     }
     else
     {
@@ -4687,7 +4681,8 @@ static void WindowRideColourInvalidate(rct_window* w)
     if (WindowRideHasTrackColour(ride, 1))
     {
         window_ride_colour_widgets[WIDX_TRACK_ADDITIONAL_COLOUR].type = WindowWidgetType::ColourBtn;
-        window_ride_colour_widgets[WIDX_TRACK_ADDITIONAL_COLOUR].image = WindowRideGetColourButtonImage(trackColour.additional);
+        window_ride_colour_widgets[WIDX_TRACK_ADDITIONAL_COLOUR].image = GetColourButtonImage(trackColour.additional)
+                                                                             .ToUInt32();
     }
     else
     {
@@ -4716,7 +4711,7 @@ static void WindowRideColourInvalidate(rct_window* w)
     if (WindowRideHasTrackColour(ride, 2) && ride->type != RIDE_TYPE_MAZE)
     {
         window_ride_colour_widgets[WIDX_TRACK_SUPPORT_COLOUR].type = WindowWidgetType::ColourBtn;
-        window_ride_colour_widgets[WIDX_TRACK_SUPPORT_COLOUR].image = WindowRideGetColourButtonImage(trackColour.supports);
+        window_ride_colour_widgets[WIDX_TRACK_SUPPORT_COLOUR].image = GetColourButtonImage(trackColour.supports).ToUInt32();
     }
     else
     {
@@ -4765,7 +4760,7 @@ static void WindowRideColourInvalidate(rct_window* w)
 
         window_ride_colour_widgets[WIDX_VEHICLE_PREVIEW].type = WindowWidgetType::Scroll;
         window_ride_colour_widgets[WIDX_VEHICLE_BODY_COLOR].type = WindowWidgetType::ColourBtn;
-        window_ride_colour_widgets[WIDX_VEHICLE_BODY_COLOR].image = WindowRideGetColourButtonImage(vehicleColour.Body);
+        window_ride_colour_widgets[WIDX_VEHICLE_BODY_COLOR].image = GetColourButtonImage(vehicleColour.Body).ToUInt32();
 
         bool allowChangingTrimColour = false;
         bool allowChangingTernaryColour = false;
@@ -4788,12 +4783,12 @@ static void WindowRideColourInvalidate(rct_window* w)
         if (allowChangingTrimColour)
         {
             window_ride_colour_widgets[WIDX_VEHICLE_TRIM_COLOUR].type = WindowWidgetType::ColourBtn;
-            window_ride_colour_widgets[WIDX_VEHICLE_TRIM_COLOUR].image = WindowRideGetColourButtonImage(vehicleColour.Trim);
+            window_ride_colour_widgets[WIDX_VEHICLE_TRIM_COLOUR].image = GetColourButtonImage(vehicleColour.Trim).ToUInt32();
             if (allowChangingTernaryColour)
             {
                 window_ride_colour_widgets[WIDX_VEHICLE_TERNARY_COLOUR].type = WindowWidgetType::ColourBtn;
-                window_ride_colour_widgets[WIDX_VEHICLE_TERNARY_COLOUR].image = WindowRideGetColourButtonImage(
-                    vehicleColour.Tertiary);
+                window_ride_colour_widgets[WIDX_VEHICLE_TERNARY_COLOUR].image = GetColourButtonImage(vehicleColour.Tertiary)
+                                                                                    .ToUInt32();
             }
             else
             {

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -815,18 +815,6 @@ bool is_csg_loaded()
     return _csgLoaded;
 }
 
-rct_size16 FASTCALL gfx_get_sprite_size(uint32_t image_id)
-{
-    const rct_g1_element* g1 = gfx_get_g1_element(image_id & 0X7FFFF);
-    rct_size16 size = {};
-    if (g1 != nullptr)
-    {
-        size.width = g1->width;
-        size.height = g1->height;
-    }
-    return size;
-}
-
 size_t g1_calculate_data_size(const rct_g1_element* g1)
 {
     if (g1->flags & G1_FLAG_PALETTE)

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -503,7 +503,7 @@ struct text_draw_info
 static void ttf_draw_character_sprite(rct_drawpixelinfo* dpi, int32_t codepoint, text_draw_info* info)
 {
     int32_t characterWidth = font_sprite_get_codepoint_width(info->font_sprite_base, codepoint);
-    int32_t sprite = font_sprite_get_codepoint_sprite(info->font_sprite_base, codepoint);
+    auto sprite = font_sprite_get_codepoint_sprite(info->font_sprite_base, codepoint);
 
     if (!(info->flags & TEXT_DRAW_FLAG_NO_DRAW))
     {

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -828,7 +828,7 @@ static void ttf_process_string_literal(rct_drawpixelinfo* dpi, std::string_view 
     else
     {
         CodepointView codepoints(text);
-        std::optional<size_t> ttfRunIndex;
+        std::optional<size_t> ttfRunIndex{};
         for (auto it = codepoints.begin(); it != codepoints.end(); it++)
         {
             auto codepoint = *it;

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -837,8 +837,18 @@ static void ttf_process_string_literal(rct_drawpixelinfo* dpi, std::string_view 
                 if (ttfRunIndex.has_value())
                 {
                     // Draw the TTF run
+                    // This error suppression abomination is here to suppress https://github.com/OpenRCT2/OpenRCT2/issues/17371.
+                    // Additionally, we have to suppress the error for the error suppression... :'-(
+                    // TODO: Re-evaluate somewhere in 2023.
+#    ifdef __MINGW32__
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#    endif
                     auto len = it.GetIndex() - ttfRunIndex.value();
                     ttf_draw_string_raw_ttf(dpi, text.substr(ttfRunIndex.value(), len), info);
+#    ifdef __MINGW32__
+#        pragma GCC diagnostic pop
+#    endif
                     ttfRunIndex = std::nullopt;
                 }
 

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -529,7 +529,7 @@ void FASTCALL gfx_bmp_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteA
 void FASTCALL gfx_rle_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, const ImageId& image_id, const ScreenCoordsXY& coords);
 void FASTCALL
-    gfx_draw_glyph(rct_drawpixelinfo* dpi, int32_t image_id, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+    gfx_draw_glyph(rct_drawpixelinfo* dpi, const ImageId& image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
 void FASTCALL gfx_draw_sprite_solid(rct_drawpixelinfo* dpi, const ImageId& image, const ScreenCoordsXY& coords, uint8_t colour);
 void FASTCALL gfx_draw_sprite_raw_masked(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const ImageId& maskImage, const ImageId& colourImage);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -575,7 +575,6 @@ class Formatter;
 ImageId scrolling_text_setup(
     struct paint_session& session, StringId stringId, Formatter& ft, uint16_t scroll, uint16_t scrollingMode, colour_t colour);
 
-rct_size16 FASTCALL gfx_get_sprite_size(uint32_t image_id);
 size_t g1_calculate_data_size(const rct_g1_element* g1);
 
 void mask_scalar(

--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -325,7 +325,7 @@ int32_t font_sprite_get_codepoint_width(FontSpriteBase fontSpriteBase, int32_t c
     return _spriteFontCharacterWidths[baseFontIndex][glyphIndex];
 }
 
-int32_t font_sprite_get_codepoint_sprite(FontSpriteBase fontSpriteBase, int32_t codepoint)
+ImageId font_sprite_get_codepoint_sprite(FontSpriteBase fontSpriteBase, int32_t codepoint)
 {
     int32_t offset = static_cast<int32_t>(fontSpriteBase);
     auto codePointOffset = font_sprite_get_codepoint_offset(codepoint);
@@ -334,7 +334,7 @@ int32_t font_sprite_get_codepoint_sprite(FontSpriteBase fontSpriteBase, int32_t 
         offset = font_get_font_index_from_sprite_base(fontSpriteBase) * SPR_G2_GLYPH_COUNT;
     }
 
-    return SPR_CHAR_START + (IMAGE_TYPE_REMAP | (offset + codePointOffset));
+    return ImageId(SPR_CHAR_START + offset + codePointOffset, COLOUR_BLACK);
 }
 
 int32_t font_get_font_index_from_sprite_base(FontSpriteBase spriteBase)

--- a/src/openrct2/drawing/Font.h
+++ b/src/openrct2/drawing/Font.h
@@ -11,6 +11,7 @@
 
 #include "../common.h"
 #include "../core/String.hpp"
+#include "../drawing/ImageId.hpp"
 
 constexpr const uint16_t FONT_SPRITE_GLYPH_COUNT = 224;
 
@@ -60,7 +61,7 @@ extern TTFFontSetDescriptor* gCurrentTTFFontSet;
 void font_sprite_initialise_characters();
 int32_t font_sprite_get_codepoint_offset(int32_t codepoint);
 int32_t font_sprite_get_codepoint_width(FontSpriteBase fontSpriteBase, int32_t codepoint);
-int32_t font_sprite_get_codepoint_sprite(FontSpriteBase fontSpriteBase, int32_t codepoint);
+ImageId font_sprite_get_codepoint_sprite(FontSpriteBase fontSpriteBase, int32_t codepoint);
 int32_t font_get_font_index_from_sprite_base(FontSpriteBase spriteBase);
 int32_t font_get_size_from_sprite_base(FontSpriteBase spriteBase);
 int32_t font_get_line_height(FontSpriteBase fontSpriteBase);

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -32,9 +32,9 @@ namespace OpenRCT2::Drawing
         virtual void DrawSpriteSolid(
             rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, uint8_t colour) abstract;
         virtual void DrawGlyph(
-            rct_drawpixelinfo* dpi, uint32_t image, int32_t x, int32_t y, const PaletteMap& palette) abstract;
+            rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, const PaletteMap& palette) abstract;
         virtual void DrawBitmap(
-            rct_drawpixelinfo* dpi, uint32_t image, const void* pixels, int32_t width, int32_t height, int32_t x,
+            rct_drawpixelinfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
             int32_t y) abstract;
     };
 

--- a/src/openrct2/drawing/ImageId.hpp
+++ b/src/openrct2/drawing/ImageId.hpp
@@ -94,20 +94,6 @@ public:
         return result;
     }
 
-    [[nodiscard]] static ImageId FromUInt32(uint32_t value, uint32_t tertiary)
-    {
-        if (!(value & FLAG_PRIMARY) && (value & FLAG_SECONDARY))
-        {
-            auto result = ImageId::FromUInt32(value).WithTertiary(tertiary);
-            assert(result.ToUInt32() == value);
-            return result;
-        }
-        else
-        {
-            return ImageId::FromUInt32(value);
-        }
-    }
-
     ImageId() = default;
 
     explicit constexpr ImageId(ImageIndex index)

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -243,7 +243,8 @@ void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, const ImageId& imageId, co
     }
 }
 
-void FASTCALL gfx_draw_glyph(rct_drawpixelinfo* dpi, int32_t image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+void FASTCALL
+    gfx_draw_glyph(rct_drawpixelinfo* dpi, const ImageId& image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -58,8 +58,7 @@ void scrolling_text_initialise_bitmaps()
     for (int32_t i = 0; i < FONT_SPRITE_GLYPH_COUNT; i++)
     {
         std::fill_n(drawingSurface, sizeof(drawingSurface), 0x00);
-        gfx_draw_sprite_software(
-            &dpi, ImageId::FromUInt32(SPR_CHAR_START + static_cast<uint32_t>(FontSpriteBase::TINY) + i), { -1, 0 });
+        gfx_draw_sprite_software(&dpi, ImageId(SPR_CHAR_START + static_cast<uint32_t>(FontSpriteBase::TINY) + i), { -1, 0 });
 
         for (int32_t x = 0; x < 8; x++)
         {
@@ -80,8 +79,7 @@ void scrolling_text_initialise_bitmaps()
     for (int32_t i = 0; i < SPR_G2_GLYPH_COUNT; i++)
     {
         std::fill_n(drawingSurface, sizeof(drawingSurface), 0x00);
-        gfx_draw_sprite_software(
-            &dpi, ImageId::FromUInt32(SPR_G2_CHAR_BEGIN + (FONT_SIZE_TINY * SPR_G2_GLYPH_COUNT) + i), { -1, 0 });
+        gfx_draw_sprite_software(&dpi, ImageId(SPR_G2_CHAR_BEGIN + (FONT_SIZE_TINY * SPR_G2_GLYPH_COUNT) + i), { -1, 0 });
 
         for (int32_t x = 0; x < 8; x++)
         {

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -729,7 +729,8 @@ void X8DrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId& im
     gfx_draw_sprite_palette_set_software(dpi, ImageId(image.GetIndex(), 0), spriteCoords, PaletteMap(palette));
 }
 
-void X8DrawingContext::DrawGlyph(rct_drawpixelinfo* dpi, uint32_t image, int32_t x, int32_t y, const PaletteMap& paletteMap)
+void X8DrawingContext::DrawGlyph(
+    rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, const PaletteMap& paletteMap)
 {
-    gfx_draw_sprite_palette_set_software(dpi, ImageId::FromUInt32(image), { x, y }, paletteMap);
+    gfx_draw_sprite_palette_set_software(dpi, image, { x, y }, paletteMap);
 }

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -146,7 +146,8 @@ namespace OpenRCT2
             void DrawSpriteRawMasked(
                 rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId& maskImage, const ImageId& colourImage) override;
             void DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, uint8_t colour) override;
-            void DrawGlyph(rct_drawpixelinfo* dpi, uint32_t image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
+            void DrawGlyph(
+                rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
             void DrawBitmap(
                 rct_drawpixelinfo* dpi, uint32_t image, const void* pixels, int32_t width, int32_t height, int32_t x,
                 int32_t y) override

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -4637,7 +4637,7 @@ void set_vehicle_type_image_max_sizes(CarEntry* vehicle_type, int32_t num_images
 
     for (int32_t i = 0; i < num_images; ++i)
     {
-        gfx_draw_sprite_software(&dpi, ImageId::FromUInt32(vehicle_type->base_image_id + i), { 0, 0 });
+        gfx_draw_sprite_software(&dpi, ImageId(vehicle_type->base_image_id + i), { 0, 0 });
     }
     int32_t al = -1;
     for (int32_t i = 99; i != 0; --i)

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -73,7 +73,7 @@ static void PaintSpaceRingsStructure(
             if (rider != nullptr)
             {
                 imageColourFlags = ImageId(0, rider->TshirtColour, rider->TrousersColour);
-                imageId = imageColourFlags.WithIndex((baseImageId & 0x7FFFF) + 352 + frameNum);
+                imageId = imageColourFlags.WithIndex(baseImageId + 352 + frameNum);
                 PaintAddImageAsChild(session, imageId, { 0, 0, height }, { 20, 20, 23 }, { -10, -10, height });
             }
         }


### PR DESCRIPTION
This removes some more usages of the old uint32 images. Two difficult areas are still left: widgets and inline sprites.