### PR TITLE
Fix #18070: Underground entrance/exit shows through terrain walls.

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#17853] Invention name tears while being dragged.
 - Fix: [#18064] Unable to dismiss notification messages.
+- Fix: [#18070] Underground entrance/exit shows through terrain walls (original bug).
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 - Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.
 - Improved: [#18192, #18214] Tycoon Park has been added Extras tab, Competition scenarios have received their own section.

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -162,7 +162,7 @@ static void PaintRideEntranceExit(paint_session& session, uint8_t direction, int
     CoordsXYZ boundBoxLength = {
         (direction & 1) ? 2 : 28,
         (direction & 1) ? 28 : 2,
-        isExit ? 35 : 51,
+        isExit ? 32 : 48,
     };
 
     // Back


### PR DESCRIPTION
Resolves #18070.

**Before & after 1:**
![Before](https://user-images.githubusercontent.com/30838294/194764081-e43dc16a-cba5-4abb-84f2-95bd5fc55b85.png)
![After](https://user-images.githubusercontent.com/30838294/194764089-04ced44c-971d-42ed-87c2-c48818255560.png)

**Before & after 2:**
![Before 2](https://user-images.githubusercontent.com/30838294/194764084-9f12faf2-f72f-4d97-b329-ad84d88c53d0.png)
![After 2](https://user-images.githubusercontent.com/30838294/194764093-d8339a5b-9076-4350-ad97-558f076df8e7.png)