### PR TITLE
Ensure argv on Windows is nullptr-terminated

### DIFF
--- a/src/openrct2-win/openrct2-win.cpp
+++ b/src/openrct2-win/openrct2-win.cpp
@@ -40,8 +40,10 @@ int wmain(int argc, wchar_t** argvW, [[maybe_unused]] wchar_t* envp)
     std::vector<const char*> argv;
     std::transform(
         argvStrings.begin(), argvStrings.end(), std::back_inserter(argv), [](const auto& string) { return string.c_str(); });
-    auto exitCode = NormalisedMain(argc, argv.data());
-    return exitCode;
+
+    // Ensure that argv[argc] == nullptr, as mandated by the standard
+    argv.push_back(nullptr);
+    return NormalisedMain(argc, argv.data());
 }
 
 static std::vector<std::string> GetCommandLineArgs(int argc, wchar_t** argvW)


### PR DESCRIPTION
This PR salvages the one good aspect of a "failed" PR #14702 that I never cherry picked before. `argv[argc]` is guaranteed to be `nullptr,` which means `argv` can safely be used as a terminated array of pointers.

On Windows, this was not guaranteed due to the performed widechar->UTF-8 conversion not accounting for this terminating elements; therefore if any code in OpenRCT2 (current or future) tries to rely on this, it'll result in hard to troubleshoot Windows-only issues.