### PR TITLE
Introduce mph literal for velocities

### DIFF
--- a/src/openrct2/common.h
+++ b/src/openrct2/common.h
@@ -125,6 +125,14 @@ constexpr money64 ToMoney64(money16 value)
     return value == MONEY16_UNDEFINED ? MONEY64_UNDEFINED : value;
 }
 
+// Note: Only valid for 5 decimal places.
+constexpr int32_t operator"" _mph(long double speedMph)
+{
+    uint32_t wholeNumber = speedMph;
+    uint64_t fraction = (speedMph - wholeNumber) * 100000;
+    return wholeNumber << 16 | ((fraction << 16) / 100000);
+}
+
 using StringId = uint16_t;
 
 #define SafeFree(x)                                                                                                            \

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -115,10 +115,12 @@ void Vehicle::CableLiftUpdate()
  */
 void Vehicle::CableLiftUpdateMovingToEndOfStation()
 {
-    if (velocity >= -6.71082_mph)
+    if (velocity >= -439800)
+    {
         acceleration = -2932;
+    }
 
-    if (velocity < -6.71082_mph)
+    if (velocity < -439800)
     {
         velocity -= velocity / 16;
         acceleration = 0;
@@ -138,10 +140,12 @@ void Vehicle::CableLiftUpdateMovingToEndOfStation()
  */
 void Vehicle::CableLiftUpdateWaitingToDepart()
 {
-    if (velocity >= -0.89478_mph)
+    if (velocity >= -58640)
+    {
         acceleration = -14660;
+    }
 
-    if (velocity < -0.89478_mph)
+    if (velocity < -58640)
     {
         velocity -= velocity / 16;
         acceleration = 0;
@@ -201,7 +205,7 @@ void Vehicle::CableLiftUpdateTravelling()
         return;
     }
 
-    velocity = std::min(passengerVehicle->velocity, 6.71082_mph);
+    velocity = std::min(passengerVehicle->velocity, 439800);
     acceleration = 0;
     if (passengerVehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_BROKEN_TRAIN))
         return;

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -115,10 +115,10 @@ void Vehicle::CableLiftUpdate()
  */
 void Vehicle::CableLiftUpdateMovingToEndOfStation()
 {
-    if (velocity >= -439800)
+    if (velocity >= -6.71082_mph)
         acceleration = -2932;
 
-    if (velocity < -439800)
+    if (velocity < -6.71082_mph)
     {
         velocity -= velocity / 16;
         acceleration = 0;
@@ -138,10 +138,10 @@ void Vehicle::CableLiftUpdateMovingToEndOfStation()
  */
 void Vehicle::CableLiftUpdateWaitingToDepart()
 {
-    if (velocity >= -58640)
+    if (velocity >= -0.89478_mph)
         acceleration = -14660;
 
-    if (velocity < -58640)
+    if (velocity < -0.89478_mph)
     {
         velocity -= velocity / 16;
         acceleration = 0;
@@ -201,7 +201,7 @@ void Vehicle::CableLiftUpdateTravelling()
         return;
     }
 
-    velocity = std::min(passengerVehicle->velocity, 439800);
+    velocity = std::min(passengerVehicle->velocity, 6.71082_mph);
     acceleration = 0;
     if (passengerVehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_BROKEN_TRAIN))
         return;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1982,11 +1982,11 @@ void Vehicle::UpdateMovingToEndOfStation()
         case RideMode::RotatingLift:
         case RideMode::DownwardLaunch:
         case RideMode::FreefallDrop:
-            if (velocity >= -2.01324_mph)
+            if (velocity >= -131940)
             {
                 acceleration = -3298;
             }
-            if (velocity < -2.01324_mph)
+            if (velocity < -131940)
             {
                 velocity -= velocity / 16;
                 acceleration = 0;
@@ -2029,12 +2029,12 @@ void Vehicle::UpdateMovingToEndOfStation()
 
             if (!(carEntry->flags & CAR_ENTRY_FLAG_POWERED))
             {
-                if (velocity <= 2.01324_mph)
+                if (velocity <= 131940)
                 {
                     acceleration = 3298;
                 }
             }
-            if (velocity > 2.01324_mph)
+            if (velocity > 131940)
             {
                 velocity -= velocity / 16;
                 acceleration = 0;
@@ -2056,7 +2056,7 @@ void Vehicle::UpdateMovingToEndOfStation()
             }
             else
             {
-                if (velocity > 1.50993_mph)
+                if (velocity > 98955)
                 {
                     sub_state = 0;
                 }
@@ -3165,7 +3165,7 @@ void Vehicle::UpdateDeparting()
     switch (curRide->mode)
     {
         case RideMode::ReverseInclineLaunchedShuttle:
-            if (velocity >= -2.01324_mph)
+            if (velocity >= -131940)
                 acceleration = -3298;
             break;
         case RideMode::PoweredLaunchPasstrough:
@@ -3194,7 +3194,7 @@ void Vehicle::UpdateDeparting()
             if (carEntry->flags & CAR_ENTRY_FLAG_POWERED)
                 break;
 
-            if (velocity <= 2.01324_mph)
+            if (velocity <= 131940)
                 acceleration = 3298;
             break;
         default:
@@ -3696,9 +3696,9 @@ void Vehicle::UpdateTravelling()
     {
         if (sub_state == 0)
         {
-            if (velocity >= -2.01324_mph)
+            if (velocity >= -131940)
                 acceleration = -3298;
-            velocity = std::max(velocity, -2.01324_mph);
+            velocity = std::max(velocity, -131940);
         }
         else
         {
@@ -3710,7 +3710,7 @@ void Vehicle::UpdateTravelling()
             }
             else
             {
-                if (velocity <= 2.01324_mph)
+                if (velocity <= 131940)
                     acceleration = 3298;
             }
         }
@@ -3789,7 +3789,7 @@ void Vehicle::UpdateArrivingPassThroughStation(const Ride& curRide, const CarEnt
             return;
         }
 
-        if (velocity <= 2.01324_mph)
+        if (velocity <= 131940)
         {
             acceleration = 3298;
             return;
@@ -3818,12 +3818,12 @@ void Vehicle::UpdateArrivingPassThroughStation(const Ride& curRide, const CarEnt
     }
     else
     {
-        if (!(carEntry.flags & CAR_ENTRY_FLAG_POWERED) && velocity >= -2.01324_mph)
+        if (!(carEntry.flags & CAR_ENTRY_FLAG_POWERED) && velocity >= -131940)
         {
             acceleration = -3298;
         }
 
-        if (velocity >= -2.01324_mph)
+        if (velocity >= -131940)
         {
             return;
         }
@@ -3937,7 +3937,7 @@ void Vehicle::UpdateArriving()
           & (VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_AT_STATION | VEHICLE_UPDATE_MOTION_TRACK_FLAG_1
              | VEHICLE_UPDATE_MOTION_TRACK_FLAG_5)))
     {
-        if (velocity > 1.50993_mph)
+        if (velocity > 98955)
             var_C0 = 0;
         return;
     }
@@ -4174,7 +4174,7 @@ void Vehicle::UpdateTravellingCableLift()
         }
     }
 
-    if (velocity <= 6.71082_mph)
+    if (velocity <= 439800)
     {
         acceleration = 4398;
     }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -1565,7 +1565,7 @@ void Vehicle::UpdateMeasurements()
                 curRide->special_track_elements |= RIDE_ELEMENT_WHIRLPOOL;
                 break;
             case TrackElemType::Watersplash:
-                if (velocity >= 0xB0000)
+                if (velocity >= 11.0_mph)
                 {
                     curRide->special_track_elements |= RIDE_ELEMENT_TUNNEL_SPLASH_OR_RAPIDS;
                 }
@@ -1881,7 +1881,7 @@ void Vehicle::Update()
         auto carEntry = &rideEntry->Cars[vehicle_type];
         if ((carEntry->flags & CAR_ENTRY_FLAG_POWERED) && curRide->breakdown_reason_pending == BREAKDOWN_SAFETY_CUT_OUT)
         {
-            if (!(carEntry->flags & CAR_ENTRY_FLAG_WATER_RIDE) || (Pitch == 2 && velocity <= 0x20000))
+            if (!(carEntry->flags & CAR_ENTRY_FLAG_WATER_RIDE) || (Pitch == 2 && velocity <= 2.0_mph))
             {
                 SetUpdateFlag(VEHICLE_UPDATE_FLAG_ZERO_VELOCITY);
             }
@@ -1982,11 +1982,11 @@ void Vehicle::UpdateMovingToEndOfStation()
         case RideMode::RotatingLift:
         case RideMode::DownwardLaunch:
         case RideMode::FreefallDrop:
-            if (velocity >= -131940)
+            if (velocity >= -2.01324_mph)
             {
                 acceleration = -3298;
             }
-            if (velocity < -131940)
+            if (velocity < -2.01324_mph)
             {
                 velocity -= velocity / 16;
                 acceleration = 0;
@@ -2029,12 +2029,12 @@ void Vehicle::UpdateMovingToEndOfStation()
 
             if (!(carEntry->flags & CAR_ENTRY_FLAG_POWERED))
             {
-                if (velocity <= 131940)
+                if (velocity <= 2.01324_mph)
                 {
                     acceleration = 3298;
                 }
             }
-            if (velocity > 131940)
+            if (velocity > 2.01324_mph)
             {
                 velocity -= velocity / 16;
                 acceleration = 0;
@@ -2056,7 +2056,7 @@ void Vehicle::UpdateMovingToEndOfStation()
             }
             else
             {
-                if (velocity > 98955)
+                if (velocity > 1.50993_mph)
                 {
                     sub_state = 0;
                 }
@@ -3165,7 +3165,7 @@ void Vehicle::UpdateDeparting()
     switch (curRide->mode)
     {
         case RideMode::ReverseInclineLaunchedShuttle:
-            if (velocity >= -131940)
+            if (velocity >= -2.01324_mph)
                 acceleration = -3298;
             break;
         case RideMode::PoweredLaunchPasstrough:
@@ -3194,7 +3194,7 @@ void Vehicle::UpdateDeparting()
             if (carEntry->flags & CAR_ENTRY_FLAG_POWERED)
                 break;
 
-            if (velocity <= 131940)
+            if (velocity <= 2.01324_mph)
                 acceleration = 3298;
             break;
         default:
@@ -3696,9 +3696,9 @@ void Vehicle::UpdateTravelling()
     {
         if (sub_state == 0)
         {
-            if (velocity >= -131940)
+            if (velocity >= -2.01324_mph)
                 acceleration = -3298;
-            velocity = std::max(velocity, -131940);
+            velocity = std::max(velocity, -2.01324_mph);
         }
         else
         {
@@ -3710,7 +3710,7 @@ void Vehicle::UpdateTravelling()
             }
             else
             {
-                if (velocity <= 131940)
+                if (velocity <= 2.01324_mph)
                     acceleration = 3298;
             }
         }
@@ -3789,14 +3789,14 @@ void Vehicle::UpdateArrivingPassThroughStation(const Ride& curRide, const CarEnt
             return;
         }
 
-        if (velocity <= 131940)
+        if (velocity <= 2.01324_mph)
         {
             acceleration = 3298;
             return;
         }
 
         int32_t velocity_diff = velocity;
-        if (velocity_diff >= 1572864)
+        if (velocity_diff >= 24.0_mph)
             velocity_diff /= 8;
         else
             velocity_diff /= 16;
@@ -3818,18 +3818,18 @@ void Vehicle::UpdateArrivingPassThroughStation(const Ride& curRide, const CarEnt
     }
     else
     {
-        if (!(carEntry.flags & CAR_ENTRY_FLAG_POWERED) && velocity >= -131940)
+        if (!(carEntry.flags & CAR_ENTRY_FLAG_POWERED) && velocity >= -2.01324_mph)
         {
             acceleration = -3298;
         }
 
-        if (velocity >= -131940)
+        if (velocity >= -2.01324_mph)
         {
             return;
         }
 
         int32_t velocity_diff = velocity;
-        if (velocity_diff < -1572864)
+        if (velocity_diff < -24.0_mph)
             velocity_diff /= 8;
         else
             velocity_diff /= 16;
@@ -3937,7 +3937,7 @@ void Vehicle::UpdateArriving()
           & (VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_AT_STATION | VEHICLE_UPDATE_MOTION_TRACK_FLAG_1
              | VEHICLE_UPDATE_MOTION_TRACK_FLAG_5)))
     {
-        if (velocity > 98955)
+        if (velocity > 1.50993_mph)
             var_C0 = 0;
         return;
     }
@@ -4174,7 +4174,7 @@ void Vehicle::UpdateTravellingCableLift()
         }
     }
 
-    if (velocity <= 439800)
+    if (velocity <= 6.71082_mph)
     {
         acceleration = 4398;
     }
@@ -5468,7 +5468,7 @@ void Vehicle::UpdateSound()
 
     CarEntry* carEntry = &rideEntry->Cars[vehicle_type];
 
-    int32_t ecx = abs(velocity) - 0x10000;
+    int32_t ecx = abs(velocity) - 1.0_mph;
     if (ecx >= 0)
     {
         frictionSound.id = carEntry->friction_sound_id;
@@ -5482,7 +5482,7 @@ void Vehicle::UpdateSound()
             screamSound.id = scream_sound_id;
             if (!(gCurrentTicks & 0x7F))
             {
-                if (velocity < 0x40000 || scream_sound_id != OpenRCT2::Audio::SoundId::Null)
+                if (velocity < 4.0_mph || scream_sound_id != OpenRCT2::Audio::SoundId::Null)
                 {
                     GetLiftHillSound(*curRide, screamSound);
                     break;
@@ -5504,7 +5504,7 @@ void Vehicle::UpdateSound()
             screamSound.id = scream_sound_id;
             if (!(gCurrentTicks & 0x7F))
             {
-                if (velocity < 0x40000 || scream_sound_id != OpenRCT2::Audio::SoundId::Null)
+                if (velocity < 4.0_mph || scream_sound_id != OpenRCT2::Audio::SoundId::Null)
                 {
                     GetLiftHillSound(*curRide, screamSound);
                     break;
@@ -5569,7 +5569,7 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
 
     if (velocity < 0)
     {
-        if (velocity > -0x2C000)
+        if (velocity > -2.75_mph)
             return OpenRCT2::Audio::SoundId::Null;
 
         for (Vehicle* vehicle2 = GetEntity<Vehicle>(Id); vehicle2 != nullptr;
@@ -5587,7 +5587,7 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
         return OpenRCT2::Audio::SoundId::Null;
     }
 
-    if (velocity < 0x2C000)
+    if (velocity < 2.75_mph)
         return OpenRCT2::Audio::SoundId::Null;
 
     for (Vehicle* vehicle2 = GetEntity<Vehicle>(Id); vehicle2 != nullptr;
@@ -5861,7 +5861,7 @@ int32_t Vehicle::UpdateMotionDodgems()
             {
                 var_34 = (ScenarioRand() & 1) ? 1 : -1;
 
-                if (oldVelocity >= 131072)
+                if (oldVelocity >= 2.0_mph)
                 {
                     collideVehicle->DodgemsCollisionDirection = direction;
                     DodgemsCollisionDirection = direction ^ (1 << 4);
@@ -5871,7 +5871,7 @@ int32_t Vehicle::UpdateMotionDodgems()
             {
                 var_34 = (ScenarioRand() & 1) ? 6 : -6;
 
-                if (oldVelocity >= 131072)
+                if (oldVelocity >= 2.0_mph)
                 {
                     DodgemsCollisionDirection = direction ^ (1 << 4);
                 }
@@ -6085,7 +6085,7 @@ void Vehicle::ApplyStopBlockBrake()
     _vehicleMotionTrackFlags |= VEHICLE_UPDATE_MOTION_TRACK_FLAG_VEHICLE_AT_BLOCK_BRAKE;
     acceleration = 0;
     // If the this is slow enough, stop it. If not, slow it down
-    if (velocity <= 0x20000)
+    if (velocity <= 2.0_mph)
     {
         velocity = 0;
     }
@@ -7479,7 +7479,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(uint16_t trackType, const Rid
         if (tileElement->AsTrack()->GetTrackType() == TrackElemType::LeftReverser
             || tileElement->AsTrack()->GetTrackType() == TrackElemType::RightReverser)
         {
-            if (IsHead() && velocity <= 0x30000)
+            if (IsHead() && velocity <= 3.0_mph)
             {
                 velocity = 0;
             }
@@ -7653,7 +7653,7 @@ Loc6DAEB9:
     }
     if (trackType == TrackElemType::LogFlumeReverser)
     {
-        if (track_progress != 16 || velocity < 0x40000)
+        if (track_progress != 16 || velocity < 4.0_mph)
         {
             if (track_progress == 32)
             {
@@ -7767,7 +7767,7 @@ Loc6DAEB9:
                     auto velocityDelta = abs(velocity - head->velocity);
                     if (!(rideEntry.flags & RIDE_ENTRY_FLAG_DISABLE_COLLISION_CRASHES))
                     {
-                        if (velocityDelta > 0xE0000)
+                        if (velocityDelta > 14.0_mph)
                         {
                             if (!(carEntry->flags & CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
                             {
@@ -8074,7 +8074,7 @@ bool Vehicle::UpdateTrackMotionBackwards(CarEntry* carEntry, const Ride& curRide
 
                         if (!(rideEntry.flags & RIDE_ENTRY_FLAG_DISABLE_COLLISION_CRASHES))
                         {
-                            if (abs(v4->velocity - v3->velocity) > 0xE0000)
+                            if (abs(v4->velocity - v3->velocity) > 14.0_mph)
                             {
                                 if (!(carEntry->flags & CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
                                 {
@@ -8569,7 +8569,7 @@ Loc6DCD6B:
             return;
         }
         Vehicle* vEDI = gCurrentVehicle;
-        if (abs(vEDI->velocity - vEBP->velocity) > 0xE0000)
+        if (abs(vEDI->velocity - vEBP->velocity) > 14.0_mph)
         {
             if (!(carEntry->flags & CAR_ENTRY_FLAG_BOAT_HIRE_COLLISION_DETECTION))
             {
@@ -8724,7 +8724,7 @@ int32_t Vehicle::UpdateTrackMotionMiniGolfCalculateAcceleration(const CarEntry& 
             }
         }
 
-        if (abs(velocity) > 0x10000)
+        if (abs(velocity) > 1.0_mph)
         {
             newAcceleration = 0;
         }
@@ -8828,7 +8828,7 @@ int32_t Vehicle::UpdateTrackMotionPoweredRideAcceleration(CarEntry* carEntry, ui
         if (velocity > (speed * 0x4000))
         {
             // Same code as none powered rides
-            if (curAcceleration <= 0 && curAcceleration >= -500 && velocity <= 0x8000)
+            if (curAcceleration <= 0 && curAcceleration >= -500 && velocity <= 0.5_mph)
             {
                 return curAcceleration + 400;
             }
@@ -8885,7 +8885,7 @@ int32_t Vehicle::UpdateTrackMotionPoweredRideAcceleration(CarEntry* carEntry, ui
         }
     }
 
-    if (std::abs(velocity) <= 0x10000)
+    if (std::abs(velocity) <= 1.0_mph)
     {
         return poweredAcceleration;
     }
@@ -9081,7 +9081,7 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
     {
         // Probably moving slowly on a flat track piece, low rolling resistance and drag.
 
-        if (vehicle->velocity <= 0x8000 && vehicle->velocity >= 0)
+        if (vehicle->velocity <= 0.5_mph && vehicle->velocity >= 0)
         {
             // Vehicle is creeping forwards very slowly (less than ~2km/h), boost speed a bit.
             curAcceleration += 400;
@@ -9102,7 +9102,7 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
         {
             if (TrackElementIsCovered(vehicle->GetTrackType()))
             {
-                if (vehicle->velocity > 0x20000)
+                if (vehicle->velocity > 2.0_mph)
                 {
                     curAcceleration -= vehicle->velocity >> 6;
                 }

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -3515,7 +3515,7 @@ static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle->TrainHead()->velocity <= 0x50000)
+    if (vehicle->TrainHead()->velocity <= 5.0_mph)
     {
         return;
     }
@@ -3538,7 +3538,7 @@ static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle->velocity <= 0x50000)
+    if (vehicle->velocity <= 5.0_mph)
     {
         return;
     }
@@ -3561,7 +3561,7 @@ static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle->velocity <= 0x50000)
+    if (vehicle->velocity <= 5.0_mph)
     {
         return;
     }
@@ -3581,7 +3581,7 @@ static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle2->velocity <= 0x50000)
+    if (vehicle2->velocity <= 5.0_mph)
     {
         return;
     }
@@ -3609,7 +3609,7 @@ static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle2->velocity <= 0x50000)
+    if (vehicle2->velocity <= 5.0_mph)
     {
         return;
     }


### PR DESCRIPTION
Partly implements https://github.com/OpenRCT2/OpenRCT2/issues/14010

I placed the `mph` operator in the `common.h` file based on https://github.com/OpenRCT2/OpenRCT2/issues/14010#issuecomment-775175208.

Constants I haven't converted:
- Acceleration
- `speed_variable * hex_constant` -- I haven't converted `hex_constant` in this case, because to me it seems more like a multiplier than a speed.

