### PR TITLE
Fix missing validation on invalid characters in file name

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,7 +7,7 @@
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 - Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.
 - Fix: [#18257] Guests ‘waiting’ on extended railway crossings.
-- Fix: [#18287] Missing validation on invalid characters in file name.
+- Fix: [#17763] Missing validation on invalid characters in file name.
 - Improved: [#18192, #18214] Tycoon Park has been added Extras tab, Competition scenarios have received their own section.
 - Improved: [#18250] Added modern style file and folder pickers on Windows.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,13 +1,13 @@
 0.4.3 (in development)
 ------------------------------------------------------------------------
 - Fix: [#14312] Research ride type message incorrect.
+- Fix: [#17763] Missing validation on invalid characters in file name.
 - Fix: [#17853] Invention name tears while being dragged.
 - Fix: [#18064] Unable to dismiss notification messages.
 - Fix: [#18070] Underground entrance/exit shows through terrain walls (original bug).
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 - Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.
 - Fix: [#18257] Guests ‘waiting’ on extended railway crossings.
-- Fix: [#17763] Missing validation on invalid characters in file name.
 - Improved: [#18192, #18214] Tycoon Park has been added Extras tab, Competition scenarios have received their own section.
 - Improved: [#18250] Added modern style file and folder pickers on Windows.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 - Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.
 - Fix: [#18257] Guests ‘waiting’ on extended railway crossings.
+- Fix: [#18287] Missing validation on invalid characters in file name.
 - Improved: [#18192, #18214] Tycoon Park has been added Extras tab, Competition scenarios have received their own section.
 - Improved: [#18250] Added modern style file and folder pickers on Windows.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -575,16 +575,16 @@ static void WindowLoadsaveTextinput(rct_window* w, WidgetIndex widgetIndex, char
     if (text == nullptr || text[0] == 0)
         return;
 
+    if (!Platform::IsFilenameValid(text))
+    {
+        context_show_error(STR_ERROR_INVALID_CHARACTERS, STR_NONE, {});
+        return;
+    }
+
     switch (widgetIndex)
     {
         case WIDX_NEW_FOLDER:
         {
-            if (!Platform::IsFilenameValid(text))
-            {
-                context_show_error(STR_ERROR_INVALID_CHARACTERS, STR_NONE, {});
-                return;
-            }
-
             const u8string path = Path::Combine(_directory, text);
             if (!Platform::EnsureDirectoryExists(path))
             {


### PR DESCRIPTION
When saving a new file with a name containing `/` or `\` on Windows, the incorrect file name would be determined since these characters represent a new folder. This would trigger a failure on save.

The user's input should be validated in all cases. Before, it was only executed for folder names. This change also applies the validation on file names.