### PR TITLE
Fix #18094: Underground shops & facilities don't show when adjacent to non-underground path

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Fix: [#17853] Invention name tears while being dragged.
 - Fix: [#18064] Unable to dismiss notification messages.
 - Fix: [#18070] Underground entrance/exit shows through terrain walls (original bug).
+- Fix: [#18094] Underground shops & facilities don't show when adjacent to non-underground path (original bug).
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 - Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.
 - Fix: [#18257] Guests ‘waiting’ on extended railway crossings.

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -65,6 +65,8 @@ static void PaintFacility(
 
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
+
+    PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 }
 
 /* 0x00762D44 */

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -52,6 +52,8 @@ static void PaintShop(
 
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
+
+    PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_shop(int32_t trackType)


### PR DESCRIPTION
Underground shops and facilities placed right next to non-underground path would be connected to the path, but the buildings themselves would remain invisible. Guests could use them though.

This has been fixed by drawing a tunnel, which is the same way ride entrances/exits are drawn. 

Resolves #18094.

**Before:**
![Before](https://user-images.githubusercontent.com/30838294/194932492-8c81b84b-a184-4a79-b9a8-da53ca4cb7f4.png)
**After:**
![After](https://user-images.githubusercontent.com/30838294/195421074-c8e082a8-82b7-4bc1-8955-19a53497f3f8.png)