### PR TITLE
Fix #17067: Random Staff Patrol Area clicks

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,6 +22,7 @@
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#14425] Ride ratings do not skip unallocated ride ids.
 - Fix: [#15969] Guests heading for ride use vanilla behaviour
+- Fix: [#17067] Random Staff Patrol Area clicks
 - Fix: [#17316] Sides of River Rapids’ corners overlay other parts of the track.
 - Fix: [#17657] When switching from buying land rights to buying construction rights, grid disables and won't re-enable afterwards.
 - Fix: [#17763] Missing validation on invalid characters in file name.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -22,7 +22,7 @@
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#14425] Ride ratings do not skip unallocated ride ids.
 - Fix: [#15969] Guests heading for ride use vanilla behaviour
-- Fix: [#17067] Random Staff Patrol Area clicks
+- Fix: [#17067] Random Staff Patrol Area clicks.
 - Fix: [#17316] Sides of River Rapids’ corners overlay other parts of the track.
 - Fix: [#17657] When switching from buying land rights to buying construction rights, grid disables and won't re-enable afterwards.
 - Fix: [#17763] Missing validation on invalid characters in file name.

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -375,6 +375,9 @@ static void GameHandleInputMouse(const ScreenCoordsXY& screenCoords, MouseState 
                         break;
                     }
 
+                    if (!input_test_flag(INPUT_FLAG_4))
+                        break;
+
                     if (w->classification != _dragWidget.window_classification || w->number != _dragWidget.window_number
                         || !(_inputFlags & INPUT_FLAG_TOOL_ACTIVE))
                     {
@@ -1043,8 +1046,8 @@ static void InputWidgetLeft(const ScreenCoordsXY& screenCoords, rct_window* w, W
                 w = window_find_by_number(gCurrentToolWidget.window_classification, gCurrentToolWidget.window_number);
                 if (w != nullptr)
                 {
+                    input_set_flag(INPUT_FLAG_4, true);
                     window_event_tool_down_call(w, gCurrentToolWidget.widget_index, screenCoords);
-                    _inputFlags |= INPUT_FLAG_4;
                 }
             }
             break;

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1361,6 +1361,7 @@ bool tool_set(const rct_window& w, WidgetIndex widgetIndex, Tool tool)
     }
 
     input_set_flag(INPUT_FLAG_TOOL_ACTIVE, true);
+    input_set_flag(INPUT_FLAG_4, false);
     input_set_flag(INPUT_FLAG_6, false);
     gCurrentToolId = tool;
     gCurrentToolWidget.window_classification = w.classification;


### PR DESCRIPTION
Clicking the tile with Global Patrol area enabled still fires OnToolDrag but the problem is that PatrolAreaWindow tool is not fully initialized with other attributes especially gMapSelectPositionA, B.

To avoid the uninitialized call behavior, add a None enum which only sets when the tool is ready to act.

You can tell this misbehavior from the patrol icon is being created when you click the tile with Global Patrol Area enabled.
Before
![before fix](https://user-images.githubusercontent.com/12020398/195522675-1fde41c0-5187-4f21-b957-d4af89b71fa5.gif)

After
![after fix](https://user-images.githubusercontent.com/12020398/195522691-546c135a-f3e1-4925-941e-6b8fe6685d6d.gif)
