### PR TITLE
Fix #18244: Invention DragWindow's starting position is inconsistent

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -32,6 +32,7 @@
 - Fix: [#18094] Underground shops & facilities don't show when adjacent to non-underground path (original bug).
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 - Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.
+- Fix: [#18244] Invention DragWindow's starting position is inconsistent.
 - Fix: [#18245] Guests stopping dead in their tracks at railway crossings.
 - Fix: [#18257] Guests ‘waiting’ on extended railway crossings.
 - Fix: [#18354] Overwrite alert does not show when save name has different casing on Windows.

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -67,7 +67,8 @@ static rct_widget _inventionListDragWidgets[] = {
 
 #pragma endregion
 
-static void WindowEditorInventionsListDragOpen(ResearchItem* researchItem);
+static void WindowEditorInventionsListDragOpen(
+    ResearchItem* researchItem, const ScreenCoordsXY& editorPos, int objectSelectionScrollWidth);
 static const ResearchItem* WindowEditorInventionsListDragGetItem();
 
 /**
@@ -94,27 +95,36 @@ static void ResearchRidesSetup()
     }
 }
 
-static std::pair<StringId, Formatter> WindowEditorInventionsListPrepareName(const ResearchItem& researchItem, bool withGap)
+static void DrawResearchItem(
+    rct_drawpixelinfo& dpi, const ResearchItem& researchItem, const int16_t& width, const ScreenCoordsXY& screenCoords,
+    StringId format, TextPaint textPaint)
 {
-    StringId drawString;
-    StringId stringId = researchItem.GetName();
-    auto ft = Formatter();
+    const StringId itemNameId = researchItem.GetName();
+    int16_t columnSplitOffset = width / 2;
 
     if (researchItem.type == Research::EntryType::Ride
         && !GetRideTypeDescriptor(researchItem.baseRideType).HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
     {
-        drawString = withGap ? STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME_DRAG : STR_WINDOW_COLOUR_2_STRINGID_STRINGID;
-        StringId rideTypeName = get_ride_naming(researchItem.baseRideType, get_ride_entry(researchItem.entryIndex)).Name;
+        const StringId rideTypeName = get_ride_naming(researchItem.baseRideType, get_ride_entry(researchItem.entryIndex)).Name;
+
+        // Draw group name
+        auto ft = Formatter();
         ft.Add<StringId>(rideTypeName);
-        ft.Add<StringId>(stringId);
+        DrawTextEllipsised(&dpi, screenCoords, columnSplitOffset - 11, format, ft, textPaint);
+
+        // Draw vehicle name
+        ft = Formatter();
+        ft.Add<StringId>(itemNameId);
+        DrawTextEllipsised(
+            &dpi, { screenCoords + ScreenCoordsXY{ columnSplitOffset, 0 } }, columnSplitOffset - 11, format, ft, textPaint);
     }
     else
     {
-        drawString = STR_WINDOW_COLOUR_2_STRINGID;
-        ft.Add<StringId>(stringId);
+        // Scenery group, flat ride or shopdis
+        auto ft = Formatter();
+        ft.Add<StringId>(itemNameId);
+        DrawTextEllipsised(&dpi, screenCoords, width, format, ft, textPaint);
     }
-
-    return std::make_pair(drawString, ft);
 }
 
 #pragma region Invention List Window
@@ -248,7 +258,8 @@ public:
             return;
 
         Invalidate();
-        WindowEditorInventionsListDragOpen(researchItem);
+
+        WindowEditorInventionsListDragOpen(researchItem, windowPos, widgets[WIDX_PRE_RESEARCHED_SCROLL].right);
     }
 
     void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
@@ -258,7 +269,6 @@ public:
         gfx_clear(&dpi, paletteIndex);
 
         int16_t boxWidth = widgets[WIDX_RESEARCH_ORDER_SCROLL].width();
-        int16_t columnSplitOffset = boxWidth / 2;
         int32_t itemY = -SCROLLABLE_ROW_HEIGHT;
         auto* dragItem = WindowEditorInventionsListDragGetItem();
 
@@ -306,35 +316,7 @@ public:
                 colour = colours[1] | COLOUR_FLAG_INSET;
             }
 
-            const StringId itemNameId = researchItem.GetName();
-
-            if (researchItem.type == Research::EntryType::Ride
-                && !GetRideTypeDescriptor(researchItem.baseRideType).HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
-            {
-                const auto rideEntry = get_ride_entry(researchItem.entryIndex);
-                const StringId rideTypeName = get_ride_naming(researchItem.baseRideType, rideEntry).Name;
-
-                // Draw group name
-                auto ft = Formatter();
-                ft.Add<StringId>(rideTypeName);
-                DrawTextEllipsised(
-                    &dpi, { 1, itemY }, columnSplitOffset - 11, STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME, ft,
-                    { colour, fontStyle, darkness });
-
-                // Draw vehicle name
-                ft = Formatter();
-                ft.Add<StringId>(itemNameId);
-                DrawTextEllipsised(
-                    &dpi, { columnSplitOffset + 1, itemY }, columnSplitOffset - 11, STR_BLACK_STRING, ft,
-                    { colour, fontStyle, darkness });
-            }
-            else
-            {
-                // Scenery group, flat ride or shop
-                auto ft = Formatter();
-                ft.Add<StringId>(itemNameId);
-                DrawTextEllipsised(&dpi, { 1, itemY }, boxWidth, STR_BLACK_STRING, ft, { colour, fontStyle, darkness });
-            }
+            DrawResearchItem(dpi, researchItem, boxWidth, { 1, itemY }, STR_BLACK_STRING, { colour, fontStyle, darkness });
         }
     }
 
@@ -423,7 +405,23 @@ public:
         screenPos = windowPos + ScreenCoordsXY{ bkWidget.midX() + 1, bkWidget.bottom + 3 };
         const auto itemWidth = width - widgets[WIDX_RESEARCH_ORDER_SCROLL].right - 6;
 
-        auto [drawString, ft] = WindowEditorInventionsListPrepareName(*researchItem, false);
+        StringId drawString = STR_WINDOW_COLOUR_2_STRINGID;
+        StringId stringId = researchItem->GetName();
+        auto ft = Formatter();
+
+        if (researchItem->type == Research::EntryType::Ride
+            && !GetRideTypeDescriptor(researchItem->baseRideType).HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
+        {
+            drawString = STR_WINDOW_COLOUR_2_STRINGID_STRINGID;
+            StringId rideTypeName = get_ride_naming(researchItem->baseRideType, get_ride_entry(researchItem->entryIndex)).Name;
+            ft.Add<StringId>(rideTypeName);
+            ft.Add<StringId>(stringId);
+        }
+        else
+        {
+            ft.Add<StringId>(stringId);
+        }
+
         DrawTextEllipsised(&dpi, screenPos, itemWidth, drawString, ft, { TextAlignment::CENTRE });
         screenPos.y += 15;
 
@@ -642,36 +640,18 @@ public:
     {
         auto screenCoords = windowPos + ScreenCoordsXY{ 0, 2 };
 
-        auto [drawString, ft] = WindowEditorInventionsListPrepareName(_draggedItem, true);
-        DrawTextBasic(&dpi, screenCoords, drawString, ft, { COLOUR_BLACK | COLOUR_FLAG_OUTLINE });
+        DrawResearchItem(
+            dpi, _draggedItem, width, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, { COLOUR_BLACK | COLOUR_FLAG_OUTLINE });
     }
 
-    void Init(ResearchItem& researchItem)
+    void Init(ResearchItem& researchItem, const ScreenCoordsXY& editorPos, int objectSelectionScrollWidth)
     {
         _draggedItem = researchItem;
-        StringId stringId = researchItem.GetName();
-        char buffer[256] = {};
-        if (researchItem.type == Research::EntryType::Ride
-            && !GetRideTypeDescriptor(researchItem.baseRideType).HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
-        {
-            const auto rideEntry = get_ride_entry(researchItem.entryIndex);
-            const StringId rideTypeName = get_ride_naming(researchItem.baseRideType, rideEntry).Name;
-            Formatter ft;
-            ft.Add<StringId>(rideTypeName);
-            ft.Add<StringId>(stringId);
-            format_string(buffer, 256, STR_INVENTIONS_LIST_RIDE_AND_VEHICLE_NAME_DRAG, &ft);
-        }
-        else
-        {
-            format_string(buffer, 256, stringId, nullptr);
-        }
 
-        auto stringWidth = gfx_get_string_width(buffer, FontStyle::Medium);
-        widgets[0].right = stringWidth;
-
+        widgets[0].right = objectSelectionScrollWidth;
         Invalidate();
-        windowPos = gTooltipCursor - ScreenCoordsXY{ stringWidth / 2, 7 };
-        width = stringWidth;
+        windowPos = ScreenCoordsXY{ editorPos.x, gTooltipCursor.y - 7 };
+        width = objectSelectionScrollWidth;
         Invalidate();
 
         InputWindowPositionBegin(*this, 0, gTooltipCursor);
@@ -683,14 +663,15 @@ public:
     }
 };
 
-static void WindowEditorInventionsListDragOpen(ResearchItem* researchItem)
+static void WindowEditorInventionsListDragOpen(
+    ResearchItem* researchItem, const ScreenCoordsXY& editorPos, int objectSelectionScrollWidth)
 {
     window_close_by_class(WindowClass::EditorInventionListDrag);
     auto* wnd = WindowCreate<InventionDragWindow>(
         WindowClass::EditorInventionListDrag, 10, 14, WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_NO_SNAPPING);
     if (wnd != nullptr)
     {
-        wnd->Init(*researchItem);
+        wnd->Init(*researchItem, editorPos, objectSelectionScrollWidth);
     }
 }
 


### PR DESCRIPTION
DragWindow's initial pos and size should match to the current scroll size and the InventionEditorWindow's position.

before
![before](https://user-images.githubusercontent.com/12020398/195263980-2cc566d0-35eb-45c3-be87-40f86bb6cba0.gif)

after

![after1](https://user-images.githubusercontent.com/12020398/195263998-be6f3125-a0ac-4fc5-ba52-5b43719de748.gif)
![after2](https://user-images.githubusercontent.com/12020398/195264000-9b650e7d-08d7-4879-8879-ace65a6a88cc.gif)
