### PR TITLE
Stop publishing develop builds to Flathub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,18 +317,6 @@ jobs:
           name: OpenRCT2-AppImage
           path: artifacts
           if-no-files-found: error
-  linux-flathub-beta:
-    name: Linux (Flathub beta channel)
-    if: github.repository == 'OpenRCT2/OpenRCT2' && github.ref == 'refs/heads/develop' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Send dispatch event to OpenRCT2 Flathub repository
-        uses: peter-evans/repository-dispatch@v1
-        with:
-          token: ${{ secrets.OPENRCT2_FLATHUB_TOKEN }}
-          repository: flathub/io.openrct2.OpenRCT2
-          event-type: openrct2_develop_push
-          client-payload: '{ "commit": "${{ github.sha }}" }'
   linux-docker:
     name: Linux (docker)
     needs: check-code-formatting

--- a/readme.md
+++ b/readme.md
@@ -73,8 +73,7 @@ OpenRCT2 requires original files of RollerCoaster Tycoon 2 to play. It can be bo
 [OpenRCT2.org](https://openrct2.org/downloads) offers precompiled builds and installers of the latest master and the develop branch. There is also a cross platform [Launcher](https://github.com/LRFLEW/OpenRCT2Launcher/releases) available that will automatically update your build of the game so that you always have the latest version.
 
 [Flathub](https://flathub.org/) offers flatpaks for Linux distributions that support this application distribution system:
-* [Latest stable release](https://flathub.org/repo/appstream/io.openrct2.OpenRCT2.flatpakref)
-* [Latest development build](https://flathub.org/beta-repo/appstream/io.openrct2.OpenRCT2.flatpakref)
+* [Latest release](https://flathub.org/apps/details/io.openrct2.OpenRCT2)
 
 Some Linux distributions offer native packages already. These packages are usually third-party, but we're trying to resolve issues they are facing.
 * ArchLinux: [openrct2-git](https://aur.archlinux.org/packages/openrct2-git) (AUR) and [openrct2](https://archlinux.org/packages/community/x86_64/openrct2/) (Community)


### PR DESCRIPTION
Flathub recently [enforced pull request workflow](https://discourse.flathub.org/t/enforcing-pull-request-workflow-and-green-ci-status-of-prs/3109), which means pushing new commits from OpenRCT2 `develop` branch to the flatpak `beta` branch doesn't work anymore.

Moreover, while the stable branch has automation in place to automatically open PRs when new releases are published, the beta branch required constant monitoring and manual interventions.

So as maintaining the beta builds will require an unreasonable amount of work, I think it's a good time to stop publishing them.

Nothing changes for stable builds, they are still published on a timely manner to Flathub.