### PR TITLE
Refactor TitleLogo window

### DIFF
--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -27,51 +27,48 @@ static rct_widget window_title_logo_widgets[] = {
     WIDGETS_END,
 };
 
-static void WindowTitleMenuMouseup(rct_window* w, WidgetIndex widgetIndex);
-static void WindowTitleLogoPaint(rct_window* w, rct_drawpixelinfo* dpi);
+class TitleLogoWindow final : public Window {
+public:
+    /**
+     * Creates the window containing the logo and the expansion packs on the title screen.
+     *  rct2: 0x0066B679 (part of 0x0066B3E8)
+     */
+    void OnOpen() override
+    {
+        widgets = window_title_logo_widgets;
+        WindowInitScrollWidgets(*this);
+        colours[0] = TRANSLUCENT(COLOUR_GREY);
+        colours[1] = TRANSLUCENT(COLOUR_GREY);
+        colours[2] = TRANSLUCENT(COLOUR_GREY);
+    }
 
-// clang-format off
-static WindowEventList window_title_logo_events([](auto& events)
-{
-    events.mouse_up = &WindowTitleMenuMouseup;
-    events.paint = &WindowTitleLogoPaint;
-});
-// clang-format on
+    void OnMouseUp(WidgetIndex widgetIndex) override {
+        switch (widgetIndex)
+        {
+            case WIDX_LOGO:
+                WindowAboutOpen();
+                break;
+        }
+    }
 
-/**
- * Creates the window containing the logo and the expansion packs on the title screen.
- *  rct2: 0x0066B679 (part of 0x0066B3E8)
- */
+    /**
+     *
+     *  rct2: 0x0066B872
+     */
+    void OnDraw(rct_drawpixelinfo& dpi) override
+    {
+        auto screenCoords = windowPos + ScreenCoordsXY{ 2, 2 };
+        gfx_draw_sprite(&dpi, ImageId(SPR_G2_LOGO), screenCoords);
+        gfx_draw_sprite(&dpi, ImageId(SPR_G2_TITLE), screenCoords + ScreenCoordsXY{ 104, 18 });
+    }
+};
+
 rct_window* WindowTitleLogoOpen()
 {
-    rct_window* window = WindowCreate(
-        ScreenCoordsXY(0, 0), WW, WH, &window_title_logo_events, WindowClass::TitleLogo, WF_STICK_TO_BACK | WF_TRANSPARENT);
-    window->widgets = window_title_logo_widgets;
-    WindowInitScrollWidgets(*window);
-    window->colours[0] = TRANSLUCENT(COLOUR_GREY);
-    window->colours[1] = TRANSLUCENT(COLOUR_GREY);
-    window->colours[2] = TRANSLUCENT(COLOUR_GREY);
-
-    return window;
-}
-
-static void WindowTitleMenuMouseup(rct_window* w, WidgetIndex widgetIndex)
-{
-    switch (widgetIndex)
+    auto* window = window_bring_to_front_by_class(WindowClass::TitleLogo);
+    if (window == nullptr)
     {
-        case WIDX_LOGO:
-            WindowAboutOpen();
-            break;
+        window = WindowCreate<TitleLogoWindow>(WindowClass::TitleLogo, ScreenCoordsXY(0, 0), WW, WH, WF_STICK_TO_BACK | WF_TRANSPARENT);
     }
-}
-
-/**
- *
- *  rct2: 0x0066B872
- */
-static void WindowTitleLogoPaint(rct_window* w, rct_drawpixelinfo* dpi)
-{
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ 2, 2 };
-    gfx_draw_sprite(dpi, ImageId(SPR_G2_LOGO), screenCoords);
-    gfx_draw_sprite(dpi, ImageId(SPR_G2_TITLE), screenCoords + ScreenCoordsXY{ 104, 18 });
+    return window;
 }

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -27,7 +27,8 @@ static rct_widget window_title_logo_widgets[] = {
     WIDGETS_END,
 };
 
-class TitleLogoWindow final : public Window {
+class TitleLogoWindow final : public Window
+{
 public:
     /**
      * Creates the window containing the logo and the expansion packs on the title screen.
@@ -42,7 +43,8 @@ public:
         colours[2] = TRANSLUCENT(COLOUR_GREY);
     }
 
-    void OnMouseUp(WidgetIndex widgetIndex) override {
+    void OnMouseUp(WidgetIndex widgetIndex) override
+    {
         switch (widgetIndex)
         {
             case WIDX_LOGO:
@@ -68,7 +70,8 @@ rct_window* WindowTitleLogoOpen()
     auto* window = window_bring_to_front_by_class(WindowClass::TitleLogo);
     if (window == nullptr)
     {
-        window = WindowCreate<TitleLogoWindow>(WindowClass::TitleLogo, ScreenCoordsXY(0, 0), WW, WH, WF_STICK_TO_BACK | WF_TRANSPARENT);
+        window = WindowCreate<TitleLogoWindow>(
+            WindowClass::TitleLogo, ScreenCoordsXY(0, 0), WW, WH, WF_STICK_TO_BACK | WF_TRANSPARENT);
     }
     return window;
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/OpenRCT2/OpenRCT2/issues/18322

## Screenshots

I'm not sure whether this is the title logo window, but it seems to make the most sense.

![Screenshot of the main window](https://user-images.githubusercontent.com/7199958/195514774-7834e482-20d3-4562-a989-3251024a623d.png)

When the window is resized to a small size, the logo occludes the buttons.

![Screenshot of the main window showing the icon goes over the buttons when the screen is too small](https://user-images.githubusercontent.com/7199958/195514773-03ca65ff-902c-4de6-affc-fb5da33c0813.png)

Clicking on the logo reveals the About window.

![Screenshot of the About window](https://user-images.githubusercontent.com/7199958/195514768-50ccbd6d-df62-409c-81bb-f98d819c6703.png)
