### PR TITLE
Code style: Remove struct snakes from Paint

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2628,7 +2628,7 @@ private:
         TileElement tempSideTrackTileElement{ 0x80, 0x8F, 128, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         TileElement tempTrackTileElement{};
         TileElement* backupTileElementArrays[5]{};
-        paint_session* session = PaintSessionAlloc(dpi, 0);
+        PaintSession* session = PaintSessionAlloc(dpi, 0);
         trackDirection &= 3;
 
         auto currentRide = get_ride(rideIndex);

--- a/src/openrct2/cmdline/BenchSpriteSort.cpp
+++ b/src/openrct2/cmdline/BenchSpriteSort.cpp
@@ -43,25 +43,25 @@ static void fixup_pointers(std::vector<RecordedPaintSession>& s)
         auto& quadrants = s[i].Session.Quadrants;
         for (size_t j = 0; j < entries.size(); j++)
         {
-            if (entries[j].AsBasic()->next_quadrant_ps == reinterpret_cast<paint_struct*>(-1))
+            if (entries[j].AsBasic()->next_quadrant_ps == reinterpret_cast<PaintStruct*>(-1))
             {
                 entries[j].AsBasic()->next_quadrant_ps = nullptr;
             }
             else
             {
-                auto nextQuadrantPs = reinterpret_cast<size_t>(entries[j].AsBasic()->next_quadrant_ps) / sizeof(paint_entry);
+                auto nextQuadrantPs = reinterpret_cast<size_t>(entries[j].AsBasic()->next_quadrant_ps) / sizeof(PaintEntry);
                 entries[j].AsBasic()->next_quadrant_ps = s[i].Entries[nextQuadrantPs].AsBasic();
             }
         }
         for (size_t j = 0; j < std::size(quadrants); j++)
         {
-            if (quadrants[j] == reinterpret_cast<paint_struct*>(-1))
+            if (quadrants[j] == reinterpret_cast<PaintStruct*>(-1))
             {
                 quadrants[j] = nullptr;
             }
             else
             {
-                auto ps = reinterpret_cast<size_t>(quadrants[j]) / sizeof(paint_entry);
+                auto ps = reinterpret_cast<size_t>(quadrants[j]) / sizeof(PaintEntry);
                 quadrants[j] = entries[ps].AsBasic();
             }
         }
@@ -160,11 +160,11 @@ static int cmdline_for_bench_sprite_sort(int argc, const char** argv)
         std::vector<RecordedPaintSession> sessions(1);
         for (auto& ps : sessions[0].Entries)
         {
-            ps.AsBasic()->next_quadrant_ps = reinterpret_cast<paint_struct*>(-1);
+            ps.AsBasic()->next_quadrant_ps = reinterpret_cast<PaintStruct*>(-1);
         }
         for (auto& quad : sessions[0].Session.Quadrants)
         {
-            quad = reinterpret_cast<paint_struct*>(-1);
+            quad = reinterpret_cast<PaintStruct*>(-1);
         }
         benchmark::RegisterBenchmark("baseline", BM_paint_session_arrange, sessions);
     }

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -571,7 +571,7 @@ void scrolling_text_invalidate();
 class Formatter;
 
 ImageId scrolling_text_setup(
-    struct paint_session& session, StringId stringId, Formatter& ft, uint16_t scroll, uint16_t scrollingMode, colour_t colour);
+    struct PaintSession& session, StringId stringId, Formatter& ft, uint16_t scroll, uint16_t scrollingMode, colour_t colour);
 
 size_t g1_calculate_data_size(const rct_g1_element* g1);
 

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -305,7 +305,7 @@ void lightfx_prepare_light_list()
                     dpi.zoom_level = _current_view_zoom_front;
                     dpi.width = 1;
 
-                    paint_session* session = PaintSessionAlloc(&dpi, w->viewport->flags);
+                    PaintSession* session = PaintSessionAlloc(&dpi, w->viewport->flags);
                     PaintSessionGenerate(*session);
                     PaintSessionArrange(*session);
                     auto info = set_interaction_info_from_paint_session(

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -1445,7 +1445,7 @@ void scrolling_text_invalidate()
 }
 
 ImageId scrolling_text_setup(
-    paint_session& session, StringId stringId, Formatter& ft, uint16_t scroll, uint16_t scrollingMode, colour_t colour)
+    PaintSession& session, StringId stringId, Formatter& ft, uint16_t scroll, uint16_t scrollingMode, colour_t colour)
 {
     std::scoped_lock<std::mutex> lock(_scrollingTextMutex);
 

--- a/src/openrct2/entity/Balloon.cpp
+++ b/src/openrct2/entity/Balloon.cpp
@@ -109,7 +109,7 @@ void Balloon::Serialise(DataSerialiser& stream)
     stream << colour;
 }
 
-void Balloon::Paint(paint_session& session, int32_t imageDirection) const
+void Balloon::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/entity/Balloon.h
+++ b/src/openrct2/entity/Balloon.h
@@ -13,7 +13,7 @@
 
 class DataSerialiser;
 struct CoordsXYZ;
-struct paint_session;
+struct PaintSession;
 
 struct Balloon : EntityBase
 {
@@ -27,5 +27,5 @@ struct Balloon : EntityBase
     void Pop();
     void Press();
     void Serialise(DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 };

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -365,7 +365,7 @@ void Duck::Serialise(DataSerialiser& stream)
     stream << state;
 }
 
-void Duck::Paint(paint_session& session, int32_t imageDirection) const
+void Duck::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/entity/Duck.h
+++ b/src/openrct2/entity/Duck.h
@@ -13,7 +13,7 @@
 
 class DataSerialiser;
 struct CoordsXY;
-struct paint_session;
+struct PaintSession;
 
 struct Duck : EntityBase
 {
@@ -39,7 +39,7 @@ struct Duck : EntityBase
     bool IsFlying();
     void Remove();
     void Serialise(DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 
 private:
     void UpdateFlyToWater();

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -395,7 +395,7 @@ void JumpingFountain::Serialise(DataSerialiser& stream)
     stream << Iteration;
 }
 
-void JumpingFountain::Paint(paint_session& session, int32_t imageDirection) const
+void JumpingFountain::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/entity/Fountain.h
+++ b/src/openrct2/entity/Fountain.h
@@ -35,7 +35,7 @@ struct JumpingFountain : EntityBase
     void Update();
     static void StartAnimation(JumpingFountainType newType, const CoordsXY& newLoc, const TileElement* tileElement);
     void Serialise(DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 
 private:
     JumpingFountainType GetType() const;

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -5065,7 +5065,7 @@ void Guest::UpdateRideShopLeave()
             return;
     }
 
-    //#11758 Previously SetState(PeepState::Walking) caused Peeps to double-back to exit point of shop
+    // #11758 Previously SetState(PeepState::Walking) caused Peeps to double-back to exit point of shop
     SetState(PeepState::Falling);
 
     auto ride = get_ride(CurrentRide);

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -170,7 +170,7 @@ static constexpr const LitterSprite _litterSprites[] = {
     { SPR_LITTER_EMPTY_BOWL_BLUE, 0x3 },
 };
 
-void Litter::Paint(paint_session& session, int32_t imageDirection) const
+void Litter::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/entity/Litter.h
+++ b/src/openrct2/entity/Litter.h
@@ -14,7 +14,7 @@
 class DataSerialiser;
 struct CoordsXYZ;
 struct CoordsXYZD;
-struct paint_session;
+struct PaintSession;
 
 struct Litter : EntityBase
 {
@@ -42,5 +42,5 @@ struct Litter : EntityBase
     void Serialise(DataSerialiser& stream);
     StringId GetName() const;
     uint32_t GetAge() const;
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 };

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -167,7 +167,7 @@ void MoneyEffect::Serialise(DataSerialiser& stream)
     stream << Wiggle;
 }
 
-void MoneyEffect::Paint(paint_session& session, int32_t imageDirection) const
+void MoneyEffect::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/entity/MoneyEffect.h
+++ b/src/openrct2/entity/MoneyEffect.h
@@ -13,7 +13,7 @@
 
 class DataSerialiser;
 struct CoordsXYZ;
-struct paint_session;
+struct PaintSession;
 
 struct MoneyEffect : EntityBase
 {
@@ -32,5 +32,5 @@ struct MoneyEffect : EntityBase
     void Update();
     std::pair<StringId, money64> GetStringId() const;
     void Serialise(DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 };

--- a/src/openrct2/entity/Particle.cpp
+++ b/src/openrct2/entity/Particle.cpp
@@ -151,7 +151,7 @@ void VehicleCrashParticle::Serialise(DataSerialiser& stream)
     stream << acceleration_z;
 }
 
-void VehicleCrashParticle::Paint(paint_session& session, int32_t imageDirection) const
+void VehicleCrashParticle::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
@@ -203,7 +203,7 @@ void CrashSplashParticle::Serialise(DataSerialiser& stream)
     stream << frame;
 }
 
-void CrashSplashParticle::Paint(paint_session& session, int32_t imageDirection) const
+void CrashSplashParticle::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
@@ -262,7 +262,7 @@ void SteamParticle::Serialise(DataSerialiser& stream)
     stream << time_to_move;
 }
 
-void SteamParticle::Paint(paint_session& session, int32_t imageDirection) const
+void SteamParticle::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
@@ -308,7 +308,7 @@ void ExplosionCloud::Serialise(DataSerialiser& stream)
     stream << frame;
 }
 
-void ExplosionCloud::Paint(paint_session& session, int32_t imageDirection) const
+void ExplosionCloud::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
@@ -353,7 +353,7 @@ void ExplosionFlare::Serialise(DataSerialiser& stream)
     stream << frame;
 }
 
-void ExplosionFlare::Paint(paint_session& session, int32_t imageDirection) const
+void ExplosionFlare::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/entity/Particle.h
+++ b/src/openrct2/entity/Particle.h
@@ -13,7 +13,7 @@
 
 class DataSerialiser;
 struct CoordsXYZ;
-struct paint_session;
+struct PaintSession;
 struct VehicleColour;
 
 struct VehicleCrashParticle : EntityBase
@@ -32,7 +32,7 @@ struct VehicleCrashParticle : EntityBase
     static void Create(VehicleColour& colours, const CoordsXYZ& vehiclePos);
     void Update();
     void Serialise(DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 };
 
 struct CrashSplashParticle : EntityBase
@@ -42,7 +42,7 @@ struct CrashSplashParticle : EntityBase
     static void Create(const CoordsXYZ& splashPos);
     void Update();
     void Serialise(DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 };
 
 struct ExplosionFlare : EntityBase
@@ -52,7 +52,7 @@ struct ExplosionFlare : EntityBase
     static void Create(const CoordsXYZ& flarePos);
     void Update();
     void Serialise(DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 };
 
 struct ExplosionCloud : EntityBase
@@ -62,7 +62,7 @@ struct ExplosionCloud : EntityBase
     static void Create(const CoordsXYZ& cloudPos);
     void Update();
     void Serialise(DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 };
 
 struct SteamParticle : EntityBase
@@ -74,5 +74,5 @@ struct SteamParticle : EntityBase
     static void Create(const CoordsXYZ& coords);
     void Update();
     void Serialise(DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 };

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -2761,7 +2761,7 @@ void Peep::Serialise(DataSerialiser& stream)
     stream << PeepFlags;
 }
 
-void Peep::Paint(paint_session& session, int32_t imageDirection) const
+void Peep::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -29,7 +29,7 @@ constexpr auto PEEP_CLEARANCE_HEIGHT = 4 * COORDS_Z_STEP;
 
 class Formatter;
 struct TileElement;
-struct paint_session;
+struct PaintSession;
 
 namespace GameActions
 {
@@ -407,7 +407,7 @@ public: // Peep
     [[nodiscard]] CoordsXY GetDestination() const;
 
     void Serialise(class DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 
     // TODO: Make these private again when done refactoring
 public: // Peep

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -16,16 +16,16 @@
 #include <optional>
 #include <vector>
 
-struct paint_session;
+struct PaintSession;
 struct RecordedPaintSession;
-struct paint_struct;
+struct PaintStruct;
 struct rct_drawpixelinfo;
 struct TileElement;
 struct rct_window;
 struct EntityBase;
 struct Guest;
 struct Staff;
-struct paint_entry;
+struct PaintEntry;
 
 // Flags must currenly retain their values to avoid breaking plugins.
 // Values can be changed when plugins move to using named constants.
@@ -94,7 +94,7 @@ constexpr uint16_t ViewportInteractionItemAll = std::numeric_limits<uint16_t>::m
 struct InteractionInfo
 {
     InteractionInfo() = default;
-    InteractionInfo(const paint_struct* ps);
+    InteractionInfo(const PaintStruct* ps);
     CoordsXY Loc;
     TileElement* Element{};
     EntityBase* Entity{};
@@ -117,7 +117,7 @@ extern ScreenCoordsXY gSavedView;
 extern ZoomLevel gSavedViewZoom;
 extern uint8_t gSavedViewRotation;
 
-extern paint_entry* gNextFreePaintStruct;
+extern PaintEntry* gNextFreePaintStruct;
 extern uint8_t gCurrentRotation;
 
 void viewport_init_all();
@@ -154,7 +154,7 @@ void viewport_set_visibility(uint8_t mode);
 InteractionInfo get_map_coordinates_from_pos(const ScreenCoordsXY& screenCoords, int32_t flags);
 InteractionInfo get_map_coordinates_from_pos_window(rct_window* window, const ScreenCoordsXY& screenCoords, int32_t flags);
 
-InteractionInfo set_interaction_info_from_paint_session(paint_session* session, uint32_t viewFlags, uint16_t filter);
+InteractionInfo set_interaction_info_from_paint_session(PaintSession* session, uint32_t viewFlags, uint16_t filter);
 InteractionInfo ViewportInteractionGetItemLeft(const ScreenCoordsXY& screenCoords);
 bool ViewportInteractionLeftOver(const ScreenCoordsXY& screenCoords);
 bool ViewportInteractionLeftClick(const ScreenCoordsXY& screenCoords);
@@ -178,4 +178,4 @@ int32_t get_height_marker_offset();
 
 void viewport_set_saved_view();
 
-VisibilityKind GetPaintStructVisibility(const paint_struct* ps, uint32_t viewFlags);
+VisibilityKind GetPaintStructVisibility(const PaintStruct* ps, uint32_t viewFlags);

--- a/src/openrct2/paint/Paint.Entity.cpp
+++ b/src/openrct2/paint/Paint.Entity.cpp
@@ -34,7 +34,7 @@
  * Paint Quadrant
  *  rct2: 0x0069E8B0
  */
-void EntityPaintSetup(paint_session& session, const CoordsXY& pos)
+void EntityPaintSetup(PaintSession& session, const CoordsXY& pos)
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/paint/Paint.Entity.h
+++ b/src/openrct2/paint/Paint.Entity.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-struct paint_session;
+struct PaintSession;
 struct CoordsXY;
 
-void EntityPaintSetup(paint_session& session, const CoordsXY& pos);
+void EntityPaintSetup(PaintSession& session, const CoordsXY& pos);

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -55,11 +55,11 @@ bool gShowDirtyVisuals;
 bool gPaintBoundingBoxes;
 bool gPaintBlockedTiles;
 
-static void PaintAttachedPS(rct_drawpixelinfo* dpi, paint_struct* ps, uint32_t viewFlags);
-static void PaintPSImageWithBoundingBoxes(rct_drawpixelinfo* dpi, paint_struct* ps, ImageId imageId, int32_t x, int32_t y);
-static ImageId PaintPSColourifyImage(const paint_struct* ps, ImageId imageId, uint32_t viewFlags);
+static void PaintAttachedPS(rct_drawpixelinfo* dpi, PaintStruct* ps, uint32_t viewFlags);
+static void PaintPSImageWithBoundingBoxes(rct_drawpixelinfo* dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y);
+static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uint32_t viewFlags);
 
-static int32_t RemapPositionToQuadrant(const paint_struct& ps, uint8_t rotation)
+static int32_t RemapPositionToQuadrant(const PaintStruct& ps, uint8_t rotation)
 {
     constexpr auto MapRangeMax = MaxPaintQuadrants * COORDS_XY_STEP;
     constexpr auto MapRangeCenter = MapRangeMax / 2;
@@ -85,7 +85,7 @@ static int32_t RemapPositionToQuadrant(const paint_struct& ps, uint8_t rotation)
     return 0;
 }
 
-static void PaintSessionAddPSToQuadrant(paint_session& session, paint_struct* ps)
+static void PaintSessionAddPSToQuadrant(PaintSession& session, PaintStruct* ps)
 {
     const auto positionHash = RemapPositionToQuadrant(*ps, session.CurrentRotation);
 
@@ -148,8 +148,8 @@ static constexpr CoordsXYZ RotateBoundBoxSize(const CoordsXYZ& bbSize, const uin
 /**
  * Extracted from 0x0098196c, 0x0098197c, 0x0098198c, 0x0098199c
  */
-static paint_struct* CreateNormalPaintStruct(
-    paint_session& session, ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
+static PaintStruct* CreateNormalPaintStruct(
+    PaintSession& session, ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
 {
     auto* const g1 = gfx_get_g1_element(image_id);
     if (g1 == nullptr)
@@ -197,7 +197,7 @@ static paint_struct* CreateNormalPaintStruct(
     return ps;
 }
 
-template<uint8_t direction> void PaintSessionGenerateRotate(paint_session& session)
+template<uint8_t direction> void PaintSessionGenerateRotate(PaintSession& session)
 {
     // Optimised modified version of viewport_coord_to_map_coord
     ScreenCoordsXY screenCoord = { floor2(session.DPI.x, 32), floor2((session.DPI.y - 16), 32) };
@@ -243,7 +243,7 @@ template<uint8_t direction> void PaintSessionGenerateRotate(paint_session& sessi
  *
  *  rct2: 0x0068B6C2
  */
-void PaintSessionGenerate(paint_session& session)
+void PaintSessionGenerate(PaintSession& session)
 {
     session.CurrentRotation = get_current_rotation();
     switch (DirectionFlipXAxis(session.CurrentRotation))
@@ -263,13 +263,12 @@ void PaintSessionGenerate(paint_session& session)
     }
 }
 
-template<uint8_t>
-static bool CheckBoundingBox(const paint_struct_bound_box& initialBBox, const paint_struct_bound_box& currentBBox)
+template<uint8_t> static bool CheckBoundingBox(const PaintStructBoundBox& initialBBox, const PaintStructBoundBox& currentBBox)
 {
     return false;
 }
 
-template<> bool CheckBoundingBox<0>(const paint_struct_bound_box& initialBBox, const paint_struct_bound_box& currentBBox)
+template<> bool CheckBoundingBox<0>(const PaintStructBoundBox& initialBBox, const PaintStructBoundBox& currentBBox)
 {
     if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end >= currentBBox.y && initialBBox.x_end >= currentBBox.x
         && !(initialBBox.z < currentBBox.z_end && initialBBox.y < currentBBox.y_end && initialBBox.x < currentBBox.x_end))
@@ -279,7 +278,7 @@ template<> bool CheckBoundingBox<0>(const paint_struct_bound_box& initialBBox, c
     return false;
 }
 
-template<> bool CheckBoundingBox<1>(const paint_struct_bound_box& initialBBox, const paint_struct_bound_box& currentBBox)
+template<> bool CheckBoundingBox<1>(const PaintStructBoundBox& initialBBox, const PaintStructBoundBox& currentBBox)
 {
     if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end >= currentBBox.y && initialBBox.x_end < currentBBox.x
         && !(initialBBox.z < currentBBox.z_end && initialBBox.y < currentBBox.y_end && initialBBox.x >= currentBBox.x_end))
@@ -289,7 +288,7 @@ template<> bool CheckBoundingBox<1>(const paint_struct_bound_box& initialBBox, c
     return false;
 }
 
-template<> bool CheckBoundingBox<2>(const paint_struct_bound_box& initialBBox, const paint_struct_bound_box& currentBBox)
+template<> bool CheckBoundingBox<2>(const PaintStructBoundBox& initialBBox, const PaintStructBoundBox& currentBBox)
 {
     if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end < currentBBox.y && initialBBox.x_end < currentBBox.x
         && !(initialBBox.z < currentBBox.z_end && initialBBox.y >= currentBBox.y_end && initialBBox.x >= currentBBox.x_end))
@@ -299,7 +298,7 @@ template<> bool CheckBoundingBox<2>(const paint_struct_bound_box& initialBBox, c
     return false;
 }
 
-template<> bool CheckBoundingBox<3>(const paint_struct_bound_box& initialBBox, const paint_struct_bound_box& currentBBox)
+template<> bool CheckBoundingBox<3>(const PaintStructBoundBox& initialBBox, const PaintStructBoundBox& currentBBox)
 {
     if (initialBBox.z_end >= currentBBox.z && initialBBox.y_end < currentBBox.y && initialBBox.x_end >= currentBBox.x
         && !(initialBBox.z < currentBBox.z_end && initialBBox.y >= currentBBox.y_end && initialBBox.x < currentBBox.x_end))
@@ -318,10 +317,10 @@ namespace PaintSortFlags
 } // namespace PaintSortFlags
 
 template<uint8_t TRotation>
-static paint_struct* PaintArrangeStructsHelperRotation(paint_struct* ps_next, uint16_t quadrantIndex, uint8_t flag)
+static PaintStruct* PaintArrangeStructsHelperRotation(PaintStruct* ps_next, uint16_t quadrantIndex, uint8_t flag)
 {
-    paint_struct* ps;
-    paint_struct* ps_temp;
+    PaintStruct* ps;
+    PaintStruct* ps_temp;
 
     // Get the first node in the specified quadrant.
     do
@@ -334,7 +333,7 @@ static paint_struct* PaintArrangeStructsHelperRotation(paint_struct* ps_next, ui
 
     // We keep track of the first node in the quadrant so the next call with a higher quadrant index
     // can use this node to skip some iterations.
-    paint_struct* psQuadrantEntry = ps;
+    PaintStruct* psQuadrantEntry = ps;
 
     // Visit all nodes in the linked quadrant list and determine their current
     // sorting relevancy.
@@ -394,7 +393,7 @@ static paint_struct* PaintArrangeStructsHelperRotation(paint_struct* ps_next, ui
         ps_temp = ps;
 
         // Compare current node against the remaining children.
-        const paint_struct_bound_box& initialBBox = ps_next->bounds;
+        const PaintStructBoundBox& initialBBox = ps_next->bounds;
         while (true)
         {
             ps = ps_next;
@@ -406,7 +405,7 @@ static paint_struct* PaintArrangeStructsHelperRotation(paint_struct* ps_next, ui
             if (!(ps_next->SortFlags & PaintSortFlags::Neighbour))
                 continue;
 
-            const paint_struct_bound_box& currentBBox = ps_next->bounds;
+            const PaintStructBoundBox& currentBBox = ps_next->bounds;
 
             const bool compareResult = CheckBoundingBox<TRotation>(initialBBox, currentBBox);
 
@@ -414,7 +413,7 @@ static paint_struct* PaintArrangeStructsHelperRotation(paint_struct* ps_next, ui
             {
                 // Child node intersects with current node, move behind.
                 ps->next_quadrant_ps = ps_next->next_quadrant_ps;
-                paint_struct* ps_temp2 = ps_temp->next_quadrant_ps;
+                PaintStruct* ps_temp2 = ps_temp->next_quadrant_ps;
                 ps_temp->next_quadrant_ps = ps_next;
                 ps_next->next_quadrant_ps = ps_temp2;
                 ps_next = ps;
@@ -427,9 +426,9 @@ static paint_struct* PaintArrangeStructsHelperRotation(paint_struct* ps_next, ui
 
 template<int TRotation> static void PaintSessionArrange(PaintSessionCore& session, bool)
 {
-    paint_struct* psHead = &session.PaintHead;
+    PaintStruct* psHead = &session.PaintHead;
 
-    paint_struct* ps = psHead;
+    PaintStruct* ps = psHead;
     ps->next_quadrant_ps = nullptr;
 
     uint32_t quadrantIndex = session.QuadrantBackIndex;
@@ -437,7 +436,7 @@ template<int TRotation> static void PaintSessionArrange(PaintSessionCore& sessio
     {
         do
         {
-            paint_struct* ps_next = session.Quadrants[quadrantIndex];
+            PaintStruct* ps_next = session.Quadrants[quadrantIndex];
             if (ps_next != nullptr)
             {
                 ps->next_quadrant_ps = ps_next;
@@ -450,7 +449,7 @@ template<int TRotation> static void PaintSessionArrange(PaintSessionCore& sessio
             }
         } while (++quadrantIndex <= session.QuadrantFrontIndex);
 
-        paint_struct* ps_cache = PaintArrangeStructsHelperRotation<TRotation>(
+        PaintStruct* ps_cache = PaintArrangeStructsHelperRotation<TRotation>(
             psHead, session.QuadrantBackIndex & 0xFFFF, PaintSortFlags::Neighbour);
 
         quadrantIndex = session.QuadrantBackIndex;
@@ -482,7 +481,7 @@ void PaintSessionArrange(PaintSessionCore& session)
     Guard::Assert(false);
 }
 
-static void PaintDrawStruct(paint_session& session, paint_struct* ps)
+static void PaintDrawStruct(PaintSession& session, PaintStruct* ps)
 {
     rct_drawpixelinfo* dpi = &session.DPI;
 
@@ -527,11 +526,11 @@ static void PaintDrawStruct(paint_session& session, paint_struct* ps)
  *
  *  rct2: 0x00688485
  */
-void PaintDrawStructs(paint_session& session)
+void PaintDrawStructs(PaintSession& session)
 {
     PROFILED_FUNCTION();
 
-    paint_struct* ps = &session.PaintHead;
+    PaintStruct* ps = &session.PaintHead;
 
     for (ps = ps->next_quadrant_ps; ps != nullptr;)
     {
@@ -546,9 +545,9 @@ void PaintDrawStructs(paint_session& session)
  *  rct2: 0x00688596
  *  Part of 0x688485
  */
-static void PaintAttachedPS(rct_drawpixelinfo* dpi, paint_struct* ps, uint32_t viewFlags)
+static void PaintAttachedPS(rct_drawpixelinfo* dpi, PaintStruct* ps, uint32_t viewFlags)
 {
-    attached_paint_struct* attached_ps = ps->attached_ps;
+    AttachedPaintStruct* attached_ps = ps->attached_ps;
     for (; attached_ps != nullptr; attached_ps = attached_ps->next)
     {
         auto screenCoords = ScreenCoordsXY{ attached_ps->x + ps->x, attached_ps->y + ps->y };
@@ -565,7 +564,7 @@ static void PaintAttachedPS(rct_drawpixelinfo* dpi, paint_struct* ps, uint32_t v
     }
 }
 
-static void PaintPSImageWithBoundingBoxes(rct_drawpixelinfo* dpi, paint_struct* ps, ImageId imageId, int32_t x, int32_t y)
+static void PaintPSImageWithBoundingBoxes(rct_drawpixelinfo* dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y)
 {
     const uint8_t colour = BoundBoxDebugColours[EnumValue(ps->sprite_type)];
     const uint8_t rotation = get_current_rotation();
@@ -651,7 +650,7 @@ static void PaintPSImageWithBoundingBoxes(rct_drawpixelinfo* dpi, paint_struct* 
     gfx_draw_line(dpi, { screenCoordFrontTop, screenCoordRightTop }, colour);
 }
 
-static ImageId PaintPSColourifyImage(const paint_struct* ps, ImageId imageId, uint32_t viewFlags)
+static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uint32_t viewFlags)
 {
     auto visibility = GetPaintStructVisibility(ps, viewFlags);
     switch (visibility)
@@ -665,12 +664,12 @@ static ImageId PaintPSColourifyImage(const paint_struct* ps, ImageId imageId, ui
     }
 }
 
-paint_session* PaintSessionAlloc(rct_drawpixelinfo* dpi, uint32_t viewFlags)
+PaintSession* PaintSessionAlloc(rct_drawpixelinfo* dpi, uint32_t viewFlags)
 {
     return GetContext()->GetPainter()->CreateSession(dpi, viewFlags);
 }
 
-void PaintSessionFree([[maybe_unused]] paint_session* session)
+void PaintSessionFree([[maybe_unused]] PaintSession* session)
 {
     GetContext()->GetPainter()->ReleaseSession(session);
 }
@@ -685,16 +684,16 @@ void PaintSessionFree([[maybe_unused]] paint_session* session)
  * @param bound_box_length_y (si)
  * @param bound_box_length_z (ah)
  * @param z_offset (dx)
- * @return (ebp) paint_struct on success (CF == 0), nullptr on failure (CF == 1)
+ * @return (ebp) PaintStruct on success (CF == 0), nullptr on failure (CF == 1)
  */
-paint_struct* PaintAddImageAsParent(
-    paint_session& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize)
+PaintStruct* PaintAddImageAsParent(
+    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize)
 {
     return PaintAddImageAsParent(session, image_id, offset, { offset, boundBoxSize });
 }
 
-paint_struct* PaintAddImageAsParent(
-    paint_session& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize,
+PaintStruct* PaintAddImageAsParent(
+    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize,
     const CoordsXYZ& boundBoxOffset)
 {
     return PaintAddImageAsParent(session, image_id, offset, { boundBoxOffset, boundBoxSize });
@@ -713,11 +712,11 @@ paint_struct* PaintAddImageAsParent(
  * @param bound_box_offset_x (0x009DEA52)
  * @param bound_box_offset_y (0x009DEA54)
  * @param bound_box_offset_z (0x009DEA56)
- * @return (ebp) paint_struct on success (CF == 0), nullptr on failure (CF == 1)
+ * @return (ebp) PaintStruct on success (CF == 0), nullptr on failure (CF == 1)
  */
 // Track Pieces, Shops.
-paint_struct* PaintAddImageAsParent(
-    paint_session& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
+PaintStruct* PaintAddImageAsParent(
+    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
 {
     session.LastPS = nullptr;
     session.LastAttachedPS = nullptr;
@@ -747,19 +746,19 @@ paint_struct* PaintAddImageAsParent(
  * @param bound_box_offset_x (0x009DEA52)
  * @param bound_box_offset_y (0x009DEA54)
  * @param bound_box_offset_z (0x009DEA56)
- * @return (ebp) paint_struct on success (CF == 0), nullptr on failure (CF == 1)
+ * @return (ebp) PaintStruct on success (CF == 0), nullptr on failure (CF == 1)
  * Creates a paint struct but does not allocate to a paint quadrant. Result cannot be ignored!
  */
-[[nodiscard]] paint_struct* PaintAddImageAsOrphan(
-    paint_session& session, const ImageId& imageId, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
+[[nodiscard]] PaintStruct* PaintAddImageAsOrphan(
+    PaintSession& session, const ImageId& imageId, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
 {
     session.LastPS = nullptr;
     session.LastAttachedPS = nullptr;
     return CreateNormalPaintStruct(session, imageId, offset, boundBox);
 }
 
-paint_struct* PaintAddImageAsChild(
-    paint_session& session, const ImageId& imageId, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
+PaintStruct* PaintAddImageAsChild(
+    PaintSession& session, const ImageId& imageId, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
     const CoordsXYZ& boundBoxOffset)
 {
     return PaintAddImageAsChild(session, imageId, offset, { boundBoxOffset, boundBoxLength });
@@ -779,13 +778,13 @@ paint_struct* PaintAddImageAsChild(
  * @param bound_box_offset_x (0x009DEA52)
  * @param bound_box_offset_y (0x009DEA54)
  * @param bound_box_offset_z (0x009DEA56)
- * @return (ebp) paint_struct on success (CF == 0), nullptr on failure (CF == 1)
+ * @return (ebp) PaintStruct on success (CF == 0), nullptr on failure (CF == 1)
  * If there is no parent paint struct then image is added as a parent
  */
-paint_struct* PaintAddImageAsChild(
-    paint_session& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
+PaintStruct* PaintAddImageAsChild(
+    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
 {
-    paint_struct* parentPS = session.LastPS;
+    PaintStruct* parentPS = session.LastPS;
     if (parentPS == nullptr)
     {
         return PaintAddImageAsParent(session, image_id, offset, boundBox);
@@ -810,7 +809,7 @@ paint_struct* PaintAddImageAsChild(
  * @param y (cx)
  * @return (!CF) success
  */
-bool PaintAttachToPreviousAttach(paint_session& session, const ImageId& imageId, int32_t x, int32_t y)
+bool PaintAttachToPreviousAttach(PaintSession& session, const ImageId& imageId, int32_t x, int32_t y)
 {
     auto* previousAttachedPS = session.LastAttachedPS;
     if (previousAttachedPS == nullptr)
@@ -843,7 +842,7 @@ bool PaintAttachToPreviousAttach(paint_session& session, const ImageId& imageId,
  * @param y (cx)
  * @return (!CF) success
  */
-bool PaintAttachToPreviousPS(paint_session& session, const ImageId& image_id, int32_t x, int32_t y)
+bool PaintAttachToPreviousPS(PaintSession& session, const ImageId& image_id, int32_t x, int32_t y)
 {
     auto* masterPs = session.LastPS;
     if (masterPs == nullptr)
@@ -862,7 +861,7 @@ bool PaintAttachToPreviousPS(paint_session& session, const ImageId& image_id, in
     ps->y = y;
     ps->IsMasked = false;
 
-    attached_paint_struct* oldFirstAttached = masterPs->attached_ps;
+    AttachedPaintStruct* oldFirstAttached = masterPs->attached_ps;
     masterPs->attached_ps = ps;
     ps->next = oldFirstAttached;
 
@@ -880,7 +879,7 @@ bool PaintAttachToPreviousPS(paint_session& session, const ImageId& image_id, in
  * @param rotation (ebp)
  */
 void PaintFloatingMoneyEffect(
-    paint_session& session, money64 amount, StringId string_id, int32_t y, int32_t z, int8_t y_offsets[], int32_t offset_x,
+    PaintSession& session, money64 amount, StringId string_id, int32_t y, int32_t z, int8_t y_offsets[], int32_t offset_x,
     uint32_t rotation)
 {
     auto* ps = session.AllocateStringPaintEntry();
@@ -910,7 +909,7 @@ void PaintFloatingMoneyEffect(
  *
  *  rct2: 0x006860C3
  */
-void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, paint_string_struct* ps)
+void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, PaintStringStruct* ps)
 {
     do
     {
@@ -958,7 +957,7 @@ PaintEntryPool::Chain& PaintEntryPool::Chain::operator=(Chain&& chain) noexcept
     return *this;
 }
 
-paint_entry* PaintEntryPool::Chain::Allocate()
+PaintEntry* PaintEntryPool::Chain::Allocate()
 {
     if (Pool == nullptr)
     {

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -25,9 +25,9 @@ struct TileElement;
 enum class RailingEntrySupportType : uint8_t;
 enum class ViewportInteractionItem : uint8_t;
 
-struct attached_paint_struct
+struct AttachedPaintStruct
 {
-    attached_paint_struct* next;
+    AttachedPaintStruct* next;
     ImageId image_id;
     ImageId ColourImageId;
     int32_t x;
@@ -35,7 +35,7 @@ struct attached_paint_struct
     bool IsMasked;
 };
 
-struct paint_struct_bound_box
+struct PaintStructBoundBox
 {
     int32_t x;
     int32_t y;
@@ -45,12 +45,12 @@ struct paint_struct_bound_box
     int32_t z_end;
 };
 
-struct paint_struct
+struct PaintStruct
 {
-    paint_struct_bound_box bounds;
-    attached_paint_struct* attached_ps;
-    paint_struct* children;
-    paint_struct* next_quadrant_ps;
+    PaintStructBoundBox bounds;
+    AttachedPaintStruct* attached_ps;
+    PaintStruct* children;
+    PaintStruct* next_quadrant_ps;
     TileElement* tileElement;
     EntityBase* entity;
     ImageId image_id;
@@ -63,46 +63,46 @@ struct paint_struct
     ViewportInteractionItem sprite_type;
 };
 
-struct paint_string_struct
+struct PaintStringStruct
 {
     StringId string_id;
-    paint_string_struct* next;
+    PaintStringStruct* next;
     int32_t x;
     int32_t y;
     uint32_t args[4];
     uint8_t* y_offsets;
 };
 
-struct paint_entry
+struct PaintEntry
 {
 private:
-    std::array<uint8_t, std::max({ sizeof(paint_struct), sizeof(attached_paint_struct), sizeof(paint_string_struct) })> data;
+    std::array<uint8_t, std::max({ sizeof(PaintStruct), sizeof(AttachedPaintStruct), sizeof(PaintStringStruct) })> data;
 
 public:
-    paint_struct* AsBasic()
+    PaintStruct* AsBasic()
     {
-        auto* res = reinterpret_cast<paint_struct*>(data.data());
-        ::new (res) paint_struct();
+        auto* res = reinterpret_cast<PaintStruct*>(data.data());
+        ::new (res) PaintStruct();
         return res;
     }
-    attached_paint_struct* AsAttached()
+    AttachedPaintStruct* AsAttached()
     {
-        auto* res = reinterpret_cast<attached_paint_struct*>(data.data());
-        ::new (res) attached_paint_struct();
+        auto* res = reinterpret_cast<AttachedPaintStruct*>(data.data());
+        ::new (res) AttachedPaintStruct();
         return res;
     }
-    paint_string_struct* AsString()
+    PaintStringStruct* AsString()
     {
-        auto* res = reinterpret_cast<paint_string_struct*>(data.data());
-        ::new (res) paint_string_struct();
+        auto* res = reinterpret_cast<PaintStringStruct*>(data.data());
+        ::new (res) PaintStringStruct();
         return res;
     }
 };
-static_assert(sizeof(paint_entry) >= sizeof(paint_struct));
-static_assert(sizeof(paint_entry) >= sizeof(attached_paint_struct));
-static_assert(sizeof(paint_entry) >= sizeof(paint_string_struct));
+static_assert(sizeof(PaintEntry) >= sizeof(PaintStruct));
+static_assert(sizeof(PaintEntry) >= sizeof(AttachedPaintStruct));
+static_assert(sizeof(PaintEntry) >= sizeof(PaintStringStruct));
 
-struct sprite_bb
+struct SpriteBb
 {
     uint32_t sprite_id;
     CoordsXYZ offset;
@@ -110,14 +110,14 @@ struct sprite_bb
     CoordsXYZ bb_size;
 };
 
-struct support_height
+struct SupportHeight
 {
     uint16_t height;
     uint8_t slope;
     uint8_t pad;
 };
 
-struct tunnel_entry
+struct TunnelEntry
 {
     uint8_t height;
     uint8_t type;
@@ -130,7 +130,7 @@ static constexpr int32_t MaxPaintQuadrants = MAXIMUM_MAP_SIZE_TECHNICAL * 2;
 #define TUNNEL_MAX_COUNT 65
 
 /**
- * A pool of paint_entry instances that can be rented out.
+ * A pool of PaintEntry instances that can be rented out.
  * The internal implementation uses an unrolled linked list so that each
  * paint session can quickly allocate a new paint entry until it requires
  * another node / block of paint entries. Only the node allocation needs to
@@ -145,7 +145,7 @@ public:
     {
         Node* Next{};
         size_t Count{};
-        paint_entry PaintStructs[NodeSize]{};
+        PaintEntry PaintStructs[NodeSize]{};
     };
 
     struct Chain
@@ -161,7 +161,7 @@ public:
 
         Chain& operator=(Chain&& chain) noexcept;
 
-        paint_entry* Allocate();
+        PaintEntry* Allocate();
         void Clear();
         size_t GetCount() const;
     };
@@ -181,29 +181,29 @@ public:
 
 struct PaintSessionCore
 {
-    paint_struct PaintHead;
-    paint_struct* Quadrants[MaxPaintQuadrants];
-    paint_struct* LastPS;
-    paint_string_struct* PSStringHead;
-    paint_string_struct* LastPSString;
-    attached_paint_struct* LastAttachedPS;
+    PaintStruct PaintHead;
+    PaintStruct* Quadrants[MaxPaintQuadrants];
+    PaintStruct* LastPS;
+    PaintStringStruct* PSStringHead;
+    PaintStringStruct* LastPSString;
+    AttachedPaintStruct* LastAttachedPS;
     const TileElement* SurfaceElement;
     EntityBase* CurrentlyDrawnEntity;
     TileElement* CurrentlyDrawnTileElement;
     const TileElement* PathElementOnSameHeight;
     const TileElement* TrackElementOnSameHeight;
-    paint_struct* WoodenSupportsPrependTo;
+    PaintStruct* WoodenSupportsPrependTo;
     CoordsXY SpritePosition;
     CoordsXY MapPosition;
     uint32_t ViewFlags;
     uint32_t QuadrantBackIndex;
     uint32_t QuadrantFrontIndex;
     ImageId TrackColours[4];
-    support_height SupportSegments[9];
-    support_height Support;
+    SupportHeight SupportSegments[9];
+    SupportHeight Support;
     uint16_t WaterHeight;
-    tunnel_entry LeftTunnels[TUNNEL_MAX_COUNT];
-    tunnel_entry RightTunnels[TUNNEL_MAX_COUNT];
+    TunnelEntry LeftTunnels[TUNNEL_MAX_COUNT];
+    TunnelEntry RightTunnels[TUNNEL_MAX_COUNT];
     uint8_t LeftTunnelCount;
     uint8_t RightTunnelCount;
     uint8_t VerticalTunnelHeight;
@@ -212,12 +212,12 @@ struct PaintSessionCore
     ViewportInteractionItem InteractionType;
 };
 
-struct paint_session : public PaintSessionCore
+struct PaintSession : public PaintSessionCore
 {
     rct_drawpixelinfo DPI;
     PaintEntryPool::Chain PaintEntryChain;
 
-    paint_struct* AllocateNormalPaintEntry() noexcept
+    PaintStruct* AllocateNormalPaintEntry() noexcept
     {
         auto* entry = PaintEntryChain.Allocate();
         if (entry != nullptr)
@@ -228,7 +228,7 @@ struct paint_session : public PaintSessionCore
         return nullptr;
     }
 
-    attached_paint_struct* AllocateAttachedPaintEntry() noexcept
+    AttachedPaintStruct* AllocateAttachedPaintEntry() noexcept
     {
         auto* entry = PaintEntryChain.Allocate();
         if (entry != nullptr)
@@ -239,7 +239,7 @@ struct paint_session : public PaintSessionCore
         return nullptr;
     }
 
-    paint_string_struct* AllocateStringPaintEntry() noexcept
+    PaintStringStruct* AllocateStringPaintEntry() noexcept
     {
         auto* entry = PaintEntryChain.Allocate();
         if (entry != nullptr)
@@ -275,10 +275,10 @@ struct FootpathPaintInfo
 struct RecordedPaintSession
 {
     PaintSessionCore Session;
-    std::vector<paint_entry> Entries;
+    std::vector<PaintEntry> Entries;
 };
 
-extern paint_session gPaintSession;
+extern PaintSession gPaintSession;
 
 // Globals for paint clipping
 extern uint8_t gClipHeight;
@@ -294,42 +294,42 @@ extern bool gPaintBoundingBoxes;
 extern bool gPaintBlockedTiles;
 extern bool gPaintWidePathsAsGhost;
 
-paint_struct* PaintAddImageAsParent(
-    paint_session& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize);
-paint_struct* PaintAddImageAsParent(
-    paint_session& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize,
+PaintStruct* PaintAddImageAsParent(
+    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize);
+PaintStruct* PaintAddImageAsParent(
+    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize,
     const CoordsXYZ& boundBoxOffset);
-paint_struct* PaintAddImageAsParent(
-    paint_session& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
-[[nodiscard]] paint_struct* PaintAddImageAsOrphan(
-    paint_session& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
-paint_struct* PaintAddImageAsChild(
-    paint_session& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
+PaintStruct* PaintAddImageAsParent(
+    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
+[[nodiscard]] PaintStruct* PaintAddImageAsOrphan(
+    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
+PaintStruct* PaintAddImageAsChild(
+    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
     const CoordsXYZ& boundBoxOffset);
-paint_struct* PaintAddImageAsChild(
-    paint_session& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
+PaintStruct* PaintAddImageAsChild(
+    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 
-paint_struct* PaintAddImageAsChildRotated(
-    paint_session& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
+PaintStruct* PaintAddImageAsChildRotated(
+    PaintSession& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset);
-paint_struct* PaintAddImageAsParentRotated(
-    paint_session& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
+PaintStruct* PaintAddImageAsParentRotated(
+    PaintSession& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize);
-paint_struct* PaintAddImageAsParentRotated(
-    paint_session& session, const uint8_t direction, const ImageId& imageId, const CoordsXYZ& offset,
+PaintStruct* PaintAddImageAsParentRotated(
+    PaintSession& session, const uint8_t direction, const ImageId& imageId, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset);
 
-void PaintUtilPushTunnelRotated(paint_session& session, uint8_t direction, uint16_t height, uint8_t type);
+void PaintUtilPushTunnelRotated(PaintSession& session, uint8_t direction, uint16_t height, uint8_t type);
 
-bool PaintAttachToPreviousAttach(paint_session& session, const ImageId& imageId, int32_t x, int32_t y);
-bool PaintAttachToPreviousPS(paint_session& session, const ImageId& image_id, int32_t x, int32_t y);
+bool PaintAttachToPreviousAttach(PaintSession& session, const ImageId& imageId, int32_t x, int32_t y);
+bool PaintAttachToPreviousPS(PaintSession& session, const ImageId& image_id, int32_t x, int32_t y);
 void PaintFloatingMoneyEffect(
-    paint_session& session, money64 amount, StringId string_id, int32_t y, int32_t z, int8_t y_offsets[], int32_t offset_x,
+    PaintSession& session, money64 amount, StringId string_id, int32_t y, int32_t z, int8_t y_offsets[], int32_t offset_x,
     uint32_t rotation);
 
-paint_session* PaintSessionAlloc(rct_drawpixelinfo* dpi, uint32_t viewFlags);
-void PaintSessionFree(paint_session* session);
-void PaintSessionGenerate(paint_session& session);
+PaintSession* PaintSessionAlloc(rct_drawpixelinfo* dpi, uint32_t viewFlags);
+void PaintSessionFree(PaintSession* session);
+void PaintSessionGenerate(PaintSession& session);
 void PaintSessionArrange(PaintSessionCore& session);
-void PaintDrawStructs(paint_session& session);
-void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, paint_string_struct* ps);
+void PaintDrawStructs(PaintSession& session);
+void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, PaintStringStruct* ps);

--- a/src/openrct2/paint/PaintHelpers.cpp
+++ b/src/openrct2/paint/PaintHelpers.cpp
@@ -11,8 +11,8 @@
 #include "../ride/TrackPaint.h"
 #include "Paint.h"
 
-paint_struct* PaintAddImageAsParentRotated(
-    paint_session& session, const uint8_t direction, const ImageId& imageId, const CoordsXYZ& offset,
+PaintStruct* PaintAddImageAsParentRotated(
+    PaintSession& session, const uint8_t direction, const ImageId& imageId, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
 {
     if (direction & 1)
@@ -25,8 +25,8 @@ paint_struct* PaintAddImageAsParentRotated(
     return PaintAddImageAsParent(session, imageId, offset, boundBoxSize, boundBoxOffset);
 }
 
-paint_struct* PaintAddImageAsParentRotated(
-    paint_session& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
+PaintStruct* PaintAddImageAsParentRotated(
+    PaintSession& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize)
 {
     if (direction & 1)
@@ -38,8 +38,8 @@ paint_struct* PaintAddImageAsParentRotated(
     return PaintAddImageAsParent(session, image_id, offset, boundBoxSize);
 }
 
-paint_struct* PaintAddImageAsChildRotated(
-    paint_session& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
+PaintStruct* PaintAddImageAsChildRotated(
+    PaintSession& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
 {
     if (direction & 1)
@@ -52,7 +52,7 @@ paint_struct* PaintAddImageAsChildRotated(
     return PaintAddImageAsChild(session, image_id, offset, boundBoxSize, boundBoxOffset);
 }
 
-void PaintUtilPushTunnelRotated(paint_session& session, uint8_t direction, uint16_t height, uint8_t type)
+void PaintUtilPushTunnelRotated(PaintSession& session, uint8_t direction, uint16_t height, uint8_t type)
 {
     if (direction & 1)
     {

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -131,11 +131,11 @@ void Painter::MeasureFPS()
     _lastSecond = currentTime;
 }
 
-paint_session* Painter::CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags)
+PaintSession* Painter::CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags)
 {
     PROFILED_FUNCTION();
 
-    paint_session* session = nullptr;
+    PaintSession* session = nullptr;
 
     if (_freePaintSessions.empty() == false)
     {
@@ -148,7 +148,7 @@ paint_session* Painter::CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags
     else
     {
         // Create new one in pool.
-        _paintSessionPool.emplace_back(std::make_unique<paint_session>());
+        _paintSessionPool.emplace_back(std::make_unique<PaintSession>());
         session = _paintSessionPool.back().get();
     }
 
@@ -172,7 +172,7 @@ paint_session* Painter::CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags
     return session;
 }
 
-void Painter::ReleaseSession(paint_session* session)
+void Painter::ReleaseSession(PaintSession* session)
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -36,8 +36,8 @@ namespace OpenRCT2
         {
         private:
             std::shared_ptr<Ui::IUiContext> const _uiContext;
-            std::vector<std::unique_ptr<paint_session>> _paintSessionPool;
-            std::vector<paint_session*> _freePaintSessions;
+            std::vector<std::unique_ptr<PaintSession>> _paintSessionPool;
+            std::vector<PaintSession*> _freePaintSessions;
             PaintEntryPool _paintStructPool;
             time_t _lastSecond = 0;
             int32_t _currentFPS = 0;
@@ -47,8 +47,8 @@ namespace OpenRCT2
             explicit Painter(const std::shared_ptr<Ui::IUiContext>& uiContext);
             void Paint(Drawing::IDrawingEngine& de);
 
-            paint_session* CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags);
-            void ReleaseSession(paint_session* session);
+            PaintSession* CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags);
+            void ReleaseSession(PaintSession* session);
             ~Painter();
 
         private:

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -456,7 +456,7 @@ static constexpr const uint16_t word_97B3C4[] = {
  * @returns (al) true if any supports have been drawn, otherwise false.
  */
 bool WoodenASupportsPaintSetup(
-    paint_session& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate)
+    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate)
 {
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
@@ -617,7 +617,7 @@ bool WoodenASupportsPaintSetup(
  * @return (al) whether supports have been drawn
  */
 bool WoodenBSupportsPaintSetup(
-    paint_session& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate)
+    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate)
 {
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
@@ -786,9 +786,9 @@ bool WoodenBSupportsPaintSetup(
  *  rct2: 0x00663105
  */
 bool MetalASupportsPaintSetup(
-    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageTemplate)
+    PaintSession& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageTemplate)
 {
-    support_height* supportSegments = session.SupportSegments;
+    SupportHeight* supportSegments = session.SupportSegments;
 
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
@@ -987,9 +987,9 @@ bool MetalASupportsPaintSetup(
  * @return (Carry Flag)
  */
 bool MetalBSupportsPaintSetup(
-    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageTemplate)
+    PaintSession& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageTemplate)
 {
-    support_height* supportSegments = session.SupportSegments;
+    SupportHeight* supportSegments = session.SupportSegments;
     uint8_t originalSegment = segment;
 
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
@@ -1169,7 +1169,7 @@ bool MetalBSupportsPaintSetup(
  * @return Whether supports were drawn
  */
 bool PathASupportsPaintSetup(
-    paint_session& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
+    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo, bool* underground)
 {
     if (underground != nullptr)
@@ -1295,7 +1295,7 @@ bool PathASupportsPaintSetup(
         }
         else
         {
-            paint_struct* paintStruct = PaintAddImageAsOrphan(
+            PaintStruct* paintStruct = PaintAddImageAsOrphan(
                 session, imageTemplate.WithIndex(imageIndex), { 0, 0, baseHeight }, boundBox);
             hasSupports = true;
             if (paintStruct != nullptr)
@@ -1324,10 +1324,10 @@ bool PathASupportsPaintSetup(
  * @return Whether supports were drawn
  */
 bool PathBSupportsPaintSetup(
-    paint_session& session, int32_t segment, int32_t special, int32_t height, ImageId imageTemplate,
+    PaintSession& session, int32_t segment, int32_t special, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo)
 {
-    support_height* supportSegments = session.SupportSegments;
+    SupportHeight* supportSegments = session.SupportSegments;
 
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {

--- a/src/openrct2/paint/Supports.h
+++ b/src/openrct2/paint/Supports.h
@@ -18,18 +18,18 @@ struct FootpathPaintInfo;
 constexpr const uint8_t NumVanillaWoodenSupportTypes = 49;
 
 bool WoodenASupportsPaintSetup(
-    paint_session& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate);
+    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate);
 bool WoodenBSupportsPaintSetup(
-    paint_session& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate);
+    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate);
 bool MetalASupportsPaintSetup(
-    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageTemplate);
+    PaintSession& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageTemplate);
 bool MetalBSupportsPaintSetup(
-    paint_session& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageTemplate);
+    PaintSession& session, uint8_t supportType, uint8_t segment, int32_t special, int32_t height, ImageId imageTemplate);
 bool PathASupportsPaintSetup(
-    paint_session& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
+    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo, bool* underground);
 bool PathBSupportsPaintSetup(
-    paint_session& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
+    PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate,
     const FootpathPaintInfo& pathPaintInfo);
 
 // There are 13 types of metal supports. A graphic showing all of them is available here:

--- a/src/openrct2/paint/VirtualFloor.cpp
+++ b/src/openrct2/paint/VirtualFloor.cpp
@@ -292,7 +292,7 @@ static void VirtualFloorGetTileProperties(
     }
 }
 
-void VirtualFloorPaint(paint_session& session)
+void VirtualFloorPaint(PaintSession& session)
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/paint/VirtualFloor.h
+++ b/src/openrct2/paint/VirtualFloor.h
@@ -20,7 +20,7 @@ enum class VirtualFloorStyles : int32_t
     Glassy
 };
 
-struct paint_session;
+struct PaintSession;
 
 uint16_t VirtualFloorGetHeight();
 
@@ -33,4 +33,4 @@ void VirtualFloorInvalidate();
 
 bool VirtualFloorTileIsFloor(const CoordsXY& loc);
 
-void VirtualFloorPaint(paint_session& session);
+void VirtualFloorPaint(PaintSession& session);

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -32,7 +32,7 @@ constexpr CoordsXY BannerBoundBoxes[][2] = {
 };
 
 static void PaintBannerScrollingText(
-    paint_session& session, const BannerSceneryEntry& bannerEntry, Banner& banner, const BannerElement& bannerElement,
+    PaintSession& session, const BannerSceneryEntry& bannerEntry, Banner& banner, const BannerElement& bannerElement,
     Direction direction, int32_t height, const CoordsXYZ& bbOffset)
 {
     PROFILED_FUNCTION();
@@ -67,7 +67,7 @@ static void PaintBannerScrollingText(
     PaintAddImageAsChild(session, imageId, { 0, 0, height + 22 }, { 1, 1, 21 }, bbOffset);
 }
 
-void PaintBanner(paint_session& session, uint8_t direction, int32_t height, const BannerElement& bannerElement)
+void PaintBanner(PaintSession& session, uint8_t direction, int32_t height, const BannerElement& bannerElement)
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -34,7 +34,7 @@
 using namespace OpenRCT2;
 
 static void PaintRideEntranceExitScrollingText(
-    paint_session& session, const EntranceElement& entranceEl, const StationObject& stationObj, Direction direction,
+    PaintSession& session, const EntranceElement& entranceEl, const StationObject& stationObj, Direction direction,
     int32_t height)
 {
     PROFILED_FUNCTION();
@@ -77,7 +77,7 @@ static void PaintRideEntranceExitScrollingText(
         { 0, 0, height + stationObj.Height }, { 28, 28, 51 }, { 2, 2, height + stationObj.Height });
 }
 
-static void PaintRideEntranceExitLightEffects(paint_session& session, int32_t height, const EntranceElement& entranceEl)
+static void PaintRideEntranceExitLightEffects(PaintSession& session, int32_t height, const EntranceElement& entranceEl)
 {
     PROFILED_FUNCTION();
 
@@ -106,7 +106,7 @@ static void PaintRideEntranceExitLightEffects(paint_session& session, int32_t he
     }
 }
 
-static void PaintRideEntranceExit(paint_session& session, uint8_t direction, int32_t height, const EntranceElement& entranceEl)
+static void PaintRideEntranceExit(PaintSession& session, uint8_t direction, int32_t height, const EntranceElement& entranceEl)
 {
     PROFILED_FUNCTION();
 
@@ -206,7 +206,7 @@ static void PaintRideEntranceExit(paint_session& session, uint8_t direction, int
 }
 
 static void PaintParkEntranceScrollingText(
-    paint_session& session, const EntranceObject& entrance, Direction direction, int32_t height)
+    PaintSession& session, const EntranceObject& entrance, Direction direction, int32_t height)
 {
     PROFILED_FUNCTION();
 
@@ -249,7 +249,7 @@ static void PaintParkEntranceScrollingText(
     PaintAddImageAsChild(session, imageIndex, { 0, 0, textHeight }, { { 2, 2, textHeight }, { 28, 28, 47 } });
 }
 
-static void PaintParkEntranceLightEffects(paint_session& session)
+static void PaintParkEntranceLightEffects(PaintSession& session)
 {
     PROFILED_FUNCTION();
 
@@ -259,7 +259,7 @@ static void PaintParkEntranceLightEffects(paint_session& session)
     }
 }
 
-static void PaintParkEntrance(paint_session& session, uint8_t direction, int32_t height, const EntranceElement& entranceEl)
+static void PaintParkEntrance(PaintSession& session, uint8_t direction, int32_t height, const EntranceElement& entranceEl)
 {
     PROFILED_FUNCTION();
 
@@ -332,7 +332,7 @@ static void PaintParkEntrance(paint_session& session, uint8_t direction, int32_t
     PaintUtilSetGeneralSupportHeight(session, height + 80, 0x20);
 }
 
-static void PaintHeightMarkers(paint_session& session, const EntranceElement& entranceEl, int32_t height)
+static void PaintHeightMarkers(PaintSession& session, const EntranceElement& entranceEl, int32_t height)
 {
     PROFILED_FUNCTION();
 
@@ -351,7 +351,7 @@ static void PaintHeightMarkers(paint_session& session, const EntranceElement& en
     }
 }
 
-void PaintEntrance(paint_session& session, uint8_t direction, int32_t height, const EntranceElement& entranceElement)
+void PaintEntrance(PaintSession& session, uint8_t direction, int32_t height, const EntranceElement& entranceElement)
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -53,7 +53,7 @@ static constexpr const BoundBoxXY LargeSceneryBoundBoxes[] = {
 // clang-format on
 
 static void PaintLargeScenerySupports(
-    paint_session& session, uint8_t direction, uint16_t height, const LargeSceneryElement& tileElement, ImageId imageTemplate,
+    PaintSession& session, uint8_t direction, uint16_t height, const LargeSceneryElement& tileElement, ImageId imageTemplate,
     const rct_large_scenery_tile& tile)
 {
     PROFILED_FUNCTION();
@@ -105,7 +105,7 @@ static int32_t DivToMinusInfinity(int32_t a, int32_t b)
 }
 
 static void PaintLargeScenery3DTextLine(
-    paint_session& session, const LargeSceneryEntry& sceneryEntry, const LargeSceneryText& text, std::string_view line,
+    PaintSession& session, const LargeSceneryEntry& sceneryEntry, const LargeSceneryText& text, std::string_view line,
     ImageId imageTemplate, Direction direction, int32_t offsetY)
 {
     PROFILED_FUNCTION();
@@ -181,7 +181,7 @@ static bool Is3DTextSingleLine(const LargeSceneryText& text, std::string_view s)
 }
 
 static void PaintLargeScenery3DText(
-    paint_session& session, const LargeSceneryEntry& sceneryEntry, const rct_large_scenery_tile& tile,
+    PaintSession& session, const LargeSceneryEntry& sceneryEntry, const rct_large_scenery_tile& tile,
     const LargeSceneryElement& tileElement, uint8_t direction, uint16_t height, bool isGhost)
 {
     PROFILED_FUNCTION();
@@ -295,7 +295,7 @@ static void PaintLargeScenery3DText(
 }
 
 static void PaintLargeSceneryScrollingText(
-    paint_session& session, const LargeSceneryEntry& sceneryEntry, const LargeSceneryElement& tileElement, uint8_t direction,
+    PaintSession& session, const LargeSceneryEntry& sceneryEntry, const LargeSceneryElement& tileElement, uint8_t direction,
     uint16_t height, const CoordsXYZ& bbOffset, bool isGhost)
 {
     PROFILED_FUNCTION();
@@ -327,7 +327,7 @@ static void PaintLargeSceneryScrollingText(
     PaintAddImageAsChild(session, imageId, { 0, 0, height + 25 }, { 1, 1, 21 }, bbOffset);
 }
 
-void PaintLargeScenery(paint_session& session, uint8_t direction, uint16_t height, const LargeSceneryElement& tileElement)
+void PaintLargeScenery(PaintSession& session, uint8_t direction, uint16_t height, const LargeSceneryElement& tileElement)
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -89,10 +89,10 @@ static constexpr const uint8_t byte_98D8A4[] = {
 // clang-format on
 
 void PathPaintBoxSupport(
-    paint_session& session, const PathElement& pathElement, int32_t height, const FootpathPaintInfo& pathPaintInfo,
+    PaintSession& session, const PathElement& pathElement, int32_t height, const FootpathPaintInfo& pathPaintInfo,
     bool hasSupports, ImageId imageTemplate, ImageId sceneryImageTemplate);
 void PathPaintPoleSupport(
-    paint_session& session, const PathElement& pathElement, int16_t height, const FootpathPaintInfo& pathPaintInfo,
+    PaintSession& session, const PathElement& pathElement, int16_t height, const FootpathPaintInfo& pathPaintInfo,
     bool hasSupports, ImageId imageTemplate, ImageId sceneryImageTemplate);
 
 static ImageIndex GetEdgeImageOffset(edge_t edge)
@@ -140,7 +140,7 @@ static ImageIndex GetFootpathBenchImage(const PathBitEntry& pathBitEntry, edge_t
 
 /* rct2: 0x006A5AE5 */
 static void PathBitLightsPaint(
-    paint_session& session, const PathBitEntry& pathBitEntry, const PathElement& pathElement, int32_t height, uint8_t edges,
+    PaintSession& session, const PathBitEntry& pathBitEntry, const PathElement& pathElement, int32_t height, uint8_t edges,
     ImageId imageTemplate)
 {
     if (pathElement.IsSloped())
@@ -173,7 +173,7 @@ static void PathBitLightsPaint(
     }
 }
 
-static bool IsBinFull(paint_session& session, const PathElement& pathElement, edge_t edge)
+static bool IsBinFull(PaintSession& session, const PathElement& pathElement, edge_t edge)
 {
     switch (edge)
     {
@@ -192,7 +192,7 @@ static bool IsBinFull(paint_session& session, const PathElement& pathElement, ed
 
 /* rct2: 0x006A5C94 */
 static void PathBitBinsPaint(
-    paint_session& session, const PathBitEntry& pathBitEntry, const PathElement& pathElement, int32_t height, uint8_t edges,
+    PaintSession& session, const PathBitEntry& pathBitEntry, const PathElement& pathElement, int32_t height, uint8_t edges,
     ImageId imageTemplate)
 {
     if (pathElement.IsSloped())
@@ -237,7 +237,7 @@ static void PathBitBinsPaint(
 
 /* rct2: 0x006A5E81 */
 static void PathBitBenchesPaint(
-    paint_session& session, const PathBitEntry& pathBitEntry, const PathElement& pathElement, int32_t height, uint8_t edges,
+    PaintSession& session, const PathBitEntry& pathBitEntry, const PathElement& pathElement, int32_t height, uint8_t edges,
     ImageId imageTemplate)
 {
     auto isBroken = pathElement.IsBroken();
@@ -271,7 +271,7 @@ static void PathBitBenchesPaint(
 
 /* rct2: 0x006A6008 */
 static void PathBitJumpingFountainsPaint(
-    paint_session& session, const PathBitEntry& pathBitEntry, int32_t height, ImageId imageTemplate, rct_drawpixelinfo* dpi)
+    PaintSession& session, const PathBitEntry& pathBitEntry, int32_t height, ImageId imageTemplate, rct_drawpixelinfo* dpi)
 {
     if (dpi->zoom_level > ZoomLevel{ 0 })
         return;
@@ -288,7 +288,7 @@ static void PathBitJumpingFountainsPaint(
  * @param tile_element (esi)
  */
 static void sub_6A4101(
-    paint_session& session, const PathElement& pathElement, uint16_t height, uint32_t connectedEdges, bool hasSupports,
+    PaintSession& session, const PathElement& pathElement, uint16_t height, uint32_t connectedEdges, bool hasSupports,
     const FootpathPaintInfo& pathPaintInfo, ImageId imageTemplate)
 {
     PROFILED_FUNCTION();
@@ -709,7 +709,7 @@ static void sub_6A4101(
  * @param sceneryImageFlags (0x00F3EF74)
  */
 static void sub_6A3F61(
-    paint_session& session, const PathElement& pathElement, uint16_t connectedEdges, uint16_t height,
+    PaintSession& session, const PathElement& pathElement, uint16_t connectedEdges, uint16_t height,
     const FootpathPaintInfo& pathPaintInfo, ImageId imageTemplate, ImageId sceneryImageTemplate, bool hasSupports)
 {
     // eax --
@@ -866,7 +866,7 @@ static FootpathPaintInfo GetFootpathPaintInfo(const PathElement& pathEl)
     return pathPaintInfo;
 }
 
-static bool ShouldDrawSupports(paint_session& session, const PathElement& pathEl, uint16_t height)
+static bool ShouldDrawSupports(PaintSession& session, const PathElement& pathEl, uint16_t height)
 {
     auto surface = MapGetSurfaceElementAt(session.MapPosition);
     if (surface == nullptr)
@@ -896,7 +896,7 @@ static bool ShouldDrawSupports(paint_session& session, const PathElement& pathEl
     return false;
 }
 
-static void PaintPatrolAreas(paint_session& session, const PathElement& pathEl)
+static void PaintPatrolAreas(PaintSession& session, const PathElement& pathEl)
 {
     auto colour = GetPatrolAreaTileColour(session.MapPosition);
     if (colour)
@@ -914,7 +914,7 @@ static void PaintPatrolAreas(paint_session& session, const PathElement& pathEl)
     }
 }
 
-static void PaintHeightMarkers(paint_session& session, const PathElement& pathEl)
+static void PaintHeightMarkers(PaintSession& session, const PathElement& pathEl)
 {
     PROFILED_FUNCTION();
 
@@ -935,7 +935,7 @@ static void PaintHeightMarkers(paint_session& session, const PathElement& pathEl
     }
 }
 
-static void PaintLampLightEffects(paint_session& session, const PathElement& pathEl, uint16_t height)
+static void PaintLampLightEffects(PaintSession& session, const PathElement& pathEl, uint16_t height)
 {
     PROFILED_FUNCTION();
 
@@ -970,7 +970,7 @@ static void PaintLampLightEffects(paint_session& session, const PathElement& pat
 /**
  * rct2: 0x0006A3590
  */
-void PaintPath(paint_session& session, uint16_t height, const PathElement& tileElement)
+void PaintPath(PaintSession& session, uint16_t height, const PathElement& tileElement)
 {
     PROFILED_FUNCTION();
 
@@ -1042,7 +1042,7 @@ void PaintPath(paint_session& session, uint16_t height, const PathElement& tileE
 }
 
 void PathPaintBoxSupport(
-    paint_session& session, const PathElement& pathElement, int32_t height, const FootpathPaintInfo& pathPaintInfo,
+    PaintSession& session, const PathElement& pathElement, int32_t height, const FootpathPaintInfo& pathPaintInfo,
     bool hasSupports, ImageId imageTemplate, ImageId sceneryImageTemplate)
 {
     PROFILED_FUNCTION();
@@ -1180,7 +1180,7 @@ void PathPaintBoxSupport(
 }
 
 void PathPaintPoleSupport(
-    paint_session& session, const PathElement& pathElement, int16_t height, const FootpathPaintInfo& pathPaintInfo,
+    PaintSession& session, const PathElement& pathElement, int16_t height, const FootpathPaintInfo& pathPaintInfo,
     bool hasSupports, ImageId imageTemplate, ImageId sceneryImageTemplate)
 {
     PROFILED_FUNCTION();

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -31,7 +31,7 @@ static constexpr const CoordsXY lengths[] = {
 };
 
 static void PaintSmallScenerySupports(
-    paint_session& session, const SmallSceneryEntry& sceneryEntry, const SmallSceneryElement& sceneryElement,
+    PaintSession& session, const SmallSceneryEntry& sceneryEntry, const SmallSceneryElement& sceneryElement,
     Direction direction, int32_t height, ImageId imageTemplate)
 {
     PROFILED_FUNCTION();
@@ -65,7 +65,7 @@ static void PaintSmallScenerySupports(
 }
 
 static void SetSupportHeights(
-    paint_session& session, const SmallSceneryEntry& sceneryEntry, const SmallSceneryElement& sceneryElement, int32_t height)
+    PaintSession& session, const SmallSceneryEntry& sceneryEntry, const SmallSceneryElement& sceneryElement, int32_t height)
 {
     height += sceneryEntry.height;
 
@@ -104,7 +104,7 @@ static void SetSupportHeights(
 }
 
 static void PaintSmallSceneryBody(
-    paint_session& session, uint8_t direction, int32_t height, const SmallSceneryElement& sceneryElement,
+    PaintSession& session, uint8_t direction, int32_t height, const SmallSceneryElement& sceneryElement,
     const SmallSceneryEntry* sceneryEntry, ImageId imageTemplate)
 {
     PROFILED_FUNCTION();
@@ -317,7 +317,7 @@ static void PaintSmallSceneryBody(
     }
 }
 
-void PaintSmallScenery(paint_session& session, uint8_t direction, int32_t height, const SmallSceneryElement& sceneryElement)
+void PaintSmallScenery(PaintSession& session, uint8_t direction, int32_t height, const SmallSceneryElement& sceneryElement)
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -314,7 +314,7 @@ static const TerrainSurfaceObject* GetSurfaceObject(size_t index)
 }
 
 static ImageId GetSurfaceImage(
-    const paint_session& session, ObjectEntryIndex index, int32_t offset, uint8_t rotation, int32_t grassLength, bool grid,
+    const PaintSession& session, ObjectEntryIndex index, int32_t offset, uint8_t rotation, int32_t grassLength, bool grid,
     bool underground)
 {
     PROFILED_FUNCTION();
@@ -444,7 +444,7 @@ static uint8_t ViewportSurfacePaintSetupGetRelativeSlope(const SurfaceElement& s
  *  rct2: 0x0065E890, 0x0065E946, 0x0065E9FC, 0x0065EAB2
  */
 static void ViewportSurfaceSmoothenEdge(
-    paint_session& session, enum edge_t edge, struct tile_descriptor self, struct tile_descriptor neighbour)
+    PaintSession& session, enum edge_t edge, struct tile_descriptor self, struct tile_descriptor neighbour)
 {
     PROFILED_FUNCTION();
 
@@ -539,7 +539,7 @@ static void ViewportSurfaceSmoothenEdge(
 
     if (PaintAttachToPreviousPS(session, image_id, 0, 0))
     {
-        attached_paint_struct* out = session.LastAttachedPS;
+        AttachedPaintStruct* out = session.LastAttachedPS;
         // set content and enable masking
         out->ColourImageId = GetSurfacePattern(neighbour.terrain, cl);
         out->IsMasked = true;
@@ -564,7 +564,7 @@ static bool TileIsInsideClipView(const tile_descriptor& tile)
 }
 
 static void ViewportSurfaceDrawTileSideBottom(
-    paint_session& session, enum edge_t edge, uint16_t height, uint8_t edgeStyle, struct tile_descriptor self,
+    PaintSession& session, enum edge_t edge, uint16_t height, uint8_t edgeStyle, struct tile_descriptor self,
     struct tile_descriptor neighbour, bool isWater)
 {
     PROFILED_FUNCTION();
@@ -578,7 +578,7 @@ static void ViewportSurfaceDrawTileSideBottom(
     CoordsXY tunnelBounds = { 1, 1 };
     CoordsXY tunnelTopBoundBoxOffset = { 0, 0 };
 
-    const tunnel_entry* tunnelArray;
+    const TunnelEntry* tunnelArray;
     switch (edge)
     {
         case EDGE_BOTTOMLEFT:
@@ -763,7 +763,7 @@ static void ViewportSurfaceDrawTileSideBottom(
  *  rct2: 0x0065EB7D, 0x0065F0D8
  */
 static void ViewportSurfaceDrawLandSideBottom(
-    paint_session& session, enum edge_t edge, uint16_t height, uint8_t edgeStyle, struct tile_descriptor self,
+    PaintSession& session, enum edge_t edge, uint16_t height, uint8_t edgeStyle, struct tile_descriptor self,
     struct tile_descriptor neighbour)
 {
     ViewportSurfaceDrawTileSideBottom(session, edge, height, edgeStyle, self, neighbour, false);
@@ -773,14 +773,14 @@ static void ViewportSurfaceDrawLandSideBottom(
  *  rct2: 0x0065F8B9, 0x0065FE26
  */
 static void ViewportSurfaceDrawWaterSideBottom(
-    paint_session& session, enum edge_t edge, uint16_t height, uint8_t edgeStyle, struct tile_descriptor self,
+    PaintSession& session, enum edge_t edge, uint16_t height, uint8_t edgeStyle, struct tile_descriptor self,
     struct tile_descriptor neighbour)
 {
     ViewportSurfaceDrawTileSideBottom(session, edge, height, edgeStyle, self, neighbour, true);
 }
 
 static void ViewportSurfaceDrawTileSideTop(
-    paint_session& session, enum edge_t edge, uint16_t height, uint8_t terrain, struct tile_descriptor self,
+    PaintSession& session, enum edge_t edge, uint16_t height, uint8_t terrain, struct tile_descriptor self,
     struct tile_descriptor neighbour, bool isWater)
 {
     PROFILED_FUNCTION();
@@ -922,7 +922,7 @@ static void ViewportSurfaceDrawTileSideTop(
  *  rct2: 0x0065F63B, 0x0065F77D
  */
 static void ViewportSurfaceDrawLandSideTop(
-    paint_session& session, enum edge_t edge, uint16_t height, uint8_t terrain, struct tile_descriptor self,
+    PaintSession& session, enum edge_t edge, uint16_t height, uint8_t terrain, struct tile_descriptor self,
     struct tile_descriptor neighbour)
 {
     ViewportSurfaceDrawTileSideTop(session, edge, height, terrain, self, neighbour, false);
@@ -932,7 +932,7 @@ static void ViewportSurfaceDrawLandSideTop(
  *  rct2: 0x0066039B, 0x006604F1
  */
 static void ViewportSurfaceDrawWaterSideTop(
-    paint_session& session, enum edge_t edge, uint16_t height, uint8_t terrain, struct tile_descriptor self,
+    PaintSession& session, enum edge_t edge, uint16_t height, uint8_t terrain, struct tile_descriptor self,
     struct tile_descriptor neighbour)
 {
     ViewportSurfaceDrawTileSideTop(session, edge, height, terrain, self, neighbour, true);
@@ -995,7 +995,7 @@ std::optional<colour_t> GetPatrolAreaTileColour(const CoordsXY& pos)
     return {};
 }
 
-static void PaintPatrolArea(paint_session& session, const SurfaceElement& element, int32_t height, uint8_t surfaceShape)
+static void PaintPatrolArea(PaintSession& session, const SurfaceElement& element, int32_t height, uint8_t surfaceShape)
 {
     auto colour = GetPatrolAreaTileColour(session.MapPosition);
     if (colour)
@@ -1014,7 +1014,7 @@ static void PaintPatrolArea(paint_session& session, const SurfaceElement& elemen
 /**
  *  rct2: 0x0066062C
  */
-void PaintSurface(paint_session& session, uint8_t direction, uint16_t height, const SurfaceElement& tileElement)
+void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, const SurfaceElement& tileElement)
 {
     PROFILED_FUNCTION();
 
@@ -1175,7 +1175,7 @@ void PaintSurface(paint_session& session, uint8_t direction, uint16_t height, co
         {
             const CoordsXY& pos = session.MapPosition;
             const int32_t height2 = (TileElementHeight({ pos.x + 16, pos.y + 16 })) + 3;
-            paint_struct* backup = session.LastPS;
+            PaintStruct* backup = session.LastPS;
             PaintAddImageAsParent(session, ImageId(SPR_LAND_OWNERSHIP_AVAILABLE), { 16, 16, height2 }, { 1, 1, 0 });
             session.LastPS = backup;
         }
@@ -1192,7 +1192,7 @@ void PaintSurface(paint_session& session, uint8_t direction, uint16_t height, co
         {
             const CoordsXY& pos = session.MapPosition;
             const int32_t height2 = TileElementHeight({ pos.x + 16, pos.y + 16 });
-            paint_struct* backup = session.LastPS;
+            PaintStruct* backup = session.LastPS;
             PaintAddImageAsParent(
                 session, ImageId(SPR_LAND_CONSTRUCTION_RIGHTS_AVAILABLE), { 16, 16, height2 + 3 }, { 1, 1, 0 });
             session.LastPS = backup;
@@ -1249,7 +1249,7 @@ void PaintSurface(paint_session& session, uint8_t direction, uint16_t height, co
                 const auto fpId = static_cast<FilterPaletteID>(38);
                 const auto image_id = ImageId(SPR_TERRAIN_SELECTION_CORNER + byte_97B444[local_surfaceShape], fpId);
 
-                paint_struct* backup = session.LastPS;
+                PaintStruct* backup = session.LastPS;
                 PaintAddImageAsParent(session, image_id, { 0, 0, local_height }, { 32, 32, 1 });
                 session.LastPS = backup;
             }

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -34,8 +34,8 @@
 
 #include <algorithm>
 
-static void BlankTilesPaint(paint_session& session, int32_t x, int32_t y);
-static void PaintTileElementBase(paint_session& session, const CoordsXY& origCoords);
+static void BlankTilesPaint(PaintSession& session, int32_t x, int32_t y);
+static void PaintTileElementBase(PaintSession& session, const CoordsXY& origCoords);
 
 const int32_t SEGMENTS_ALL = SEGMENT_B4 | SEGMENT_B8 | SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC
     | SEGMENT_D0 | SEGMENT_D4;
@@ -44,7 +44,7 @@ const int32_t SEGMENTS_ALL = SEGMENT_B4 | SEGMENT_B8 | SEGMENT_BC | SEGMENT_C0 |
  *
  *  rct2: 0x0068B35F
  */
-void TileElementPaintSetup(paint_session& session, const CoordsXY& mapCoords, bool isTrackPiecePreview)
+void TileElementPaintSetup(PaintSession& session, const CoordsXY& mapCoords, bool isTrackPiecePreview)
 {
     PROFILED_FUNCTION();
 
@@ -67,7 +67,7 @@ void TileElementPaintSetup(paint_session& session, const CoordsXY& mapCoords, bo
  *
  *  rct2: 0x0068B60E
  */
-static void BlankTilesPaint(paint_session& session, int32_t x, int32_t y)
+static void BlankTilesPaint(PaintSession& session, int32_t x, int32_t y)
 {
     int32_t dx = 0;
     switch (session.CurrentRotation)
@@ -113,7 +113,7 @@ bool gShowSupportSegmentHeights = false;
  *
  *  rct2: 0x0068B3FB
  */
-static void PaintTileElementBase(paint_session& session, const CoordsXY& origCoords)
+static void PaintTileElementBase(PaintSession& session, const CoordsXY& origCoords)
 {
     PROFILED_FUNCTION();
 
@@ -330,7 +330,7 @@ static void PaintTileElementBase(paint_session& session, const CoordsXY& origCoo
 
             int32_t xOffset = sy * 10;
             int32_t yOffset = -22 + sx * 10;
-            paint_struct* ps = PaintAddImageAsParent(
+            PaintStruct* ps = PaintAddImageAsParent(
                 session, imageColourFlats, { xOffset, yOffset, segmentHeight }, { 10, 10, 1 },
                 { xOffset + 1, yOffset + 16, segmentHeight });
             if (ps != nullptr)
@@ -341,7 +341,7 @@ static void PaintTileElementBase(paint_session& session, const CoordsXY& origCoo
     }
 }
 
-void PaintUtilPushTunnelLeft(paint_session& session, uint16_t height, uint8_t type)
+void PaintUtilPushTunnelLeft(PaintSession& session, uint16_t height, uint8_t type)
 {
     session.LeftTunnels[session.LeftTunnelCount] = { static_cast<uint8_t>((height / 16)), type };
     if (session.LeftTunnelCount < TUNNEL_MAX_COUNT - 1)
@@ -351,7 +351,7 @@ void PaintUtilPushTunnelLeft(paint_session& session, uint16_t height, uint8_t ty
     }
 }
 
-void PaintUtilPushTunnelRight(paint_session& session, uint16_t height, uint8_t type)
+void PaintUtilPushTunnelRight(PaintSession& session, uint16_t height, uint8_t type)
 {
     session.RightTunnels[session.RightTunnelCount] = { static_cast<uint8_t>((height / 16)), type };
     if (session.RightTunnelCount < TUNNEL_MAX_COUNT - 1)
@@ -361,12 +361,12 @@ void PaintUtilPushTunnelRight(paint_session& session, uint16_t height, uint8_t t
     }
 }
 
-void PaintUtilSetVerticalTunnel(paint_session& session, uint16_t height)
+void PaintUtilSetVerticalTunnel(PaintSession& session, uint16_t height)
 {
     session.VerticalTunnelHeight = height / 16;
 }
 
-void PaintUtilSetGeneralSupportHeight(paint_session& session, int16_t height, uint8_t slope)
+void PaintUtilSetGeneralSupportHeight(PaintSession& session, int16_t height, uint8_t slope)
 {
     if (session.Support.height >= height)
     {
@@ -376,7 +376,7 @@ void PaintUtilSetGeneralSupportHeight(paint_session& session, int16_t height, ui
     PaintUtilForceSetGeneralSupportHeight(session, height, slope);
 }
 
-void PaintUtilForceSetGeneralSupportHeight(paint_session& session, int16_t height, uint8_t slope)
+void PaintUtilForceSetGeneralSupportHeight(PaintSession& session, int16_t height, uint8_t slope)
 {
     session.Support.height = height;
     session.Support.slope = slope;
@@ -386,9 +386,9 @@ const uint16_t segment_offsets[9] = {
     SEGMENT_B4, SEGMENT_B8, SEGMENT_BC, SEGMENT_C0, SEGMENT_C4, SEGMENT_C8, SEGMENT_CC, SEGMENT_D0, SEGMENT_D4,
 };
 
-void PaintUtilSetSegmentSupportHeight(paint_session& session, int32_t segments, uint16_t height, uint8_t slope)
+void PaintUtilSetSegmentSupportHeight(PaintSession& session, int32_t segments, uint16_t height, uint8_t slope)
 {
-    support_height* supportSegments = session.SupportSegments;
+    SupportHeight* supportSegments = session.SupportSegments;
     for (int32_t s = 0; s < 9; s++)
     {
         if (segments & segment_offsets[s])
@@ -410,7 +410,7 @@ uint16_t PaintUtilRotateSegments(uint16_t segments, uint8_t rotation)
     return (segments & 0xFF00) | temp;
 }
 
-bool PaintShouldShowHeightMarkers(const paint_session& session, const uint32_t viewportFlag)
+bool PaintShouldShowHeightMarkers(const PaintSession& session, const uint32_t viewportFlag)
 {
     auto dpi = &session.DPI;
     return (session.ViewFlags & viewportFlag) && (dpi->zoom_level <= ZoomLevel{ 0 });

--- a/src/openrct2/paint/tile_element/Paint.TileElement.h
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.h
@@ -12,7 +12,7 @@
 #include "../../common.h"
 #include "../../world/Map.h"
 
-struct paint_session;
+struct PaintSession;
 
 enum edge_t
 {
@@ -86,24 +86,24 @@ extern const CoordsXY BannerBoundBoxes[][2];
 
 extern const uint8_t PathSlopeToLandSlope[4];
 
-void PaintUtilPushTunnelLeft(paint_session& session, uint16_t height, uint8_t type);
-void PaintUtilPushTunnelRight(paint_session& session, uint16_t height, uint8_t type);
-void PaintUtilSetVerticalTunnel(paint_session& session, uint16_t height);
+void PaintUtilPushTunnelLeft(PaintSession& session, uint16_t height, uint8_t type);
+void PaintUtilPushTunnelRight(PaintSession& session, uint16_t height, uint8_t type);
+void PaintUtilSetVerticalTunnel(PaintSession& session, uint16_t height);
 
-void PaintUtilSetGeneralSupportHeight(paint_session& session, int16_t height, uint8_t slope);
-void PaintUtilForceSetGeneralSupportHeight(paint_session& session, int16_t height, uint8_t slope);
-void PaintUtilSetSegmentSupportHeight(paint_session& session, int32_t segments, uint16_t height, uint8_t slope);
+void PaintUtilSetGeneralSupportHeight(PaintSession& session, int16_t height, uint8_t slope);
+void PaintUtilForceSetGeneralSupportHeight(PaintSession& session, int16_t height, uint8_t slope);
+void PaintUtilSetSegmentSupportHeight(PaintSession& session, int32_t segments, uint16_t height, uint8_t slope);
 uint16_t PaintUtilRotateSegments(uint16_t segments, uint8_t rotation);
 
-void TileElementPaintSetup(paint_session& session, const CoordsXY& mapCoords, bool isTrackPiecePreview = false);
+void TileElementPaintSetup(PaintSession& session, const CoordsXY& mapCoords, bool isTrackPiecePreview = false);
 
-void PaintEntrance(paint_session& session, uint8_t direction, int32_t height, const EntranceElement& entranceElement);
-void PaintBanner(paint_session& session, uint8_t direction, int32_t height, const BannerElement& bannerElement);
-void PaintSurface(paint_session& session, uint8_t direction, uint16_t height, const SurfaceElement& tileElement);
-void PaintPath(paint_session& session, uint16_t height, const PathElement& tileElement);
-void PaintSmallScenery(paint_session& session, uint8_t direction, int32_t height, const SmallSceneryElement& sceneryElement);
-void PaintWall(paint_session& session, uint8_t direction, int32_t height, const WallElement& tileElement);
-void PaintLargeScenery(paint_session& session, uint8_t direction, uint16_t height, const LargeSceneryElement& tileElement);
-void PaintTrack(paint_session& session, uint8_t direction, int32_t height, const TrackElement& tileElement);
+void PaintEntrance(PaintSession& session, uint8_t direction, int32_t height, const EntranceElement& entranceElement);
+void PaintBanner(PaintSession& session, uint8_t direction, int32_t height, const BannerElement& bannerElement);
+void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, const SurfaceElement& tileElement);
+void PaintPath(PaintSession& session, uint16_t height, const PathElement& tileElement);
+void PaintSmallScenery(PaintSession& session, uint8_t direction, int32_t height, const SmallSceneryElement& sceneryElement);
+void PaintWall(PaintSession& session, uint8_t direction, int32_t height, const WallElement& tileElement);
+void PaintLargeScenery(PaintSession& session, uint8_t direction, uint16_t height, const LargeSceneryElement& tileElement);
+void PaintTrack(PaintSession& session, uint8_t direction, int32_t height, const TrackElement& tileElement);
 
-bool PaintShouldShowHeightMarkers(const paint_session& session, const uint32_t viewportFlag);
+bool PaintShouldShowHeightMarkers(const PaintSession& session, const uint32_t viewportFlag);

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -46,7 +46,7 @@ static constexpr const uint8_t* DirectionToDoorImageOffset[] = { DirectionToDoor
                                                                  DirectionToDoorImageOffset2, DirectionToDoorImageOffset3 };
 
 static void PaintWallDoor(
-    paint_session& session, const WallSceneryEntry& wallEntry, ImageId imageId, CoordsXYZ offset, BoundBoxXYZ bbR1,
+    PaintSession& session, const WallSceneryEntry& wallEntry, ImageId imageId, CoordsXYZ offset, BoundBoxXYZ bbR1,
     BoundBoxXYZ bbR2, BoundBoxXYZ bbL)
 {
     PROFILED_FUNCTION();
@@ -66,7 +66,7 @@ static void PaintWallDoor(
 }
 
 static void PaintWallDoor(
-    paint_session& session, const WallSceneryEntry& wallEntry, const WallElement& wallElement, ImageId imageTemplate,
+    PaintSession& session, const WallSceneryEntry& wallEntry, const WallElement& wallElement, ImageId imageTemplate,
     Direction direction, int32_t height)
 {
     PROFILED_FUNCTION();
@@ -130,7 +130,7 @@ static void PaintWallDoor(
 }
 
 static void PaintWallWall(
-    paint_session& session, const WallSceneryEntry& wallEntry, ImageId imageTemplate, uint32_t imageOffset, CoordsXYZ offset,
+    PaintSession& session, const WallSceneryEntry& wallEntry, ImageId imageTemplate, uint32_t imageOffset, CoordsXYZ offset,
     BoundBoxXYZ boundBox, bool isGhost)
 {
     PROFILED_FUNCTION();
@@ -146,7 +146,7 @@ static void PaintWallWall(
 }
 
 static void PaintWallScrollingText(
-    paint_session& session, const WallSceneryEntry& wallEntry, const WallElement& wallElement, Direction direction,
+    PaintSession& session, const WallSceneryEntry& wallEntry, const WallElement& wallElement, Direction direction,
     int32_t height, const CoordsXYZ& boundsOffset, bool isGhost)
 {
     PROFILED_FUNCTION();
@@ -188,7 +188,7 @@ static void PaintWallScrollingText(
 }
 
 static void PaintWallWall(
-    paint_session& session, const WallSceneryEntry& wallEntry, const WallElement& wallElement, ImageId imageTemplate,
+    PaintSession& session, const WallSceneryEntry& wallEntry, const WallElement& wallElement, ImageId imageTemplate,
     Direction direction, int32_t height, bool isGhost)
 {
     PROFILED_FUNCTION();
@@ -296,7 +296,7 @@ static void PaintWallWall(
     PaintWallScrollingText(session, wallEntry, wallElement, direction, height, boundBox.offset, isGhost);
 }
 
-void PaintWall(paint_session& session, uint8_t direction, int32_t height, const WallElement& wallElement)
+void PaintWall(PaintSession& session, uint8_t direction, int32_t height, const WallElement& wallElement)
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -262,7 +262,7 @@ bool track_paint_util_has_fence(
 }
 
 void track_paint_util_paint_floor(
-    paint_session& session, uint8_t edges, ImageId colourFlags, uint16_t height, const uint32_t floorSprites[4],
+    PaintSession& session, uint8_t edges, ImageId colourFlags, uint16_t height, const uint32_t floorSprites[4],
     const StationObject* stationStyle)
 {
     if (stationStyle != nullptr && stationStyle->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -291,7 +291,7 @@ void track_paint_util_paint_floor(
 }
 
 void track_paint_util_paint_fences(
-    paint_session& session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
+    PaintSession& session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
     const ImageId& colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation)
 {
     if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, rotation))
@@ -329,31 +329,31 @@ bool track_paint_util_should_paint_supports(const CoordsXY& position)
 }
 
 static void track_paint_util_draw_station_impl(
-    paint_session& session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
+    PaintSession& session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TrackElement& trackElement, int32_t fenceOffsetA, int32_t fenceOffsetB);
 
 void track_paint_util_draw_station(
-    paint_session& session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement)
+    PaintSession& session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement)
 {
     track_paint_util_draw_station_impl(session, ride, direction, height, height, trackElement, 5, 7);
 }
 
 void track_paint_util_draw_station_2(
-    paint_session& session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement,
+    PaintSession& session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement,
     int32_t fenceOffsetA, int32_t fenceOffsetB)
 {
     track_paint_util_draw_station_impl(session, ride, direction, height, height, trackElement, fenceOffsetA, fenceOffsetB);
 }
 
 void track_paint_util_draw_station_3(
-    paint_session& session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
+    PaintSession& session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TrackElement& trackElement)
 {
     track_paint_util_draw_station_impl(session, ride, direction, height, coverHeight, trackElement, 5, 7);
 }
 
 static void track_paint_util_draw_station_impl(
-    paint_session& session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
+    PaintSession& session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TrackElement& trackElement, int32_t fenceOffsetA, int32_t fenceOffsetB)
 {
     CoordsXY position = session.MapPosition;
@@ -556,7 +556,7 @@ static void track_paint_util_draw_station_impl(
 }
 
 void track_paint_util_draw_station_inverted(
-    paint_session& session, const Ride& ride, Direction direction, int32_t height, const TrackElement& trackElement,
+    PaintSession& session, const Ride& ride, Direction direction, int32_t height, const TrackElement& trackElement,
     uint8_t stationVariant)
 {
     CoordsXY position = session.MapPosition;
@@ -759,13 +759,13 @@ void track_paint_util_draw_station_inverted(
 }
 
 bool track_paint_util_draw_station_covers(
-    paint_session& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height)
+    PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height)
 {
     return track_paint_util_draw_station_covers_2(session, edge, hasFence, stationObject, height, STATION_VARIANT_BASIC);
 }
 
 bool track_paint_util_draw_station_covers_2(
-    paint_session& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height,
+    PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height,
     uint8_t stationVariant)
 {
     if (stationObject == nullptr)
@@ -831,7 +831,7 @@ bool track_paint_util_draw_station_covers_2(
 }
 
 void track_paint_util_draw_narrow_station_platform(
-    paint_session& session, const Ride& ride, Direction direction, int32_t height, int32_t zOffset,
+    PaintSession& session, const Ride& ride, Direction direction, int32_t height, int32_t zOffset,
     const TrackElement& trackElement)
 {
     CoordsXY position = session.MapPosition;
@@ -880,7 +880,7 @@ void track_paint_util_draw_narrow_station_platform(
 }
 
 void track_paint_util_draw_pier(
-    paint_session& session, const Ride& ride, const StationObject* stationObj, const CoordsXY& position, Direction direction,
+    PaintSession& session, const Ride& ride, const StationObject* stationObj, const CoordsXY& position, Direction direction,
     int32_t height, const TrackElement& trackElement, uint8_t rotation)
 {
     if (stationObj != nullptr && stationObj->Flags & STATION_OBJECT_FLAGS::NO_PLATFORMS)
@@ -929,13 +929,13 @@ void track_paint_util_draw_pier(
     }
 }
 
-void track_paint_util_draw_station_metal_supports(paint_session& session, Direction direction, uint16_t height, ImageId colour)
+void track_paint_util_draw_station_metal_supports(PaintSession& session, Direction direction, uint16_t height, ImageId colour)
 {
     track_paint_util_draw_station_metal_supports_2(session, direction, height, colour, 3);
 }
 
 void track_paint_util_draw_station_metal_supports_2(
-    paint_session& session, Direction direction, uint16_t height, ImageId colour, uint8_t type)
+    PaintSession& session, Direction direction, uint16_t height, ImageId colour, uint8_t type)
 {
     if (direction & 1)
     {
@@ -1003,7 +1003,7 @@ static constexpr const int8_t right_helix_up_small_quarter_tiles_sprite_map[] = 
 };
 
 void track_paint_util_right_helix_up_small_quarter_tiles_paint(
-    paint_session& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
     const CoordsXY boundsLengths[4][3][2], const CoordsXYZ boundsOffsets[4][3][2])
 {
@@ -1103,7 +1103,7 @@ static constexpr const int8_t right_helix_up_large_quarter_sprite_map[] = {
     0, -1, 1, 2, -1, 3, 4,
 };
 void track_paint_util_right_helix_up_large_quarter_tiles_paint(
-    paint_session& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
     const CoordsXY boundsLengths[4][5][2], const CoordsXYZ boundsOffsets[4][5][2])
 {
@@ -1280,7 +1280,7 @@ static constexpr const int8_t eighth_to_diag_sprite_map[] = {
     0, 1, 2, -1, 3,
 };
 void track_paint_util_eighth_to_diag_tiles_paint(
-    paint_session& session, const int8_t thickness[4][4], int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, const int8_t thickness[4][4], int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
     const CoordsXYZ boundsOffsets[4][4])
 {
@@ -1322,7 +1322,7 @@ static constexpr const int8_t diag_sprite_map[4][4] = {
 };
 
 void track_paint_util_diag_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4],
     const CoordsXYZ boundsOffsets[4])
 {
@@ -1444,7 +1444,7 @@ static constexpr const int8_t right_quarter_turn_5_tiles_sprite_map[] = {
 };
 
 void track_paint_util_right_quarter_turn_5_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
     const CoordsXYZ boundsOffsets[4][5])
 {
@@ -1465,8 +1465,8 @@ void track_paint_util_right_quarter_turn_5_tiles_paint(
 }
 
 void track_paint_util_right_quarter_turn_5_tiles_paint_2(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
-    const sprite_bb sprites[][5])
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    const SpriteBb sprites[][5])
 {
     int8_t sprite = right_quarter_turn_5_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1474,7 +1474,7 @@ void track_paint_util_right_quarter_turn_5_tiles_paint_2(
         return;
     }
 
-    const sprite_bb* spriteBB = &sprites[direction][sprite];
+    const SpriteBb* spriteBB = &sprites[direction][sprite];
     const auto imageId = colourFlags.WithIndex(spriteBB->sprite_id);
     const auto& offset = spriteBB->offset;
     const auto& bbOffset = spriteBB->bb_offset;
@@ -1484,8 +1484,8 @@ void track_paint_util_right_quarter_turn_5_tiles_paint_2(
 }
 
 void track_paint_util_right_quarter_turn_5_tiles_paint_3(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
-    const sprite_bb sprites[][5])
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    const SpriteBb sprites[][5])
 {
     int8_t sprite = right_quarter_turn_5_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1493,14 +1493,14 @@ void track_paint_util_right_quarter_turn_5_tiles_paint_3(
         return;
     }
 
-    const sprite_bb* spriteBB = &sprites[direction][sprite];
+    const SpriteBb* spriteBB = &sprites[direction][sprite];
     const auto imageId = colourFlags.WithIndex(spriteBB->sprite_id);
     const auto& offset = spriteBB->offset;
     PaintAddImageAsParent(session, imageId, { offset.x, offset.y, height + offset.z }, spriteBB->bb_size);
 }
 
 void track_paint_util_right_quarter_turn_5_tiles_tunnel(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType)
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType)
 {
     if (direction == 0 && trackSequence == 0)
     {
@@ -1521,7 +1521,7 @@ void track_paint_util_right_quarter_turn_5_tiles_tunnel(
 }
 
 void track_paint_util_right_quarter_turn_5_tiles_wooden_supports(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence)
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence)
 {
     if (trackSequence != 1 && trackSequence != 4)
     {
@@ -1620,7 +1620,7 @@ static constexpr const int8_t right_quarter_turn_3_tiles_sprite_map[] = {
 };
 
 void track_paint_util_right_quarter_turn_3_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
     const CoordsXYZ boundsOffsets[4][3])
 {
@@ -1641,7 +1641,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint(
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_2(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3])
 {
     track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
@@ -1649,7 +1649,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_2(
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset)
 {
     int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
@@ -1737,15 +1737,15 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_3(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
-    const sprite_bb sprites[4][3])
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    const SpriteBb sprites[4][3])
 {
     int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
     if (sprite < 0)
     {
         return;
     }
-    const sprite_bb* spriteBB = &sprites[direction][sprite];
+    const SpriteBb* spriteBB = &sprites[direction][sprite];
     const auto& offset = spriteBB->offset;
     const auto& bbOffset = spriteBB->bb_offset;
     PaintAddImageAsParent(
@@ -1754,8 +1754,8 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_3(
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_4(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
-    const sprite_bb sprites[4][3])
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    const SpriteBb sprites[4][3])
 {
     int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1763,14 +1763,14 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_4(
         return;
     }
 
-    const sprite_bb* spriteBB = &sprites[direction][sprite];
+    const SpriteBb* spriteBB = &sprites[direction][sprite];
     const auto imageId = colourFlags.WithIndex(spriteBB->sprite_id);
     const auto& offset = spriteBB->offset;
     PaintAddImageAsParent(session, imageId, { offset.x, offset.y, height + offset.z }, spriteBB->bb_size);
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_tunnel(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType)
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType)
 {
     if (direction == 0 && trackSequence == 0)
     {
@@ -1794,8 +1794,7 @@ void track_paint_util_right_quarter_turn_3_tiles_tunnel(
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_25_deg_up_tunnel(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType0,
-    uint8_t tunnelType3)
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType0, uint8_t tunnelType3)
 {
     if (direction == 0 && trackSequence == 0)
     {
@@ -1816,8 +1815,7 @@ void track_paint_util_right_quarter_turn_3_tiles_25_deg_up_tunnel(
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_25_deg_down_tunnel(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType0,
-    uint8_t tunnelType3)
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType0, uint8_t tunnelType3)
 {
     if (direction == 0 && trackSequence == 0)
     {
@@ -1845,7 +1843,7 @@ static constexpr const int8_t left_quarter_turn_3_tiles_sprite_map[] = {
 };
 
 void track_paint_util_left_quarter_turn_3_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3])
 {
     track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
@@ -1853,7 +1851,7 @@ void track_paint_util_left_quarter_turn_3_tiles_paint(
 }
 
 void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset)
 {
     int8_t sprite = left_quarter_turn_3_tiles_sprite_map[trackSequence];
@@ -1941,7 +1939,7 @@ void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
 }
 
 void track_paint_util_left_quarter_turn_3_tiles_tunnel(
-    paint_session& session, int16_t height, uint8_t tunnelType, Direction direction, uint8_t trackSequence)
+    PaintSession& session, int16_t height, uint8_t tunnelType, Direction direction, uint8_t trackSequence)
 {
     if (direction == 0 && trackSequence == 0)
     {
@@ -1965,7 +1963,7 @@ void track_paint_util_left_quarter_turn_3_tiles_tunnel(
 }
 
 void track_paint_util_left_quarter_turn_1_tile_paint(
-    paint_session& session, int8_t thickness, int16_t height, int16_t boundBoxZOffset, Direction direction,
+    PaintSession& session, int8_t thickness, int16_t height, int16_t boundBoxZOffset, Direction direction,
     const ImageId& colourFlags, const uint32_t* sprites)
 {
     auto imageId = colourFlags.WithIndex(sprites[direction]);
@@ -1992,7 +1990,7 @@ void track_paint_util_left_quarter_turn_1_tile_paint(
 }
 
 void track_paint_util_right_quarter_turn_1_tile_tunnel(
-    paint_session& session, Direction direction, uint16_t baseHeight, int8_t startOffset, uint8_t startTunnel, int8_t endOffset,
+    PaintSession& session, Direction direction, uint16_t baseHeight, int8_t startOffset, uint8_t startTunnel, int8_t endOffset,
     uint8_t endTunnel)
 {
     track_paint_util_left_quarter_turn_1_tile_tunnel(
@@ -2000,7 +1998,7 @@ void track_paint_util_right_quarter_turn_1_tile_tunnel(
 }
 
 void track_paint_util_left_quarter_turn_1_tile_tunnel(
-    paint_session& session, Direction direction, uint16_t baseHeight, int8_t startOffset, uint8_t startTunnel, int8_t endOffset,
+    PaintSession& session, Direction direction, uint16_t baseHeight, int8_t startOffset, uint8_t startTunnel, int8_t endOffset,
     uint8_t endTunnel)
 {
     switch (direction)
@@ -2018,7 +2016,7 @@ void track_paint_util_left_quarter_turn_1_tile_tunnel(
     }
 }
 
-void track_paint_util_spinning_tunnel_paint(paint_session& session, int8_t thickness, int16_t height, Direction direction)
+void track_paint_util_spinning_tunnel_paint(PaintSession& session, int8_t thickness, int16_t height, Direction direction)
 {
     int32_t frame = gCurrentTicks >> 2 & 3;
     auto colourFlags = session.TrackColours[SCHEME_SUPPORTS];
@@ -2051,7 +2049,7 @@ void track_paint_util_spinning_tunnel_paint(paint_session& session, int8_t thick
 }
 
 void track_paint_util_onride_photo_small_paint(
-    paint_session& session, Direction direction, int32_t height, const TrackElement& trackElement)
+    PaintSession& session, Direction direction, int32_t height, const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
         { SPR_ON_RIDE_PHOTO_SIGN_SMALL_SW_NE, SPR_ON_RIDE_PHOTO_CAMERA_SMALL_S, SPR_ON_RIDE_PHOTO_CAMERA_FLASH_SMALL_S },
@@ -2089,7 +2087,7 @@ void track_paint_util_onride_photo_small_paint(
 }
 
 void track_paint_util_onride_photo_paint(
-    paint_session& session, Direction direction, int32_t height, const TrackElement& trackElement)
+    PaintSession& session, Direction direction, int32_t height, const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
         { SPR_ON_RIDE_PHOTO_SIGN_SW_NE, SPR_ON_RIDE_PHOTO_CAMERA_S, SPR_ON_RIDE_PHOTO_CAMERA_FLASH_S },
@@ -2139,7 +2137,7 @@ static constexpr const uint16_t RightVerticalLoopSegments[] = {
     SEGMENT_B4 | SEGMENT_B8 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0,
 };
 
-void track_paint_util_right_vertical_loop_segments(paint_session& session, Direction direction, uint8_t trackSequence)
+void track_paint_util_right_vertical_loop_segments(PaintSession& session, Direction direction, uint8_t trackSequence)
 {
     if (trackSequence > 9)
     {
@@ -2151,7 +2149,7 @@ void track_paint_util_right_vertical_loop_segments(paint_session& session, Direc
         session, PaintUtilRotateSegments(RightVerticalLoopSegments[trackSequence], direction), 0xFFFF, 0);
 }
 
-void track_paint_util_left_corkscrew_up_supports(paint_session& session, Direction direction, uint16_t height)
+void track_paint_util_left_corkscrew_up_supports(PaintSession& session, Direction direction, uint16_t height)
 {
     // TODO: Figure out which of these looks best, and use one to keep a consistent world
     if (direction == 2)
@@ -2173,7 +2171,7 @@ void track_paint_util_left_corkscrew_up_supports(paint_session& session, Directi
  *
  *  rct2: 0x006C4794
  */
-void PaintTrack(paint_session& session, Direction direction, int32_t height, const TrackElement& trackElement)
+void PaintTrack(PaintSession& session, Direction direction, int32_t height, const TrackElement& trackElement)
 {
     RideId rideIndex = trackElement.GetRideIndex();
     auto ride = get_ride(rideIndex);

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -282,122 +282,122 @@ extern const size_t MiniGolfPeepAnimationLengths[];
 bool track_paint_util_has_fence(
     enum edge_t edge, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride, uint8_t rotation);
 void track_paint_util_paint_floor(
-    paint_session& session, uint8_t edges, ImageId colourFlags, uint16_t height, const uint32_t floorSprites[4],
+    PaintSession& session, uint8_t edges, ImageId colourFlags, uint16_t height, const uint32_t floorSprites[4],
     const StationObject* stationStyle);
 void track_paint_util_paint_fences(
-    paint_session& session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
+    PaintSession& session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
     const ImageId& colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation);
 bool track_paint_util_draw_station_covers(
-    paint_session& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height);
+    PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height);
 bool track_paint_util_draw_station_covers_2(
-    paint_session& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height,
+    PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height,
     uint8_t stationVariant);
 void track_paint_util_draw_narrow_station_platform(
-    paint_session& session, const Ride& ride, Direction direction, int32_t height, int32_t zOffset,
+    PaintSession& session, const Ride& ride, Direction direction, int32_t height, int32_t zOffset,
     const TrackElement& trackElement);
 void track_paint_util_draw_station(
-    paint_session& session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement);
+    PaintSession& session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement);
 void track_paint_util_draw_station_2(
-    paint_session& session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement,
+    PaintSession& session, const Ride& ride, Direction direction, uint16_t height, const TrackElement& trackElement,
     int32_t fenceOffsetA, int32_t fenceOffsetB);
 void track_paint_util_draw_station_3(
-    paint_session& session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
+    PaintSession& session, const Ride& ride, Direction direction, uint16_t height, uint16_t coverHeight,
     const TrackElement& trackElement);
 void track_paint_util_draw_station_inverted(
-    paint_session& session, const Ride& ride, Direction direction, int32_t height, const TrackElement& trackElement,
+    PaintSession& session, const Ride& ride, Direction direction, int32_t height, const TrackElement& trackElement,
     uint8_t stationVariant);
 bool track_paint_util_should_paint_supports(const CoordsXY& position);
 void track_paint_util_draw_pier(
-    paint_session& session, const Ride& ride, const StationObject* stationObject, const CoordsXY& position, Direction direction,
+    PaintSession& session, const Ride& ride, const StationObject* stationObject, const CoordsXY& position, Direction direction,
     int32_t height, const TrackElement& trackElement, uint8_t rotation);
-void track_paint_util_draw_station_metal_supports(paint_session& session, Direction direction, uint16_t height, ImageId colour);
+void track_paint_util_draw_station_metal_supports(PaintSession& session, Direction direction, uint16_t height, ImageId colour);
 void track_paint_util_draw_station_metal_supports_2(
-    paint_session& session, Direction direction, uint16_t height, ImageId colour, uint8_t type);
+    PaintSession& session, Direction direction, uint16_t height, ImageId colour, uint8_t type);
 
 void track_paint_util_right_quarter_turn_5_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
     const CoordsXYZ boundsOffsets[4][5]);
 void track_paint_util_right_quarter_turn_5_tiles_paint_2(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
-    const sprite_bb sprites[][5]);
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    const SpriteBb sprites[][5]);
 void track_paint_util_right_quarter_turn_5_tiles_paint_3(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
-    const sprite_bb sprites[][5]);
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    const SpriteBb sprites[][5]);
 void track_paint_util_right_quarter_turn_5_tiles_tunnel(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType);
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType);
 void track_paint_util_right_quarter_turn_5_tiles_wooden_supports(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence);
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence);
 void track_paint_util_right_quarter_turn_3_tiles_25_deg_up_tunnel(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType0,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType0,
     uint8_t tunnelType3);
 void track_paint_util_right_quarter_turn_3_tiles_25_deg_down_tunnel(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType0,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType0,
     uint8_t tunnelType3);
 void track_paint_util_right_quarter_turn_3_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
     const CoordsXYZ boundsOffsets[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_paint_2(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset);
 void track_paint_util_right_quarter_turn_3_tiles_paint_3(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
-    const sprite_bb sprites[4][3]);
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    const SpriteBb sprites[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_paint_4(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
-    const sprite_bb sprites[4][3]);
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    const SpriteBb sprites[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_tunnel(
-    paint_session& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType);
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType);
 void track_paint_util_left_quarter_turn_3_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3]);
 void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset);
 void track_paint_util_left_quarter_turn_3_tiles_tunnel(
-    paint_session& session, int16_t height, uint8_t tunnelType, Direction direction, uint8_t trackSequence);
+    PaintSession& session, int16_t height, uint8_t tunnelType, Direction direction, uint8_t trackSequence);
 void track_paint_util_left_quarter_turn_1_tile_paint(
-    paint_session& session, int8_t thickness, int16_t height, int16_t boundBoxZOffset, Direction direction,
+    PaintSession& session, int8_t thickness, int16_t height, int16_t boundBoxZOffset, Direction direction,
     const ImageId& colourFlags, const uint32_t* sprites);
-void track_paint_util_spinning_tunnel_paint(paint_session& session, int8_t thickness, int16_t height, Direction direction);
+void track_paint_util_spinning_tunnel_paint(PaintSession& session, int8_t thickness, int16_t height, Direction direction);
 void track_paint_util_onride_photo_small_paint(
-    paint_session& session, Direction direction, int32_t height, const TrackElement& trackElement);
+    PaintSession& session, Direction direction, int32_t height, const TrackElement& trackElement);
 void track_paint_util_onride_photo_paint(
-    paint_session& session, Direction direction, int32_t height, const TrackElement& trackElement);
+    PaintSession& session, Direction direction, int32_t height, const TrackElement& trackElement);
 void track_paint_util_right_helix_up_small_quarter_tiles_paint(
-    paint_session& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
     const CoordsXY boundsLengths[4][3][2], const CoordsXYZ boundsOffsets[4][3][2]);
 void track_paint_util_right_helix_up_large_quarter_tiles_paint(
-    paint_session& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
     const CoordsXY boundsLengths[4][5][2], const CoordsXYZ boundsOffsets[4][5][2]);
 void track_paint_util_eighth_to_diag_tiles_paint(
-    paint_session& session, const int8_t thickness[4][4], int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, const int8_t thickness[4][4], int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
     const CoordsXYZ boundsOffsets[4][4]);
 void track_paint_util_diag_tiles_paint(
-    paint_session& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
+    PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
     const ImageId& colourFlags, const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4],
     const CoordsXYZ boundsOffsets[4]);
 
 void track_paint_util_left_quarter_turn_1_tile_tunnel(
-    paint_session& session, Direction direction, uint16_t baseHeight, int8_t startOffset, uint8_t startTunnel, int8_t endOffset,
+    PaintSession& session, Direction direction, uint16_t baseHeight, int8_t startOffset, uint8_t startTunnel, int8_t endOffset,
     uint8_t endTunnel);
 void track_paint_util_right_quarter_turn_1_tile_tunnel(
-    paint_session& session, Direction direction, uint16_t baseHeight, int8_t startOffset, uint8_t startTunnel, int8_t endOffset,
+    PaintSession& session, Direction direction, uint16_t baseHeight, int8_t startOffset, uint8_t startTunnel, int8_t endOffset,
     uint8_t endTunnel);
 
-void track_paint_util_right_vertical_loop_segments(paint_session& session, Direction direction, uint8_t trackSequence);
+void track_paint_util_right_vertical_loop_segments(PaintSession& session, Direction direction, uint8_t trackSequence);
 
-void track_paint_util_left_corkscrew_up_supports(paint_session& session, Direction direction, uint16_t height);
+void track_paint_util_left_corkscrew_up_supports(PaintSession& session, Direction direction, uint16_t height);
 
 using TRACK_PAINT_FUNCTION = void (*)(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement);
 using TRACK_PAINT_FUNCTION_GETTER = TRACK_PAINT_FUNCTION (*)(int32_t trackType);
 

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -30,7 +30,7 @@ struct Ride;
 struct rct_ride_entry;
 struct CarEntry;
 class DataSerialiser;
-struct paint_session;
+struct PaintSession;
 
 struct GForces
 {
@@ -270,7 +270,7 @@ struct Vehicle : EntityBase
     }
     void ApplyMass(int16_t appliedMass);
     void Serialise(DataSerialiser& stream);
-    void Paint(paint_session& session, int32_t imageDirection) const;
+    void Paint(PaintSession& session, int32_t imageDirection) const;
 
     friend void UpdateRotatingDefault(Vehicle& vehicle);
     friend void UpdateRotatingEnterprise(Vehicle& vehicle);

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -939,7 +939,7 @@ const vehicle_boundbox VehicleBoundboxes[16][224] = {
 #pragma region VehiclePaintUtil
 
 static void PaintVehicleRiders(
-    paint_session& session, const Vehicle* vehicle, const CarEntry* carEntry, uint32_t baseImageId, int32_t z,
+    PaintSession& session, const Vehicle* vehicle, const CarEntry* carEntry, uint32_t baseImageId, int32_t z,
     const vehicle_boundbox& bb)
 {
     baseImageId += carEntry->NumCarImages;
@@ -971,7 +971,7 @@ static void PaintVehicleRiders(
 
 // 6D5214
 static void vehicle_sprite_paint(
-    paint_session& session, const Vehicle* vehicle, int32_t spriteNum, const vehicle_boundbox& bb, int32_t z,
+    PaintSession& session, const Vehicle* vehicle, int32_t spriteNum, const vehicle_boundbox& bb, int32_t z,
     const CarEntry* carEntry)
 {
     if (carEntry->draw_order >= std::size(VehicleBoundboxes))
@@ -1008,7 +1008,7 @@ static void vehicle_sprite_paint(
 
 // 6D520E
 static void VehicleSpritePaintWithSwinging(
-    paint_session& session, const Vehicle* vehicle, int32_t spriteNum, int32_t boundingBoxNum, int32_t z,
+    PaintSession& session, const Vehicle* vehicle, int32_t spriteNum, int32_t boundingBoxNum, int32_t z,
     const CarEntry* carEntry)
 {
     vehicle_sprite_paint(
@@ -1017,7 +1017,7 @@ static void VehicleSpritePaintWithSwinging(
 }
 
 static void VehicleSpritePaintRestraints(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     int32_t boundingBoxNum = YawTo16(imageDirection);
     auto restraintFrame = ((vehicle->restraints_position - 64) / 64) * 4;
@@ -1033,7 +1033,7 @@ static void VehicleSpritePaintRestraints(
 
 // 6D51DE
 static void VehicleSpriteFlatUnbanked(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     // Restraint animations are only drawn for vehicles that are in a cardinal direction (north, east, south, west)
     if (vehicle->restraints_position >= 64 && carEntry->GroupEnabled(SpriteGroupType::RestraintAnimation)
@@ -1049,7 +1049,7 @@ static void VehicleSpriteFlatUnbanked(
 
 // 6D4EE7
 static void vehicle_sprite_0_1(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked22))
     {
@@ -1065,7 +1065,7 @@ static void vehicle_sprite_0_1(
 
 // 6D4F34
 static void vehicle_sprite_0_2(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked45))
     {
@@ -1081,7 +1081,7 @@ static void vehicle_sprite_0_2(
 
 // 6D4F0C
 static void vehicle_sprite_0_3(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked22))
     {
@@ -1097,7 +1097,7 @@ static void vehicle_sprite_0_3(
 
 // 6D4F5C
 static void vehicle_sprite_0_4(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::FlatBanked45))
     {
@@ -1113,7 +1113,7 @@ static void vehicle_sprite_0_4(
 
 // 6D4F84
 static void vehicle_sprite_0_5(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1133,7 +1133,7 @@ static void vehicle_sprite_0_5(
 
 // 6D4FE4
 static void vehicle_sprite_0_6(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1153,7 +1153,7 @@ static void vehicle_sprite_0_6(
 
 // 6D5055
 static void vehicle_sprite_0_7(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1173,7 +1173,7 @@ static void vehicle_sprite_0_7(
 
 // 6D50C6
 static void vehicle_sprite_0_8(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1193,7 +1193,7 @@ static void vehicle_sprite_0_8(
 
 // 6D5137
 static void vehicle_sprite_0_9(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1213,7 +1213,7 @@ static void vehicle_sprite_0_9(
 
 // 6D4FB1
 static void vehicle_sprite_0_10(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1233,7 +1233,7 @@ static void vehicle_sprite_0_10(
 
 // 6D501B
 static void vehicle_sprite_0_11(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1253,7 +1253,7 @@ static void vehicle_sprite_0_11(
 
 // 6D508C
 static void vehicle_sprite_0_12(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1273,7 +1273,7 @@ static void vehicle_sprite_0_12(
 
 // 6D50FD
 static void vehicle_sprite_0_13(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1293,7 +1293,7 @@ static void vehicle_sprite_0_13(
 
 // 6D516E
 static void vehicle_sprite_0_14(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -1313,7 +1313,7 @@ static void vehicle_sprite_0_14(
 
 // 6D4EE4
 static void vehicle_sprite_0_16(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     carEntry--;
     vehicle_sprite_0_1(session, vehicle, imageDirection, z, carEntry);
@@ -1321,7 +1321,7 @@ static void vehicle_sprite_0_16(
 
 // 6D4F31
 static void vehicle_sprite_0_17(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     carEntry--;
     vehicle_sprite_0_2(session, vehicle, imageDirection, z, carEntry);
@@ -1329,7 +1329,7 @@ static void vehicle_sprite_0_17(
 
 // 6D4F09
 static void vehicle_sprite_0_18(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     carEntry--;
     vehicle_sprite_0_3(session, vehicle, imageDirection, z, carEntry);
@@ -1337,7 +1337,7 @@ static void vehicle_sprite_0_18(
 
 // 6D4F59
 static void vehicle_sprite_0_19(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     carEntry--;
     vehicle_sprite_0_4(session, vehicle, imageDirection, z, carEntry);
@@ -1345,7 +1345,7 @@ static void vehicle_sprite_0_19(
 
 // 6D51D7
 static void VehiclePitchFlat(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     // 0x009A3DE4:
     switch (vehicle->bank_rotation)
@@ -1422,7 +1422,7 @@ static void VehiclePitchFlat(
 
 // 6D4614
 static void VehiclePitchUp12Unbanked(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12))
     {
@@ -1438,7 +1438,7 @@ static void VehiclePitchUp12Unbanked(
 
 // 6D4662
 static void VehiclePitchUp12BankedLeft22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
@@ -1454,7 +1454,7 @@ static void VehiclePitchUp12BankedLeft22(
 
 // 6D46DB
 static void VehiclePitchUp12BankedLeft45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
@@ -1470,7 +1470,7 @@ static void VehiclePitchUp12BankedLeft45(
 
 // 6D467D
 static void VehiclePitchUp12BankedRight22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
@@ -1486,7 +1486,7 @@ static void VehiclePitchUp12BankedRight22(
 
 // 6D46FD
 static void VehiclePitchUp12BankedRight45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
@@ -1502,7 +1502,7 @@ static void VehiclePitchUp12BankedRight45(
 
 // 6D460D
 static void VehiclePitchUp12(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     // 0x009A3C04:
     switch (vehicle->bank_rotation)
@@ -1545,7 +1545,7 @@ static void VehiclePitchUp12(
 
 // 6D4791
 static void VehiclePitchUp25Unbanked(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25))
     {
@@ -1561,7 +1561,7 @@ static void VehiclePitchUp25Unbanked(
 
 // 6D4833
 static void VehiclePitchUp25BankedLeft22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
@@ -1577,7 +1577,7 @@ static void VehiclePitchUp25BankedLeft22(
 
 // 6D48D6
 static void VehiclePitchUp25BankedLeft45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -1598,7 +1598,7 @@ static void VehiclePitchUp25BankedLeft45(
 
 // 6D4858
 static void VehiclePitchUp25BankedRight22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
@@ -1614,7 +1614,7 @@ static void VehiclePitchUp25BankedRight22(
 
 // 6D4910
 static void VehiclePitchUp25BankedRight45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -1633,7 +1633,7 @@ static void VehiclePitchUp25BankedRight45(
 }
 
 static void VehiclePitchUp25BankedLeft67(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
@@ -1648,7 +1648,7 @@ static void VehiclePitchUp25BankedLeft67(
 }
 
 static void VehiclePitchUp25BankedLeft90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
@@ -1663,7 +1663,7 @@ static void VehiclePitchUp25BankedLeft90(
 }
 
 static void VehiclePitchUp25BankedLeft112(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -1678,7 +1678,7 @@ static void VehiclePitchUp25BankedLeft112(
 }
 
 static void VehiclePitchUp25BankedLeft135(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -1693,7 +1693,7 @@ static void VehiclePitchUp25BankedLeft135(
 }
 
 static void VehiclePitchUp25BankedLeft157(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -1708,7 +1708,7 @@ static void VehiclePitchUp25BankedLeft157(
 }
 
 static void VehiclePitchUp25BankedRight67(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
@@ -1723,7 +1723,7 @@ static void VehiclePitchUp25BankedRight67(
 }
 
 static void VehiclePitchUp25BankedRight90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
@@ -1738,7 +1738,7 @@ static void VehiclePitchUp25BankedRight90(
 }
 
 static void VehiclePitchUp25BankedRight112(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -1753,7 +1753,7 @@ static void VehiclePitchUp25BankedRight112(
 }
 
 static void VehiclePitchUp25BankedRight135(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -1768,7 +1768,7 @@ static void VehiclePitchUp25BankedRight135(
 }
 
 static void VehiclePitchUp25BankedRight157(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -1784,7 +1784,7 @@ static void VehiclePitchUp25BankedRight157(
 
 // 6D476C
 static void VehiclePitchUp25(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     // 0x009A3CA4:
     switch (vehicle->bank_rotation)
@@ -1860,7 +1860,7 @@ static void VehiclePitchUp25(
 
 // 6D49DC
 static void VehiclePitchUp42Unbanked(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42))
     {
@@ -1875,7 +1875,7 @@ static void VehiclePitchUp42Unbanked(
 }
 
 static void VehiclePitchUp42BankedLeft22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
@@ -1890,7 +1890,7 @@ static void VehiclePitchUp42BankedLeft22(
 }
 
 static void VehiclePitchUp42BankedLeft45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
@@ -1905,7 +1905,7 @@ static void VehiclePitchUp42BankedLeft45(
 }
 
 static void VehiclePitchUp42BankedRight22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
@@ -1920,7 +1920,7 @@ static void VehiclePitchUp42BankedRight22(
 }
 
 static void VehiclePitchUp42BankedRight45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
@@ -1935,7 +1935,7 @@ static void VehiclePitchUp42BankedRight45(
 }
 
 static void VehiclePitchUp42BankedLeft67(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
@@ -1950,7 +1950,7 @@ static void VehiclePitchUp42BankedLeft67(
 }
 
 static void VehiclePitchUp42BankedLeft90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
@@ -1965,7 +1965,7 @@ static void VehiclePitchUp42BankedLeft90(
 }
 
 static void VehiclePitchUp42BankedRight67(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
@@ -1980,7 +1980,7 @@ static void VehiclePitchUp42BankedRight67(
 }
 
 static void VehiclePitchUp42BankedRight90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
@@ -1996,7 +1996,7 @@ static void VehiclePitchUp42BankedRight90(
 
 // 6D49DC
 static void VehiclePitchUp42(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     switch (vehicle->bank_rotation)
     {
@@ -2034,7 +2034,7 @@ static void VehiclePitchUp42(
 
 // 6D4A31
 static void VehiclePitchUp60Unbanked(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60))
     {
@@ -2049,7 +2049,7 @@ static void VehiclePitchUp60Unbanked(
 }
 
 static void VehiclePitchUp60BankedLeft22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
@@ -2064,7 +2064,7 @@ static void VehiclePitchUp60BankedLeft22(
 }
 
 static void VehiclePitchUp60BankedRight22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
@@ -2079,7 +2079,7 @@ static void VehiclePitchUp60BankedRight22(
 }
 
 static void VehiclePitchUp60(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     switch (vehicle->bank_rotation)
     {
@@ -2105,7 +2105,7 @@ static void VehiclePitchUp60(
 
 // 6D463D
 static void VehiclePitchDown12Unbanked(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12))
     {
@@ -2121,7 +2121,7 @@ static void VehiclePitchDown12Unbanked(
 
 // 6D469B
 static void VehiclePitchDown12BankedLeft22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
@@ -2137,7 +2137,7 @@ static void VehiclePitchDown12BankedLeft22(
 
 // 6D4722
 static void VehiclePitchDown12BankedLeft45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
@@ -2153,7 +2153,7 @@ static void VehiclePitchDown12BankedLeft45(
 
 // 6D46B9
 static void VehiclePitchDown12BankedRight22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked22))
     {
@@ -2169,7 +2169,7 @@ static void VehiclePitchDown12BankedRight22(
 
 // 6D4747
 static void VehiclePitchDown12BankedRight45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes12Banked45))
     {
@@ -2185,7 +2185,7 @@ static void VehiclePitchDown12BankedRight45(
 
 // 6D4636
 static void VehiclePitchDown12(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     // 0x009A3C54:
     switch (vehicle->bank_rotation)
@@ -2262,7 +2262,7 @@ static void VehiclePitchDown12(
 
 // 6D47E4
 static void VehiclePitchDown25Unbanked(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25))
     {
@@ -2278,7 +2278,7 @@ static void VehiclePitchDown25Unbanked(
 
 // 6D4880
 static void VehiclePitchDown25BankedLeft22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
@@ -2294,7 +2294,7 @@ static void VehiclePitchDown25BankedLeft22(
 
 // 6D4953
 static void VehiclePitchDown25BankedLeft45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -2315,7 +2315,7 @@ static void VehiclePitchDown25BankedLeft45(
 
 // 6D48AB
 static void VehiclePitchDown25BankedRight22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked22))
     {
@@ -2331,7 +2331,7 @@ static void VehiclePitchDown25BankedRight22(
 
 // 6D4996
 static void VehiclePitchDown25BankedRight45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked45))
     {
@@ -2351,7 +2351,7 @@ static void VehiclePitchDown25BankedRight45(
 }
 
 static void VehiclePitchDown25BankedLeft67(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
@@ -2366,7 +2366,7 @@ static void VehiclePitchDown25BankedLeft67(
 }
 
 static void VehiclePitchDown25BankedLeft90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
@@ -2381,7 +2381,7 @@ static void VehiclePitchDown25BankedLeft90(
 }
 
 static void VehiclePitchDown25BankedLeft11BankedLeft45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -2396,7 +2396,7 @@ static void VehiclePitchDown25BankedLeft11BankedLeft45(
 }
 
 static void VehiclePitchDown25BankedLeft135(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -2411,7 +2411,7 @@ static void VehiclePitchDown25BankedLeft135(
 }
 
 static void VehiclePitchDown25BankedLeft157(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -2426,7 +2426,7 @@ static void VehiclePitchDown25BankedLeft157(
 }
 
 static void VehiclePitchDown25BankedRight67(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked67))
     {
@@ -2441,7 +2441,7 @@ static void VehiclePitchDown25BankedRight67(
 }
 
 static void VehiclePitchDown25BankedRight90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25Banked90))
     {
@@ -2456,7 +2456,7 @@ static void VehiclePitchDown25BankedRight90(
 }
 
 static void VehiclePitchDown25BankedRight11BankedLeft45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -2471,7 +2471,7 @@ static void VehiclePitchDown25BankedRight11BankedLeft45(
 }
 
 static void VehiclePitchDown25BankedRight135(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -2486,7 +2486,7 @@ static void VehiclePitchDown25BankedRight135(
 }
 
 static void VehiclePitchDown25BankedRight157(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes25InlineTwists))
     {
@@ -2502,7 +2502,7 @@ static void VehiclePitchDown25BankedRight157(
 
 // 6D47DD
 static void VehiclePitchDown25(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     // 0x009A3CF4:
     switch (vehicle->bank_rotation)
@@ -2578,7 +2578,7 @@ static void VehiclePitchDown25(
 
 // 6D4A05
 static void VehiclePitchDown42Unbanked(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42))
     {
@@ -2593,7 +2593,7 @@ static void VehiclePitchDown42Unbanked(
 }
 
 static void VehiclePitchDown42BankedLeft22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
@@ -2608,7 +2608,7 @@ static void VehiclePitchDown42BankedLeft22(
 }
 
 static void VehiclePitchDown42BankedLeft45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
@@ -2623,7 +2623,7 @@ static void VehiclePitchDown42BankedLeft45(
 }
 
 static void VehiclePitchDown42BankedRight22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked22))
     {
@@ -2638,7 +2638,7 @@ static void VehiclePitchDown42BankedRight22(
 }
 
 static void VehiclePitchDown42BankedRight45(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked45))
     {
@@ -2653,7 +2653,7 @@ static void VehiclePitchDown42BankedRight45(
 }
 
 static void VehiclePitchDown42BankedLeft67(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
@@ -2668,7 +2668,7 @@ static void VehiclePitchDown42BankedLeft67(
 }
 
 static void VehiclePitchDown42BankedLeft90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
@@ -2683,7 +2683,7 @@ static void VehiclePitchDown42BankedLeft90(
 }
 
 static void VehiclePitchDown42BankedRight67(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked67))
     {
@@ -2698,7 +2698,7 @@ static void VehiclePitchDown42BankedRight67(
 }
 
 static void VehiclePitchDown42BankedRight90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes42Banked90))
     {
@@ -2713,7 +2713,7 @@ static void VehiclePitchDown42BankedRight90(
 }
 
 static void VehiclePitchDown42(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     switch (vehicle->bank_rotation)
     {
@@ -2751,7 +2751,7 @@ static void VehiclePitchDown42(
 
 // 6D4A59
 static void VehiclePitchDown60Unbanked(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60))
     {
@@ -2766,7 +2766,7 @@ static void VehiclePitchDown60Unbanked(
 }
 
 static void VehiclePitchDown60BankedLeft22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
@@ -2781,7 +2781,7 @@ static void VehiclePitchDown60BankedLeft22(
 }
 
 static void VehiclePitchDown60BankedRight22(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes60Banked22))
     {
@@ -2796,7 +2796,7 @@ static void VehiclePitchDown60BankedRight22(
 }
 
 static void VehiclePitchDown60(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     switch (vehicle->bank_rotation)
     {
@@ -2820,7 +2820,7 @@ static void VehiclePitchDown60(
 
 // 6D4A81
 static void VehiclePitchUp75(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes75))
     {
@@ -2836,7 +2836,7 @@ static void VehiclePitchUp75(
 
 // 6D4AE8
 static void VehiclePitchUp90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes90))
     {
@@ -2856,7 +2856,7 @@ static void VehiclePitchUp90(
 
 // 6D4B57
 static void VehiclePitchUp105(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
@@ -2872,7 +2872,7 @@ static void VehiclePitchUp105(
 
 // 6D4BB7
 static void VehiclePitchUp120(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
@@ -2888,7 +2888,7 @@ static void VehiclePitchUp120(
 
 // 6D4C17
 static void VehiclePitchUp135(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
@@ -2904,7 +2904,7 @@ static void VehiclePitchUp135(
 
 // 6D4C77
 static void VehiclePitchUp150(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
@@ -2920,7 +2920,7 @@ static void VehiclePitchUp150(
 
 // 6D4CD7
 static void VehiclePitchUp165(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::SlopesLoop))
     {
@@ -2940,7 +2940,7 @@ static void VehiclePitchUp165(
 
 // 6D4D37
 static void VehiclePitchInverted(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::SlopeInverted))
     {
@@ -2960,7 +2960,7 @@ static void VehiclePitchInverted(
 
 // 6D4AA3
 static void VehiclePitchDown75(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -2984,7 +2984,7 @@ static void VehiclePitchDown75(
 
 // 6D4B0D
 static void VehiclePitchDown90(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -3012,7 +3012,7 @@ static void VehiclePitchDown90(
 
 // 6D4B80
 static void VehiclePitchDown105(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -3032,7 +3032,7 @@ static void VehiclePitchDown105(
 
 // 6D4BE0
 static void VehiclePitchDown120(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -3052,7 +3052,7 @@ static void VehiclePitchDown120(
 
 // 6D4C40
 static void VehiclePitchDown135(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -3072,7 +3072,7 @@ static void VehiclePitchDown135(
 
 // 6D4CA0
 static void VehiclePitchDown150(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -3092,7 +3092,7 @@ static void VehiclePitchDown150(
 
 // 6D4D00
 static void VehiclePitchDown165(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -3116,7 +3116,7 @@ static void VehiclePitchDown165(
 
 // 6D51A5
 static void VehiclePitchCorkscrew(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (vehicle->HasUpdateFlag(VEHICLE_UPDATE_FLAG_USE_INVERTED_SPRITES))
     {
@@ -3144,7 +3144,7 @@ static void VehiclePitchCorkscrew(
 
 // 6D4D67
 static void vehicle_sprite_50_0(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8))
     {
@@ -3160,7 +3160,7 @@ static void vehicle_sprite_50_0(
 
 // 6D4DB5
 static void vehicle_sprite_50_1(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
@@ -3176,7 +3176,7 @@ static void vehicle_sprite_50_1(
 
 // 6D4DD3
 static void vehicle_sprite_50_3(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
@@ -3192,7 +3192,7 @@ static void vehicle_sprite_50_3(
 
 // 6D4D60
 static void VehiclePitchUp8(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     // 0x009A3D44:
     switch (vehicle->bank_rotation)
@@ -3266,7 +3266,7 @@ static void VehiclePitchUp8(
 
 // 6D4E3A
 static void VehiclePitchUp16(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16))
     {
@@ -3286,7 +3286,7 @@ static void VehiclePitchUp16(
 
 // 6D4E8F
 static void VehiclePitchUp50(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50))
     {
@@ -3310,7 +3310,7 @@ static void VehiclePitchUp50(
 
 // 6D4D90
 static void vehicle_sprite_53_0(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8))
     {
@@ -3326,7 +3326,7 @@ static void vehicle_sprite_53_0(
 
 // 6D4DF4
 static void vehicle_sprite_53_1(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
@@ -3342,7 +3342,7 @@ static void vehicle_sprite_53_1(
 
 // 6D4E15
 static void vehicle_sprite_53_3(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes8Banked22))
     {
@@ -3358,7 +3358,7 @@ static void vehicle_sprite_53_3(
 
 // 6D4D89
 static void VehiclePitchDown8(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     // 0x009A3D94:
     switch (vehicle->bank_rotation)
@@ -3432,7 +3432,7 @@ static void VehiclePitchDown8(
 
 // 6D4E63
 static void VehiclePitchDown16(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes16))
     {
@@ -3452,7 +3452,7 @@ static void VehiclePitchDown16(
 
 // 6D4EB8
 static void VehiclePitchDown50(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::Slopes50))
     {
@@ -3474,7 +3474,7 @@ static void VehiclePitchDown50(
 
 // 6D47DA
 static void VehiclePitchInvertingDown25(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     carEntry--;
     VehiclePitchDown25(session, vehicle, imageDirection, z, carEntry);
@@ -3482,7 +3482,7 @@ static void VehiclePitchInvertingDown25(
 
 // 6D4A02
 static void VehiclePitchInvertingDown42(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     carEntry--;
     VehiclePitchDown42(session, vehicle, imageDirection, z, carEntry);
@@ -3490,7 +3490,7 @@ static void VehiclePitchInvertingDown42(
 
 // 6D4A56
 static void VehiclePitchInvertingDown60(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     carEntry--;
     VehiclePitchDown60(session, vehicle, imageDirection, z, carEntry);
@@ -3502,7 +3502,7 @@ static void VehiclePitchInvertingDown60(
 
 // 6D4773
 static void VehiclePitchSpiralLift(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry)
 {
     if (carEntry->GroupEnabled(SpriteGroupType::CurvedLiftHill))
     {
@@ -3520,7 +3520,7 @@ static void VehiclePitchSpiralLift(
 
 // 0x009A3B14:
 using vehicle_sprite_func = void (*)(
-    paint_session& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry);
+    PaintSession& session, const Vehicle* vehicle, int32_t imageDirection, int32_t z, const CarEntry* carEntry);
 
 // clang-format off
 static constexpr const vehicle_sprite_func PaintFunctionsByPitch[] = {
@@ -3593,7 +3593,7 @@ static constexpr const vehicle_sprite_func PaintFunctionsByPitch[] = {
  *
  *  rct2: 0x006D5600
  */
-static void vehicle_visual_splash1_effect(paint_session& session, int32_t z, const Vehicle* vehicle)
+static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
     if (vehicle->GetTrackType() != TrackElemType::Watersplash)
     {
@@ -3620,7 +3620,7 @@ static void vehicle_visual_splash1_effect(paint_session& session, int32_t z, con
  *
  *  rct2: 0x006D5696
  */
-static void vehicle_visual_splash2_effect(paint_session& session, int32_t z, const Vehicle* vehicle)
+static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
     if (vehicle->sprite_direction & 7)
     {
@@ -3643,7 +3643,7 @@ static void vehicle_visual_splash2_effect(paint_session& session, int32_t z, con
  *
  *  rct2: 0x006D57EE
  */
-static void vehicle_visual_splash3_effect(paint_session& session, int32_t z, const Vehicle* vehicle)
+static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
     if (vehicle->sprite_direction & 7)
     {
@@ -3666,7 +3666,7 @@ static void vehicle_visual_splash3_effect(paint_session& session, int32_t z, con
  *
  *  rct2: 0x006D5783
  */
-static void vehicle_visual_splash4_effect(paint_session& session, int32_t z, const Vehicle* vehicle)
+static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
     Vehicle* vehicle2 = GetEntity<Vehicle>(vehicle->prev_vehicle_on_ride);
     if (vehicle2 == nullptr)
@@ -3694,7 +3694,7 @@ static void vehicle_visual_splash4_effect(paint_session& session, int32_t z, con
  *
  *  rct2: 0x006D5701
  */
-static void vehicle_visual_splash5_effect(paint_session& session, int32_t z, const Vehicle* vehicle)
+static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
     Vehicle* vehicle2 = GetEntity<Vehicle>(vehicle->prev_vehicle_on_ride);
     if (vehicle2 == nullptr)
@@ -3722,7 +3722,7 @@ static void vehicle_visual_splash5_effect(paint_session& session, int32_t z, con
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { 1, 1, 0 }, { 0, 0, z });
 }
 
-void vehicle_visual_splash_effect(paint_session& session, int32_t z, const Vehicle* vehicle, const CarEntry* carEntry)
+void vehicle_visual_splash_effect(PaintSession& session, int32_t z, const Vehicle* vehicle, const CarEntry* carEntry)
 {
     switch (carEntry->effect_visual)
     {
@@ -3751,7 +3751,7 @@ void vehicle_visual_splash_effect(paint_session& session, int32_t z, const Vehic
  *  rct2: 0x006D45F8
  */
 void vehicle_visual_default(
-    paint_session& session, int32_t imageDirection, int32_t z, const Vehicle* vehicle, const CarEntry* carEntry)
+    PaintSession& session, int32_t imageDirection, int32_t z, const Vehicle* vehicle, const CarEntry* carEntry)
 {
     if (vehicle->Pitch < std::size(PaintFunctionsByPitch))
     {
@@ -3759,7 +3759,7 @@ void vehicle_visual_default(
     }
 }
 
-void Vehicle::Paint(paint_session& session, int32_t imageDirection) const
+void Vehicle::Paint(PaintSession& session, int32_t imageDirection) const
 {
     const CarEntry* carEntry;
 

--- a/src/openrct2/ride/VehiclePaint.h
+++ b/src/openrct2/ride/VehiclePaint.h
@@ -11,7 +11,7 @@
 
 #include "../common.h"
 
-struct paint_session;
+struct PaintSession;
 struct CarEntry;
 struct Vehicle;
 
@@ -28,33 +28,33 @@ struct vehicle_boundbox
 extern const vehicle_boundbox VehicleBoundboxes[16][224];
 
 void vehicle_visual_default(
-    paint_session& session, int32_t imageDirection, int32_t z, const Vehicle* vehicle, const CarEntry* carEntry);
+    PaintSession& session, int32_t imageDirection, int32_t z, const Vehicle* vehicle, const CarEntry* carEntry);
 void vehicle_visual_roto_drop(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry);
 void VehicleVisualObservationTower(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry);
 void vehicle_visual_river_rapids(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry);
 void vehicle_visual_reverser(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry);
 void vehicle_visual_splash_boats_or_water_coaster(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry);
 void vehicle_visual_launched_freefall(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry);
-void vehicle_visual_splash_effect(paint_session& session, int32_t z, const Vehicle* vehicle, const CarEntry* carEntry);
+void vehicle_visual_splash_effect(PaintSession& session, int32_t z, const Vehicle* vehicle, const CarEntry* carEntry);
 void vehicle_visual_virginia_reel(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry);
 void vehicle_visual_submarine(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry);
 void vehicle_visual_mini_golf_player(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle);
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle);
 void VehicleVisualMiniGolfBall(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle);
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle);

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -164,7 +164,7 @@ enum
     SPR_AIR_POWERED_VERTICAL_RC_BANKED_QUARTER_TURN_5_FRONT_SE_NE_PART_0 = 22333,
 };
 
-static ImageId air_powered_vertical_rc_get_support_colour(paint_session& session)
+static ImageId air_powered_vertical_rc_get_support_colour(PaintSession& session)
 {
     auto colourFlags = session.TrackColours[SCHEME_SUPPORTS];
     auto trackColour = session.TrackColours[SCHEME_TRACK];
@@ -177,7 +177,7 @@ static ImageId air_powered_vertical_rc_get_support_colour(paint_session& session
 
 /** rct2: 0x008AFAD4 */
 static void air_powered_vertical_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -199,7 +199,7 @@ static void air_powered_vertical_rc_track_flat(
 }
 
 static void air_powered_vertical_rc_track_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -227,10 +227,10 @@ static void air_powered_vertical_rc_track_station(
 }
 
 static void air_powered_vertical_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    static constexpr const sprite_bb imageIds[4][5] = {
+    static constexpr const SpriteBb imageIds[4][5] = {
         {
             { SPR_AIR_POWERED_VERTICAL_RC_QUARTER_TURN_5_SW_SE_PART_0, { 0, 2, 0 }, { 0, 0, 0 }, { 32, 32, 2 } },
             { SPR_AIR_POWERED_VERTICAL_RC_QUARTER_TURN_5_SW_SE_PART_1, { 0, 16, 0 }, { 0, 0, 0 }, { 32, 16, 2 } },
@@ -308,7 +308,7 @@ static void air_powered_vertical_rc_track_right_quarter_turn_5(
 }
 
 static void air_powered_vertical_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -317,7 +317,7 @@ static void air_powered_vertical_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AFB74 */
 static void air_powered_vertical_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -346,7 +346,7 @@ static void air_powered_vertical_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AFB84 */
 static void air_powered_vertical_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -374,7 +374,7 @@ static void air_powered_vertical_rc_track_flat_to_right_bank(
 }
 
 static void air_powered_vertical_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     air_powered_vertical_rc_track_flat_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -382,17 +382,17 @@ static void air_powered_vertical_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008AFBA4 */
 static void air_powered_vertical_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     air_powered_vertical_rc_track_flat_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void air_powered_vertical_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    static constexpr const sprite_bb imageIds[4][5] = {
+    static constexpr const SpriteBb imageIds[4][5] = {
         {
             { SPR_AIR_POWERED_VERTICAL_RC_BANKED_QUARTER_TURN_5_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 3 } },
             { SPR_AIR_POWERED_VERTICAL_RC_BANKED_QUARTER_TURN_5_SW_SE_PART_1, { 0, 0, 0 }, { 0, 16, 0 }, { 32, 16, 3 } },
@@ -484,7 +484,7 @@ static void air_powered_vertical_rc_track_banked_right_quarter_turn_5(
 }
 
 static void air_powered_vertical_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -494,7 +494,7 @@ static void air_powered_vertical_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008AFBD4 */
 static void air_powered_vertical_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -523,14 +523,14 @@ static void air_powered_vertical_rc_track_left_bank(
 }
 
 static void air_powered_vertical_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     air_powered_vertical_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void air_powered_vertical_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -552,7 +552,7 @@ static void air_powered_vertical_rc_track_brakes(
 }
 
 static void air_powered_vertical_rc_track_vertical_slope_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t trackImageIds[7][4] = {
@@ -774,7 +774,7 @@ static void air_powered_vertical_rc_track_vertical_slope_up(
 }
 
 static void air_powered_vertical_rc_track_vertical_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -811,7 +811,7 @@ static void air_powered_vertical_rc_track_vertical_up(
 }
 
 static void air_powered_vertical_rc_track_vertical_top(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -901,14 +901,14 @@ static void air_powered_vertical_rc_track_vertical_top(
 }
 
 static void air_powered_vertical_rc_track_vertical_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     air_powered_vertical_rc_track_vertical_up(session, ride, trackSequence ^ 1, (direction + 2) & 3, height, trackElement);
 }
 
 static void air_powered_vertical_rc_track_vertical_slope_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     air_powered_vertical_rc_track_vertical_slope_up(
@@ -916,7 +916,7 @@ static void air_powered_vertical_rc_track_vertical_slope_down(
 }
 
 static void air_powered_vertical_rc_track_booster(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     // The booster piece is borrowed from the Reverse Freefall Colour.
@@ -946,7 +946,7 @@ static void air_powered_vertical_rc_track_booster(
 }
 
 static void air_powered_vertical_rc_track_onride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {

--- a/src/openrct2/ride/coaster/AlpineCoaster.cpp
+++ b/src/openrct2/ride/coaster/AlpineCoaster.cpp
@@ -27,7 +27,7 @@
 namespace AlpineRC
 {
     static void TrackFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -93,7 +93,7 @@ namespace AlpineRC
     }
 
     static void TrackStation(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         static constexpr const uint32_t imageIds[4][3] = {
@@ -126,7 +126,7 @@ namespace AlpineRC
     }
 
     static void Track25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -209,7 +209,7 @@ namespace AlpineRC
     }
 
     static void TrackFlatTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -290,7 +290,7 @@ namespace AlpineRC
     }
 
     static void Track25DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -371,28 +371,28 @@ namespace AlpineRC
     }
 
     static void Track25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftQuarterTurn3(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -519,7 +519,7 @@ namespace AlpineRC
     }
 
     static void TrackRightQuarterTurn3(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -527,7 +527,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -727,7 +727,7 @@ namespace AlpineRC
     }
 
     static void TrackRightQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -735,7 +735,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftEighthToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -899,7 +899,7 @@ namespace AlpineRC
     }
 
     static void TrackRightEighthToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1063,7 +1063,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftEighthToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1071,7 +1071,7 @@ namespace AlpineRC
     }
 
     static void TrackRightEighthToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1079,7 +1079,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1232,7 +1232,7 @@ namespace AlpineRC
     }
 
     static void TrackDiag25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1385,7 +1385,7 @@ namespace AlpineRC
     }
 
     static void TrackDiag25DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1538,7 +1538,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagFlatTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1691,7 +1691,7 @@ namespace AlpineRC
     }
 
     static void TrackDiag25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1844,7 +1844,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagFlatTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1995,7 +1995,7 @@ namespace AlpineRC
     }
 
     static void TrackDiag25DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2148,7 +2148,7 @@ namespace AlpineRC
     }
 
     static void TrackFlatToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -2193,7 +2193,7 @@ namespace AlpineRC
     }
 
     static void TrackFlatToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -2240,21 +2240,21 @@ namespace AlpineRC
     }
 
     static void TrackLeftBankToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -2312,7 +2312,7 @@ namespace AlpineRC
     }
 
     static void TrackRightBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -2370,7 +2370,7 @@ namespace AlpineRC
     }
 
     static void Track25DegUpToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -2428,7 +2428,7 @@ namespace AlpineRC
     }
 
     static void Track25DegUpToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -2486,35 +2486,35 @@ namespace AlpineRC
     }
 
     static void TrackLeftBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -2557,14 +2557,14 @@ namespace AlpineRC
     }
 
     static void TrackRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackDiagFlatToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2647,7 +2647,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagFlatToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2730,7 +2730,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagLeftBankToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2813,7 +2813,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagRightBankToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2896,7 +2896,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagLeftBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2979,7 +2979,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagRightBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3062,7 +3062,7 @@ namespace AlpineRC
     }
 
     static void TrackDiag25DegUpToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3145,7 +3145,7 @@ namespace AlpineRC
     }
 
     static void TrackDiag25DegUpToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3228,7 +3228,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagLeftBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3309,7 +3309,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagRightBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3390,7 +3390,7 @@ namespace AlpineRC
     }
 
     static void TrackDiag25DegDownToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3473,7 +3473,7 @@ namespace AlpineRC
     }
 
     static void TrackDiag25DegDownToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3556,7 +3556,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3635,7 +3635,7 @@ namespace AlpineRC
     }
 
     static void TrackDiagRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3714,7 +3714,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftQuarterTurn3Bank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3849,7 +3849,7 @@ namespace AlpineRC
     }
 
     static void TrackRightQuarterTurn3Bank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3857,7 +3857,7 @@ namespace AlpineRC
     }
 
     static void TrackBankedLeftQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4065,7 +4065,7 @@ namespace AlpineRC
     }
 
     static void TrackBankedRightQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -4073,7 +4073,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftEighthBankToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4237,7 +4237,7 @@ namespace AlpineRC
     }
 
     static void TrackRightEighthBankToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4401,7 +4401,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftEighthBankToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4409,7 +4409,7 @@ namespace AlpineRC
     }
 
     static void TrackRightEighthBankToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4417,7 +4417,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4515,7 +4515,7 @@ namespace AlpineRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4618,7 +4618,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4626,7 +4626,7 @@ namespace AlpineRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4634,7 +4634,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftQuarterTurn525DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4834,7 +4834,7 @@ namespace AlpineRC
     }
 
     static void TrackRightQuarterTurn525DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5034,7 +5034,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftQuarterTurn525DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -5042,7 +5042,7 @@ namespace AlpineRC
     }
 
     static void TrackRightQuarterTurn525DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -5050,7 +5050,7 @@ namespace AlpineRC
     }
 
     static void TrackSBendLeft(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5204,7 +5204,7 @@ namespace AlpineRC
     }
 
     static void TrackSBendRight(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5358,7 +5358,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftHalfBankedHelixUpSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5623,7 +5623,7 @@ namespace AlpineRC
     }
 
     static void TrackRightHalfBankedHelixUpSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5888,7 +5888,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftHalfBankedHelixDownSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 4)
@@ -5901,7 +5901,7 @@ namespace AlpineRC
     }
 
     static void TrackRightHalfBankedHelixDownSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 4)
@@ -5914,7 +5914,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftHalfBankedHelixUpLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6324,7 +6324,7 @@ namespace AlpineRC
         }
     }
     static void TrackRightHalfBankedHelixUpLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6745,7 +6745,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftHalfBankedHelixDownLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 7)
@@ -6758,7 +6758,7 @@ namespace AlpineRC
     }
 
     static void TrackRightHalfBankedHelixDownLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 7)
@@ -6771,7 +6771,7 @@ namespace AlpineRC
     }
 
     static void TrackBrakes(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6802,7 +6802,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftBankToLeftQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6904,7 +6904,7 @@ namespace AlpineRC
     }
 
     static void TrackRightBankToRightQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7006,7 +7006,7 @@ namespace AlpineRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDownToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7108,7 +7108,7 @@ namespace AlpineRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDownToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)

--- a/src/openrct2/ride/coaster/BobsleighCoaster.cpp
+++ b/src/openrct2/ride/coaster/BobsleighCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _BobsleighBlockBrakeImages[NumOrthogonalDirectio
 
 /** rct2: 0x006FE5B4 */
 static void bobsleigh_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -98,7 +98,7 @@ static void bobsleigh_rc_track_flat(
 }
 
 static void bobsleigh_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -123,7 +123,7 @@ static void bobsleigh_rc_track_station(
 
 /** rct2: 0x006FE5C4 */
 static void bobsleigh_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -225,7 +225,7 @@ static void bobsleigh_rc_track_25_deg_up(
 
 /** rct2: 0x006FE5D4 */
 static void bobsleigh_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -327,7 +327,7 @@ static void bobsleigh_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x006FE5E4 */
 static void bobsleigh_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -429,7 +429,7 @@ static void bobsleigh_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x006FE5F4 */
 static void bobsleigh_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -437,7 +437,7 @@ static void bobsleigh_rc_track_25_deg_down(
 
 /** rct2: 0x006FE604 */
 static void bobsleigh_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -445,7 +445,7 @@ static void bobsleigh_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x006FE614 */
 static void bobsleigh_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -453,7 +453,7 @@ static void bobsleigh_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x006FE624 */
 static void bobsleigh_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -688,7 +688,7 @@ static void bobsleigh_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x006FE634 */
 static void bobsleigh_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -697,7 +697,7 @@ static void bobsleigh_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x006FE644 */
 static void bobsleigh_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -747,7 +747,7 @@ static void bobsleigh_rc_track_flat_to_left_bank(
 
 /** rct2: 0x006FE654 */
 static void bobsleigh_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -797,7 +797,7 @@ static void bobsleigh_rc_track_flat_to_right_bank(
 
 /** rct2: 0x006FE664 */
 static void bobsleigh_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -847,7 +847,7 @@ static void bobsleigh_rc_track_left_bank_to_flat(
 
 /** rct2: 0x006FE674 */
 static void bobsleigh_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -897,7 +897,7 @@ static void bobsleigh_rc_track_right_bank_to_flat(
 
 /** rct2: 0x006FE684 */
 static void bobsleigh_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1132,7 +1132,7 @@ static void bobsleigh_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x006FE694 */
 static void bobsleigh_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1141,7 +1141,7 @@ static void bobsleigh_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x006FE6A4 */
 static void bobsleigh_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1198,7 +1198,7 @@ static void bobsleigh_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x006FE6B4 */
 static void bobsleigh_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1255,7 +1255,7 @@ static void bobsleigh_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x006FE6C4 */
 static void bobsleigh_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1312,7 +1312,7 @@ static void bobsleigh_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x006FE6D4 */
 static void bobsleigh_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1369,7 +1369,7 @@ static void bobsleigh_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x006FE6E4 */
 static void bobsleigh_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1377,7 +1377,7 @@ static void bobsleigh_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x006FE6F4 */
 static void bobsleigh_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1385,7 +1385,7 @@ static void bobsleigh_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x006FE704 */
 static void bobsleigh_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1393,7 +1393,7 @@ static void bobsleigh_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x006FE714 */
 static void bobsleigh_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1401,7 +1401,7 @@ static void bobsleigh_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x006FE724 */
 static void bobsleigh_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1451,7 +1451,7 @@ static void bobsleigh_rc_track_left_bank(
 
 /** rct2: 0x006FE734 */
 static void bobsleigh_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bobsleigh_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1459,7 +1459,7 @@ static void bobsleigh_rc_track_right_bank(
 
 /** rct2: 0x006FE744 */
 static void bobsleigh_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1656,7 +1656,7 @@ static void bobsleigh_rc_track_s_bend_left(
 
 /** rct2: 0x006FE754 */
 static void bobsleigh_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1853,7 +1853,7 @@ static void bobsleigh_rc_track_s_bend_right(
 
 /** rct2: 0x006FE794 */
 static void bobsleigh_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2001,7 +2001,7 @@ static void bobsleigh_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x006FE7A4 */
 static void bobsleigh_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2010,7 +2010,7 @@ static void bobsleigh_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x006FE7B4 */
 static void bobsleigh_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2158,7 +2158,7 @@ static void bobsleigh_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x006FE7C4 */
 static void bobsleigh_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2167,7 +2167,7 @@ static void bobsleigh_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x006FE7D4 */
 static void bobsleigh_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2457,7 +2457,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x006FE7E4 */
 static void bobsleigh_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2747,7 +2747,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x006FE7F4 */
 static void bobsleigh_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -2762,7 +2762,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x006FE804 */
 static void bobsleigh_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -2776,7 +2776,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x006FE814 */
 static void bobsleigh_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3240,7 +3240,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x006FE824 */
 static void bobsleigh_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3704,7 +3704,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x006FE834 */
 static void bobsleigh_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3719,7 +3719,7 @@ static void bobsleigh_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x006FE844 */
 static void bobsleigh_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3733,7 +3733,7 @@ static void bobsleigh_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x006FE854 */
 static void bobsleigh_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3769,7 +3769,7 @@ static void bobsleigh_rc_track_brakes(
 
 /** rct2: 0x006FE864 */
 static void bobsleigh_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -3807,7 +3807,7 @@ static void bobsleigh_rc_track_block_brakes(
 }
 
 static void bobsleigh_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
+++ b/src/openrct2/ride/coaster/BolligerMabillardTrack.hpp
@@ -34,7 +34,7 @@ static constexpr const uint32_t _BolligerMabillardBlockBrakeImages[NumOrthogonal
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -80,7 +80,7 @@ static void bolliger_mabillard_track_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -119,7 +119,7 @@ static void bolliger_mabillard_track_station(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -197,7 +197,7 @@ static void bolliger_mabillard_track_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -275,7 +275,7 @@ static void bolliger_mabillard_track_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -353,7 +353,7 @@ static void bolliger_mabillard_track_flat_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -443,7 +443,7 @@ static void bolliger_mabillard_track_25_deg_up_to_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -533,7 +533,7 @@ static void bolliger_mabillard_track_60_deg_up_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -611,7 +611,7 @@ static void bolliger_mabillard_track_25_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up<supportType>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -619,7 +619,7 @@ static void bolliger_mabillard_track_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_60_deg_up<supportType>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -627,7 +627,7 @@ static void bolliger_mabillard_track_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_flat<supportType>(
@@ -636,7 +636,7 @@ static void bolliger_mabillard_track_flat_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_60_deg_up_to_25_deg_up<supportType>(
@@ -645,7 +645,7 @@ static void bolliger_mabillard_track_25_deg_down_to_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_60_deg_up<supportType>(
@@ -654,7 +654,7 @@ static void bolliger_mabillard_track_60_deg_down_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_flat_to_25_deg_up<supportType>(
@@ -663,7 +663,7 @@ static void bolliger_mabillard_track_25_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -838,7 +838,7 @@ static void bolliger_mabillard_track_left_quarter_turn_5(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -848,7 +848,7 @@ static void bolliger_mabillard_track_right_quarter_turn_5(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -892,7 +892,7 @@ static void bolliger_mabillard_track_flat_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -936,7 +936,7 @@ static void bolliger_mabillard_track_flat_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -980,7 +980,7 @@ static void bolliger_mabillard_track_left_bank_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1024,7 +1024,7 @@ static void bolliger_mabillard_track_right_bank_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1208,7 +1208,7 @@ static void bolliger_mabillard_track_banked_left_quarter_turn_5(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1218,7 +1218,7 @@ static void bolliger_mabillard_track_banked_right_quarter_turn_5(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1269,7 +1269,7 @@ static void bolliger_mabillard_track_left_bank_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1320,7 +1320,7 @@ static void bolliger_mabillard_track_right_bank_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1371,7 +1371,7 @@ static void bolliger_mabillard_track_25_deg_up_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1422,7 +1422,7 @@ static void bolliger_mabillard_track_25_deg_up_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_right_bank<supportType>(
@@ -1431,7 +1431,7 @@ static void bolliger_mabillard_track_left_bank_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_left_bank<supportType>(
@@ -1440,7 +1440,7 @@ static void bolliger_mabillard_track_right_bank_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_bank_to_25_deg_up<supportType>(
@@ -1449,7 +1449,7 @@ static void bolliger_mabillard_track_25_deg_down_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_bank_to_25_deg_up<supportType>(
@@ -1458,7 +1458,7 @@ static void bolliger_mabillard_track_25_deg_down_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1496,7 +1496,7 @@ static void bolliger_mabillard_track_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_bank<supportType>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1504,7 +1504,7 @@ static void bolliger_mabillard_track_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1679,7 +1679,7 @@ static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1854,7 +1854,7 @@ static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1864,7 +1864,7 @@ static void bolliger_mabillard_track_left_quarter_turn_5_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1874,7 +1874,7 @@ static void bolliger_mabillard_track_right_quarter_turn_5_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2019,7 +2019,7 @@ static void bolliger_mabillard_track_s_bend_left(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2164,7 +2164,7 @@ static void bolliger_mabillard_track_s_bend_right(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2445,7 +2445,7 @@ static void bolliger_mabillard_track_left_vertical_loop(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2694,7 +2694,7 @@ static void bolliger_mabillard_track_right_vertical_loop(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2806,7 +2806,7 @@ static void bolliger_mabillard_track_left_quarter_turn_3(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2816,7 +2816,7 @@ static void bolliger_mabillard_track_right_quarter_turn_3(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2934,7 +2934,7 @@ static void bolliger_mabillard_track_left_quarter_turn_3_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2944,7 +2944,7 @@ static void bolliger_mabillard_track_right_quarter_turn_3_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3031,7 +3031,7 @@ static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3121,7 +3121,7 @@ static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3131,7 +3131,7 @@ static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3141,7 +3141,7 @@ static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3371,7 +3371,7 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_small(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3601,7 +3601,7 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_small(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3616,7 +3616,7 @@ static void bolliger_mabillard_track_left_half_banked_helix_down_small(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3631,7 +3631,7 @@ static void bolliger_mabillard_track_right_half_banked_helix_down_small(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3987,7 +3987,7 @@ static void bolliger_mabillard_track_left_half_banked_helix_up_large(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4349,7 +4349,7 @@ static void bolliger_mabillard_track_right_half_banked_helix_up_large(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4364,7 +4364,7 @@ static void bolliger_mabillard_track_left_half_banked_helix_down_large(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4379,7 +4379,7 @@ static void bolliger_mabillard_track_right_half_banked_helix_down_large(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4424,7 +4424,7 @@ static void bolliger_mabillard_track_left_quarter_turn_1_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4469,7 +4469,7 @@ static void bolliger_mabillard_track_right_quarter_turn_1_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_60_deg_up<supportType>(
@@ -4478,7 +4478,7 @@ static void bolliger_mabillard_track_left_quarter_turn_1_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_60_deg_up<supportType>(
@@ -4487,7 +4487,7 @@ static void bolliger_mabillard_track_right_quarter_turn_1_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4517,7 +4517,7 @@ static void bolliger_mabillard_track_brakes(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4562,7 +4562,7 @@ static void bolliger_mabillard_track_25_deg_up_left_banked(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4607,7 +4607,7 @@ static void bolliger_mabillard_track_25_deg_up_right_banked(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4657,7 +4657,7 @@ static void bolliger_mabillard_track_on_ride_photo(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_right_banked<supportType>(
@@ -4666,7 +4666,7 @@ static void bolliger_mabillard_track_25_deg_down_left_banked(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_left_banked<supportType>(
@@ -4675,7 +4675,7 @@ static void bolliger_mabillard_track_25_deg_down_right_banked(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4716,7 +4716,7 @@ static void bolliger_mabillard_track_90_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_90_deg_up<supportType>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4724,7 +4724,7 @@ static void bolliger_mabillard_track_90_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_up_to_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4769,7 +4769,7 @@ static void bolliger_mabillard_track_60_deg_up_to_90_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_90_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_60_deg_up_to_90_deg_up<supportType>(
@@ -4778,7 +4778,7 @@ static void bolliger_mabillard_track_90_deg_down_to_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_90_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4820,7 +4820,7 @@ static void bolliger_mabillard_track_90_deg_up_to_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_down_to_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4864,7 +4864,7 @@ static void bolliger_mabillard_track_60_deg_down_to_90_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5005,7 +5005,7 @@ static void bolliger_mabillard_track_left_eighth_to_diag(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5146,7 +5146,7 @@ static void bolliger_mabillard_track_right_eighth_to_diag(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5156,7 +5156,7 @@ static void bolliger_mabillard_track_left_eighth_to_orthogonal(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5166,7 +5166,7 @@ static void bolliger_mabillard_track_right_eighth_to_orthogonal(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5307,7 +5307,7 @@ static void bolliger_mabillard_track_left_eighth_bank_to_diag(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5448,7 +5448,7 @@ static void bolliger_mabillard_track_right_eighth_bank_to_diag(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5458,7 +5458,7 @@ static void bolliger_mabillard_track_left_eighth_bank_to_orthogonal(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5468,7 +5468,7 @@ static void bolliger_mabillard_track_right_eighth_bank_to_orthogonal(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5606,7 +5606,7 @@ static void bolliger_mabillard_track_diag_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5744,7 +5744,7 @@ static void bolliger_mabillard_track_diag_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5882,7 +5882,7 @@ static void bolliger_mabillard_track_diag_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6020,7 +6020,7 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6158,7 +6158,7 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6296,7 +6296,7 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6434,7 +6434,7 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6572,7 +6572,7 @@ static void bolliger_mabillard_track_diag_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6710,7 +6710,7 @@ static void bolliger_mabillard_track_diag_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6846,7 +6846,7 @@ static void bolliger_mabillard_track_diag_flat_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6984,7 +6984,7 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7122,7 +7122,7 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7260,7 +7260,7 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7398,7 +7398,7 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7536,7 +7536,7 @@ static void bolliger_mabillard_track_diag_60_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7674,7 +7674,7 @@ static void bolliger_mabillard_track_diag_flat_to_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7812,7 +7812,7 @@ static void bolliger_mabillard_track_diag_60_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7887,7 +7887,7 @@ static void bolliger_mabillard_track_diag_flat_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7962,7 +7962,7 @@ static void bolliger_mabillard_track_diag_flat_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8037,7 +8037,7 @@ static void bolliger_mabillard_track_diag_left_bank_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8112,7 +8112,7 @@ static void bolliger_mabillard_track_diag_right_bank_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8187,7 +8187,7 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8262,7 +8262,7 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8337,7 +8337,7 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8412,7 +8412,7 @@ static void bolliger_mabillard_track_diag_25_deg_up_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8485,7 +8485,7 @@ static void bolliger_mabillard_track_diag_left_bank_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8558,7 +8558,7 @@ static void bolliger_mabillard_track_diag_right_bank_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8633,7 +8633,7 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8708,7 +8708,7 @@ static void bolliger_mabillard_track_diag_25_deg_down_to_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8780,7 +8780,7 @@ static void bolliger_mabillard_track_diag_left_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8852,7 +8852,7 @@ static void bolliger_mabillard_track_diag_right_bank(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8942,7 +8942,7 @@ static void bolliger_mabillard_track_left_bank_to_left_quarter_turn_3_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9035,7 +9035,7 @@ static void bolliger_mabillard_track_right_bank_to_right_quarter_turn_3_25_deg_u
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9128,7 +9128,7 @@ static void bolliger_mabillard_track_left_quarter_turn_3_25_deg_down_to_left_ban
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9218,7 +9218,7 @@ static void bolliger_mabillard_track_right_quarter_turn_3_25_deg_down_to_right_b
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -9251,7 +9251,7 @@ static void bolliger_mabillard_track_block_brakes(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9338,7 +9338,7 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9428,7 +9428,7 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -9438,7 +9438,7 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_3_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -9448,7 +9448,7 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_3_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9623,7 +9623,7 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9798,7 +9798,7 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -9808,7 +9808,7 @@ static void bolliger_mabillard_track_left_banked_quarter_turn_5_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -9818,7 +9818,7 @@ static void bolliger_mabillard_track_right_banked_quarter_turn_5_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9866,7 +9866,7 @@ static void bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9914,7 +9914,7 @@ static void bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9962,7 +9962,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10010,7 +10010,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_25_deg_up<supportType>(
@@ -10019,7 +10019,7 @@ static void bolliger_mabillard_track_25_deg_down_to_left_banked_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_25_deg_up<supportType>(
@@ -10028,7 +10028,7 @@ static void bolliger_mabillard_track_25_deg_down_to_right_banked_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_right_banked_25_deg_up<supportType>(
@@ -10037,7 +10037,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_down_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_25_deg_up_to_left_banked_25_deg_up<supportType>(
@@ -10046,7 +10046,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_down_to_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10091,7 +10091,7 @@ static void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10136,7 +10136,7 @@ static void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10181,7 +10181,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10226,7 +10226,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_right_banked_flat<supportType>(
@@ -10235,7 +10235,7 @@ static void bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_down
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_left_banked_flat<supportType>(
@@ -10244,7 +10244,7 @@ static void bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_do
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_banked_flat_to_right_banked_25_deg_up<supportType>(
@@ -10253,7 +10253,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_down_to_left_banked_flat
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_banked_flat_to_left_banked_25_deg_up<supportType>(
@@ -10262,7 +10262,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_down_to_right_banked_fl
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10310,7 +10310,7 @@ static void bolliger_mabillard_track_flat_to_left_banked_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10358,7 +10358,7 @@ static void bolliger_mabillard_track_flat_to_right_banked_25_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10406,7 +10406,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10454,7 +10454,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_banked_25_deg_up_to_flat<supportType>(
@@ -10463,7 +10463,7 @@ static void bolliger_mabillard_track_flat_to_left_banked_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_banked_25_deg_up_to_flat<supportType>(
@@ -10472,7 +10472,7 @@ static void bolliger_mabillard_track_flat_to_right_banked_25_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_flat_to_right_banked_25_deg_up<supportType>(
@@ -10481,7 +10481,7 @@ static void bolliger_mabillard_track_left_banked_25_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_flat_to_left_banked_25_deg_up<supportType>(
@@ -10490,7 +10490,7 @@ static void bolliger_mabillard_track_right_banked_25_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10537,7 +10537,7 @@ static void bolliger_mabillard_track_left_quarter_turn_1_90_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10584,7 +10584,7 @@ static void bolliger_mabillard_track_right_quarter_turn_1_90_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_quarter_turn_1_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_quarter_turn_1_90_deg_up<supportType>(
@@ -10593,7 +10593,7 @@ static void bolliger_mabillard_track_left_quarter_turn_1_90_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_quarter_turn_1_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_quarter_turn_1_90_deg_up<supportType>(
@@ -10603,7 +10603,7 @@ static void bolliger_mabillard_track_right_quarter_turn_1_90_deg_down(
 /* The following track elements used to be specific to the Vertical Roller Coaster */
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -10687,7 +10687,7 @@ static void bolliger_mabillard_track_flat_to_60_deg_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -10771,7 +10771,7 @@ static void bolliger_mabillard_track_60_deg_up_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_60_deg_up_to_flat<supportType>(
@@ -10780,7 +10780,7 @@ static void bolliger_mabillard_track_flat_to_60_deg_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_up<supportType>(
@@ -10789,7 +10789,7 @@ static void bolliger_mabillard_track_60_deg_down_to_flat(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_brake_for_drop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10838,7 +10838,7 @@ static void bolliger_mabillard_track_brake_for_drop(
 /* The following track elements used to be specific to the Steel Twister */
 template<uint8_t supportType>
 static void bolliger_mabillard_track_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10974,7 +10974,7 @@ static void bolliger_mabillard_track_half_loop_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_half_loop_up<supportType>(session, ride, 3 - trackSequence, direction, height, trackElement);
@@ -10982,7 +10982,7 @@ static void bolliger_mabillard_track_half_loop_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11093,7 +11093,7 @@ static void bolliger_mabillard_track_left_corkscrew_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11205,7 +11205,7 @@ static void bolliger_mabillard_track_right_corkscrew_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_corkscrew_up<supportType>(
@@ -11214,7 +11214,7 @@ static void bolliger_mabillard_track_left_corkscrew_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_corkscrew_up<supportType>(
@@ -11223,7 +11223,7 @@ static void bolliger_mabillard_track_right_corkscrew_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11375,7 +11375,7 @@ static void bolliger_mabillard_track_flat_to_60_deg_up_long_base(
 /** rct2: 0x008AC104 */
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11526,7 +11526,7 @@ static void bolliger_mabillard_track_60_deg_up_to_flat_long_base(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_60_deg_down_to_flat_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_flat_to_60_deg_up_long_base<supportType>(
@@ -11535,7 +11535,7 @@ static void bolliger_mabillard_track_60_deg_down_to_flat_long_base(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_flat_to_60_deg_down_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_60_deg_up_to_flat_long_base<supportType>(
@@ -11544,7 +11544,7 @@ static void bolliger_mabillard_track_flat_to_60_deg_down_long_base(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_barrel_roll_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11695,7 +11695,7 @@ static void bolliger_mabillard_track_left_barrel_roll_up_to_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_barrel_roll_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11846,7 +11846,7 @@ static void bolliger_mabillard_track_right_barrel_roll_up_to_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_barrel_roll_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_barrel_roll_up_to_down<supportType>(
@@ -11855,7 +11855,7 @@ static void bolliger_mabillard_track_left_barrel_roll_down_to_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_barrel_roll_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_barrel_roll_up_to_down<supportType>(
@@ -11864,7 +11864,7 @@ static void bolliger_mabillard_track_right_barrel_roll_down_to_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_powered_lift(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -11906,7 +11906,7 @@ static void bolliger_mabillard_track_powered_lift(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_large_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12134,7 +12134,7 @@ static void bolliger_mabillard_track_left_large_half_loop_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_large_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12362,7 +12362,7 @@ static void bolliger_mabillard_track_right_large_half_loop_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_large_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_right_large_half_loop_up<supportType>(
@@ -12371,7 +12371,7 @@ static void bolliger_mabillard_track_right_large_half_loop_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_large_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_left_large_half_loop_up<supportType>(
@@ -12380,7 +12380,7 @@ static void bolliger_mabillard_track_left_large_half_loop_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12478,7 +12478,7 @@ static void bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bolliger_mabillard_track_90_deg_to_inverted_flat_quarter_loop_up<supportType>(
@@ -12487,7 +12487,7 @@ static void bolliger_mabillard_track_inverted_flat_to_90_deg_quarter_loop_down(
 
 template<uint8_t supportType>
 void bolliger_mabillard_track_booster(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     // These offsets could be moved to the g2.dat file when that supports offsets.
@@ -12523,7 +12523,7 @@ void bolliger_mabillard_track_booster(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_twist_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12639,7 +12639,7 @@ static void bolliger_mabillard_track_left_twist_down_to_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_twist_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12755,7 +12755,7 @@ static void bolliger_mabillard_track_right_twist_down_to_up(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_left_twist_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12871,7 +12871,7 @@ static void bolliger_mabillard_track_left_twist_up_to_down(
 
 template<uint8_t supportType>
 static void bolliger_mabillard_track_right_twist_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/ClassicWoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ClassicWoodenRollerCoaster.cpp
@@ -228,7 +228,7 @@ enum
 };
 
 static void classic_wooden_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 
 {
@@ -259,7 +259,7 @@ static void classic_wooden_rc_track_flat_to_left_bank(
 }
 
 static void classic_wooden_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][1][2] = {
@@ -292,21 +292,21 @@ static void classic_wooden_rc_track_flat_to_right_bank(
 }
 
 static void classic_wooden_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_flat_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void classic_wooden_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_flat_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void classic_wooden_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][1][2] = {
@@ -338,14 +338,14 @@ static void classic_wooden_rc_track_left_bank(
 }
 
 static void classic_wooden_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void classic_wooden_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][1][2] = {
@@ -385,7 +385,7 @@ static void classic_wooden_rc_track_left_bank_to_25_deg_up(
 }
 
 static void classic_wooden_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][1][2] = {
@@ -426,7 +426,7 @@ static void classic_wooden_rc_track_right_bank_to_25_deg_up(
 }
 
 static void classic_wooden_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][1][2] = {
@@ -467,7 +467,7 @@ static void classic_wooden_rc_track_25_deg_up_to_left_bank(
 }
 
 static void classic_wooden_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][1][2] = {
@@ -508,35 +508,35 @@ static void classic_wooden_rc_track_25_deg_up_to_right_bank(
 }
 
 static void classic_wooden_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void classic_wooden_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void classic_wooden_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void classic_wooden_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void classic_wooden_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][7][2] = {
@@ -704,7 +704,7 @@ static void classic_wooden_rc_track_banked_right_quarter_turn_5(
 }
 
 static void classic_wooden_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -713,7 +713,7 @@ static void classic_wooden_rc_track_banked_left_quarter_turn_5(
 }
 
 static void classic_wooden_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][4][2] = {
@@ -824,7 +824,7 @@ static void classic_wooden_rc_track_right_quarter_turn_3_bank(
 }
 
 static void classic_wooden_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -832,7 +832,7 @@ static void classic_wooden_rc_track_left_quarter_turn_3_bank(
 }
 
 static void classic_wooden_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][5][2] = {
@@ -963,7 +963,7 @@ static void classic_wooden_rc_track_left_eighth_bank_to_diag(
 }
 
 static void classic_wooden_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][5][2] = {
@@ -1102,7 +1102,7 @@ static void classic_wooden_rc_track_right_eighth_bank_to_diag(
 }
 
 static void classic_wooden_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1110,7 +1110,7 @@ static void classic_wooden_rc_track_left_eighth_bank_to_orthogonal(
 }
 
 static void classic_wooden_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1118,7 +1118,7 @@ static void classic_wooden_rc_track_right_eighth_bank_to_orthogonal(
 }
 
 static void classic_wooden_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][4][2] = {
@@ -1216,7 +1216,7 @@ static void classic_wooden_rc_track_diag_flat_to_left_bank(
 }
 
 static void classic_wooden_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][4][2] = {
@@ -1314,7 +1314,7 @@ static void classic_wooden_rc_track_diag_flat_to_right_bank(
 }
 
 static void classic_wooden_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_diag_flat_to_right_bank(
@@ -1322,14 +1322,14 @@ static void classic_wooden_rc_track_diag_left_bank_to_flat(
 }
 
 static void classic_wooden_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_diag_flat_to_left_bank(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void classic_wooden_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][4][2] = {
@@ -1427,14 +1427,14 @@ static void classic_wooden_rc_track_diag_left_bank(
 }
 
 static void classic_wooden_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_diag_left_bank(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void classic_wooden_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][4][2] = {
@@ -1532,7 +1532,7 @@ static void classic_wooden_rc_track_diag_left_bank_to_25_deg_up(
 }
 
 static void classic_wooden_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][4][2] = {
@@ -1630,7 +1630,7 @@ static void classic_wooden_rc_track_diag_right_bank_to_25_deg_up(
 }
 
 static void classic_wooden_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][4][2] = {
@@ -1728,7 +1728,7 @@ static void classic_wooden_rc_track_diag_25_deg_up_to_left_bank(
 }
 
 static void classic_wooden_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[4][4][2] = {
@@ -1826,7 +1826,7 @@ static void classic_wooden_rc_track_diag_25_deg_up_to_right_bank(
 }
 
 static void classic_wooden_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_diag_25_deg_up_to_right_bank(
@@ -1834,7 +1834,7 @@ static void classic_wooden_rc_track_diag_left_bank_to_25_deg_down(
 }
 
 static void classic_wooden_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_diag_25_deg_up_to_left_bank(
@@ -1842,7 +1842,7 @@ static void classic_wooden_rc_track_diag_right_bank_to_25_deg_down(
 }
 
 static void classic_wooden_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_diag_right_bank_to_25_deg_up(
@@ -1850,7 +1850,7 @@ static void classic_wooden_rc_track_diag_25_deg_down_to_left_bank(
 }
 
 static void classic_wooden_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, Direction direction, int32_t height,
     const TrackElement& trackElement)
 {
     classic_wooden_rc_track_diag_left_bank_to_25_deg_up(

--- a/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008AE6E0 */
 static void compact_inverted_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -74,7 +74,7 @@ static void compact_inverted_rc_track_flat(
 
 /** rct2: 0x008AE950, 0x008AE960, 0x008AE970 */
 static void compact_inverted_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -102,7 +102,7 @@ static void compact_inverted_rc_track_station(
 
 /** rct2: 0x008AE6F0 */
 static void compact_inverted_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -196,7 +196,7 @@ static void compact_inverted_rc_track_25_deg_up(
 
 /** rct2: 0x008AE700 */
 static void compact_inverted_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -266,7 +266,7 @@ static void compact_inverted_rc_track_60_deg_up(
 
 /** rct2: 0x008AE710 */
 static void compact_inverted_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -360,7 +360,7 @@ static void compact_inverted_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AE720 */
 static void compact_inverted_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -442,7 +442,7 @@ static void compact_inverted_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AE730 */
 static void compact_inverted_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -548,7 +548,7 @@ static void compact_inverted_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AE740 */
 static void compact_inverted_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -642,7 +642,7 @@ static void compact_inverted_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AE750 */
 static void compact_inverted_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -650,7 +650,7 @@ static void compact_inverted_rc_track_25_deg_down(
 
 /** rct2: 0x008AE760 */
 static void compact_inverted_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -658,7 +658,7 @@ static void compact_inverted_rc_track_60_deg_down(
 
 /** rct2: 0x008AE770 */
 static void compact_inverted_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -666,7 +666,7 @@ static void compact_inverted_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AE780 */
 static void compact_inverted_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -674,7 +674,7 @@ static void compact_inverted_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AE790 */
 static void compact_inverted_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -682,7 +682,7 @@ static void compact_inverted_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008AE7A0 */
 static void compact_inverted_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -690,7 +690,7 @@ static void compact_inverted_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008AE7B0 */
 static void compact_inverted_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -873,7 +873,7 @@ static void compact_inverted_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AE7C0 */
 static void compact_inverted_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -882,7 +882,7 @@ static void compact_inverted_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008AE7D0 */
 static void compact_inverted_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -925,7 +925,7 @@ static void compact_inverted_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AE7E0 */
 static void compact_inverted_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -968,7 +968,7 @@ static void compact_inverted_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008AE7F0 */
 static void compact_inverted_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1011,7 +1011,7 @@ static void compact_inverted_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008AE800 */
 static void compact_inverted_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1054,7 +1054,7 @@ static void compact_inverted_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008AE810 */
 static void compact_inverted_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1237,7 +1237,7 @@ static void compact_inverted_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008AE820 */
 static void compact_inverted_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1247,7 +1247,7 @@ static void compact_inverted_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008AE830 */
 static void compact_inverted_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1314,7 +1314,7 @@ static void compact_inverted_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AE840 */
 static void compact_inverted_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1381,7 +1381,7 @@ static void compact_inverted_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AE850 */
 static void compact_inverted_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1448,7 +1448,7 @@ static void compact_inverted_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AE860 */
 static void compact_inverted_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1515,7 +1515,7 @@ static void compact_inverted_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AE870 */
 static void compact_inverted_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1523,7 +1523,7 @@ static void compact_inverted_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008AE880 */
 static void compact_inverted_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1531,7 +1531,7 @@ static void compact_inverted_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008AE890 */
 static void compact_inverted_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1539,7 +1539,7 @@ static void compact_inverted_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008AE8A0 */
 static void compact_inverted_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1547,7 +1547,7 @@ static void compact_inverted_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008AE8B0 */
 static void compact_inverted_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1590,7 +1590,7 @@ static void compact_inverted_rc_track_left_bank(
 
 /** rct2: 0x008AE8C0 */
 static void compact_inverted_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1598,7 +1598,7 @@ static void compact_inverted_rc_track_right_bank(
 
 /** rct2: 0x008AE8D0 */
 static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1781,7 +1781,7 @@ static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AE8E0 */
 static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1964,7 +1964,7 @@ static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AE8F0 */
 static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1974,7 +1974,7 @@ static void compact_inverted_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008AE900 */
 static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1984,7 +1984,7 @@ static void compact_inverted_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008AE910 */
 static void compact_inverted_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2157,7 +2157,7 @@ static void compact_inverted_rc_track_s_bend_left(
 
 /** rct2: 0x008AE920 */
 static void compact_inverted_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2330,7 +2330,7 @@ static void compact_inverted_rc_track_s_bend_right(
 
 /** rct2: 0x008AE930 */
 static void compact_inverted_rc_track_left_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2635,7 +2635,7 @@ static void compact_inverted_rc_track_left_vertical_loop(
 
 /** rct2: 0x008AE940 */
 static void compact_inverted_rc_track_right_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2940,7 +2940,7 @@ static void compact_inverted_rc_track_right_vertical_loop(
 
 /** rct2: 0x008AE980 */
 static void compact_inverted_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3060,7 +3060,7 @@ static void compact_inverted_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AE990 */
 static void compact_inverted_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3069,7 +3069,7 @@ static void compact_inverted_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008AE9A0 */
 static void compact_inverted_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3189,7 +3189,7 @@ static void compact_inverted_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008AE9B0 */
 static void compact_inverted_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3198,7 +3198,7 @@ static void compact_inverted_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008AE9C0 */
 static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3293,7 +3293,7 @@ static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AE9D0 */
 static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3388,7 +3388,7 @@ static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AE9E0 */
 static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3398,7 +3398,7 @@ static void compact_inverted_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008AE9F0 */
 static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3408,7 +3408,7 @@ static void compact_inverted_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008AEA00 */
 static void compact_inverted_rc_track_left_twist_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3527,7 +3527,7 @@ static void compact_inverted_rc_track_left_twist_down_to_up(
 
 /** rct2: 0x008AEA10 */
 static void compact_inverted_rc_track_right_twist_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3646,7 +3646,7 @@ static void compact_inverted_rc_track_right_twist_down_to_up(
 
 /** rct2: 0x008AEA20 */
 static void compact_inverted_rc_track_left_twist_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3765,7 +3765,7 @@ static void compact_inverted_rc_track_left_twist_up_to_down(
 
 /** rct2: 0x008AEA30 */
 static void compact_inverted_rc_track_right_twist_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3884,7 +3884,7 @@ static void compact_inverted_rc_track_right_twist_up_to_down(
 
 /** rct2: 0x008AEA40 */
 static void compact_inverted_rc_track_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4036,7 +4036,7 @@ static void compact_inverted_rc_track_half_loop_up(
 
 /** rct2: 0x008AEA50 */
 static void compact_inverted_rc_track_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, trackElement);
@@ -4044,7 +4044,7 @@ static void compact_inverted_rc_track_half_loop_down(
 
 /** rct2: 0x008AEA60 */
 static void compact_inverted_rc_track_left_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4162,7 +4162,7 @@ static void compact_inverted_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008AEA70 */
 static void compact_inverted_rc_track_right_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4280,7 +4280,7 @@ static void compact_inverted_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008AEA80 */
 static void compact_inverted_rc_track_left_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4288,7 +4288,7 @@ static void compact_inverted_rc_track_left_corkscrew_down(
 
 /** rct2: 0x008AEA90 */
 static void compact_inverted_rc_track_right_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4296,7 +4296,7 @@ static void compact_inverted_rc_track_right_corkscrew_down(
 
 /** rct2: 0x008AEAD0 */
 static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4341,7 +4341,7 @@ static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008AEAB0 */
 static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4387,7 +4387,7 @@ static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008AEAC0 */
 static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_right_quarter_turn_1_60_deg_up(
@@ -4396,7 +4396,7 @@ static void compact_inverted_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008AEAE0 */
 static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_left_quarter_turn_1_60_deg_up(
@@ -4405,7 +4405,7 @@ static void compact_inverted_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008AEAA0 */
 static void compact_inverted_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4438,7 +4438,7 @@ static void compact_inverted_rc_track_brakes(
 
 /** rct2: 0x008AEAF0 */
 static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4621,7 +4621,7 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_up(
 
 /** rct2: 0x008AEB00 */
 static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4804,7 +4804,7 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_up(
 
 /** rct2: 0x008AEB10 */
 static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4987,7 +4987,7 @@ static void compact_inverted_rc_track_left_quarter_banked_helix_large_down(
 
 /** rct2: 0x008AEB20 */
 static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5170,7 +5170,7 @@ static void compact_inverted_rc_track_right_quarter_banked_helix_large_down(
 
 /** rct2: 0x008AEB30 */
 static void compact_inverted_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5228,7 +5228,7 @@ static void compact_inverted_rc_track_on_ride_photo(
 
 /** rct2: 0x008AEDB0 */
 static void compact_inverted_rc_track_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5298,7 +5298,7 @@ static void compact_inverted_rc_track_90_deg_up(
 
 /** rct2: 0x008AEDC0 */
 static void compact_inverted_rc_track_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5306,7 +5306,7 @@ static void compact_inverted_rc_track_90_deg_down(
 
 /** rct2: 0x008AED70 */
 static void compact_inverted_rc_track_60_deg_up_to_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5380,7 +5380,7 @@ static void compact_inverted_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x008AED80 */
 static void compact_inverted_rc_track_90_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     compact_inverted_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5388,7 +5388,7 @@ static void compact_inverted_rc_track_90_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AED90 */
 static void compact_inverted_rc_track_90_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -5459,7 +5459,7 @@ static void compact_inverted_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AEDA0 */
 static void compact_inverted_rc_track_60_deg_down_to_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5532,7 +5532,7 @@ static void compact_inverted_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x008AEB40 */
 static void compact_inverted_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5693,7 +5693,7 @@ static void compact_inverted_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008AEB50 */
 static void compact_inverted_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5854,7 +5854,7 @@ static void compact_inverted_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008AEB60 */
 static void compact_inverted_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5863,7 +5863,7 @@ static void compact_inverted_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008AEB70 */
 static void compact_inverted_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5872,7 +5872,7 @@ static void compact_inverted_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008AED30 */
 static void compact_inverted_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6034,7 +6034,7 @@ static void compact_inverted_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008AED40 */
 static void compact_inverted_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6196,7 +6196,7 @@ static void compact_inverted_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008AED50 */
 static void compact_inverted_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6206,7 +6206,7 @@ static void compact_inverted_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008AED60 */
 static void compact_inverted_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6215,7 +6215,7 @@ static void compact_inverted_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008AEB80 */
 static void compact_inverted_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6354,7 +6354,7 @@ static void compact_inverted_rc_track_diag_flat(
 
 /** rct2: 0x008AEBB0 */
 static void compact_inverted_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6493,7 +6493,7 @@ static void compact_inverted_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008AEC10 */
 static void compact_inverted_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6576,7 +6576,7 @@ static void compact_inverted_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008AEB90 */
 static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6715,7 +6715,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AEBF0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6798,7 +6798,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AEC00 */
 static void compact_inverted_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6881,7 +6881,7 @@ static void compact_inverted_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AEBA0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7020,7 +7020,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AEBE0 */
 static void compact_inverted_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7159,7 +7159,7 @@ static void compact_inverted_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008AEC40 */
 static void compact_inverted_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7242,7 +7242,7 @@ static void compact_inverted_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008AEBC0 */
 static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7378,7 +7378,7 @@ static void compact_inverted_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008AEC20 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7461,7 +7461,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AEC30 */
 static void compact_inverted_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7544,7 +7544,7 @@ static void compact_inverted_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008AEBD0 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7683,7 +7683,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008AEC70 */
 static void compact_inverted_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7767,7 +7767,7 @@ static void compact_inverted_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008AEC80 */
 static void compact_inverted_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7851,7 +7851,7 @@ static void compact_inverted_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008AEC90 */
 static void compact_inverted_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7935,7 +7935,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008AECA0 */
 static void compact_inverted_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8019,7 +8019,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008AECD0 */
 static void compact_inverted_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8102,7 +8102,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AECE0 */
 static void compact_inverted_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8185,7 +8185,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AECB0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8268,7 +8268,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AECC0 */
 static void compact_inverted_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8351,7 +8351,7 @@ static void compact_inverted_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AECF0 */
 static void compact_inverted_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8431,7 +8431,7 @@ static void compact_inverted_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008AED00 */
 static void compact_inverted_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8511,7 +8511,7 @@ static void compact_inverted_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008AED10 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8594,7 +8594,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008AED20 */
 static void compact_inverted_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8677,7 +8677,7 @@ static void compact_inverted_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008AEC50 */
 static void compact_inverted_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8761,7 +8761,7 @@ static void compact_inverted_rc_track_diag_left_bank(
 
 /** rct2: 0x008AEC60 */
 static void compact_inverted_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8845,7 +8845,7 @@ static void compact_inverted_rc_track_diag_right_bank(
 
 /** rct2: 0x008AEAA0 */
 static void compact_inverted_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/CorkscrewRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _CorkscrewRCBlockBrakeImages[NumOrthogonalDirect
 
 /** rct2: 0x008A7AF8 */
 static void corkscrew_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -95,7 +95,7 @@ static void corkscrew_rc_track_flat(
 
 /** rct2: 0x008A7D68, 0x008A7D78, 0x008A7D88 */
 static void corkscrew_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -130,7 +130,7 @@ static void corkscrew_rc_track_station(
 
 /** rct2: 0x008A7B08 */
 static void corkscrew_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -208,7 +208,7 @@ static void corkscrew_rc_track_25_deg_up(
 
 /** rct2: 0x008A7B18 */
 static void corkscrew_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -286,7 +286,7 @@ static void corkscrew_rc_track_60_deg_up(
 
 /** rct2: 0x008A7B28 */
 static void corkscrew_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -364,7 +364,7 @@ static void corkscrew_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A7B38 */
 static void corkscrew_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -454,7 +454,7 @@ static void corkscrew_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A7B48 */
 static void corkscrew_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -544,7 +544,7 @@ static void corkscrew_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7B58 */
 static void corkscrew_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -622,7 +622,7 @@ static void corkscrew_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A7B68 */
 static void corkscrew_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -630,7 +630,7 @@ static void corkscrew_rc_track_25_deg_down(
 
 /** rct2: 0x008A7B78 */
 static void corkscrew_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -638,7 +638,7 @@ static void corkscrew_rc_track_60_deg_down(
 
 /** rct2: 0x008A7B88 */
 static void corkscrew_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -646,7 +646,7 @@ static void corkscrew_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A7B98 */
 static void corkscrew_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -654,7 +654,7 @@ static void corkscrew_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A7BA8 */
 static void corkscrew_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -662,7 +662,7 @@ static void corkscrew_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A7BB8 */
 static void corkscrew_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -670,7 +670,7 @@ static void corkscrew_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A7BC8 */
 static void corkscrew_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -845,7 +845,7 @@ static void corkscrew_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A7BD8 */
 static void corkscrew_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -854,7 +854,7 @@ static void corkscrew_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A7BE8 */
 static void corkscrew_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -898,7 +898,7 @@ static void corkscrew_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A7BF8 */
 static void corkscrew_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -942,7 +942,7 @@ static void corkscrew_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A7C08 */
 static void corkscrew_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -986,7 +986,7 @@ static void corkscrew_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A7C18 */
 static void corkscrew_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1030,7 +1030,7 @@ static void corkscrew_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A7C28 */
 static void corkscrew_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1211,7 +1211,7 @@ static void corkscrew_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A7C38 */
 static void corkscrew_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1220,7 +1220,7 @@ static void corkscrew_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008A7C48 */
 static void corkscrew_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1271,7 +1271,7 @@ static void corkscrew_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A7C58 */
 static void corkscrew_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1322,7 +1322,7 @@ static void corkscrew_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A7C68 */
 static void corkscrew_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1373,7 +1373,7 @@ static void corkscrew_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A7C78 */
 static void corkscrew_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1424,7 +1424,7 @@ static void corkscrew_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A7C88 */
 static void corkscrew_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1432,7 +1432,7 @@ static void corkscrew_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A7C98 */
 static void corkscrew_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1440,7 +1440,7 @@ static void corkscrew_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A7CA8 */
 static void corkscrew_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1448,7 +1448,7 @@ static void corkscrew_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A7CB8 */
 static void corkscrew_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1456,7 +1456,7 @@ static void corkscrew_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A7CC8 */
 static void corkscrew_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1494,7 +1494,7 @@ static void corkscrew_rc_track_left_bank(
 
 /** rct2: 0x008A7CD8 */
 static void corkscrew_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1502,7 +1502,7 @@ static void corkscrew_rc_track_right_bank(
 
 /** rct2: 0x008A7CE8 */
 static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1677,7 +1677,7 @@ static void corkscrew_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7CF8 */
 static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1852,7 +1852,7 @@ static void corkscrew_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7D08 */
 static void corkscrew_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1861,7 +1861,7 @@ static void corkscrew_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A7D18 */
 static void corkscrew_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1870,7 +1870,7 @@ static void corkscrew_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A7D28 */
 static void corkscrew_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2019,7 +2019,7 @@ static void corkscrew_rc_track_s_bend_left(
 
 /** rct2: 0x008A7D38 */
 static void corkscrew_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2168,7 +2168,7 @@ static void corkscrew_rc_track_s_bend_right(
 
 /** rct2: 0x008A7D48 */
 static void corkscrew_rc_track_left_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2465,7 +2465,7 @@ static void corkscrew_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A7D58 */
 static void corkscrew_rc_track_right_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2722,7 +2722,7 @@ static void corkscrew_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A7D98 */
 static void corkscrew_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2834,7 +2834,7 @@ static void corkscrew_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A7DA8 */
 static void corkscrew_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2843,7 +2843,7 @@ static void corkscrew_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A7DB8 */
 static void corkscrew_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2961,7 +2961,7 @@ static void corkscrew_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A7DC8 */
 static void corkscrew_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2970,7 +2970,7 @@ static void corkscrew_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008A7DD8 */
 static void corkscrew_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3057,7 +3057,7 @@ static void corkscrew_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7DE8 */
 static void corkscrew_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3151,7 +3151,7 @@ static void corkscrew_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7DF8 */
 static void corkscrew_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3160,7 +3160,7 @@ static void corkscrew_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A7E08 */
 static void corkscrew_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3169,7 +3169,7 @@ static void corkscrew_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A7E18 */
 static void corkscrew_rc_track_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3309,7 +3309,7 @@ static void corkscrew_rc_track_half_loop_up(
 
 /** rct2: 0x008A7E28 */
 static void corkscrew_rc_track_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, trackElement);
@@ -3317,7 +3317,7 @@ static void corkscrew_rc_track_half_loop_down(
 
 /** rct2: 0x008A7E38 */
 static void corkscrew_rc_track_left_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3428,7 +3428,7 @@ static void corkscrew_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A7E48 */
 static void corkscrew_rc_track_right_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3540,7 +3540,7 @@ static void corkscrew_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A7E58 */
 static void corkscrew_rc_track_left_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
@@ -3548,7 +3548,7 @@ static void corkscrew_rc_track_left_corkscrew_down(
 
 /** rct2: 0x008A7E68 */
 static void corkscrew_rc_track_right_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -3556,7 +3556,7 @@ static void corkscrew_rc_track_right_corkscrew_down(
 
 /** rct2: 0x008A7E78 */
 static void corkscrew_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3786,7 +3786,7 @@ static void corkscrew_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A7E88 */
 static void corkscrew_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4016,7 +4016,7 @@ static void corkscrew_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A7E98 */
 static void corkscrew_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -4031,7 +4031,7 @@ static void corkscrew_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008A7EA8 */
 static void corkscrew_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -4045,7 +4045,7 @@ static void corkscrew_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008A7EB8 */
 static void corkscrew_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4401,7 +4401,7 @@ static void corkscrew_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A7EC8 */
 static void corkscrew_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4757,7 +4757,7 @@ static void corkscrew_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A7ED8 */
 static void corkscrew_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4772,7 +4772,7 @@ static void corkscrew_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008A7EE8 */
 static void corkscrew_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4786,7 +4786,7 @@ static void corkscrew_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008A7F18 */
 static void corkscrew_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4831,7 +4831,7 @@ static void corkscrew_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A7EF8 */
 static void corkscrew_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4876,7 +4876,7 @@ static void corkscrew_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A7F08 */
 static void corkscrew_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4884,7 +4884,7 @@ static void corkscrew_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A7F28 */
 static void corkscrew_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4892,7 +4892,7 @@ static void corkscrew_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A7F38 */
 static void corkscrew_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4922,7 +4922,7 @@ static void corkscrew_rc_track_brakes(
 
 /** rct2: 0x008A7F48 */
 static void corkscrew_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4972,7 +4972,7 @@ static void corkscrew_rc_track_on_ride_photo(
 
 /** rct2: 0x008A8198 */
 static void corkscrew_rc_track_flat_to_60_deg_up_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5123,7 +5123,7 @@ static void corkscrew_rc_track_flat_to_60_deg_up_long_base(
 
 /** rct2: 0x008A81A8 */
 static void corkscrew_rc_track_60_deg_up_to_flat_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5274,7 +5274,7 @@ static void corkscrew_rc_track_60_deg_up_to_flat_long_base(
 
 /** rct2: 0x008A81B8 */
 static void corkscrew_rc_track_60_deg_down_to_flat_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_flat_to_60_deg_up_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5282,7 +5282,7 @@ static void corkscrew_rc_track_60_deg_down_to_flat_long_base(
 
 /** rct2: 0x008A81C8 */
 static void corkscrew_rc_track_flat_to_60_deg_down_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     corkscrew_rc_track_60_deg_up_to_flat_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5290,7 +5290,7 @@ static void corkscrew_rc_track_flat_to_60_deg_down_long_base(
 
 /** rct2: 0x008A7F68 */
 static void corkscrew_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5435,7 +5435,7 @@ static void corkscrew_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A7F78 */
 static void corkscrew_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5580,7 +5580,7 @@ static void corkscrew_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A7F88 */
 static void corkscrew_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5589,7 +5589,7 @@ static void corkscrew_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A7F98 */
 static void corkscrew_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5598,7 +5598,7 @@ static void corkscrew_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A7FA8 */
 static void corkscrew_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5743,7 +5743,7 @@ static void corkscrew_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A7FB8 */
 static void corkscrew_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5888,7 +5888,7 @@ static void corkscrew_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A7FC8 */
 static void corkscrew_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5897,7 +5897,7 @@ static void corkscrew_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A7FD8 */
 static void corkscrew_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5906,7 +5906,7 @@ static void corkscrew_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A7F58 */
 static void corkscrew_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6052,7 +6052,7 @@ static void corkscrew_rc_track_diag_flat(
 
 /** rct2: 0x008A8008 */
 static void corkscrew_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6198,7 +6198,7 @@ static void corkscrew_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A8068 */
 static void corkscrew_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6344,7 +6344,7 @@ static void corkscrew_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A7FE8 */
 static void corkscrew_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6490,7 +6490,7 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A8048 */
 static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6636,7 +6636,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A8058 */
 static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6782,7 +6782,7 @@ static void corkscrew_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7FF8 */
 static void corkscrew_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6928,7 +6928,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A8038 */
 static void corkscrew_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7074,7 +7074,7 @@ static void corkscrew_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A8098 */
 static void corkscrew_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7220,7 +7220,7 @@ static void corkscrew_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A8018 */
 static void corkscrew_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7364,7 +7364,7 @@ static void corkscrew_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A8078 */
 static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7510,7 +7510,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A8088 */
 static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7656,7 +7656,7 @@ static void corkscrew_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A8028 */
 static void corkscrew_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7802,7 +7802,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A80C8 */
 static void corkscrew_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7881,7 +7881,7 @@ static void corkscrew_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A80D8 */
 static void corkscrew_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7960,7 +7960,7 @@ static void corkscrew_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A80E8 */
 static void corkscrew_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8039,7 +8039,7 @@ static void corkscrew_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A80F8 */
 static void corkscrew_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8118,7 +8118,7 @@ static void corkscrew_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A8128 */
 static void corkscrew_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8197,7 +8197,7 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A8138 */
 static void corkscrew_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8276,7 +8276,7 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A8108 */
 static void corkscrew_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8355,7 +8355,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A8118 */
 static void corkscrew_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8434,7 +8434,7 @@ static void corkscrew_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A8148 */
 static void corkscrew_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8511,7 +8511,7 @@ static void corkscrew_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A8158 */
 static void corkscrew_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8588,7 +8588,7 @@ static void corkscrew_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A8168 */
 static void corkscrew_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8667,7 +8667,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A8178 */
 static void corkscrew_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8746,7 +8746,7 @@ static void corkscrew_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A80A8 */
 static void corkscrew_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8822,7 +8822,7 @@ static void corkscrew_rc_track_diag_left_bank(
 
 /** rct2: 0x008A80B8 */
 static void corkscrew_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8898,7 +8898,7 @@ static void corkscrew_rc_track_diag_right_bank(
 
 /** rct2: 0x008A8188 */
 static void corkscrew_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -8913,7 +8913,7 @@ static void corkscrew_rc_track_block_brakes(
 }
 
 static void corkscrew_rc_track_booster(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!is_csg_loaded())
@@ -8959,7 +8959,7 @@ static void corkscrew_rc_track_booster(
 }
 
 static void corkscrew_rc_track_left_twist_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9076,7 +9076,7 @@ static void corkscrew_rc_track_left_twist_down_to_up(
 }
 
 static void corkscrew_rc_track_right_twist_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9193,7 +9193,7 @@ static void corkscrew_rc_track_right_twist_down_to_up(
 }
 
 static void corkscrew_rc_track_left_twist_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9310,7 +9310,7 @@ static void corkscrew_rc_track_left_twist_up_to_down(
 }
 
 static void corkscrew_rc_track_right_twist_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -21,7 +21,7 @@
 
 /** rct2: 0x007C6FF4 */
 static void flying_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -139,7 +139,7 @@ static void flying_rc_track_flat(
 
 /** rct2: 0x007C7244, 0x007C7254, 0x007C7264 */
 static void flying_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -197,7 +197,7 @@ static void flying_rc_track_station(
 
 /** rct2: 0x007C7004 */
 static void flying_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -365,7 +365,7 @@ static void flying_rc_track_25_deg_up(
 
 /** rct2: 0x007C7014 */
 static void flying_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -451,7 +451,7 @@ static void flying_rc_track_60_deg_up(
 
 /** rct2: 0x007C7024 */
 static void flying_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -619,7 +619,7 @@ static void flying_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x007C7034 */
 static void flying_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -717,7 +717,7 @@ static void flying_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x007C7044 */
 static void flying_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -839,7 +839,7 @@ static void flying_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7054 */
 static void flying_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1007,7 +1007,7 @@ static void flying_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x007C7064 */
 static void flying_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1015,7 +1015,7 @@ static void flying_rc_track_25_deg_down(
 
 /** rct2: 0x007C7074 */
 static void flying_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1023,7 +1023,7 @@ static void flying_rc_track_60_deg_down(
 
 /** rct2: 0x007C7084 */
 static void flying_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1031,7 +1031,7 @@ static void flying_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x007C7094 */
 static void flying_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1039,7 +1039,7 @@ static void flying_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x007C70A4 */
 static void flying_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1047,7 +1047,7 @@ static void flying_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x007C70B4 */
 static void flying_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1055,7 +1055,7 @@ static void flying_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x007C70C4 */
 static void flying_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1418,7 +1418,7 @@ static void flying_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x007C70D4 */
 static void flying_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1427,7 +1427,7 @@ static void flying_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x007C70E4 */
 static void flying_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1514,7 +1514,7 @@ static void flying_rc_track_flat_to_left_bank(
 
 /** rct2: 0x007C70F4 */
 static void flying_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1601,7 +1601,7 @@ static void flying_rc_track_flat_to_right_bank(
 
 /** rct2: 0x007C7104 */
 static void flying_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1688,7 +1688,7 @@ static void flying_rc_track_left_bank_to_flat(
 
 /** rct2: 0x007C7114 */
 static void flying_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1775,7 +1775,7 @@ static void flying_rc_track_right_bank_to_flat(
 
 /** rct2: 0x007C7124 */
 static void flying_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2144,7 +2144,7 @@ static void flying_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x007C7134 */
 static void flying_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2153,7 +2153,7 @@ static void flying_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x007C7144 */
 static void flying_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2271,7 +2271,7 @@ static void flying_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x007C7154 */
 static void flying_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2389,7 +2389,7 @@ static void flying_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x007C7164 */
 static void flying_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2507,7 +2507,7 @@ static void flying_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x007C7174 */
 static void flying_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2625,7 +2625,7 @@ static void flying_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x007C7184 */
 static void flying_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2633,7 +2633,7 @@ static void flying_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x007C7194 */
 static void flying_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2641,7 +2641,7 @@ static void flying_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x007C71A4 */
 static void flying_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2649,7 +2649,7 @@ static void flying_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x007C71B4 */
 static void flying_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2657,7 +2657,7 @@ static void flying_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x007C71C4 */
 static void flying_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2738,7 +2738,7 @@ static void flying_rc_track_left_bank(
 
 /** rct2: 0x007C71D4 */
 static void flying_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2746,7 +2746,7 @@ static void flying_rc_track_right_bank(
 
 /** rct2: 0x007C71E4 */
 static void flying_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3109,7 +3109,7 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C71F4 */
 static void flying_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3472,7 +3472,7 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C7204 */
 static void flying_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -3481,7 +3481,7 @@ static void flying_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x007C7214 */
 static void flying_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -3490,7 +3490,7 @@ static void flying_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x007C7224 */
 static void flying_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3817,7 +3817,7 @@ static void flying_rc_track_s_bend_left(
 
 /** rct2: 0x007C7234 */
 static void flying_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4144,7 +4144,7 @@ static void flying_rc_track_s_bend_right(
 
 /** rct2: 0x007C7274 */
 static void flying_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4377,7 +4377,7 @@ static void flying_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x007C7284 */
 static void flying_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4386,7 +4386,7 @@ static void flying_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x007C7294 */
 static void flying_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4625,7 +4625,7 @@ static void flying_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x007C72A4 */
 static void flying_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4634,7 +4634,7 @@ static void flying_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x007C72B4 */
 static void flying_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4817,7 +4817,7 @@ static void flying_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C72C4 */
 static void flying_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5006,7 +5006,7 @@ static void flying_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C72D4 */
 static void flying_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5015,7 +5015,7 @@ static void flying_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x007C72E4 */
 static void flying_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5024,7 +5024,7 @@ static void flying_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x007C7314 */
 static void flying_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5258,7 +5258,7 @@ static void flying_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x007C7324 */
 static void flying_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5492,7 +5492,7 @@ static void flying_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x007C7334 */
 static void flying_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -5506,7 +5506,7 @@ static void flying_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x007C7344 */
 static void flying_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -5520,7 +5520,7 @@ static void flying_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x007C7354 */
 static void flying_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5880,7 +5880,7 @@ static void flying_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x007C7364 */
 static void flying_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6240,7 +6240,7 @@ static void flying_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x007C7374 */
 static void flying_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6254,7 +6254,7 @@ static void flying_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x007C7384 */
 static void flying_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6268,7 +6268,7 @@ static void flying_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x007C73B4 */
 static void flying_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6355,7 +6355,7 @@ static void flying_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x007C7394 */
 static void flying_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6441,7 +6441,7 @@ static void flying_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x007C73A4 */
 static void flying_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -6449,7 +6449,7 @@ static void flying_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x007C73C4 */
 static void flying_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -6457,7 +6457,7 @@ static void flying_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x007C73D4 */
 static void flying_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6519,7 +6519,7 @@ static void flying_rc_track_brakes(
 }
 
 static void flying_rc_track_booster(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6549,7 +6549,7 @@ static void flying_rc_track_booster(
 
 /** rct2: 0x007C7674 */
 static void flying_rc_track_left_quarter_banked_helix_large_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6732,7 +6732,7 @@ static void flying_rc_track_left_quarter_banked_helix_large_up(
 
 /** rct2: 0x007C7684 */
 static void flying_rc_track_right_quarter_banked_helix_large_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6915,7 +6915,7 @@ static void flying_rc_track_right_quarter_banked_helix_large_up(
 
 /** rct2: 0x007C7694 */
 static void flying_rc_track_left_quarter_banked_helix_large_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7098,7 +7098,7 @@ static void flying_rc_track_left_quarter_banked_helix_large_down(
 
 /** rct2: 0x007C76A4 */
 static void flying_rc_track_right_quarter_banked_helix_large_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7281,7 +7281,7 @@ static void flying_rc_track_right_quarter_banked_helix_large_down(
 
 /** rct2: 0x007C78B4 */
 static void flying_rc_track_25_deg_up_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7391,7 +7391,7 @@ static void flying_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x007C78C4 */
 static void flying_rc_track_25_deg_up_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7501,7 +7501,7 @@ static void flying_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x007C73E4 */
 static void flying_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7616,7 +7616,7 @@ static void flying_rc_track_on_ride_photo(
 
 /** rct2: 0x007C78D4 */
 static void flying_rc_track_25_deg_down_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -7624,7 +7624,7 @@ static void flying_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x007C78E4 */
 static void flying_rc_track_25_deg_down_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -7632,7 +7632,7 @@ static void flying_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x007C7404 */
 static void flying_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7942,7 +7942,7 @@ static void flying_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x007C7414 */
 static void flying_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8252,7 +8252,7 @@ static void flying_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x007C7424 */
 static void flying_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8261,7 +8261,7 @@ static void flying_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x007C7434 */
 static void flying_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8270,7 +8270,7 @@ static void flying_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x007C7444 */
 static void flying_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8580,7 +8580,7 @@ static void flying_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x007C7454 */
 static void flying_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8890,7 +8890,7 @@ static void flying_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x007C7464 */
 static void flying_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8899,7 +8899,7 @@ static void flying_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x007C7474 */
 static void flying_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8908,7 +8908,7 @@ static void flying_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x007C73F4 */
 static void flying_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9192,7 +9192,7 @@ static void flying_rc_track_diag_flat(
 
 /** rct2: 0x007C74A4 */
 static void flying_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9476,7 +9476,7 @@ static void flying_rc_track_diag_25_deg_up(
 
 /** rct2: 0x007C7504 */
 static void flying_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9704,7 +9704,7 @@ static void flying_rc_track_diag_60_deg_up(
 
 /** rct2: 0x007C7484 */
 static void flying_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9988,7 +9988,7 @@ static void flying_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x007C74E4 */
 static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10216,7 +10216,7 @@ static void flying_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x007C74F4 */
 static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10444,7 +10444,7 @@ static void flying_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7494 */
 static void flying_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10728,7 +10728,7 @@ static void flying_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x007C74D4 */
 static void flying_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10956,7 +10956,7 @@ static void flying_rc_track_diag_25_deg_down(
 
 /** rct2: 0x007C7534 */
 static void flying_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11184,7 +11184,7 @@ static void flying_rc_track_diag_60_deg_down(
 
 /** rct2: 0x007C74B4 */
 static void flying_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11405,7 +11405,7 @@ static void flying_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x007C7514 */
 static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11633,7 +11633,7 @@ static void flying_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x007C7524 */
 static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11861,7 +11861,7 @@ static void flying_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x007C74C4 */
 static void flying_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12089,7 +12089,7 @@ static void flying_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x007C7564 */
 static void flying_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12251,7 +12251,7 @@ static void flying_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x007C7574 */
 static void flying_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12413,7 +12413,7 @@ static void flying_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x007C7584 */
 static void flying_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12575,7 +12575,7 @@ static void flying_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x007C7594 */
 static void flying_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12737,7 +12737,7 @@ static void flying_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x007C75C4 */
 static void flying_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12898,7 +12898,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x007C75D4 */
 static void flying_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13059,7 +13059,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x007C75A4 */
 static void flying_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13220,7 +13220,7 @@ static void flying_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x007C75B4 */
 static void flying_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13381,7 +13381,7 @@ static void flying_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x007C75E4 */
 static void flying_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13535,7 +13535,7 @@ static void flying_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x007C75F4 */
 static void flying_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13689,7 +13689,7 @@ static void flying_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x007C7604 */
 static void flying_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13850,7 +13850,7 @@ static void flying_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x007C7614 */
 static void flying_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -14011,7 +14011,7 @@ static void flying_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x007C7544 */
 static void flying_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -14170,7 +14170,7 @@ static void flying_rc_track_diag_left_bank(
 
 /** rct2: 0x007C7554 */
 static void flying_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -14329,7 +14329,7 @@ static void flying_rc_track_diag_right_bank(
 
 /** rct2: 0x007C7624 */
 static void flying_rc_track_left_flyer_twist_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14448,7 +14448,7 @@ static void flying_rc_track_left_flyer_twist_up(
 
 /** rct2: 0x007C7634 */
 static void flying_rc_track_right_flyer_twist_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14567,7 +14567,7 @@ static void flying_rc_track_right_flyer_twist_up(
 
 /** rct2: 0x007C7644 */
 static void flying_rc_track_left_flyer_twist_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14686,7 +14686,7 @@ static void flying_rc_track_left_flyer_twist_down(
 
 /** rct2: 0x007C7654 */
 static void flying_rc_track_right_flyer_twist_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14805,7 +14805,7 @@ static void flying_rc_track_right_flyer_twist_down(
 
 /** rct2: 0x007C72F4 */
 static void flying_rc_track_flyer_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14946,7 +14946,7 @@ static void flying_rc_track_flyer_half_loop_up(
 
 /** rct2: 0x007C7304 */
 static void flying_rc_track_flyer_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15087,7 +15087,7 @@ static void flying_rc_track_flyer_half_loop_down(
 
 /** rct2: 0x007C7664 */
 static void flying_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -15146,7 +15146,7 @@ static void flying_rc_track_block_brakes(
 
 /** rct2: 0x007C76B4 */
 static void flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -15329,7 +15329,7 @@ static void flying_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C76C4 */
 static void flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -15518,7 +15518,7 @@ static void flying_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x007C76D4 */
 static void flying_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -15528,7 +15528,7 @@ static void flying_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x007C76E4 */
 static void flying_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -15538,7 +15538,7 @@ static void flying_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x007C76F4 */
 static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -15901,7 +15901,7 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C7704 */
 static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16264,7 +16264,7 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x007C7714 */
 static void flying_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -16274,7 +16274,7 @@ static void flying_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x007C7724 */
 static void flying_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -16284,7 +16284,7 @@ static void flying_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x007C7734 */
 static void flying_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16397,7 +16397,7 @@ static void flying_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x007C7744 */
 static void flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16510,7 +16510,7 @@ static void flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x007C7754 */
 static void flying_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16623,7 +16623,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7764 */
 static void flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16736,7 +16736,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x007C7774 */
 static void flying_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_banked_25_deg_up_to_25_deg_up(
@@ -16745,7 +16745,7 @@ static void flying_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x007C7784 */
 static void flying_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -16753,7 +16753,7 @@ static void flying_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x007C7794 */
 static void flying_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_right_banked_25_deg_up(
@@ -16762,7 +16762,7 @@ static void flying_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x007C77A4 */
 static void flying_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -16770,7 +16770,7 @@ static void flying_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x007C77B4 */
 static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16880,7 +16880,7 @@ static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x007C77C4 */
 static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -16990,7 +16990,7 @@ static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x007C77F4 */
 static void flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17100,7 +17100,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x007C7804 */
 static void flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17210,7 +17210,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x007C7814 */
 static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -17219,7 +17219,7 @@ static void flying_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x007C7824 */
 static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -17228,7 +17228,7 @@ static void flying_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x007C77D4 */
 static void flying_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -17237,7 +17237,7 @@ static void flying_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x007C77E4 */
 static void flying_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -17246,7 +17246,7 @@ static void flying_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x007C7834 */
 static void flying_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17359,7 +17359,7 @@ static void flying_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x007C7844 */
 static void flying_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17472,7 +17472,7 @@ static void flying_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x007C7854 */
 static void flying_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17585,7 +17585,7 @@ static void flying_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x007C7864 */
 static void flying_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -17698,7 +17698,7 @@ static void flying_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x007C7874 */
 static void flying_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -17706,7 +17706,7 @@ static void flying_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x007C7884 */
 static void flying_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -17714,7 +17714,7 @@ static void flying_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x007C7894 */
 static void flying_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -17722,14 +17722,14 @@ static void flying_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x007C78A4 */
 static void flying_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void flying_rc_track_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -17773,14 +17773,14 @@ static void flying_rc_track_90_deg_up(
 }
 
 static void flying_rc_track_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void flying_rc_track_60_deg_up_to_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -17826,14 +17826,14 @@ static void flying_rc_track_60_deg_up_to_90_deg_up(
 }
 
 static void flying_rc_track_90_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void flying_rc_track_90_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -17876,7 +17876,7 @@ static void flying_rc_track_90_deg_up_to_60_deg_up(
 }
 
 static void flying_rc_track_60_deg_down_to_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -17921,7 +17921,7 @@ static void flying_rc_track_60_deg_down_to_90_deg_down(
 }
 
 static void flying_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -18018,14 +18018,14 @@ static void flying_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
 }
 
 static void flying_rc_track_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_90_deg_to_inverted_flat_quarter_loop_up(session, ride, 2 - trackSequence, direction, height, trackElement);
 }
 
 static void flying_rc_track_flat_to_60_deg_up_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -18035,7 +18035,7 @@ static void flying_rc_track_flat_to_60_deg_up_long_base(
 }
 
 static void flying_rc_track_60_deg_up_to_flat_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -18045,7 +18045,7 @@ static void flying_rc_track_60_deg_up_to_flat_long_base(
 }
 
 static void flying_rc_track_60_deg_down_to_flat_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -18055,7 +18055,7 @@ static void flying_rc_track_60_deg_down_to_flat_long_base(
 }
 
 static void flying_rc_track_flat_to_60_deg_down_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -18064,7 +18064,7 @@ static void flying_rc_track_flat_to_60_deg_down_long_base(
         session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
 }
 static void flying_rc_track_half_loop_inverted_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -18215,14 +18215,14 @@ static void flying_rc_track_half_loop_inverted_up(
 }
 
 static void flying_rc_track_half_loop_uninverted_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_half_loop_inverted_up(session, ride, 3 - trackSequence, direction, height, trackElement);
 }
 
 static void flying_rc_track_left_flying_large_half_loop_inverted_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -18451,7 +18451,7 @@ static void flying_rc_track_left_flying_large_half_loop_inverted_up(
 }
 
 static void flying_rc_track_right_flying_large_half_loop_inverted_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -18680,14 +18680,14 @@ static void flying_rc_track_right_flying_large_half_loop_inverted_up(
 }
 
 static void flying_rc_track_left_flying_large_half_loop_uninverted_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_left_flying_large_half_loop_inverted_up(session, ride, 6 - trackSequence, direction, height, trackElement);
 }
 
 static void flying_rc_track_right_flying_large_half_loop_uninverted_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     flying_rc_track_right_flying_large_half_loop_inverted_up(session, ride, 6 - trackSequence, direction, height, trackElement);

--- a/src/openrct2/ride/coaster/GigaCoaster.cpp
+++ b/src/openrct2/ride/coaster/GigaCoaster.cpp
@@ -41,7 +41,7 @@ static constexpr const uint32_t _GigaCoasterBrakeImages[NumOrthogonalDirections]
 
 /** rct2: 0x008AD674 */
 static void giga_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -125,7 +125,7 @@ static void giga_rc_track_flat(
 }
 
 static void giga_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -160,7 +160,7 @@ static void giga_rc_track_station(
 
 /** rct2: 0x008AD684 */
 static void giga_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -268,7 +268,7 @@ static void giga_rc_track_25_deg_up(
 
 /** rct2: 0x008AD694 */
 static void giga_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -346,7 +346,7 @@ static void giga_rc_track_60_deg_up(
 
 /** rct2: 0x008AD6A4 */
 static void giga_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -454,7 +454,7 @@ static void giga_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AD6B4 */
 static void giga_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -544,7 +544,7 @@ static void giga_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008AD6C4 */
 static void giga_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -634,7 +634,7 @@ static void giga_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008AD6D4 */
 static void giga_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasCableLift())
@@ -742,7 +742,7 @@ static void giga_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AD6E4 */
 static void giga_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -750,7 +750,7 @@ static void giga_rc_track_25_deg_down(
 
 /** rct2: 0x008AD6F4 */
 static void giga_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -758,7 +758,7 @@ static void giga_rc_track_60_deg_down(
 
 /** rct2: 0x008AD704 */
 static void giga_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -766,7 +766,7 @@ static void giga_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AD714 */
 static void giga_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -774,7 +774,7 @@ static void giga_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008AD724 */
 static void giga_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -782,7 +782,7 @@ static void giga_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008AD734 */
 static void giga_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -790,7 +790,7 @@ static void giga_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008AD744 */
 static void giga_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -965,7 +965,7 @@ static void giga_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AD754 */
 static void giga_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -974,7 +974,7 @@ static void giga_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008AD764 */
 static void giga_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1018,7 +1018,7 @@ static void giga_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008AD774 */
 static void giga_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1062,7 +1062,7 @@ static void giga_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008AD784 */
 static void giga_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1106,7 +1106,7 @@ static void giga_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008AD794 */
 static void giga_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1150,7 +1150,7 @@ static void giga_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008AD7A4 */
 static void giga_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1331,7 +1331,7 @@ static void giga_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008AD7B4 */
 static void giga_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1340,7 +1340,7 @@ static void giga_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008AD7C4 */
 static void giga_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1391,7 +1391,7 @@ static void giga_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008AD7D4 */
 static void giga_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1442,7 +1442,7 @@ static void giga_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008AD7E4 */
 static void giga_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1493,7 +1493,7 @@ static void giga_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008AD7F4 */
 static void giga_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1544,7 +1544,7 @@ static void giga_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008AD804 */
 static void giga_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1552,7 +1552,7 @@ static void giga_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008AD814 */
 static void giga_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1560,7 +1560,7 @@ static void giga_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008AD824 */
 static void giga_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1568,7 +1568,7 @@ static void giga_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008AD834 */
 static void giga_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1576,7 +1576,7 @@ static void giga_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008AD844 */
 static void giga_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1614,7 +1614,7 @@ static void giga_rc_track_left_bank(
 
 /** rct2: 0x008AD854 */
 static void giga_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1622,7 +1622,7 @@ static void giga_rc_track_right_bank(
 
 /** rct2: 0x008AD864 */
 static void giga_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1797,7 +1797,7 @@ static void giga_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AD874 */
 static void giga_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1972,7 +1972,7 @@ static void giga_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008AD884 */
 static void giga_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1981,7 +1981,7 @@ static void giga_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008AD894 */
 static void giga_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1990,7 +1990,7 @@ static void giga_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008AD8A4 */
 static void giga_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2139,7 +2139,7 @@ static void giga_rc_track_s_bend_left(
 
 /** rct2: 0x008AD8B4 */
 static void giga_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2288,7 +2288,7 @@ static void giga_rc_track_s_bend_right(
 
 /** rct2: 0x008AD8F4 */
 static void giga_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2400,7 +2400,7 @@ static void giga_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AD904 */
 static void giga_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2409,7 +2409,7 @@ static void giga_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008AD914 */
 static void giga_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2527,7 +2527,7 @@ static void giga_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008AD924 */
 static void giga_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2536,7 +2536,7 @@ static void giga_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008AD934 */
 static void giga_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2623,7 +2623,7 @@ static void giga_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AD944 */
 static void giga_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2717,7 +2717,7 @@ static void giga_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008AD954 */
 static void giga_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2726,7 +2726,7 @@ static void giga_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008AD964 */
 static void giga_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2735,7 +2735,7 @@ static void giga_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008AD974 */
 static void giga_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2965,7 +2965,7 @@ static void giga_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008AD984 */
 static void giga_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3195,7 +3195,7 @@ static void giga_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008AD994 */
 static void giga_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3209,7 +3209,7 @@ static void giga_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008AD9A4 */
 static void giga_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3223,7 +3223,7 @@ static void giga_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008AD9B4 */
 static void giga_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3579,7 +3579,7 @@ static void giga_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008AD9C4 */
 static void giga_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3949,7 +3949,7 @@ static void giga_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008AD9D4 */
 static void giga_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3963,7 +3963,7 @@ static void giga_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008AD9E4 */
 static void giga_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3977,7 +3977,7 @@ static void giga_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008ADA14 */
 static void giga_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4022,7 +4022,7 @@ static void giga_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008AD9F4 */
 static void giga_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4067,7 +4067,7 @@ static void giga_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008ADA04 */
 static void giga_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4075,7 +4075,7 @@ static void giga_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008ADA24 */
 static void giga_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4083,7 +4083,7 @@ static void giga_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008ADA34 */
 static void giga_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4119,7 +4119,7 @@ static void giga_rc_track_brakes(
 
 /** rct2: 0x008ADC84 */
 static void giga_rc_track_25_deg_up_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4164,7 +4164,7 @@ static void giga_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008ADC94 */
 static void giga_rc_track_25_deg_up_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4209,7 +4209,7 @@ static void giga_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008ADA44 */
 static void giga_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4259,7 +4259,7 @@ static void giga_rc_track_on_ride_photo(
 
 /** rct2: 0x008ADCA4 */
 static void giga_rc_track_25_deg_down_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4267,7 +4267,7 @@ static void giga_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x008ADCB4 */
 static void giga_rc_track_25_deg_down_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4275,7 +4275,7 @@ static void giga_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x008ADED4 */
 static void giga_rc_track_flat_to_60_deg_up_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4566,7 +4566,7 @@ static void giga_rc_track_flat_to_60_deg_up_long_base(
 
 /** rct2: 0x008ADEE4 */
 static void giga_rc_track_60_deg_up_to_flat_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4717,7 +4717,7 @@ static void giga_rc_track_60_deg_up_to_flat_long_base(
 
 /** rct2: 0x008ADEF4 */
 static void giga_rc_track_60_deg_down_to_flat_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_flat_to_60_deg_up_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4725,7 +4725,7 @@ static void giga_rc_track_60_deg_down_to_flat_long_base(
 
 /** rct2: 0x008ADF04 */
 static void giga_rc_track_flat_to_60_deg_down_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_60_deg_up_to_flat_long_base(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4733,7 +4733,7 @@ static void giga_rc_track_flat_to_60_deg_down_long_base(
 
 /** rct2: 0x008ADF14 */
 static void giga_rc_track_cable_lift_hill(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4909,7 +4909,7 @@ static void giga_rc_track_cable_lift_hill(
 
 /** rct2: 0x008ADA64 */
 static void giga_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5054,7 +5054,7 @@ static void giga_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008ADA74 */
 static void giga_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5199,7 +5199,7 @@ static void giga_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008ADA84 */
 static void giga_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5208,7 +5208,7 @@ static void giga_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008ADA94 */
 static void giga_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5217,7 +5217,7 @@ static void giga_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008ADAA4 */
 static void giga_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5362,7 +5362,7 @@ static void giga_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008ADAB4 */
 static void giga_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5507,7 +5507,7 @@ static void giga_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008ADAC4 */
 static void giga_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5516,7 +5516,7 @@ static void giga_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008ADAD4 */
 static void giga_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5525,7 +5525,7 @@ static void giga_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008ADA54 */
 static void giga_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5671,7 +5671,7 @@ static void giga_rc_track_diag_flat(
 
 /** rct2: 0x008ADB04 */
 static void giga_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5817,7 +5817,7 @@ static void giga_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008ADB64 */
 static void giga_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5893,7 +5893,7 @@ static void giga_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008ADAE4 */
 static void giga_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6039,7 +6039,7 @@ static void giga_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008ADB44 */
 static void giga_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6115,7 +6115,7 @@ static void giga_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008ADB54 */
 static void giga_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6191,7 +6191,7 @@ static void giga_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ADAF4 */
 static void giga_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6337,7 +6337,7 @@ static void giga_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008ADB34 */
 static void giga_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6483,7 +6483,7 @@ static void giga_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008ADB94 */
 static void giga_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6559,7 +6559,7 @@ static void giga_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008ADB14 */
 static void giga_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6703,7 +6703,7 @@ static void giga_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008ADB74 */
 static void giga_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6779,7 +6779,7 @@ static void giga_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008ADB84 */
 static void giga_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6855,7 +6855,7 @@ static void giga_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008ADB24 */
 static void giga_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7001,7 +7001,7 @@ static void giga_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008ADBC4 */
 static void giga_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7080,7 +7080,7 @@ static void giga_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008ADBD4 */
 static void giga_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7159,7 +7159,7 @@ static void giga_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008ADBE4 */
 static void giga_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7238,7 +7238,7 @@ static void giga_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008ADBF4 */
 static void giga_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7317,7 +7317,7 @@ static void giga_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008ADC24 */
 static void giga_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7396,7 +7396,7 @@ static void giga_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008ADC34 */
 static void giga_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7475,7 +7475,7 @@ static void giga_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008ADC04 */
 static void giga_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7554,7 +7554,7 @@ static void giga_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008ADC14 */
 static void giga_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7633,7 +7633,7 @@ static void giga_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008ADC44 */
 static void giga_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7710,7 +7710,7 @@ static void giga_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008ADC54 */
 static void giga_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7787,7 +7787,7 @@ static void giga_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008ADC64 */
 static void giga_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7866,7 +7866,7 @@ static void giga_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008ADC74 */
 static void giga_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7945,7 +7945,7 @@ static void giga_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008ADBA4 */
 static void giga_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8021,7 +8021,7 @@ static void giga_rc_track_diag_left_bank(
 
 /** rct2: 0x008ADBB4 */
 static void giga_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8097,7 +8097,7 @@ static void giga_rc_track_diag_right_bank(
 
 /** rct2: 0x008ADEC4 */
 static void giga_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -8120,7 +8120,7 @@ static void giga_rc_track_block_brakes(
 
 /** rct2: 0x008ADCC4 */
 static void giga_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8207,7 +8207,7 @@ static void giga_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ADCD4 */
 static void giga_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8301,7 +8301,7 @@ static void giga_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008ADCE4 */
 static void giga_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -8311,7 +8311,7 @@ static void giga_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008ADCF4 */
 static void giga_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -8320,7 +8320,7 @@ static void giga_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008ADD04 */
 static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8495,7 +8495,7 @@ static void giga_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008ADD14 */
 static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8670,7 +8670,7 @@ static void giga_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008ADD24 */
 static void giga_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8680,7 +8680,7 @@ static void giga_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008ADD34 */
 static void giga_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8689,7 +8689,7 @@ static void giga_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008ADD44 */
 static void giga_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8737,7 +8737,7 @@ static void giga_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ADD54 */
 static void giga_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8785,7 +8785,7 @@ static void giga_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ADD64 */
 static void giga_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8833,7 +8833,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ADD74 */
 static void giga_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8881,7 +8881,7 @@ static void giga_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008ADD84 */
 static void giga_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8889,7 +8889,7 @@ static void giga_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x008ADD94 */
 static void giga_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8897,7 +8897,7 @@ static void giga_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x008ADDA4 */
 static void giga_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8905,7 +8905,7 @@ static void giga_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008ADDB4 */
 static void giga_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8913,7 +8913,7 @@ static void giga_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008ADDC4 */
 static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8958,7 +8958,7 @@ static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ADDD4 */
 static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9003,7 +9003,7 @@ static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ADE04 */
 static void giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9048,7 +9048,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008ADE14 */
 static void giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9093,7 +9093,7 @@ static void giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008ADE24 */
 static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -9102,7 +9102,7 @@ static void giga_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008ADE34 */
 static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -9111,7 +9111,7 @@ static void giga_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008ADDE4 */
 static void giga_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -9120,7 +9120,7 @@ static void giga_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x008ADDF4 */
 static void giga_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -9129,7 +9129,7 @@ static void giga_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x008ADE44 */
 static void giga_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9177,7 +9177,7 @@ static void giga_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008ADE54 */
 static void giga_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9225,7 +9225,7 @@ static void giga_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008ADE64 */
 static void giga_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9273,7 +9273,7 @@ static void giga_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008ADE74 */
 static void giga_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9321,7 +9321,7 @@ static void giga_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008ADE84 */
 static void giga_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9329,7 +9329,7 @@ static void giga_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008ADE94 */
 static void giga_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9337,7 +9337,7 @@ static void giga_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008ADEA4 */
 static void giga_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9345,14 +9345,14 @@ static void giga_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x008ADEB4 */
 static void giga_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     giga_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void giga_rc_track_booster(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     // These offsets could be moved to the g2.dat file when that supports offsets.

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x0087694C */
 static void heartline_twister_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -97,7 +97,7 @@ static void heartline_twister_rc_track_flat(
 }
 
 static void heartline_twister_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -122,7 +122,7 @@ static void heartline_twister_rc_track_station(
 
 /** rct2: 0x0087695C */
 static void heartline_twister_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -223,7 +223,7 @@ static void heartline_twister_rc_track_25_deg_up(
 
 /** rct2: 0x008769FC */
 static void heartline_twister_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -324,7 +324,7 @@ static void heartline_twister_rc_track_60_deg_up(
 
 /** rct2: 0x0087696C */
 static void heartline_twister_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -425,7 +425,7 @@ static void heartline_twister_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008769BC */
 static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -526,7 +526,7 @@ static void heartline_twister_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008769CC */
 static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -627,7 +627,7 @@ static void heartline_twister_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0087697C */
 static void heartline_twister_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -728,7 +728,7 @@ static void heartline_twister_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0087698C */
 static void heartline_twister_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -736,7 +736,7 @@ static void heartline_twister_rc_track_25_deg_down(
 
 /** rct2: 0x00876A0C */
 static void heartline_twister_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -744,7 +744,7 @@ static void heartline_twister_rc_track_60_deg_down(
 
 /** rct2: 0x0087699C */
 static void heartline_twister_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -752,7 +752,7 @@ static void heartline_twister_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008769DC */
 static void heartline_twister_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -760,7 +760,7 @@ static void heartline_twister_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008769EC */
 static void heartline_twister_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -768,7 +768,7 @@ static void heartline_twister_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008769AC */
 static void heartline_twister_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     heartline_twister_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -776,7 +776,7 @@ static void heartline_twister_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x00876A6C */
 static void heartline_twister_rc_track_heartline_transfer_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -994,7 +994,7 @@ static void heartline_twister_rc_track_heartline_transfer_up(
 
 /** rct2: 0x00876A7C */
 static void heartline_twister_rc_track_heartline_transfer_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1212,7 +1212,7 @@ static void heartline_twister_rc_track_heartline_transfer_down(
 
 /** rct2: 0x00876A4C */
 static void heartline_twister_rc_track_left_heartline_roll(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1482,7 +1482,7 @@ static void heartline_twister_rc_track_left_heartline_roll(
 
 /** rct2: 0x00876A5C */
 static void heartline_twister_rc_track_right_heartline_roll(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/HybridCoaster.cpp
+++ b/src/openrct2/ride/coaster/HybridCoaster.cpp
@@ -26,7 +26,7 @@
 
 namespace HybridRC
 {
-    static ImageId GetTrackColour(paint_session& session)
+    static ImageId GetTrackColour(PaintSession& session)
     {
         if (session.TrackColours[SCHEME_TRACK].ToUInt32() == 0x21600000)
             return session.TrackColours[SCHEME_TRACK]; // TODO dirty hack
@@ -35,7 +35,7 @@ namespace HybridRC
     }
 
     static void TrackFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -57,7 +57,7 @@ namespace HybridRC
     }
 
     static void TrackStation(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         static constexpr const uint32_t imageIds[4][3] = {
@@ -90,7 +90,7 @@ namespace HybridRC
     }
 
     static void Track25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -119,7 +119,7 @@ namespace HybridRC
     }
 
     static void Track60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -173,7 +173,7 @@ namespace HybridRC
     }
 
     static void TrackFlatTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -202,7 +202,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpTo60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -283,7 +283,7 @@ namespace HybridRC
     }
 
     static void Track60DegUpTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -365,7 +365,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -394,49 +394,49 @@ namespace HybridRC
     }
 
     static void Track25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownTo60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDownTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpTo60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -474,14 +474,14 @@ namespace HybridRC
     }
 
     static void Track90DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegUpTo90DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -525,14 +525,14 @@ namespace HybridRC
     }
 
     static void Track90DegDownTo60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpTo90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegUpTo60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         const CoordsXYZ boundBoxOffsets[4] = {
@@ -572,7 +572,7 @@ namespace HybridRC
     }
 
     static void Track60DegDownTo90DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -614,7 +614,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -733,7 +733,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -741,7 +741,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -941,7 +941,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -949,7 +949,7 @@ namespace HybridRC
     }
 
     static void TrackLeftEighthToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1101,7 +1101,7 @@ namespace HybridRC
     }
 
     static void TrackRightEighthToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1253,7 +1253,7 @@ namespace HybridRC
     }
 
     static void TrackLeftEighthToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1261,7 +1261,7 @@ namespace HybridRC
     }
 
     static void TrackRightEighthToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1269,7 +1269,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1418,7 +1418,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1565,7 +1565,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1712,7 +1712,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlatTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1859,7 +1859,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2006,7 +2006,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlatTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2151,7 +2151,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2298,7 +2298,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2445,7 +2445,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpTo60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2592,7 +2592,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegUpTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2739,7 +2739,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2886,7 +2886,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownTo60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3033,7 +3033,7 @@ namespace HybridRC
     }
 
     static void TrackDiag60DegDownTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3180,7 +3180,7 @@ namespace HybridRC
     }
 
     static void TrackFlatToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3219,7 +3219,7 @@ namespace HybridRC
     }
 
     static void TrackFlatToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3258,21 +3258,21 @@ namespace HybridRC
     }
 
     static void TrackLeftBankToflat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankToflat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3318,7 +3318,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3364,7 +3364,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3410,7 +3410,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3456,35 +3456,35 @@ namespace HybridRC
     }
 
     static void TrackLeftBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftbank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3523,14 +3523,14 @@ namespace HybridRC
     }
 
     static void TrackRightbank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftbank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackDiagFlatToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3625,7 +3625,7 @@ namespace HybridRC
     }
 
     static void TrackDiagFlatToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3720,7 +3720,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBankToflat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3815,7 +3815,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBankToflat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3910,7 +3910,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4005,7 +4005,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4100,7 +4100,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4195,7 +4195,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegUpToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4290,7 +4290,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4383,7 +4383,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4476,7 +4476,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4571,7 +4571,7 @@ namespace HybridRC
     }
 
     static void TrackDiag25DegDownToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4666,7 +4666,7 @@ namespace HybridRC
     }
 
     static void TrackDiagLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4761,7 +4761,7 @@ namespace HybridRC
     }
 
     static void TrackDiagRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4856,7 +4856,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Bank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4987,7 +4987,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Bank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4995,7 +4995,7 @@ namespace HybridRC
     }
 
     static void TrackBankedLeftQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5210,7 +5210,7 @@ namespace HybridRC
     }
 
     static void TrackBankedRightQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -5218,7 +5218,7 @@ namespace HybridRC
     }
 
     static void TrackLeftEighthBankToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5382,7 +5382,7 @@ namespace HybridRC
     }
 
     static void TrackRightEighthBankToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5548,7 +5548,7 @@ namespace HybridRC
     }
 
     static void TrackLeftEighthBankToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5556,7 +5556,7 @@ namespace HybridRC
     }
 
     static void TrackRightEighthBankToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5564,7 +5564,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5671,7 +5671,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5778,7 +5778,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5786,7 +5786,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5794,7 +5794,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn5Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5994,7 +5994,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn5Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6194,7 +6194,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn5Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -6202,7 +6202,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn5Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -6210,7 +6210,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn1Tile60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6258,7 +6258,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn1Tile60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6307,21 +6307,21 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn1Tile60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightQuarterTurn1Tile60DegUp(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightQuarterTurn1Tile60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftQuarterTurn1Tile60DegUp(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
     }
 
     static void TrackLeftQuarterTurn1Tile90DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6366,7 +6366,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn1Tile90DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6411,21 +6411,21 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn1Tile90DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightQuarterTurn1Tile90DegUp(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightQuarterTurn1Tile90DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftQuarterTurn1Tile90DegUp(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
     }
 
     static void Track25DegUpToLeftBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6468,7 +6468,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpToRightBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6511,7 +6511,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegUpTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6554,7 +6554,7 @@ namespace HybridRC
     }
 
     static void TrackRightBanked25DegUpTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6597,35 +6597,35 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegDownTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToLeftBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToRightBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6671,7 +6671,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedFlatToRightBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6717,7 +6717,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegUpToLeftBankedFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6763,7 +6763,7 @@ namespace HybridRC
     }
 
     static void TrackRightBanked25DegUpToRightBankedFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6809,35 +6809,35 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpToRightBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankedFlatToRightBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpToLeftBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBanked25DegDownToLeftBankedFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBankedFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownToRightBankedFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBankedFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegUpLeftBanked(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6877,7 +6877,7 @@ namespace HybridRC
     }
 
     static void Track25DegUpRightBanked(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6917,21 +6917,21 @@ namespace HybridRC
     }
 
     static void Track25DegDownLeftBanked(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpRightBanked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownRightBanked(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpLeftBanked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatToLeftBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6974,7 +6974,7 @@ namespace HybridRC
     }
 
     static void TrackFlatToRightBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7017,7 +7017,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBanked25DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7060,7 +7060,7 @@ namespace HybridRC
     }
 
     static void TrackRightBanked25DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7103,35 +7103,35 @@ namespace HybridRC
     }
 
     static void TrackFlatToLeftBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatToRightBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBanked25DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7258,7 +7258,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7385,7 +7385,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7393,7 +7393,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7401,7 +7401,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedQuarterTurn5Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7645,7 +7645,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedQuarterTurn5Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7889,7 +7889,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBankedQuarterTurn5Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -7897,7 +7897,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankedQuarterTurn5Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -7905,7 +7905,7 @@ namespace HybridRC
     }
 
     static void TrackSBendLeft(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8059,7 +8059,7 @@ namespace HybridRC
     }
 
     static void TrackSBendRight(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8213,7 +8213,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixUpSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8496,7 +8496,7 @@ namespace HybridRC
     }
 
     static void TrackRightHalfBankedHelixUpSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8779,7 +8779,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixDownSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 4)
@@ -8792,7 +8792,7 @@ namespace HybridRC
     }
 
     static void TrackRightHalfBankedHelixDownSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 4)
@@ -8805,7 +8805,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixUpLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9226,7 +9226,7 @@ namespace HybridRC
     }
 
     static void TrackRightHalfBankedHelixUpLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9647,7 +9647,7 @@ namespace HybridRC
     }
 
     static void TrackLeftHalfBankedHelixDownLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 7)
@@ -9660,7 +9660,7 @@ namespace HybridRC
     }
 
     static void TrackRightHalfBankedHelixDownLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 7)
@@ -9673,7 +9673,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBarrelRollUpToDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9815,7 +9815,7 @@ namespace HybridRC
     }
 
     static void TrackRightBarrelRollUpToDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9957,21 +9957,21 @@ namespace HybridRC
     }
 
     static void TrackLeftBarrelRollDownToUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBarrelRollDownToUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftZeroGRollUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10111,7 +10111,7 @@ namespace HybridRC
     }
 
     static void TrackRightZeroGRollUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10250,21 +10250,21 @@ namespace HybridRC
     }
 
     static void TrackLeftZeroGRollDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftZeroGRollUp(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightZeroGRollDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightZeroGRollUp(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftLargeZeroGRollUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10448,7 +10448,7 @@ namespace HybridRC
     }
 
     static void TrackRightLargeZeroGRollUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10632,21 +10632,21 @@ namespace HybridRC
     }
 
     static void TrackLeftLargeZeroGRollDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftLargeZeroGRollUp(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightLargeZeroGRollDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightLargeZeroGRollUp(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegToInvertedFlatQuarterLoopUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10778,14 +10778,14 @@ namespace HybridRC
     }
 
     static void TrackInvertedFlatTo90DegQuarterLoopDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track90DegToInvertedFlatQuarterLoopUp(session, ride, 2 - trackSequence, direction, height, trackElement);
     }
 
     static void Trackbrakes(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
@@ -10798,7 +10798,7 @@ namespace HybridRC
     }
 
     static void TrackOnRidePhoto(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
@@ -10814,7 +10814,7 @@ namespace HybridRC
     }
 
     static void TrackFlatTo60DegUpLongBase(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10952,7 +10952,7 @@ namespace HybridRC
     }
 
     static void Track60DegUpToFlatLongBase(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11090,21 +11090,21 @@ namespace HybridRC
     }
 
     static void TrackFlatTo60DegDownLongBase(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpToFlatLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDownToFlatLongBase(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo60DegUpLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackBlockBrakes(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
@@ -11117,7 +11117,7 @@ namespace HybridRC
     }
 
     static void Trackbooster(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
@@ -11130,7 +11130,7 @@ namespace HybridRC
     }
 
     static void Trackpowered_lift(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         PaintAddImageAsParentRotated(
@@ -11150,7 +11150,7 @@ namespace HybridRC
     }
 
     static void TrackLeftBankToLeftQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11260,7 +11260,7 @@ namespace HybridRC
     }
 
     static void TrackRightBankToRightQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11378,7 +11378,7 @@ namespace HybridRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDownToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11496,7 +11496,7 @@ namespace HybridRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDownToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)

--- a/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x00890CB4 */
 static void inverted_hairpin_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -82,7 +82,7 @@ static void inverted_hairpin_rc_track_flat(
 
 /** rct2: 0x00890D84, 0x00890D94, 0x00890DA4 */
 static void inverted_hairpin_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -110,7 +110,7 @@ static void inverted_hairpin_rc_track_station(
 
 /** rct2: 0x00890CC4 */
 static void inverted_hairpin_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -204,7 +204,7 @@ static void inverted_hairpin_rc_track_25_deg_up(
 
 /** rct2: 0x00890CD4 */
 static void inverted_hairpin_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -274,7 +274,7 @@ static void inverted_hairpin_rc_track_60_deg_up(
 
 /** rct2: 0x00890CE4 */
 static void inverted_hairpin_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -368,7 +368,7 @@ static void inverted_hairpin_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x00890CF4 */
 static void inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -450,7 +450,7 @@ static void inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x00890D04 */
 static void inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -556,7 +556,7 @@ static void inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00890D14 */
 static void inverted_hairpin_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -650,7 +650,7 @@ static void inverted_hairpin_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x00890D24 */
 static void inverted_hairpin_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -658,7 +658,7 @@ static void inverted_hairpin_rc_track_25_deg_down(
 
 /** rct2: 0x00890D34 */
 static void inverted_hairpin_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -666,7 +666,7 @@ static void inverted_hairpin_rc_track_60_deg_down(
 
 /** rct2: 0x00890D44 */
 static void inverted_hairpin_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -674,7 +674,7 @@ static void inverted_hairpin_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x00890D54 */
 static void inverted_hairpin_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -682,7 +682,7 @@ static void inverted_hairpin_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x00890D64 */
 static void inverted_hairpin_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -690,7 +690,7 @@ static void inverted_hairpin_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x00890D74 */
 static void inverted_hairpin_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -698,7 +698,7 @@ static void inverted_hairpin_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x00890DB4 */
 static void inverted_hairpin_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -818,7 +818,7 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x00890DC4 */
 static void inverted_hairpin_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -827,7 +827,7 @@ static void inverted_hairpin_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x00890DD4 */
 static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -922,7 +922,7 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00890DE4 */
 static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1017,7 +1017,7 @@ static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00890DF4 */
 static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1027,7 +1027,7 @@ static void inverted_hairpin_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x00890E04 */
 static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1037,7 +1037,7 @@ static void inverted_hairpin_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x00890E64 */
 static void inverted_hairpin_rc_track_left_quarter_turn_1(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1086,7 +1086,7 @@ static void inverted_hairpin_rc_track_left_quarter_turn_1(
 
 /** rct2: 0x00890E74 */
 static void inverted_hairpin_rc_track_right_quarter_turn_1(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_left_quarter_turn_1(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -1094,7 +1094,7 @@ static void inverted_hairpin_rc_track_right_quarter_turn_1(
 
 /** rct2: 0x00890E24 */
 static void inverted_hairpin_rc_track_flat_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -1176,7 +1176,7 @@ static void inverted_hairpin_rc_track_flat_to_60_deg_up(
 
 /** rct2: 0x00890E34 */
 static void inverted_hairpin_rc_track_60_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -1279,7 +1279,7 @@ static void inverted_hairpin_rc_track_60_deg_up_to_flat(
 
 /** rct2: 0x00890E44 */
 static void inverted_hairpin_rc_track_flat_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_60_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1287,7 +1287,7 @@ static void inverted_hairpin_rc_track_flat_to_60_deg_down(
 
 /** rct2: 0x00890E54 */
 static void inverted_hairpin_rc_track_60_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_hairpin_rc_track_flat_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1295,7 +1295,7 @@ static void inverted_hairpin_rc_track_60_deg_down_to_flat(
 
 /** rct2: 0x00890E14 */
 static void inverted_hairpin_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1328,7 +1328,7 @@ static void inverted_hairpin_rc_track_brakes(
 
 /** rct2: 0x00890E84 */
 static void inverted_hairpin_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008B0460 */
 static void inverted_impulse_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -53,7 +53,7 @@ static void inverted_impulse_rc_track_flat(
 
 /** rct2: 0x008B0470, 0x008B0480, 0x008B0490 */
 static void inverted_impulse_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -81,7 +81,7 @@ static void inverted_impulse_rc_track_station(
 
 /** rct2: 0x008B04A0 */
 static void inverted_impulse_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -146,7 +146,7 @@ static void inverted_impulse_rc_track_25_deg_up(
 
 /** rct2: 0x008B04B0 */
 static void inverted_impulse_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -187,7 +187,7 @@ static void inverted_impulse_rc_track_60_deg_up(
 
 /** rct2: 0x008B04C0 */
 static void inverted_impulse_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -249,7 +249,7 @@ static void inverted_impulse_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008B04D0 */
 static void inverted_impulse_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -296,7 +296,7 @@ static void inverted_impulse_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008B04E0 */
 static void inverted_impulse_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -343,7 +343,7 @@ static void inverted_impulse_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008B04F0 */
 static void inverted_impulse_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -405,7 +405,7 @@ static void inverted_impulse_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008B0500 */
 static void inverted_impulse_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -413,7 +413,7 @@ static void inverted_impulse_rc_track_25_deg_down(
 
 /** rct2: 0x008B0510 */
 static void inverted_impulse_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -421,7 +421,7 @@ static void inverted_impulse_rc_track_60_deg_down(
 
 /** rct2: 0x008B0520 */
 static void inverted_impulse_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -429,7 +429,7 @@ static void inverted_impulse_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008B0530 */
 static void inverted_impulse_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -437,7 +437,7 @@ static void inverted_impulse_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008B0540 */
 static void inverted_impulse_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -445,7 +445,7 @@ static void inverted_impulse_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008B0550 */
 static void inverted_impulse_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -453,7 +453,7 @@ static void inverted_impulse_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008B05A0 */
 static void inverted_impulse_rc_track_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -494,7 +494,7 @@ static void inverted_impulse_rc_track_90_deg_up(
 
 /** rct2: 0x008B05B0 */
 static void inverted_impulse_rc_track_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -502,7 +502,7 @@ static void inverted_impulse_rc_track_90_deg_down(
 
 /** rct2: 0x008B0560 */
 static void inverted_impulse_rc_track_60_deg_up_to_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -547,7 +547,7 @@ static void inverted_impulse_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x008B0570 */
 static void inverted_impulse_rc_track_90_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -555,7 +555,7 @@ static void inverted_impulse_rc_track_90_deg_down_to_60_deg_down(
 
 /** rct2: 0x008B0580 */
 static void inverted_impulse_rc_track_90_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -597,7 +597,7 @@ static void inverted_impulse_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x008B0590 */
 static void inverted_impulse_rc_track_60_deg_down_to_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -641,7 +641,7 @@ static void inverted_impulse_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x008B05C0 */
 static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -691,7 +691,7 @@ static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008B05D0 */
 static void inverted_impulse_rc_track_right_quarter_turn_1_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -741,7 +741,7 @@ static void inverted_impulse_rc_track_right_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008B05E0 */
 static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_right_quarter_turn_1_90_deg_up(
@@ -750,7 +750,7 @@ static void inverted_impulse_rc_track_left_quarter_turn_1_90_deg_down(
 
 /** rct2: 0x008B05F0 */
 static void inverted_impulse_rc_track_right_quarter_turn_1_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_impulse_rc_track_left_quarter_turn_1_90_deg_up(

--- a/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008A92E8 */
 static void inverted_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -73,7 +73,7 @@ static void inverted_rc_track_flat(
 
 /** rct2: 0x008A9558, 0x008A9568, 0x008A9578 */
 static void inverted_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -101,7 +101,7 @@ static void inverted_rc_track_station(
 
 /** rct2: 0x008A92F8 */
 static void inverted_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -195,7 +195,7 @@ static void inverted_rc_track_25_deg_up(
 
 /** rct2: 0x008A9308 */
 static void inverted_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -236,7 +236,7 @@ static void inverted_rc_track_60_deg_up(
 
 /** rct2: 0x008A9318 */
 static void inverted_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -330,7 +330,7 @@ static void inverted_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A9328 */
 static void inverted_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -377,7 +377,7 @@ static void inverted_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A9338 */
 static void inverted_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -448,7 +448,7 @@ static void inverted_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A9348 */
 static void inverted_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -542,7 +542,7 @@ static void inverted_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A9358 */
 static void inverted_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -550,7 +550,7 @@ static void inverted_rc_track_25_deg_down(
 
 /** rct2: 0x008A9368 */
 static void inverted_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -558,7 +558,7 @@ static void inverted_rc_track_60_deg_down(
 
 /** rct2: 0x008A9378 */
 static void inverted_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -566,7 +566,7 @@ static void inverted_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A9388 */
 static void inverted_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -574,7 +574,7 @@ static void inverted_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A9398 */
 static void inverted_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -582,7 +582,7 @@ static void inverted_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A93A8 */
 static void inverted_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -590,7 +590,7 @@ static void inverted_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A93B8 */
 static void inverted_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -771,7 +771,7 @@ static void inverted_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A93C8 */
 static void inverted_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -780,7 +780,7 @@ static void inverted_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A93D8 */
 static void inverted_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -822,7 +822,7 @@ static void inverted_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A93E8 */
 static void inverted_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -864,7 +864,7 @@ static void inverted_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A93F8 */
 static void inverted_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -906,7 +906,7 @@ static void inverted_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A9408 */
 static void inverted_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -948,7 +948,7 @@ static void inverted_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A9418 */
 static void inverted_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1129,7 +1129,7 @@ static void inverted_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A9428 */
 static void inverted_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1138,7 +1138,7 @@ static void inverted_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008A9438 */
 static void inverted_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1205,7 +1205,7 @@ static void inverted_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A9448 */
 static void inverted_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1272,7 +1272,7 @@ static void inverted_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A9458 */
 static void inverted_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1339,7 +1339,7 @@ static void inverted_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A9468 */
 static void inverted_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1406,7 +1406,7 @@ static void inverted_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A9478 */
 static void inverted_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1414,7 +1414,7 @@ static void inverted_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A9488 */
 static void inverted_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1422,7 +1422,7 @@ static void inverted_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A9498 */
 static void inverted_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1430,7 +1430,7 @@ static void inverted_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A94A8 */
 static void inverted_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1438,7 +1438,7 @@ static void inverted_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A94B8 */
 static void inverted_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1480,7 +1480,7 @@ static void inverted_rc_track_left_bank(
 
 /** rct2: 0x008A94C8 */
 static void inverted_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1488,7 +1488,7 @@ static void inverted_rc_track_right_bank(
 
 /** rct2: 0x008A94D8 */
 static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1669,7 +1669,7 @@ static void inverted_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A94E8 */
 static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1850,7 +1850,7 @@ static void inverted_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A94F8 */
 static void inverted_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1859,7 +1859,7 @@ static void inverted_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A9508 */
 static void inverted_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1868,7 +1868,7 @@ static void inverted_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A9518 */
 static void inverted_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2039,7 +2039,7 @@ static void inverted_rc_track_s_bend_left(
 
 /** rct2: 0x008A9528 */
 static void inverted_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2210,7 +2210,7 @@ static void inverted_rc_track_s_bend_right(
 
 /** rct2: 0x008A9538 */
 static void inverted_rc_track_left_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2515,7 +2515,7 @@ static void inverted_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A9548 */
 static void inverted_rc_track_right_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2820,7 +2820,7 @@ static void inverted_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A9588 */
 static void inverted_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2938,7 +2938,7 @@ static void inverted_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A9598 */
 static void inverted_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2947,7 +2947,7 @@ static void inverted_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A95A8 */
 static void inverted_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3065,7 +3065,7 @@ static void inverted_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A95B8 */
 static void inverted_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3074,7 +3074,7 @@ static void inverted_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008A95C8 */
 static void inverted_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3167,7 +3167,7 @@ static void inverted_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A95D8 */
 static void inverted_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3260,7 +3260,7 @@ static void inverted_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A95E8 */
 static void inverted_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3269,7 +3269,7 @@ static void inverted_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A95F8 */
 static void inverted_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3278,7 +3278,7 @@ static void inverted_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A9608 */
 static void inverted_rc_track_left_twist_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3395,7 +3395,7 @@ static void inverted_rc_track_left_twist_down_to_up(
 
 /** rct2: 0x008A9618 */
 static void inverted_rc_track_right_twist_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3512,7 +3512,7 @@ static void inverted_rc_track_right_twist_down_to_up(
 
 /** rct2: 0x008A9628 */
 static void inverted_rc_track_left_twist_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3629,7 +3629,7 @@ static void inverted_rc_track_left_twist_up_to_down(
 
 /** rct2: 0x008A9638 */
 static void inverted_rc_track_right_twist_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3746,7 +3746,7 @@ static void inverted_rc_track_right_twist_up_to_down(
 
 /** rct2: 0x008A9648 */
 static void inverted_rc_track_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3898,7 +3898,7 @@ static void inverted_rc_track_half_loop_up(
 
 /** rct2: 0x008A9658 */
 static void inverted_rc_track_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, trackElement);
@@ -3906,7 +3906,7 @@ static void inverted_rc_track_half_loop_down(
 
 /** rct2: 0x008A9668 */
 static void inverted_rc_track_left_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4022,7 +4022,7 @@ static void inverted_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A9678 */
 static void inverted_rc_track_right_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4138,7 +4138,7 @@ static void inverted_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A9688 */
 static void inverted_rc_track_left_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4146,7 +4146,7 @@ static void inverted_rc_track_left_corkscrew_down(
 
 /** rct2: 0x008A9698 */
 static void inverted_rc_track_right_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4154,7 +4154,7 @@ static void inverted_rc_track_right_corkscrew_down(
 
 /** rct2: 0x008A96D8 */
 static void inverted_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4199,7 +4199,7 @@ static void inverted_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A96B8 */
 static void inverted_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4245,7 +4245,7 @@ static void inverted_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A96C8 */
 static void inverted_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4253,7 +4253,7 @@ static void inverted_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A96E8 */
 static void inverted_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4261,7 +4261,7 @@ static void inverted_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A96A8 */
 static void inverted_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4293,7 +4293,7 @@ static void inverted_rc_track_brakes(
 
 /** rct2: 0x008A96F8 */
 static void inverted_rc_track_left_quarter_banked_helix_large_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4474,7 +4474,7 @@ static void inverted_rc_track_left_quarter_banked_helix_large_up(
 
 /** rct2: 0x008A9708 */
 static void inverted_rc_track_right_quarter_banked_helix_large_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4655,7 +4655,7 @@ static void inverted_rc_track_right_quarter_banked_helix_large_up(
 
 /** rct2: 0x008A9718 */
 static void inverted_rc_track_left_quarter_banked_helix_large_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4836,7 +4836,7 @@ static void inverted_rc_track_left_quarter_banked_helix_large_down(
 
 /** rct2: 0x008A9728 */
 static void inverted_rc_track_right_quarter_banked_helix_large_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5017,7 +5017,7 @@ static void inverted_rc_track_right_quarter_banked_helix_large_down(
 
 /** rct2: 0x008A9A38 */
 static void inverted_rc_track_25_deg_up_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5082,7 +5082,7 @@ static void inverted_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008A9A48 */
 static void inverted_rc_track_25_deg_up_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5147,7 +5147,7 @@ static void inverted_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008A9738 */
 static void inverted_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5197,7 +5197,7 @@ static void inverted_rc_track_on_ride_photo(
 
 /** rct2: 0x008A9A58 */
 static void inverted_rc_track_25_deg_down_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5205,7 +5205,7 @@ static void inverted_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x008A9A68 */
 static void inverted_rc_track_25_deg_down_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5213,7 +5213,7 @@ static void inverted_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x008A9748 */
 static void inverted_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5373,7 +5373,7 @@ static void inverted_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A9758 */
 static void inverted_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5533,7 +5533,7 @@ static void inverted_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A9768 */
 static void inverted_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5542,7 +5542,7 @@ static void inverted_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A9778 */
 static void inverted_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5551,7 +5551,7 @@ static void inverted_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A9938 */
 static void inverted_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5712,7 +5712,7 @@ static void inverted_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A9948 */
 static void inverted_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5873,7 +5873,7 @@ static void inverted_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A9958 */
 static void inverted_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5882,7 +5882,7 @@ static void inverted_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A9968 */
 static void inverted_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5891,7 +5891,7 @@ static void inverted_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A9788 */
 static void inverted_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6030,7 +6030,7 @@ static void inverted_rc_track_diag_flat(
 
 /** rct2: 0x008A97B8 */
 static void inverted_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6169,7 +6169,7 @@ static void inverted_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A9818 */
 static void inverted_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6252,7 +6252,7 @@ static void inverted_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A9798 */
 static void inverted_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6391,7 +6391,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A97F8 */
 static void inverted_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6474,7 +6474,7 @@ static void inverted_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A9808 */
 static void inverted_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6557,7 +6557,7 @@ static void inverted_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A97A8 */
 static void inverted_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6696,7 +6696,7 @@ static void inverted_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A97E8 */
 static void inverted_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6835,7 +6835,7 @@ static void inverted_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A9848 */
 static void inverted_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6918,7 +6918,7 @@ static void inverted_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A97C8 */
 static void inverted_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7054,7 +7054,7 @@ static void inverted_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A9828 */
 static void inverted_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7137,7 +7137,7 @@ static void inverted_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A9838 */
 static void inverted_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7220,7 +7220,7 @@ static void inverted_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A97D8 */
 static void inverted_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7359,7 +7359,7 @@ static void inverted_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A9878 */
 static void inverted_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7443,7 +7443,7 @@ static void inverted_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A9888 */
 static void inverted_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7527,7 +7527,7 @@ static void inverted_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A9898 */
 static void inverted_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7611,7 +7611,7 @@ static void inverted_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A98A8 */
 static void inverted_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7695,7 +7695,7 @@ static void inverted_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A98D8 */
 static void inverted_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7778,7 +7778,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A98E8 */
 static void inverted_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7861,7 +7861,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A98B8 */
 static void inverted_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7944,7 +7944,7 @@ static void inverted_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A98C8 */
 static void inverted_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8027,7 +8027,7 @@ static void inverted_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A98F8 */
 static void inverted_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8107,7 +8107,7 @@ static void inverted_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A9908 */
 static void inverted_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8187,7 +8187,7 @@ static void inverted_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A9918 */
 static void inverted_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8270,7 +8270,7 @@ static void inverted_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A9928 */
 static void inverted_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8353,7 +8353,7 @@ static void inverted_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A9858 */
 static void inverted_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8437,7 +8437,7 @@ static void inverted_rc_track_diag_left_bank(
 
 /** rct2: 0x008A9868 */
 static void inverted_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8521,7 +8521,7 @@ static void inverted_rc_track_diag_right_bank(
 
 /** rct2: 0x008A9978 */
 static void inverted_rc_track_left_large_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8751,7 +8751,7 @@ static void inverted_rc_track_left_large_half_loop_up(
 
 /** rct2: 0x008A9988 */
 static void inverted_rc_track_right_large_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8981,7 +8981,7 @@ static void inverted_rc_track_right_large_half_loop_up(
 
 /** rct2: 0x008A9998 */
 static void inverted_rc_track_right_large_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_large_half_loop_up(session, ride, 6 - trackSequence, direction, height, trackElement);
@@ -8989,7 +8989,7 @@ static void inverted_rc_track_right_large_half_loop_down(
 
 /** rct2: 0x008A99A8 */
 static void inverted_rc_track_left_large_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_large_half_loop_up(session, ride, 6 - trackSequence, direction, height, trackElement);
@@ -8997,7 +8997,7 @@ static void inverted_rc_track_left_large_half_loop_down(
 
 /** rct2: 0x008A96A8 */
 static void inverted_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9029,7 +9029,7 @@ static void inverted_rc_track_block_brakes(
 
 /** rct2: 0x008A9A78 */
 static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9122,7 +9122,7 @@ static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A9A88 */
 static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9215,7 +9215,7 @@ static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A9A98 */
 static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -9225,7 +9225,7 @@ static void inverted_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A9AA8 */
 static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -9235,7 +9235,7 @@ static void inverted_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A9BB8 */
 static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9416,7 +9416,7 @@ static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A9BC8 */
 static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9597,7 +9597,7 @@ static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A9BD8 */
 static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -9607,7 +9607,7 @@ static void inverted_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A9BE8 */
 static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -9617,7 +9617,7 @@ static void inverted_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A9AB8 */
 static void inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9682,7 +9682,7 @@ static void inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A9AC8 */
 static void inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9747,7 +9747,7 @@ static void inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A9AD8 */
 static void inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9812,7 +9812,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A9AE8 */
 static void inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9877,7 +9877,7 @@ static void inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A9AF8 */
 static void inverted_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_banked_25_deg_up_to_25_deg_up(
@@ -9886,7 +9886,7 @@ static void inverted_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A9B08 */
 static void inverted_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_banked_25_deg_up_to_25_deg_up(
@@ -9895,7 +9895,7 @@ static void inverted_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A9B18 */
 static void inverted_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_right_banked_25_deg_up(
@@ -9904,7 +9904,7 @@ static void inverted_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A9B28 */
 static void inverted_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_25_deg_up_to_left_banked_25_deg_up(
@@ -9913,7 +9913,7 @@ static void inverted_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A9B38 */
 static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9978,7 +9978,7 @@ static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A9B48 */
 static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10043,7 +10043,7 @@ static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A9B58 */
 static void inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10108,7 +10108,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008A9B68 */
 static void inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10173,7 +10173,7 @@ static void inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008A9B78 */
 static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -10182,7 +10182,7 @@ static void inverted_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A9B88 */
 static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -10191,7 +10191,7 @@ static void inverted_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A9B98 */
 static void inverted_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -10200,7 +10200,7 @@ static void inverted_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x008A9BA8 */
 static void inverted_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -10209,7 +10209,7 @@ static void inverted_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x008A99B8 */
 static void inverted_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10274,7 +10274,7 @@ static void inverted_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A99C8 */
 static void inverted_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10339,7 +10339,7 @@ static void inverted_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A99D8 */
 static void inverted_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10404,7 +10404,7 @@ static void inverted_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A99E8 */
 static void inverted_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -10469,7 +10469,7 @@ static void inverted_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A99F8 */
 static void inverted_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -10477,7 +10477,7 @@ static void inverted_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A9A08 */
 static void inverted_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -10485,7 +10485,7 @@ static void inverted_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A9A18 */
 static void inverted_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -10493,7 +10493,7 @@ static void inverted_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x008A9A28 */
 static void inverted_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     inverted_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -1844,7 +1844,7 @@ static constexpr const uint32_t junior_rc_track_pieces_diag_60_deg_down_to_25_de
 };
 
 void junior_rc_paint_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_flat[EnumValue(chainType)][direction]);
@@ -1864,7 +1864,7 @@ void junior_rc_paint_track_flat(
 }
 
 void junior_rc_paint_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, bool drawBlockBrake)
 {
     ImageId imageId;
@@ -1922,7 +1922,7 @@ void junior_rc_paint_station(
 }
 
 void junior_rc_paint_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
@@ -1945,7 +1945,7 @@ void junior_rc_paint_track_25_deg_up(
 }
 
 void junior_rc_paint_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
@@ -1974,7 +1974,7 @@ void junior_rc_paint_track_flat_to_25_deg_up(
 }
 
 void junior_rc_paint_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
@@ -2022,7 +2022,7 @@ static constexpr const int8_t junior_rc_track_right_quarter_turn_5_tiles_support
 };
 
 static void junior_rc_right_quarter_turn_5_tiles_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -2102,7 +2102,7 @@ static constexpr const uint8_t junior_rc_left_quarter_turn_5_tiles_to_right_turn
 
 /* rct2: 0x0051917A */
 static void junior_rc_left_quarter_turn_5_tiles_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence];
@@ -2113,7 +2113,7 @@ static void junior_rc_left_quarter_turn_5_tiles_paint_setup(
  * rct2: 0x008AAFC0, 0x00521593, 0x005216A1, 0x005217AF, 0x00521884
  */
 static void junior_rc_flat_to_left_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId image_id;
@@ -2161,7 +2161,7 @@ static void junior_rc_flat_to_left_bank_paint_setup(
  * rct2: 0x008AAFD0, 0x00521959, 0x00521A2E, 0x00521B03, 0x00521C11
  */
 static void junior_rc_flat_to_right_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId image_id;
@@ -2206,14 +2206,14 @@ static void junior_rc_flat_to_right_bank_paint_setup(
 }
 
 static void junior_rc_left_bank_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_flat_to_right_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void junior_rc_right_bank_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_flat_to_left_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -2283,7 +2283,7 @@ static constexpr const CoordsXYZ junior_rc_banked_right_quarter_turn_5_tiles_bou
 
 /* rct2: 0x008AB010, 0x0052304C */
 static void junior_rc_banked_right_quarter_turn_5_tiles_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t thickness = 1;
@@ -2375,7 +2375,7 @@ static void junior_rc_banked_right_quarter_turn_5_tiles_paint_setup(
 
 /* rct2: 0x008AB000 */
 static void junior_rc_banked_left_quarter_turn_5_tiles_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = junior_rc_left_quarter_turn_5_tiles_to_right_turn_map[trackSequence];
@@ -2387,7 +2387,7 @@ static void junior_rc_banked_left_quarter_turn_5_tiles_paint_setup(
  * rct2: 0x008AB020, 0x00522073, 0x00522182, 0x00522291, 0x00522367
  */
 static void junior_rc_left_bank_to_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId image_id;
@@ -2447,7 +2447,7 @@ static void junior_rc_left_bank_to_25_deg_up_paint_setup(
  * rct2: 0x008AB030, 0x0052243D, 0x00522513, 0x005225E9, 0x005226F8
  */
 static void junior_rc_right_bank_to_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId image_id;
@@ -2507,7 +2507,7 @@ static void junior_rc_right_bank_to_25_deg_up_paint_setup(
  * rct2: 0x008AB040, 0x00522807, 0x0052291A, 0x00522A2D, 0x00522B07
  */
 static void junior_rc_25_deg_up_to_left_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId image_id;
@@ -2568,7 +2568,7 @@ static void junior_rc_25_deg_up_to_left_bank_paint_setup(
  * rct2: 0x008AB050, 0x00522BE1, 0x00522CBB, 0x00522D95, 0x00522EA8
  */
 static void junior_rc_25_deg_up_to_right_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId image_id;
@@ -2629,7 +2629,7 @@ static void junior_rc_25_deg_up_to_right_bank_paint_setup(
  * rct2: 0x008AB060
  */
 static void junior_rc_left_bank_to_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_25_deg_up_to_right_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -2639,7 +2639,7 @@ static void junior_rc_left_bank_to_25_deg_down_paint_setup(
  * rct2: 0x008AB070
  */
 static void junior_rc_right_bank_to_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_25_deg_up_to_left_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -2649,7 +2649,7 @@ static void junior_rc_right_bank_to_25_deg_down_paint_setup(
  * rct2: 0x008AB080
  */
 static void junior_rc_25_deg_down_to_left_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_right_bank_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -2659,7 +2659,7 @@ static void junior_rc_25_deg_down_to_left_bank_paint_setup(
  * rct2: 0x008AB090
  */
 static void junior_rc_25_deg_down_to_right_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_left_bank_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -2683,7 +2683,7 @@ static constexpr const CoordsXY junior_rc_left_bank_bound_offsets[4] = {
  * rct2: 0x008AB0A0, 0x00521D1F, 0x00521DF4, 0x00521EC9, 0x00521F9E
  */
 static void junior_rc_left_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId image_id;
@@ -2717,14 +2717,14 @@ static void junior_rc_left_bank_paint_setup(
  * rct2: 0x008AB0B0
  */
 static void junior_rc_right_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_left_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -2802,7 +2802,7 @@ void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
 }
 
 void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -2881,7 +2881,7 @@ void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
 
 /* rct2: 0x008AAE10, 0x00519D88, 0x00519DAC, 0x00519DD0, 0x00519DF4 */
 static void junior_rc_left_quarter_turn_5_tiles_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -2892,7 +2892,7 @@ static void junior_rc_left_quarter_turn_5_tiles_25_deg_up_paint_setup(
 
 /* rct2: 0x008AAE20, 0x00519E18, 0x0051A148, 0x0051A452, 0x0051A738 */
 static void junior_rc_right_quarter_turn_5_tiles_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -2903,7 +2903,7 @@ static void junior_rc_right_quarter_turn_5_tiles_25_deg_up_paint_setup(
 
 /* rct2: 0x008AAE30, 0x0051AA42, 0x0051AA68, 0x0051AA8C, 0x0051AAB0 */
 static void junior_rc_left_quarter_turn_5_tiles_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_right_quarter_turn_5_tiles_25_deg_up_paint_setup(
@@ -2913,7 +2913,7 @@ static void junior_rc_left_quarter_turn_5_tiles_25_deg_down_paint_setup(
 
 /* rct2: 0x008AAE40, 0x0051AAD4, 0x0051AE04, 0x0051B10E, 0x0051B3F4 */
 static void junior_rc_right_quarter_turn_5_tiles_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_left_quarter_turn_5_tiles_25_deg_up_paint_setup(
@@ -2923,7 +2923,7 @@ static void junior_rc_right_quarter_turn_5_tiles_25_deg_down_paint_setup(
 
 /* rct2: 0x008AAE50, 0x0051B6FE, 0x0051B946, 0x0051BB8E, 0x0051BBA8 */
 static void junior_rc_s_bend_left_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -3022,7 +3022,7 @@ static void junior_rc_s_bend_left_paint_setup(
 
 /* rct2: 0x008AAE60, 0x0051BBC0, 0x0051BE06, 0x0051C04E, 0x0051C068 */
 static void junior_rc_s_bend_right_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -3121,7 +3121,7 @@ static void junior_rc_s_bend_right_paint_setup(
 
 /** rct2: 0x008AAEB0, 0x0051C0E0, 0x0051C2C1, 0x0051C47F, 0x0051C61D */
 static void junior_rc_right_quarter_turn_3_tiles_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -3163,7 +3163,7 @@ static void junior_rc_right_quarter_turn_3_tiles_paint_setup(
 
 /** rct2: 0x008AAEA0 */
 static void junior_rc_left_quarter_turn_3_tiles_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3218,7 +3218,7 @@ static constexpr const CoordsXYZ junior_rc_right_quarter_turn_3_tiles_bank_offse
 
 /** rct2: 0x008AA0D0, 0x00523EA0, 0x005240CC, 0x0052430F, 0x00524500*/
 static void junior_rc_right_quarter_turn_3_tiles_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t thickness[4][4] = {
@@ -3277,7 +3277,7 @@ static void junior_rc_right_quarter_turn_3_tiles_bank_paint_setup(
 }
 
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     auto imageId = ImageId(0);
@@ -3359,7 +3359,7 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
 }
 
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     auto imageId = ImageId(0);
@@ -3443,7 +3443,7 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
 
 /** rct2: 0x008AA0C0 */
 static void junior_rc_left_quarter_turn_3_tiles_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3453,7 +3453,7 @@ static void junior_rc_left_quarter_turn_3_tiles_bank_paint_setup(
 
 /** rct2: 0x008AAED0, 0x0051C83C, 0x0051C9EC, 0x0051CB76, 0x0051CCDC*/
 static void junior_rc_right_quarter_turn_3_tiles_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -3464,7 +3464,7 @@ static void junior_rc_right_quarter_turn_3_tiles_25_deg_up_paint_setup(
 
 /** rct2: 0x008AAEF0, 0x0051CEC8, 0x0051D078, 0x0051D202, 0x0051D368*/
 static void junior_rc_right_quarter_turn_3_tiles_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -3482,7 +3482,7 @@ static constexpr const uint8_t junior_rc_left_quarter_turn_3_tiles_to_right_turn
 
 /** rct2: 0x008AAEC0 */
 static void junior_rc_left_quarter_turn_3_tiles_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = junior_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
@@ -3492,7 +3492,7 @@ static void junior_rc_left_quarter_turn_3_tiles_25_deg_up_paint_setup(
 
 /** rct2: 0x008AAEE0 */
 static void junior_rc_left_quarter_turn_3_tiles_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = junior_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
@@ -3502,7 +3502,7 @@ static void junior_rc_left_quarter_turn_3_tiles_25_deg_down_paint_setup(
 
 /** rct2: 0x008AB0F0, 0x0052B3A4, 0x0052B5F8, 0x0052B863, 0x0052BA78 */
 static void junior_rc_right_half_banked_helix_up_small_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t thickness[2] = { 1, 26 };
@@ -3570,7 +3570,7 @@ static void junior_rc_right_half_banked_helix_up_small_paint_setup(
 
 /** rct2: 0x008AB110, 0x0052BD80, 0x0052BFD4, 0x0052C23B, 0x0052C450 */
 static void junior_rc_right_half_banked_helix_down_small_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t thickness[2] = { 1, 26 };
@@ -3638,7 +3638,7 @@ static void junior_rc_right_half_banked_helix_down_small_paint_setup(
 
 /** rct2: 0x008AB0E0 */
 static void junior_rc_left_half_banked_helix_up_small_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence > 3)
@@ -3654,7 +3654,7 @@ static void junior_rc_left_half_banked_helix_up_small_paint_setup(
 
 /** rct2: 0x008AB100 */
 static void junior_rc_left_half_banked_helix_down_small_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence > 3)
@@ -3670,7 +3670,7 @@ static void junior_rc_left_half_banked_helix_down_small_paint_setup(
 
 /** rct2: 0x008AB130, 0x0052C7BC, 0x0052CB6B, 0x0052CF32, 0x0052D2B3 */
 static void junior_rc_right_half_banked_helix_up_large_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t thickness[2] = { 1, 26 };
@@ -3754,7 +3754,7 @@ static void junior_rc_right_half_banked_helix_up_large_paint_setup(
 
 /** rct2: 0x008AB150, 0x0052D778, 0x0052DB27, 0x0052DEEA, 0x0052E26B */
 static void junior_rc_right_half_banked_helix_down_large_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t thickness[2] = { 1, 26 };
@@ -3838,7 +3838,7 @@ static void junior_rc_right_half_banked_helix_down_large_paint_setup(
 
 /** rct2: 0x008AB120 */
 static void junior_rc_left_half_banked_helix_up_large_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence > 6)
@@ -3854,7 +3854,7 @@ static void junior_rc_left_half_banked_helix_up_large_paint_setup(
 
 /** rct2: 0x008AB140 */
 static void junior_rc_left_half_banked_helix_down_large_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence > 6)
@@ -3872,7 +3872,7 @@ static void junior_rc_left_half_banked_helix_down_large_paint_setup(
  * rct2: 0x008AAF00, 0x0051851C, 0x005185D8
  */
 static void junior_rc_brake_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId image_id;
@@ -3906,7 +3906,7 @@ static void junior_rc_brake_paint_setup(
  * rct2: 0x008AB280, 0x00518694, 0x00518759
  */
 static void junior_rc_block_brake_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId image_id;
@@ -3940,7 +3940,7 @@ static void junior_rc_block_brake_paint_setup(
 
 /** rct2: 0x008AAF80 */
 static void junior_rc_left_eighth_to_diag_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -4002,7 +4002,7 @@ static void junior_rc_left_eighth_to_diag_paint_setup(
 
 /** rct2: 0x008AAF90 */
 static void junior_rc_right_eighth_to_diag_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -4064,7 +4064,7 @@ static void junior_rc_right_eighth_to_diag_paint_setup(
 
 /** rct2: 0x008AAFA0 */
 static void junior_rc_left_eighth_to_orthogonal_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -4074,7 +4074,7 @@ static void junior_rc_left_eighth_to_orthogonal_paint_setup(
 
 /** rct2: 0x008AAFB0 */
 static void junior_rc_right_eighth_to_orthogonal_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -4165,7 +4165,7 @@ static constexpr const int8_t junior_rc_left_eighth_to_diag_bank_thickness[4][4]
 
 /** rct2: 0x008AB160 */
 static void junior_rc_left_eighth_to_diag_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -4308,7 +4308,7 @@ static constexpr const int8_t junior_rc_right_eighth_to_diag_bank_thickness[4][4
 
 /** rct2: 0x008AB170 */
 static void junior_rc_right_eighth_to_diag_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_eighth_to_diag_tiles_paint(
@@ -4370,7 +4370,7 @@ static void junior_rc_right_eighth_to_diag_bank_paint_setup(
 
 /** rct2: 0x008AB180 */
 static void junior_rc_left_eighth_to_orthogonal_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -4380,7 +4380,7 @@ static void junior_rc_left_eighth_to_orthogonal_bank_paint_setup(
 
 /** rct2: 0x008AB190 */
 static void junior_rc_right_eighth_to_orthogonal_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -4403,7 +4403,7 @@ static constexpr const uint8_t junior_rc_diag_support_segment[] = {
 };
 
 void junior_rc_paint_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4423,7 +4423,7 @@ void junior_rc_paint_track_diag_flat(
 }
 
 void junior_rc_paint_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4443,7 +4443,7 @@ void junior_rc_paint_track_diag_25_deg_up(
 }
 
 void junior_rc_paint_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4464,7 +4464,7 @@ void junior_rc_paint_track_diag_flat_to_25_deg_up(
 }
 
 void junior_rc_paint_track_diag_flat_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4488,7 +4488,7 @@ void junior_rc_paint_track_diag_flat_to_60_deg_up(
 }
 
 void junior_rc_paint_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4509,7 +4509,7 @@ void junior_rc_paint_track_diag_25_deg_up_to_flat(
 }
 
 void junior_rc_paint_track_diag_60_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4533,7 +4533,7 @@ void junior_rc_paint_track_diag_60_deg_up_to_flat(
 }
 
 void junior_rc_paint_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4554,7 +4554,7 @@ void junior_rc_paint_track_diag_25_deg_down(
 }
 
 void junior_rc_paint_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4575,7 +4575,7 @@ void junior_rc_paint_track_diag_flat_to_25_deg_down(
 }
 
 void junior_rc_paint_track_diag_flat_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4599,7 +4599,7 @@ void junior_rc_paint_track_diag_flat_to_60_deg_down(
 }
 
 void junior_rc_paint_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -4620,7 +4620,7 @@ void junior_rc_paint_track_diag_25_deg_down_to_flat(
 }
 
 void junior_rc_paint_track_diag_60_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     // There is no specific chain for the Water Coaster, use the Junior RC chain instead
@@ -4645,7 +4645,7 @@ void junior_rc_paint_track_diag_60_deg_down_to_flat(
 
 /** rct2: 0x008AAF10 */
 static void junior_rc_diag_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4656,7 +4656,7 @@ static void junior_rc_diag_flat_paint_setup(
 
 /** rct2: 0x008AAF40 */
 static void junior_rc_diag_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4667,7 +4667,7 @@ static void junior_rc_diag_25_deg_up_paint_setup(
 
 /** rct2: 0x008AAF20 */
 static void junior_rc_diag_flat_to_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4677,7 +4677,7 @@ static void junior_rc_diag_flat_to_25_deg_up_paint_setup(
 }
 
 static void junior_rc_diag_flat_to_60_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4688,7 +4688,7 @@ static void junior_rc_diag_flat_to_60_deg_up_paint_setup(
 
 /** rct2: 0x008AAF30 */
 static void junior_rc_diag_25_deg_up_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4698,7 +4698,7 @@ static void junior_rc_diag_25_deg_up_to_flat_paint_setup(
 }
 
 static void junior_rc_diag_60_deg_up_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4709,7 +4709,7 @@ static void junior_rc_diag_60_deg_up_to_flat_paint_setup(
 
 /** rct2: 0x008AAF70 */
 static void junior_rc_diag_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4720,7 +4720,7 @@ static void junior_rc_diag_25_deg_down_paint_setup(
 
 /** rct2: 0x008AAF50 */
 static void junior_rc_diag_flat_to_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4730,7 +4730,7 @@ static void junior_rc_diag_flat_to_25_deg_down_paint_setup(
 }
 
 static void junior_rc_diag_flat_to_60_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4741,7 +4741,7 @@ static void junior_rc_diag_flat_to_60_deg_down_paint_setup(
 
 /** rct2: 0x008AAF60 */
 static void junior_rc_diag_25_deg_down_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4751,7 +4751,7 @@ static void junior_rc_diag_25_deg_down_to_flat_paint_setup(
 }
 
 static void junior_rc_diag_60_deg_down_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -4762,7 +4762,7 @@ static void junior_rc_diag_60_deg_down_to_flat_paint_setup(
 
 /** rct2: 0x008AB1C0 */
 static void junior_rc_diag_flat_to_left_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4789,7 +4789,7 @@ static void junior_rc_diag_flat_to_left_bank_paint_setup(
 
 /** rct2: 0x008AB1D0 */
 static void junior_rc_diag_flat_to_right_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4816,7 +4816,7 @@ static void junior_rc_diag_flat_to_right_bank_paint_setup(
 
 /** rct2: 0x008AB1E0 */
 static void junior_rc_diag_left_bank_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4843,7 +4843,7 @@ static void junior_rc_diag_left_bank_to_flat_paint_setup(
 
 /** rct2: 0x008AB1F0 */
 static void junior_rc_diag_right_bank_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4870,7 +4870,7 @@ static void junior_rc_diag_right_bank_to_flat_paint_setup(
 
 /** rct2: 0x008AB220 */
 static void junior_rc_diag_left_bank_to_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4897,7 +4897,7 @@ static void junior_rc_diag_left_bank_to_25_deg_up_paint_setup(
 
 /** rct2: 0x008AB230 */
 static void junior_rc_diag_right_bank_to_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4924,7 +4924,7 @@ static void junior_rc_diag_right_bank_to_25_deg_up_paint_setup(
 
 /** rct2: 0x008AB200 */
 static void junior_rc_diag_25_deg_up_to_left_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4951,7 +4951,7 @@ static void junior_rc_diag_25_deg_up_to_left_bank_paint_setup(
 
 /** rct2: 0x008AB210 */
 static void junior_rc_diag_25_deg_up_to_right_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -4978,7 +4978,7 @@ static void junior_rc_diag_25_deg_up_to_right_bank_paint_setup(
 
 /** rct2: 0x008AB200 */
 static void junior_rc_diag_left_bank_to_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -5005,7 +5005,7 @@ static void junior_rc_diag_left_bank_to_25_deg_down_paint_setup(
 
 /** rct2: 0x008AB210 */
 static void junior_rc_diag_right_bank_to_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -5032,7 +5032,7 @@ static void junior_rc_diag_right_bank_to_25_deg_down_paint_setup(
 
 /** rct2: 0x008AB220 */
 static void junior_rc_diag_25_deg_down_to_left_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -5059,7 +5059,7 @@ static void junior_rc_diag_25_deg_down_to_left_bank_paint_setup(
 
 /** rct2: 0x008AB230 */
 static void junior_rc_diag_25_deg_down_to_right_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_diag_tiles_paint(
@@ -5100,7 +5100,7 @@ static constexpr const CoordsXYZ junior_rc_diag_right_bank_bound_offsets[4] = {
 
 /** rct2: 0x008AB1A0 */
 static void junior_rc_diag_left_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t thickness = direction == 0 ? 0 : 1;
@@ -5123,7 +5123,7 @@ static void junior_rc_diag_left_bank_paint_setup(
 
 /** rct2: 0x008AB1B0 */
 static void junior_rc_diag_right_bank_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t thickness = direction == 2 ? 0 : 1;
@@ -5173,7 +5173,7 @@ static constexpr const CoordsXY junior_rc_60_deg_up_bound_lengths[4] = {
 };
 
 void junior_rc_paint_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     auto image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
@@ -5214,7 +5214,7 @@ void junior_rc_paint_track_60_deg_up(
 }
 
 static void junior_rc_60_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5224,7 +5224,7 @@ static void junior_rc_60_deg_up_paint_setup(
 }
 
 static void junior_rc_60_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_60_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -5252,7 +5252,7 @@ static constexpr const CoordsXY junior_rc_25_deg_up_to_60_deg_up_bound_offsets[4
 };
 
 void junior_rc_paint_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     auto image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
@@ -5306,7 +5306,7 @@ void junior_rc_paint_track_25_deg_up_to_60_deg_up(
 }
 
 static void junior_rc_25_deg_up_to_60_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5316,14 +5316,14 @@ static void junior_rc_25_deg_up_to_60_deg_up_paint_setup(
 }
 
 static void junior_rc_60_deg_down_to_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_25_deg_up_to_60_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 void junior_rc_paint_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     auto image_id = session.TrackColours[SCHEME_TRACK].WithIndex(
@@ -5376,7 +5376,7 @@ void junior_rc_paint_track_60_deg_up_to_25_deg_up(
 }
 
 static void junior_rc_60_deg_up_to_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5386,14 +5386,14 @@ static void junior_rc_60_deg_up_to_25_deg_up_paint_setup(
 }
 
 static void junior_rc_25_deg_down_to_60_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_60_deg_up_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 void junior_rc_paint_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5413,7 +5413,7 @@ void junior_rc_paint_track_diag_60_deg_up(
 }
 
 void junior_rc_paint_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5434,7 +5434,7 @@ void junior_rc_paint_track_diag_60_deg_down(
 }
 
 void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5455,7 +5455,7 @@ void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
 }
 
 void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     if (direction == 1 && trackSequence == 3)
@@ -5487,7 +5487,7 @@ void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
 }
 
 void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     if (direction == 3 && trackSequence == 0)
@@ -5519,7 +5519,7 @@ void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
 }
 
 void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
     track_paint_util_diag_tiles_paint(
@@ -5540,7 +5540,7 @@ void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
 }
 
 static void junior_rc_diag_60_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5550,7 +5550,7 @@ static void junior_rc_diag_60_deg_up_paint_setup(
 }
 
 static void junior_rc_diag_60_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5560,7 +5560,7 @@ static void junior_rc_diag_60_deg_down_paint_setup(
 }
 
 static void junior_rc_diag_25_deg_up_to_60_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5570,7 +5570,7 @@ static void junior_rc_diag_25_deg_up_to_60_deg_up_paint_setup(
 }
 
 static void junior_rc_diag_60_deg_up_to_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5580,7 +5580,7 @@ static void junior_rc_diag_60_deg_up_to_25_deg_up_paint_setup(
 }
 
 static void junior_rc_diag_25_deg_down_to_60_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5590,7 +5590,7 @@ static void junior_rc_diag_25_deg_down_to_60_deg_down_paint_setup(
 }
 
 static void junior_rc_diag_60_deg_down_to_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5635,7 +5635,7 @@ static constexpr const CoordsXY junior_rc_60_deg_up_to_flat_tile_offsets[4][2] =
 };
 
 static void junior_rc_flat_to_60_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5688,14 +5688,14 @@ static void junior_rc_flat_to_60_deg_up_paint_setup(
 }
 
 static void junior_rc_60_deg_down_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_flat_to_60_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void junior_rc_60_deg_up_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5747,7 +5747,7 @@ static void junior_rc_60_deg_up_to_flat_paint_setup(
 }
 
 static void junior_rc_flat_to_60_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_60_deg_up_to_flat_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5755,7 +5755,7 @@ static void junior_rc_flat_to_60_deg_down_paint_setup(
 
 /* rct2: 0x00518394 */
 static void junior_rc_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5766,7 +5766,7 @@ static void junior_rc_flat_paint_setup(
 
 /* rct2: 0x00515629, 0x00514D22, 0x005151B9 */
 static void paint_junior_rc_station_track(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_station(session, ride, trackSequence, direction, height, trackElement, true);
@@ -5774,7 +5774,7 @@ static void paint_junior_rc_station_track(
 
 /* rct2: 0x0051881E */
 static void junior_rc_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5785,7 +5785,7 @@ static void junior_rc_25_deg_up_paint_setup(
 
 /* rct2: 0x00518B42 */
 static void junior_rc_flat_to_25_deg_up_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5796,7 +5796,7 @@ static void junior_rc_flat_to_25_deg_up_paint_setup(
 
 /* rct2: 0x00518E56 */
 static void junior_rc_25_deg_up_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -5807,7 +5807,7 @@ static void junior_rc_25_deg_up_to_flat_paint_setup(
 
 /* rct2: 0x005189B0 */
 static void junior_rc_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5815,7 +5815,7 @@ static void junior_rc_25_deg_down_paint_setup(
 
 /* rct2: 0x00518FE8 */
 static void junior_rc_flat_to_25_deg_down_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_25_deg_up_to_flat_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5823,14 +5823,14 @@ static void junior_rc_flat_to_25_deg_down_paint_setup(
 
 /* rct2: 0x00518CCC */
 static void junior_rc_25_deg_down_to_flat_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_flat_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void junior_rc_booster_paint_setup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction & 1)
@@ -5862,7 +5862,7 @@ static void junior_rc_booster_paint_setup(
 }
 
 static void junior_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(junior_rc_track_pieces_flat[0][direction]);

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.h
@@ -19,97 +19,97 @@ enum class JuniorRcChainType : uint8_t
 };
 
 struct Ride;
-struct paint_session;
+struct PaintSession;
 struct TrackElement;
 
 void junior_rc_paint_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, bool drawBlockBrake);
 
 void junior_rc_paint_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 
 void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 
 void junior_rc_paint_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_flat_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 void junior_rc_paint_track_diag_60_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);

--- a/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x0082491C */
 static void lay_down_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -138,7 +138,7 @@ static void lay_down_rc_track_flat(
 
 /** rct2: 0x00824B8C, 0x00824B9C, 0x00824BAC */
 static void lay_down_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.IsInverted())
@@ -197,7 +197,7 @@ static void lay_down_rc_track_station(
 
 /** rct2: 0x0082492C */
 static void lay_down_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -370,7 +370,7 @@ static void lay_down_rc_track_25_deg_up(
 
 /** rct2: 0x0082493C */
 static void lay_down_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -490,7 +490,7 @@ static void lay_down_rc_track_60_deg_up(
 
 /** rct2: 0x0082494C */
 static void lay_down_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -663,7 +663,7 @@ static void lay_down_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x0082495C */
 static void lay_down_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -801,7 +801,7 @@ static void lay_down_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0082496C */
 static void lay_down_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -963,7 +963,7 @@ static void lay_down_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0082497C */
 static void lay_down_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1136,7 +1136,7 @@ static void lay_down_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0082498C */
 static void lay_down_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1144,7 +1144,7 @@ static void lay_down_rc_track_25_deg_down(
 
 /** rct2: 0x0082499C */
 static void lay_down_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1152,7 +1152,7 @@ static void lay_down_rc_track_60_deg_down(
 
 /** rct2: 0x008249AC */
 static void lay_down_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1160,7 +1160,7 @@ static void lay_down_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008249BC */
 static void lay_down_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1168,7 +1168,7 @@ static void lay_down_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008249CC */
 static void lay_down_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1176,7 +1176,7 @@ static void lay_down_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008249DC */
 static void lay_down_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1184,7 +1184,7 @@ static void lay_down_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008249EC */
 static void lay_down_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1547,7 +1547,7 @@ static void lay_down_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008249FC */
 static void lay_down_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1556,7 +1556,7 @@ static void lay_down_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x00824A0C */
 static void lay_down_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1643,7 +1643,7 @@ static void lay_down_rc_track_flat_to_left_bank(
 
 /** rct2: 0x00824A1C */
 static void lay_down_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1730,7 +1730,7 @@ static void lay_down_rc_track_flat_to_right_bank(
 
 /** rct2: 0x00824A2C */
 static void lay_down_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1817,7 +1817,7 @@ static void lay_down_rc_track_left_bank_to_flat(
 
 /** rct2: 0x00824A3C */
 static void lay_down_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1904,7 +1904,7 @@ static void lay_down_rc_track_right_bank_to_flat(
 
 /** rct2: 0x00824A4C */
 static void lay_down_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2273,7 +2273,7 @@ static void lay_down_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x00824A5C */
 static void lay_down_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2282,7 +2282,7 @@ static void lay_down_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x00824A6C */
 static void lay_down_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2400,7 +2400,7 @@ static void lay_down_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x00824A7C */
 static void lay_down_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2518,7 +2518,7 @@ static void lay_down_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x00824A8C */
 static void lay_down_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2636,7 +2636,7 @@ static void lay_down_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x00824A9C */
 static void lay_down_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2754,7 +2754,7 @@ static void lay_down_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x00824AAC */
 static void lay_down_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2762,7 +2762,7 @@ static void lay_down_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x00824ABC */
 static void lay_down_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2770,7 +2770,7 @@ static void lay_down_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x00824ACC */
 static void lay_down_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2778,7 +2778,7 @@ static void lay_down_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x00824ADC */
 static void lay_down_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2786,7 +2786,7 @@ static void lay_down_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x00824AEC */
 static void lay_down_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2867,7 +2867,7 @@ static void lay_down_rc_track_left_bank(
 
 /** rct2: 0x00824AFC */
 static void lay_down_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2875,7 +2875,7 @@ static void lay_down_rc_track_right_bank(
 
 /** rct2: 0x00824B0C */
 static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3238,7 +3238,7 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x00824B1C */
 static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3601,7 +3601,7 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x00824B2C */
 static void lay_down_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -3610,7 +3610,7 @@ static void lay_down_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x00824B3C */
 static void lay_down_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -3619,7 +3619,7 @@ static void lay_down_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x00824B4C */
 static void lay_down_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3946,7 +3946,7 @@ static void lay_down_rc_track_s_bend_left(
 
 /** rct2: 0x00824B5C */
 static void lay_down_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -4273,7 +4273,7 @@ static void lay_down_rc_track_s_bend_right(
 
 /** rct2: 0x00824B6C */
 static void lay_down_rc_track_left_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4570,7 +4570,7 @@ static void lay_down_rc_track_left_vertical_loop(
 
 /** rct2: 0x00824B7C */
 static void lay_down_rc_track_right_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4829,7 +4829,7 @@ static void lay_down_rc_track_right_vertical_loop(
 
 /** rct2: 0x00824BBC */
 static void lay_down_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5062,7 +5062,7 @@ static void lay_down_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x00824BCC */
 static void lay_down_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5071,7 +5071,7 @@ static void lay_down_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x00824BDC */
 static void lay_down_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5310,7 +5310,7 @@ static void lay_down_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x00824BEC */
 static void lay_down_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5319,7 +5319,7 @@ static void lay_down_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x00824BFC */
 static void lay_down_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5502,7 +5502,7 @@ static void lay_down_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00824C0C */
 static void lay_down_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5691,7 +5691,7 @@ static void lay_down_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x00824C1C */
 static void lay_down_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5700,7 +5700,7 @@ static void lay_down_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x00824C2C */
 static void lay_down_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5709,7 +5709,7 @@ static void lay_down_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x00824C9C */
 static void lay_down_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5943,7 +5943,7 @@ static void lay_down_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x00824CAC */
 static void lay_down_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6177,7 +6177,7 @@ static void lay_down_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x00824CBC */
 static void lay_down_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -6191,7 +6191,7 @@ static void lay_down_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x00824CCC */
 static void lay_down_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -6205,7 +6205,7 @@ static void lay_down_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x00824CDC */
 static void lay_down_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6565,7 +6565,7 @@ static void lay_down_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x00824CEC */
 static void lay_down_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6925,7 +6925,7 @@ static void lay_down_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x00824CFC */
 static void lay_down_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6939,7 +6939,7 @@ static void lay_down_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x00824D0C */
 static void lay_down_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6953,7 +6953,7 @@ static void lay_down_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x00824D3C */
 static void lay_down_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7039,7 +7039,7 @@ static void lay_down_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x00824D1C */
 static void lay_down_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7126,7 +7126,7 @@ static void lay_down_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x00824D2C */
 static void lay_down_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -7134,7 +7134,7 @@ static void lay_down_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x00824D4C */
 static void lay_down_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -7142,7 +7142,7 @@ static void lay_down_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x00824D5C */
 static void lay_down_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7205,7 +7205,7 @@ static void lay_down_rc_track_brakes(
 
 /** rct2: 0x00824D6C */
 static void lay_down_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7320,7 +7320,7 @@ static void lay_down_rc_track_on_ride_photo(
 
 /** rct2: 0x00824D8C */
 static void lay_down_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7630,7 +7630,7 @@ static void lay_down_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x00824D9C */
 static void lay_down_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7940,7 +7940,7 @@ static void lay_down_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x00824DAC */
 static void lay_down_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -7949,7 +7949,7 @@ static void lay_down_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x00824DBC */
 static void lay_down_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -7958,7 +7958,7 @@ static void lay_down_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x00824DCC */
 static void lay_down_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8268,7 +8268,7 @@ static void lay_down_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x00824DDC */
 static void lay_down_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8578,7 +8578,7 @@ static void lay_down_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x00824DEC */
 static void lay_down_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8587,7 +8587,7 @@ static void lay_down_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x00824DFC */
 static void lay_down_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8596,7 +8596,7 @@ static void lay_down_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x00824D7C */
 static void lay_down_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8880,7 +8880,7 @@ static void lay_down_rc_track_diag_flat(
 
 /** rct2: 0x00824E2C */
 static void lay_down_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9164,7 +9164,7 @@ static void lay_down_rc_track_diag_25_deg_up(
 
 /** rct2: 0x00824E8C */
 static void lay_down_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9392,7 +9392,7 @@ static void lay_down_rc_track_diag_60_deg_up(
 
 /** rct2: 0x00824E0C */
 static void lay_down_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9676,7 +9676,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x00824E6C */
 static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9904,7 +9904,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x00824E7C */
 static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10132,7 +10132,7 @@ static void lay_down_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00824E1C */
 static void lay_down_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10416,7 +10416,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x00824E5C */
 static void lay_down_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10644,7 +10644,7 @@ static void lay_down_rc_track_diag_25_deg_down(
 
 /** rct2: 0x00824EBC */
 static void lay_down_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10872,7 +10872,7 @@ static void lay_down_rc_track_diag_60_deg_down(
 
 /** rct2: 0x00824E3C */
 static void lay_down_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11093,7 +11093,7 @@ static void lay_down_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x00824E9C */
 static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11321,7 +11321,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x00824EAC */
 static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11549,7 +11549,7 @@ static void lay_down_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x00824E4C */
 static void lay_down_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11777,7 +11777,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x00824EEC */
 static void lay_down_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11939,7 +11939,7 @@ static void lay_down_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x00824EFC */
 static void lay_down_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12101,7 +12101,7 @@ static void lay_down_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x00824F0C */
 static void lay_down_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12263,7 +12263,7 @@ static void lay_down_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x00824F1C */
 static void lay_down_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12425,7 +12425,7 @@ static void lay_down_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x00824F4C */
 static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12586,7 +12586,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x00824F5C */
 static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12747,7 +12747,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x00824F2C */
 static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12908,7 +12908,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x00824F3C */
 static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13069,7 +13069,7 @@ static void lay_down_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x00824F6C */
 static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13223,7 +13223,7 @@ static void lay_down_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x00824F7C */
 static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13377,7 +13377,7 @@ static void lay_down_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x00824F8C */
 static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13538,7 +13538,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x00824F9C */
 static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13699,7 +13699,7 @@ static void lay_down_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x00824ECC */
 static void lay_down_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -13858,7 +13858,7 @@ static void lay_down_rc_track_diag_left_bank(
 
 /** rct2: 0x00824EDC */
 static void lay_down_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -14017,7 +14017,7 @@ static void lay_down_rc_track_diag_right_bank(
 
 /** rct2: 0x00824FAC */
 static void lay_down_rc_track_left_flyer_twist_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14136,7 +14136,7 @@ static void lay_down_rc_track_left_flyer_twist_up(
 
 /** rct2: 0x00824FBC */
 static void lay_down_rc_track_right_flyer_twist_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14255,7 +14255,7 @@ static void lay_down_rc_track_right_flyer_twist_up(
 
 /** rct2: 0x00824FCC */
 static void lay_down_rc_track_left_flyer_twist_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14374,7 +14374,7 @@ static void lay_down_rc_track_left_flyer_twist_down(
 
 /** rct2: 0x00824FDC */
 static void lay_down_rc_track_right_flyer_twist_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14493,7 +14493,7 @@ static void lay_down_rc_track_right_flyer_twist_down(
 
 /** rct2: 0x00824C3C */
 static void lay_down_rc_track_flyer_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14634,7 +14634,7 @@ static void lay_down_rc_track_flyer_half_loop_up(
 
 /** rct2: 0x00824C4C */
 static void lay_down_rc_track_flyer_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14775,7 +14775,7 @@ static void lay_down_rc_track_flyer_half_loop_down(
 
 /** rct2: 0x00824C5C */
 static void lay_down_rc_track_left_flyer_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -14900,7 +14900,7 @@ static void lay_down_rc_track_left_flyer_corkscrew_up(
 
 /** rct2: 0x00824C6C */
 static void lay_down_rc_track_right_flyer_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15014,7 +15014,7 @@ static void lay_down_rc_track_right_flyer_corkscrew_up(
 
 /** rct2: 0x00824C7C */
 static void lay_down_rc_track_left_flyer_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15128,7 +15128,7 @@ static void lay_down_rc_track_left_flyer_corkscrew_down(
 
 /** rct2: 0x00824C8C */
 static void lay_down_rc_track_right_flyer_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_left_flyer_corkscrew_up(session, ride, 2 - trackSequence, (direction + 3) % 4, height, trackElement);
@@ -15136,7 +15136,7 @@ static void lay_down_rc_track_right_flyer_corkscrew_down(
 
 /** rct2: 0x00824FEC */
 static void lay_down_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -15194,7 +15194,7 @@ static void lay_down_rc_track_block_brakes(
 }
 
 static void lay_down_rc_track_left_quarter_banked_helix_large_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15376,7 +15376,7 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_up(
 }
 
 static void lay_down_rc_track_right_quarter_banked_helix_large_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15558,7 +15558,7 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_up(
 }
 
 static void lay_down_rc_track_left_quarter_banked_helix_large_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15740,7 +15740,7 @@ static void lay_down_rc_track_left_quarter_banked_helix_large_down(
 }
 
 static void lay_down_rc_track_right_quarter_banked_helix_large_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -15921,7 +15921,7 @@ static void lay_down_rc_track_right_quarter_banked_helix_large_down(
     }
 }
 static void lay_down_rc_track_half_loop_inverted_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -16072,7 +16072,7 @@ static void lay_down_rc_track_half_loop_inverted_up(
 }
 
 static void lay_down_rc_track_half_loop_uninverted_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lay_down_rc_track_half_loop_inverted_up(session, ride, 3 - trackSequence, direction, height, trackElement);

--- a/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LimLaunchedRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _LimLauncherBlockBrakeImages[NumOrthogonalDirect
 
 /** rct2: 0x008A6D50, 0x008A6D60, 0x008A6D70 */
 static void lim_launched_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -67,7 +67,7 @@ static void lim_launched_rc_track_station(
 
 /** rct2: 0x008A65E0 */
 static void lim_launched_rc_track_left_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -348,7 +348,7 @@ static void lim_launched_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A65F0 */
 static void lim_launched_rc_track_right_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -589,7 +589,7 @@ static void lim_launched_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A6D10 */
 static void lim_launched_rc_track_left_twist_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -737,7 +737,7 @@ static void lim_launched_rc_track_left_twist_down_to_up(
 
 /** rct2: 0x008A6D20 */
 static void lim_launched_rc_track_right_twist_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -885,7 +885,7 @@ static void lim_launched_rc_track_right_twist_down_to_up(
 
 /** rct2: 0x008A6D30 */
 static void lim_launched_rc_track_left_twist_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1033,7 +1033,7 @@ static void lim_launched_rc_track_left_twist_up_to_down(
 
 /** rct2: 0x008A6D40 */
 static void lim_launched_rc_track_right_twist_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1181,7 +1181,7 @@ static void lim_launched_rc_track_right_twist_up_to_down(
 
 /** rct2: 0x008A6CD0 */
 static void lim_launched_rc_track_left_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1292,7 +1292,7 @@ static void lim_launched_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A6CE0 */
 static void lim_launched_rc_track_right_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1404,7 +1404,7 @@ static void lim_launched_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A6CF0 */
 static void lim_launched_rc_track_left_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
@@ -1412,7 +1412,7 @@ static void lim_launched_rc_track_left_corkscrew_down(
 
 /** rct2: 0x008A6D00 */
 static void lim_launched_rc_track_right_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -1420,7 +1420,7 @@ static void lim_launched_rc_track_right_corkscrew_down(
 
 /** rct2: 0x008A6D80 */
 static void lim_launched_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1450,7 +1450,7 @@ static void lim_launched_rc_track_brakes(
 
 /** rct2: 0x008A6C10 */
 static void lim_launched_rc_track_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1491,7 +1491,7 @@ static void lim_launched_rc_track_90_deg_up(
 
 /** rct2: 0x008A6C20 */
 static void lim_launched_rc_track_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1499,7 +1499,7 @@ static void lim_launched_rc_track_90_deg_down(
 
 /** rct2: 0x008A6C30 */
 static void lim_launched_rc_track_60_deg_up_to_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1544,7 +1544,7 @@ static void lim_launched_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x008A6C40 */
 static void lim_launched_rc_track_90_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1552,7 +1552,7 @@ static void lim_launched_rc_track_90_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A6C50 */
 static void lim_launched_rc_track_90_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1594,7 +1594,7 @@ static void lim_launched_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A6C60 */
 static void lim_launched_rc_track_60_deg_down_to_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1638,7 +1638,7 @@ static void lim_launched_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x008A6C70 */
 static void lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1736,7 +1736,7 @@ static void lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
 
 /** rct2: 0x008A6C80 */
 static void lim_launched_rc_track_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_90_deg_to_inverted_flat_quarter_loop_up(
@@ -1745,7 +1745,7 @@ static void lim_launched_rc_track_inverted_flat_to_90_deg_quarter_loop_down(
 
 /** rct2: 0x008A6D90 */
 static void lim_launched_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -1764,7 +1764,7 @@ static void lim_launched_rc_track_block_brakes(
 }
 
 static void lim_launched_rc_track_left_quarter_turn_1_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1811,7 +1811,7 @@ static void lim_launched_rc_track_left_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008A6CA0 */
 static void lim_launched_rc_track_right_quarter_turn_1_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1858,7 +1858,7 @@ static void lim_launched_rc_track_right_quarter_turn_1_90_deg_up(
 
 /** rct2: 0x008A6CB0 */
 static void lim_launched_rc_track_left_quarter_turn_1_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_right_quarter_turn_1_90_deg_up(
@@ -1867,7 +1867,7 @@ static void lim_launched_rc_track_left_quarter_turn_1_90_deg_down(
 
 /** rct2: 0x008A6CC0 */
 static void lim_launched_rc_track_right_quarter_turn_1_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_left_quarter_turn_1_90_deg_up(
@@ -1875,7 +1875,7 @@ static void lim_launched_rc_track_right_quarter_turn_1_90_deg_down(
 }
 
 static void lim_launched_rc_track_left_barrel_roll_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2053,7 +2053,7 @@ static void lim_launched_rc_track_left_barrel_roll_up_to_down(
 }
 
 static void lim_launched_rc_track_right_barrel_roll_up_to_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2231,7 +2231,7 @@ static void lim_launched_rc_track_right_barrel_roll_up_to_down(
 }
 
 static void lim_launched_rc_track_left_barrel_roll_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_left_barrel_roll_up_to_down(
@@ -2239,7 +2239,7 @@ static void lim_launched_rc_track_left_barrel_roll_down_to_up(
 }
 
 static void lim_launched_rc_track_right_barrel_roll_down_to_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_right_barrel_roll_up_to_down(
@@ -2247,7 +2247,7 @@ static void lim_launched_rc_track_right_barrel_roll_down_to_up(
 }
 
 static void lim_launched_rc_track_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2402,14 +2402,14 @@ static void lim_launched_rc_track_half_loop_up(
 }
 
 static void lim_launched_rc_track_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, trackElement);
 }
 
 static void lim_launched_rc_track_flat_to_60_deg_up_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2574,7 +2574,7 @@ static void lim_launched_rc_track_flat_to_60_deg_up_long_base(
     }
 }
 static void lim_launched_rc_track_60_deg_up_to_flat_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2740,7 +2740,7 @@ static void lim_launched_rc_track_60_deg_up_to_flat_long_base(
 }
 
 static void lim_launched_rc_track_flat_to_60_deg_down_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_60_deg_up_to_flat_long_base(
@@ -2748,7 +2748,7 @@ static void lim_launched_rc_track_flat_to_60_deg_down_long_base(
 }
 
 static void lim_launched_rc_track_60_deg_down_to_flat_long_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_flat_to_60_deg_up_long_base(
@@ -2756,7 +2756,7 @@ static void lim_launched_rc_track_60_deg_down_to_flat_long_base(
 }
 
 static void lim_launched_rc_track_left_large_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2969,7 +2969,7 @@ static void lim_launched_rc_track_left_large_corkscrew_up(
 }
 
 static void lim_launched_rc_track_right_large_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3181,21 +3181,21 @@ static void lim_launched_rc_track_right_large_corkscrew_up(
 }
 
 static void lim_launched_rc_track_left_large_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_right_large_corkscrew_up(session, ride, 5 - trackSequence, (direction + 1) & 3, height, trackElement);
 }
 
 static void lim_launched_rc_track_right_large_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_left_large_corkscrew_up(session, ride, 5 - trackSequence, (direction - 1) & 3, height, trackElement);
 }
 
 static void lim_launched_rc_track_left_medium_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3390,7 +3390,7 @@ static void lim_launched_rc_track_left_medium_half_loop_up(
 }
 
 static void lim_launched_rc_track_right_medium_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3585,21 +3585,21 @@ static void lim_launched_rc_track_right_medium_half_loop_up(
 }
 
 static void lim_launched_rc_track_left_medium_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_right_medium_half_loop_up(session, ride, 4 - trackSequence, direction, height, trackElement);
 }
 
 static void lim_launched_rc_track_right_medium_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_left_medium_half_loop_up(session, ride, 4 - trackSequence, direction, height, trackElement);
 }
 
 static void lim_launched_rc_track_left_zero_g_roll_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3747,7 +3747,7 @@ static void lim_launched_rc_track_left_zero_g_roll_up(
 }
 
 static void lim_launched_rc_track_right_zero_g_roll_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3894,21 +3894,21 @@ static void lim_launched_rc_track_right_zero_g_roll_up(
 }
 
 static void lim_launched_rc_track_left_zero_g_roll_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_left_zero_g_roll_up(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void lim_launched_rc_track_right_zero_g_roll_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_right_zero_g_roll_up(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void lim_launched_rc_track_left_large_zero_g_roll_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4087,7 +4087,7 @@ static void lim_launched_rc_track_left_large_zero_g_roll_up(
 }
 
 static void lim_launched_rc_track_right_large_zero_g_roll_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4267,7 +4267,7 @@ static void lim_launched_rc_track_right_large_zero_g_roll_up(
 }
 
 static void lim_launched_rc_track_left_large_zero_g_roll_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_left_large_zero_g_roll_up(
@@ -4275,7 +4275,7 @@ static void lim_launched_rc_track_left_large_zero_g_roll_down(
 }
 
 static void lim_launched_rc_track_right_large_zero_g_roll_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_right_large_zero_g_roll_up(
@@ -4283,7 +4283,7 @@ static void lim_launched_rc_track_right_large_zero_g_roll_down(
 }
 
 static void lim_launched_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4381,7 +4381,7 @@ static void lim_launched_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
 }
 
 static void lim_launched_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4479,7 +4479,7 @@ static void lim_launched_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
 }
 
 static void lim_launched_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4577,7 +4577,7 @@ static void lim_launched_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
 }
 
 static void lim_launched_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4675,7 +4675,7 @@ static void lim_launched_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank
 }
 
 static void lim_launched_rc_track_left_large_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4941,7 +4941,7 @@ static void lim_launched_rc_track_left_large_half_loop_up(
 }
 
 static void lim_launched_rc_track_right_large_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5207,21 +5207,21 @@ static void lim_launched_rc_track_right_large_half_loop_up(
 }
 
 static void lim_launched_rc_track_right_large_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_right_large_half_loop_up(session, ride, 6 - trackSequence, direction, height, trackElement);
 }
 
 static void lim_launched_rc_track_left_large_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_left_large_half_loop_up(session, ride, 6 - trackSequence, direction, height, trackElement);
 }
 
 static void lim_launched_rc_track_flat_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5277,7 +5277,7 @@ static void lim_launched_rc_track_flat_to_60_deg_up(
 }
 
 static void lim_launched_rc_track_60_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5330,21 +5330,21 @@ static void lim_launched_rc_track_60_deg_up_to_flat(
 }
 
 static void lim_launched_rc_track_flat_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_60_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void lim_launched_rc_track_60_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     lim_launched_rc_track_flat_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void lim_launched_rc_track_diag_flat_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5423,7 +5423,7 @@ static void lim_launched_rc_track_diag_flat_to_60_deg_up(
 }
 
 static void lim_launched_rc_track_diag_60_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5502,7 +5502,7 @@ static void lim_launched_rc_track_diag_60_deg_up_to_flat(
 }
 
 static void lim_launched_rc_track_diag_flat_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5581,7 +5581,7 @@ static void lim_launched_rc_track_diag_flat_to_60_deg_down(
 }
 
 static void lim_launched_rc_track_diag_60_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5660,7 +5660,7 @@ static void lim_launched_rc_track_diag_60_deg_down_to_flat(
 }
 
 static void lim_launched_rc_track_booster(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
@@ -26,7 +26,7 @@ static constexpr auto SPR_LOOPING_RC_FLAT_CHAINED_NW_SE = 15017;
 
 /** rct2: 0x008A6370 */
 static void looping_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -88,7 +88,7 @@ static void looping_rc_track_flat(
 }
 
 static void looping_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIdsFrictionWheels[4][2] = {
@@ -120,7 +120,7 @@ static void looping_rc_track_station(
 
 /** rct2: 0x008A6380 */
 static void looping_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -198,7 +198,7 @@ static void looping_rc_track_25_deg_up(
 
 /** rct2: 0x008A6390 */
 static void looping_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -276,7 +276,7 @@ static void looping_rc_track_60_deg_up(
 
 /** rct2: 0x008A63A0 */
 static void looping_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -354,7 +354,7 @@ static void looping_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A63B0 */
 static void looping_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -444,7 +444,7 @@ static void looping_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A63C0 */
 static void looping_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -534,7 +534,7 @@ static void looping_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A63D0 */
 static void looping_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -612,7 +612,7 @@ static void looping_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A63E0 */
 static void looping_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -620,7 +620,7 @@ static void looping_rc_track_25_deg_down(
 
 /** rct2: 0x008A63F0 */
 static void looping_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -628,7 +628,7 @@ static void looping_rc_track_60_deg_down(
 
 /** rct2: 0x008A6400 */
 static void looping_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -636,7 +636,7 @@ static void looping_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A6410 */
 static void looping_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -644,7 +644,7 @@ static void looping_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A6420 */
 static void looping_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -652,7 +652,7 @@ static void looping_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A6430 */
 static void looping_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -660,7 +660,7 @@ static void looping_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A6440 */
 static void looping_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -835,7 +835,7 @@ static void looping_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A6450 */
 static void looping_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -844,7 +844,7 @@ static void looping_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A6460 */
 static void looping_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -888,7 +888,7 @@ static void looping_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A6470 */
 static void looping_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -932,7 +932,7 @@ static void looping_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A6480 */
 static void looping_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -976,7 +976,7 @@ static void looping_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A6490 */
 static void looping_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1020,7 +1020,7 @@ static void looping_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A64A0 */
 static void looping_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1201,7 +1201,7 @@ static void looping_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A64B0 */
 static void looping_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1210,7 +1210,7 @@ static void looping_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008A64C0 */
 static void looping_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1261,7 +1261,7 @@ static void looping_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A64D0 */
 static void looping_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1312,7 +1312,7 @@ static void looping_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A64E0 */
 static void looping_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1363,7 +1363,7 @@ static void looping_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A64F0 */
 static void looping_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1414,7 +1414,7 @@ static void looping_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A6500 */
 static void looping_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1422,7 +1422,7 @@ static void looping_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A6510 */
 static void looping_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1430,7 +1430,7 @@ static void looping_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A6520 */
 static void looping_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1438,7 +1438,7 @@ static void looping_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A6530 */
 static void looping_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1446,7 +1446,7 @@ static void looping_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A6540 */
 static void looping_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1484,7 +1484,7 @@ static void looping_rc_track_left_bank(
 
 /** rct2: 0x008A6550 */
 static void looping_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1492,7 +1492,7 @@ static void looping_rc_track_right_bank(
 
 /** rct2: 0x008A6560 */
 static void looping_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1667,7 +1667,7 @@ static void looping_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6570 */
 static void looping_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1842,7 +1842,7 @@ static void looping_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6580 */
 static void looping_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1851,7 +1851,7 @@ static void looping_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A6590 */
 static void looping_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1860,7 +1860,7 @@ static void looping_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A65A0 */
 static void looping_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2009,7 +2009,7 @@ static void looping_rc_track_s_bend_left(
 
 /** rct2: 0x008A65B0 */
 static void looping_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2158,7 +2158,7 @@ static void looping_rc_track_s_bend_right(
 
 /** rct2: 0x008A65C0 */
 static void looping_rc_track_left_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2463,7 +2463,7 @@ static void looping_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A65D0 */
 static void looping_rc_track_right_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2742,7 +2742,7 @@ static void looping_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A6630 */
 static void looping_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2854,7 +2854,7 @@ static void looping_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A6640 */
 static void looping_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2863,7 +2863,7 @@ static void looping_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A6650 */
 static void looping_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2981,7 +2981,7 @@ static void looping_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A6660 */
 static void looping_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2990,7 +2990,7 @@ static void looping_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008A6670 */
 static void looping_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3077,7 +3077,7 @@ static void looping_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6680 */
 static void looping_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3171,7 +3171,7 @@ static void looping_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6690 */
 static void looping_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3180,7 +3180,7 @@ static void looping_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A66A0 */
 static void looping_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3189,7 +3189,7 @@ static void looping_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A66B0 */
 static void looping_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3419,7 +3419,7 @@ static void looping_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A66C0 */
 static void looping_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3649,7 +3649,7 @@ static void looping_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A66D0 */
 static void looping_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3663,7 +3663,7 @@ static void looping_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008A66E0 */
 static void looping_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3677,7 +3677,7 @@ static void looping_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008A66F0 */
 static void looping_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4033,7 +4033,7 @@ static void looping_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A6700 */
 static void looping_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4389,7 +4389,7 @@ static void looping_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A6710 */
 static void looping_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4403,7 +4403,7 @@ static void looping_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008A6720 */
 static void looping_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4417,7 +4417,7 @@ static void looping_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008A6750 */
 static void looping_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4462,7 +4462,7 @@ static void looping_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A6730 */
 static void looping_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4507,7 +4507,7 @@ static void looping_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A6740 */
 static void looping_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4515,7 +4515,7 @@ static void looping_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A6760 */
 static void looping_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4523,7 +4523,7 @@ static void looping_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A6770 */
 static void looping_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4559,7 +4559,7 @@ static void looping_rc_track_brakes(
 
 /** rct2: 0x008A6A40 */
 static void looping_rc_track_25_deg_up_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4604,7 +4604,7 @@ static void looping_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008A6A50 */
 static void looping_rc_track_25_deg_up_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4649,7 +4649,7 @@ static void looping_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008A6780 */
 static void looping_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4703,7 +4703,7 @@ static void looping_rc_track_on_ride_photo(
 
 /** rct2: 0x008A6A60 */
 static void looping_rc_track_25_deg_down_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4711,7 +4711,7 @@ static void looping_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x008A6A70 */
 static void looping_rc_track_25_deg_down_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4719,7 +4719,7 @@ static void looping_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x008A6860 */
 static void looping_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4864,7 +4864,7 @@ static void looping_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A6870 */
 static void looping_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5009,7 +5009,7 @@ static void looping_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A6880 */
 static void looping_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5018,7 +5018,7 @@ static void looping_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A6890 */
 static void looping_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5027,7 +5027,7 @@ static void looping_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A68A0 */
 static void looping_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5172,7 +5172,7 @@ static void looping_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A68B0 */
 static void looping_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5317,7 +5317,7 @@ static void looping_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A68C0 */
 static void looping_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5326,7 +5326,7 @@ static void looping_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A68D0 */
 static void looping_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5335,7 +5335,7 @@ static void looping_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A6790 */
 static void looping_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5481,7 +5481,7 @@ static void looping_rc_track_diag_flat(
 
 /** rct2: 0x008A67C0 */
 static void looping_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5627,7 +5627,7 @@ static void looping_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A67F0 */
 static void looping_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5773,7 +5773,7 @@ static void looping_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A67A0 */
 static void looping_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5919,7 +5919,7 @@ static void looping_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A67D0 */
 static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6065,7 +6065,7 @@ static void looping_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A67E0 */
 static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6211,7 +6211,7 @@ static void looping_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A67B0 */
 static void looping_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6357,7 +6357,7 @@ static void looping_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A6820 */
 static void looping_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6503,7 +6503,7 @@ static void looping_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A6850 */
 static void looping_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6649,7 +6649,7 @@ static void looping_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A6800 */
 static void looping_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6793,7 +6793,7 @@ static void looping_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A6830 */
 static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6939,7 +6939,7 @@ static void looping_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A6840 */
 static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7085,7 +7085,7 @@ static void looping_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A6810 */
 static void looping_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7231,7 +7231,7 @@ static void looping_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A6900 */
 static void looping_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7310,7 +7310,7 @@ static void looping_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A6910 */
 static void looping_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7389,7 +7389,7 @@ static void looping_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A6920 */
 static void looping_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7468,7 +7468,7 @@ static void looping_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A6930 */
 static void looping_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7547,7 +7547,7 @@ static void looping_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A6960 */
 static void looping_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7626,7 +7626,7 @@ static void looping_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A6970 */
 static void looping_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7705,7 +7705,7 @@ static void looping_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A6940 */
 static void looping_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7784,7 +7784,7 @@ static void looping_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A6950 */
 static void looping_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7863,7 +7863,7 @@ static void looping_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A6980 */
 static void looping_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7940,7 +7940,7 @@ static void looping_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A6990 */
 static void looping_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8017,7 +8017,7 @@ static void looping_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A69A0 */
 static void looping_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8096,7 +8096,7 @@ static void looping_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A69B0 */
 static void looping_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8175,7 +8175,7 @@ static void looping_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A68E0 */
 static void looping_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8251,7 +8251,7 @@ static void looping_rc_track_diag_left_bank(
 
 /** rct2: 0x008A68F0 */
 static void looping_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8327,7 +8327,7 @@ static void looping_rc_track_diag_right_bank(
 
 /** rct2: 0x008A6C00 */
 static void looping_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8363,7 +8363,7 @@ static void looping_rc_track_block_brakes(
 
 /** rct2: 0x008A6BC0 */
 static void looping_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8450,7 +8450,7 @@ static void looping_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6BD0 */
 static void looping_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8544,7 +8544,7 @@ static void looping_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A6BE0 */
 static void looping_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -8554,7 +8554,7 @@ static void looping_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A6BF0 */
 static void looping_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -8564,7 +8564,7 @@ static void looping_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A6B80 */
 static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8739,7 +8739,7 @@ static void looping_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6B90 */
 static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8914,7 +8914,7 @@ static void looping_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A6BA0 */
 static void looping_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8924,7 +8924,7 @@ static void looping_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A6BB0 */
 static void looping_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8934,7 +8934,7 @@ static void looping_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A6A80 */
 static void looping_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8982,7 +8982,7 @@ static void looping_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A6A90 */
 static void looping_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9030,7 +9030,7 @@ static void looping_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A6AA0 */
 static void looping_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9078,7 +9078,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A6AB0 */
 static void looping_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9126,7 +9126,7 @@ static void looping_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A6AC0 */
 static void looping_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_banked_25_deg_up_to_25_deg_up(
@@ -9135,7 +9135,7 @@ static void looping_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A6AD0 */
 static void looping_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_banked_25_deg_up_to_25_deg_up(
@@ -9144,7 +9144,7 @@ static void looping_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A6AE0 */
 static void looping_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_right_banked_25_deg_up(
@@ -9153,7 +9153,7 @@ static void looping_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A6AF0 */
 static void looping_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_25_deg_up_to_left_banked_25_deg_up(
@@ -9162,7 +9162,7 @@ static void looping_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A6B00 */
 static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9207,7 +9207,7 @@ static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A6B10 */
 static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9252,7 +9252,7 @@ static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A6B40 */
 static void looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9297,7 +9297,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008A6B50 */
 static void looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9342,7 +9342,7 @@ static void looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008A6B60 */
 static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -9351,7 +9351,7 @@ static void looping_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A6B70 */
 static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -9360,7 +9360,7 @@ static void looping_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A6B20 */
 static void looping_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -9369,7 +9369,7 @@ static void looping_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x008A6B30 */
 static void looping_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -9378,7 +9378,7 @@ static void looping_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x008A69C0 */
 static void looping_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9426,7 +9426,7 @@ static void looping_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A69D0 */
 static void looping_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9474,7 +9474,7 @@ static void looping_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A69E0 */
 static void looping_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9522,7 +9522,7 @@ static void looping_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A69F0 */
 static void looping_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9570,7 +9570,7 @@ static void looping_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A6A00 */
 static void looping_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9578,7 +9578,7 @@ static void looping_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A6A10 */
 static void looping_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9586,7 +9586,7 @@ static void looping_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A6A20 */
 static void looping_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9594,14 +9594,14 @@ static void looping_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x008A6A30 */
 static void looping_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     looping_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void looping_rc_track_booster(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/MineRide.cpp
+++ b/src/openrct2/ride/coaster/MineRide.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008B08D0 */
 static void mine_ride_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -53,7 +53,7 @@ static void mine_ride_track_flat(
 }
 
 static void mine_ride_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -78,7 +78,7 @@ static void mine_ride_track_station(
 
 /** rct2: 0x008B08E0 */
 static void mine_ride_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -137,7 +137,7 @@ static void mine_ride_track_25_deg_up(
 
 /** rct2: 0x008B08F0 */
 static void mine_ride_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -194,7 +194,7 @@ static void mine_ride_track_flat_to_25_deg_up(
 
 /** rct2: 0x008B0900 */
 static void mine_ride_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -253,7 +253,7 @@ static void mine_ride_track_25_deg_up_to_flat(
 
 /** rct2: 0x008B0910 */
 static void mine_ride_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -261,7 +261,7 @@ static void mine_ride_track_25_deg_down(
 
 /** rct2: 0x008B0920 */
 static void mine_ride_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -269,7 +269,7 @@ static void mine_ride_track_flat_to_25_deg_down(
 
 /** rct2: 0x008B0930 */
 static void mine_ride_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -277,7 +277,7 @@ static void mine_ride_track_25_deg_down_to_flat(
 
 /** rct2: 0x008B0940 */
 static void mine_ride_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -462,7 +462,7 @@ static void mine_ride_track_left_quarter_turn_5(
 
 /** rct2: 0x008B0950 */
 static void mine_ride_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -471,7 +471,7 @@ static void mine_ride_track_right_quarter_turn_5(
 
 /** rct2: 0x008B0960 */
 static void mine_ride_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -527,7 +527,7 @@ static void mine_ride_track_flat_to_left_bank(
 
 /** rct2: 0x008B0970 */
 static void mine_ride_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -583,7 +583,7 @@ static void mine_ride_track_flat_to_right_bank(
 
 /** rct2: 0x008B0980 */
 static void mine_ride_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -639,7 +639,7 @@ static void mine_ride_track_left_bank_to_flat(
 
 /** rct2: 0x008B0990 */
 static void mine_ride_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -695,7 +695,7 @@ static void mine_ride_track_right_bank_to_flat(
 
 /** rct2: 0x008B09A0 */
 static void mine_ride_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -886,7 +886,7 @@ static void mine_ride_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008B09B0 */
 static void mine_ride_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -895,7 +895,7 @@ static void mine_ride_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008B09C0 */
 static void mine_ride_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -958,7 +958,7 @@ static void mine_ride_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008B09D0 */
 static void mine_ride_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1021,7 +1021,7 @@ static void mine_ride_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008B09E0 */
 static void mine_ride_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1086,7 +1086,7 @@ static void mine_ride_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008B09F0 */
 static void mine_ride_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1151,7 +1151,7 @@ static void mine_ride_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008B0A00 */
 static void mine_ride_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1159,7 +1159,7 @@ static void mine_ride_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008B0A10 */
 static void mine_ride_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1167,7 +1167,7 @@ static void mine_ride_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008B0A20 */
 static void mine_ride_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1175,7 +1175,7 @@ static void mine_ride_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008B0A30 */
 static void mine_ride_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1183,7 +1183,7 @@ static void mine_ride_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008B0A40 */
 static void mine_ride_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1233,7 +1233,7 @@ static void mine_ride_track_left_bank(
 
 /** rct2: 0x008B0A50 */
 static void mine_ride_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_ride_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1241,7 +1241,7 @@ static void mine_ride_track_right_bank(
 
 /** rct2: 0x008B0A60 */
 static void mine_ride_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1398,7 +1398,7 @@ static void mine_ride_track_s_bend_left(
 
 /** rct2: 0x008B0A70 */
 static void mine_ride_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1555,7 +1555,7 @@ static void mine_ride_track_s_bend_right(
 
 /** rct2: 0x008B0AB0 */
 static void mine_ride_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1677,7 +1677,7 @@ static void mine_ride_track_left_quarter_turn_3(
 
 /** rct2: 0x008B0AC0 */
 static void mine_ride_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1686,7 +1686,7 @@ static void mine_ride_track_right_quarter_turn_3(
 
 /** rct2: 0x008B0AD0 */
 static void mine_ride_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1814,7 +1814,7 @@ static void mine_ride_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008B0AE0 */
 static void mine_ride_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1823,7 +1823,7 @@ static void mine_ride_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008B0AF0 */
 static void mine_ride_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2077,7 +2077,7 @@ static void mine_ride_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008B0B00 */
 static void mine_ride_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2331,7 +2331,7 @@ static void mine_ride_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008B0B10 */
 static void mine_ride_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -2345,7 +2345,7 @@ static void mine_ride_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008B0B20 */
 static void mine_ride_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -2359,7 +2359,7 @@ static void mine_ride_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008B0B30 */
 static void mine_ride_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2739,7 +2739,7 @@ static void mine_ride_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008B0B40 */
 static void mine_ride_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3119,7 +3119,7 @@ static void mine_ride_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008B0B50 */
 static void mine_ride_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3133,7 +3133,7 @@ static void mine_ride_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008B0B60 */
 static void mine_ride_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -3147,7 +3147,7 @@ static void mine_ride_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008B0B70 */
 static void mine_ride_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3197,7 +3197,7 @@ static void mine_ride_track_on_ride_photo(
 
 /** rct2: 0x008B0B90 */
 static void mine_ride_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3345,7 +3345,7 @@ static void mine_ride_track_left_eighth_to_diag(
 
 /** rct2: 0x008B0BA0 */
 static void mine_ride_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3493,7 +3493,7 @@ static void mine_ride_track_right_eighth_to_diag(
 
 /** rct2: 0x008B0BB0 */
 static void mine_ride_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -3502,7 +3502,7 @@ static void mine_ride_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008B0BC0 */
 static void mine_ride_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -3511,7 +3511,7 @@ static void mine_ride_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008B0BD0 */
 static void mine_ride_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3659,7 +3659,7 @@ static void mine_ride_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008B0BE0 */
 static void mine_ride_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3807,7 +3807,7 @@ static void mine_ride_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008B0BF0 */
 static void mine_ride_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -3816,7 +3816,7 @@ static void mine_ride_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008B0C00 */
 static void mine_ride_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -3825,7 +3825,7 @@ static void mine_ride_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008B0B80 */
 static void mine_ride_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3899,7 +3899,7 @@ static void mine_ride_track_diag_flat(
 
 /** rct2: 0x008B0C30 */
 static void mine_ride_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3975,7 +3975,7 @@ static void mine_ride_track_diag_25_deg_up(
 
 /** rct2: 0x008B0C10 */
 static void mine_ride_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4049,7 +4049,7 @@ static void mine_ride_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008B0C20 */
 static void mine_ride_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4125,7 +4125,7 @@ static void mine_ride_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008B0C60 */
 static void mine_ride_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4201,7 +4201,7 @@ static void mine_ride_track_diag_25_deg_down(
 
 /** rct2: 0x008B0C40 */
 static void mine_ride_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4275,7 +4275,7 @@ static void mine_ride_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008B0C50 */
 static void mine_ride_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4349,7 +4349,7 @@ static void mine_ride_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008B0C90 */
 static void mine_ride_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4426,7 +4426,7 @@ static void mine_ride_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008B0CA0 */
 static void mine_ride_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4503,7 +4503,7 @@ static void mine_ride_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008B0CB0 */
 static void mine_ride_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4580,7 +4580,7 @@ static void mine_ride_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008B0CC0 */
 static void mine_ride_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4657,7 +4657,7 @@ static void mine_ride_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008B0CF0 */
 static void mine_ride_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4734,7 +4734,7 @@ static void mine_ride_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008B0D00 */
 static void mine_ride_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4811,7 +4811,7 @@ static void mine_ride_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008B0CD0 */
 static void mine_ride_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4890,7 +4890,7 @@ static void mine_ride_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008B0CE0 */
 static void mine_ride_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4969,7 +4969,7 @@ static void mine_ride_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008B0D10 */
 static void mine_ride_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5046,7 +5046,7 @@ static void mine_ride_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008B0D20 */
 static void mine_ride_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5123,7 +5123,7 @@ static void mine_ride_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008B0D30 */
 static void mine_ride_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5200,7 +5200,7 @@ static void mine_ride_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008B0D40 */
 static void mine_ride_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5277,7 +5277,7 @@ static void mine_ride_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008B0C70 */
 static void mine_ride_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5351,7 +5351,7 @@ static void mine_ride_track_diag_left_bank(
 
 /** rct2: 0x008B0C80 */
 static void mine_ride_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _MineTrainBlockBrakeImages[NumOrthogonalDirectio
 
 /** rct2: 0x0071BFA4 */
 static void mine_train_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -92,7 +92,7 @@ static void mine_train_rc_track_flat(
 
 /** rct2: 0x0071C154, 0x0071C164, 0x0071C174 */
 static void mine_train_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -127,7 +127,7 @@ static void mine_train_rc_track_station(
 
 /** rct2: 0x0071BFB4 */
 static void mine_train_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -204,7 +204,7 @@ static void mine_train_rc_track_25_deg_up(
 
 /** rct2: 0x0071BFC4 */
 static void mine_train_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -248,7 +248,7 @@ static void mine_train_rc_track_60_deg_up(
 
 /** rct2: 0x0071BFD4 */
 static void mine_train_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -325,7 +325,7 @@ static void mine_train_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x0071BFE4 */
 static void mine_train_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -375,7 +375,7 @@ static void mine_train_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0071BFF4 */
 static void mine_train_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -425,7 +425,7 @@ static void mine_train_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0071C004 */
 static void mine_train_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -502,7 +502,7 @@ static void mine_train_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0071C014 */
 static void mine_train_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -510,7 +510,7 @@ static void mine_train_rc_track_25_deg_down(
 
 /** rct2: 0x0071C024 */
 static void mine_train_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -518,7 +518,7 @@ static void mine_train_rc_track_60_deg_down(
 
 /** rct2: 0x0071C034 */
 static void mine_train_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -526,7 +526,7 @@ static void mine_train_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x0071C044 */
 static void mine_train_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -534,7 +534,7 @@ static void mine_train_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x0071C054 */
 static void mine_train_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -542,7 +542,7 @@ static void mine_train_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x0071C064 */
 static void mine_train_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -550,7 +550,7 @@ static void mine_train_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x0071C0B4 */
 static void mine_train_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -749,7 +749,7 @@ static void mine_train_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x0071C0C4 */
 static void mine_train_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -758,7 +758,7 @@ static void mine_train_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x0071C074 */
 static void mine_train_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -801,7 +801,7 @@ static void mine_train_rc_track_flat_to_left_bank(
 
 /** rct2: 0x0071C084 */
 static void mine_train_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -844,7 +844,7 @@ static void mine_train_rc_track_flat_to_right_bank(
 
 /** rct2: 0x0071C094 */
 static void mine_train_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -887,7 +887,7 @@ static void mine_train_rc_track_left_bank_to_flat(
 
 /** rct2: 0x0071C0A4 */
 static void mine_train_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -930,7 +930,7 @@ static void mine_train_rc_track_right_bank_to_flat(
 
 /** rct2: 0x0071C0D4 */
 static void mine_train_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1135,7 +1135,7 @@ static void mine_train_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x0071C0E4 */
 static void mine_train_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1144,7 +1144,7 @@ static void mine_train_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x0071C204 */
 static void mine_train_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1194,7 +1194,7 @@ static void mine_train_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x0071C214 */
 static void mine_train_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1244,7 +1244,7 @@ static void mine_train_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x0071C224 */
 static void mine_train_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1294,7 +1294,7 @@ static void mine_train_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x0071C234 */
 static void mine_train_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1344,7 +1344,7 @@ static void mine_train_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x0071C244 */
 static void mine_train_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1352,7 +1352,7 @@ static void mine_train_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x0071C254 */
 static void mine_train_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1360,7 +1360,7 @@ static void mine_train_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x0071C264 */
 static void mine_train_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1368,7 +1368,7 @@ static void mine_train_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x0071C274 */
 static void mine_train_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1376,7 +1376,7 @@ static void mine_train_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x0071C304 */
 static void mine_train_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1413,7 +1413,7 @@ static void mine_train_rc_track_left_bank(
 
 /** rct2: 0x0071C314 */
 static void mine_train_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mine_train_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1421,7 +1421,7 @@ static void mine_train_rc_track_right_bank(
 
 /** rct2: 0x0071C0F4 */
 static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1620,7 +1620,7 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x0071C104 */
 static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1819,7 +1819,7 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x0071C114 */
 static void mine_train_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1828,7 +1828,7 @@ static void mine_train_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x0071C124 */
 static void mine_train_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1837,7 +1837,7 @@ static void mine_train_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x0071C134 */
 static void mine_train_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1990,7 +1990,7 @@ static void mine_train_rc_track_s_bend_left(
 
 /** rct2: 0x0071C144 */
 static void mine_train_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2143,7 +2143,7 @@ static void mine_train_rc_track_s_bend_right(
 
 /** rct2: 0x0071C184 */
 static void mine_train_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2274,7 +2274,7 @@ static void mine_train_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x0071C194 */
 static void mine_train_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2283,7 +2283,7 @@ static void mine_train_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x0071C1A4 */
 static void mine_train_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2420,7 +2420,7 @@ static void mine_train_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x0071C1B4 */
 static void mine_train_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2429,7 +2429,7 @@ static void mine_train_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x0071C1C4 */
 static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2537,7 +2537,7 @@ static void mine_train_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0071C1D4 */
 static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2645,7 +2645,7 @@ static void mine_train_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0071C1E4 */
 static void mine_train_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2654,7 +2654,7 @@ static void mine_train_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x0071C1F4 */
 static void mine_train_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2663,7 +2663,7 @@ static void mine_train_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x0071C284 */
 static void mine_train_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2943,7 +2943,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x0071C294 */
 static void mine_train_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3223,7 +3223,7 @@ static void mine_train_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x0071C2A4 */
 static void mine_train_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3238,7 +3238,7 @@ static void mine_train_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x0071C2B4 */
 static void mine_train_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3253,7 +3253,7 @@ static void mine_train_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x0071C2C4 */
 static void mine_train_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3677,7 +3677,7 @@ static void mine_train_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x0071C2D4 */
 static void mine_train_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4089,7 +4089,7 @@ static void mine_train_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x0071C2E4 */
 static void mine_train_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4104,7 +4104,7 @@ static void mine_train_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x0071C2F4 */
 static void mine_train_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4119,7 +4119,7 @@ static void mine_train_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x0071C324 */
 static void mine_train_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4146,7 +4146,7 @@ static void mine_train_rc_track_brakes(
 
 /** rct2: 0x0071C334 */
 static void mine_train_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4184,7 +4184,7 @@ static void mine_train_rc_track_on_ride_photo(
 
 /** rct2: 0x0071C354 */
 static void mine_train_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4337,7 +4337,7 @@ static void mine_train_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x0071C364 */
 static void mine_train_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4490,7 +4490,7 @@ static void mine_train_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x0071C374 */
 static void mine_train_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4499,7 +4499,7 @@ static void mine_train_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x0071C384 */
 static void mine_train_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4508,7 +4508,7 @@ static void mine_train_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x0071C394 */
 static void mine_train_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4661,7 +4661,7 @@ static void mine_train_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x0071C3A4 */
 static void mine_train_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4814,7 +4814,7 @@ static void mine_train_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x0071C3B4 */
 static void mine_train_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4823,7 +4823,7 @@ static void mine_train_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x0071C3C4 */
 static void mine_train_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4832,7 +4832,7 @@ static void mine_train_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x0071C344 */
 static void mine_train_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4986,7 +4986,7 @@ static void mine_train_rc_track_diag_flat(
 
 /** rct2: 0x0071C414 */
 static void mine_train_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5140,7 +5140,7 @@ static void mine_train_rc_track_diag_25_deg_up(
 
 /** rct2: 0x0071C474 */
 static void mine_train_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5218,7 +5218,7 @@ static void mine_train_rc_track_diag_60_deg_up(
 
 /** rct2: 0x0071C3F4 */
 static void mine_train_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5372,7 +5372,7 @@ static void mine_train_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x0071C454 */
 static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5450,7 +5450,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0071C464 */
 static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5528,7 +5528,7 @@ static void mine_train_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0071C404 */
 static void mine_train_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5682,7 +5682,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x0071C444 */
 static void mine_train_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5836,7 +5836,7 @@ static void mine_train_rc_track_diag_25_deg_down(
 
 /** rct2: 0x0071C4A4 */
 static void mine_train_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5914,7 +5914,7 @@ static void mine_train_rc_track_diag_60_deg_down(
 
 /** rct2: 0x0071C424 */
 static void mine_train_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6066,7 +6066,7 @@ static void mine_train_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x0071C484 */
 static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6144,7 +6144,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x0071C494 */
 static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6222,7 +6222,7 @@ static void mine_train_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x0071C434 */
 static void mine_train_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6376,7 +6376,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x0071C4D4 */
 static void mine_train_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6457,7 +6457,7 @@ static void mine_train_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x0071C4B4 */
 static void mine_train_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6538,7 +6538,7 @@ static void mine_train_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x0071C4C4 */
 static void mine_train_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6619,7 +6619,7 @@ static void mine_train_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x0071C4E4 */
 static void mine_train_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6700,7 +6700,7 @@ static void mine_train_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x0071C514 */
 static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6781,7 +6781,7 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x0071C524 */
 static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6862,7 +6862,7 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x0071C4F4 */
 static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6943,7 +6943,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x0071C504 */
 static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7024,7 +7024,7 @@ static void mine_train_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x0071C534 */
 static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7100,7 +7100,7 @@ static void mine_train_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x0071C544 */
 static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7176,7 +7176,7 @@ static void mine_train_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x0071C554 */
 static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7257,7 +7257,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x0071C564 */
 static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7338,7 +7338,7 @@ static void mine_train_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x0071C3D4 */
 static void mine_train_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7420,7 +7420,7 @@ static void mine_train_rc_track_diag_left_bank(
 
 /** rct2: 0x0071C3E4 */
 static void mine_train_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7502,7 +7502,7 @@ static void mine_train_rc_track_diag_right_bank(
 
 /** rct2: 0x0071C574 */
 static void mine_train_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();

--- a/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _MiniRCBlockBrakeImages[NumOrthogonalDirections]
 
 /** rct2: 0x008A4ABC */
 static void mini_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -113,7 +113,7 @@ static void mini_rc_track_flat(
 }
 
 static void mini_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -148,7 +148,7 @@ static void mini_rc_track_station(
 
 /** rct2: 0x008A4ACC */
 static void mini_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -258,7 +258,7 @@ static void mini_rc_track_25_deg_up(
 
 /** rct2: 0x008A4ADC */
 static void mini_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -317,7 +317,7 @@ static void mini_rc_track_60_deg_up(
 
 /** rct2: 0x008A4AEC */
 static void mini_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -423,7 +423,7 @@ static void mini_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A4AFC */
 static void mini_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -488,7 +488,7 @@ static void mini_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A4B0C */
 static void mini_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -553,7 +553,7 @@ static void mini_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A4B1C */
 static void mini_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -663,7 +663,7 @@ static void mini_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A4B2C */
 static void mini_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -671,7 +671,7 @@ static void mini_rc_track_25_deg_down(
 
 /** rct2: 0x008A4B3C */
 static void mini_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -679,7 +679,7 @@ static void mini_rc_track_60_deg_down(
 
 /** rct2: 0x008A4B4C */
 static void mini_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -687,7 +687,7 @@ static void mini_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A4B5C */
 static void mini_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -695,7 +695,7 @@ static void mini_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A4B6C */
 static void mini_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -703,7 +703,7 @@ static void mini_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A4B7C */
 static void mini_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -711,7 +711,7 @@ static void mini_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A4B8C */
 static void mini_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -896,7 +896,7 @@ static void mini_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A4B9C */
 static void mini_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -905,7 +905,7 @@ static void mini_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A4BAC */
 static void mini_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -961,7 +961,7 @@ static void mini_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A4BBC */
 static void mini_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1017,7 +1017,7 @@ static void mini_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A4BCC */
 static void mini_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1073,7 +1073,7 @@ static void mini_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A4BDC */
 static void mini_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1129,7 +1129,7 @@ static void mini_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A4BEC */
 static void mini_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1320,7 +1320,7 @@ static void mini_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A4BFC */
 static void mini_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1329,7 +1329,7 @@ static void mini_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008A4C0C */
 static void mini_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1392,7 +1392,7 @@ static void mini_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A4C1C */
 static void mini_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1455,7 +1455,7 @@ static void mini_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A4C2C */
 static void mini_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1520,7 +1520,7 @@ static void mini_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A4C3C */
 static void mini_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1585,7 +1585,7 @@ static void mini_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A4C4C */
 static void mini_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1593,7 +1593,7 @@ static void mini_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A4C5C */
 static void mini_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1601,7 +1601,7 @@ static void mini_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A4C6C */
 static void mini_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1609,7 +1609,7 @@ static void mini_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A4C7C */
 static void mini_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1617,7 +1617,7 @@ static void mini_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A4C8C */
 static void mini_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1667,7 +1667,7 @@ static void mini_rc_track_left_bank(
 
 /** rct2: 0x008A4C9C */
 static void mini_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1675,7 +1675,7 @@ static void mini_rc_track_right_bank(
 
 /** rct2: 0x008A4CAC */
 static void mini_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1864,7 +1864,7 @@ static void mini_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A4CBC */
 static void mini_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2053,7 +2053,7 @@ static void mini_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A4CCC */
 static void mini_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2062,7 +2062,7 @@ static void mini_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A4CDC */
 static void mini_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2071,7 +2071,7 @@ static void mini_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A4CEC */
 static void mini_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2228,7 +2228,7 @@ static void mini_rc_track_s_bend_left(
 
 /** rct2: 0x008A4CFC */
 static void mini_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2385,7 +2385,7 @@ static void mini_rc_track_s_bend_right(
 
 /** rct2: 0x008A4D3C */
 static void mini_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2507,7 +2507,7 @@ static void mini_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A4D4C */
 static void mini_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2516,7 +2516,7 @@ static void mini_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A4D5C */
 static void mini_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2644,7 +2644,7 @@ static void mini_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A4D6C */
 static void mini_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2653,7 +2653,7 @@ static void mini_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008A4D7C */
 static void mini_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2754,7 +2754,7 @@ static void mini_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A4D8C */
 static void mini_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2855,7 +2855,7 @@ static void mini_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A4D9C */
 static void mini_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2864,7 +2864,7 @@ static void mini_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A4DAC */
 static void mini_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2873,7 +2873,7 @@ static void mini_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A4DBC */
 static void mini_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3127,7 +3127,7 @@ static void mini_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A4DCC */
 static void mini_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3381,7 +3381,7 @@ static void mini_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A4DDC */
 static void mini_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3395,7 +3395,7 @@ static void mini_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008A4DEC */
 static void mini_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -3409,7 +3409,7 @@ static void mini_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008A4DFC */
 static void mini_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3789,7 +3789,7 @@ static void mini_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A4E0C */
 static void mini_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4169,7 +4169,7 @@ static void mini_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A4E1C */
 static void mini_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4183,7 +4183,7 @@ static void mini_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008A4E2C */
 static void mini_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4197,7 +4197,7 @@ static void mini_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008A4E5C */
 static void mini_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4242,7 +4242,7 @@ static void mini_rc_track_left_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A4E3C */
 static void mini_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4287,7 +4287,7 @@ static void mini_rc_track_right_quarter_turn_1_60_deg_up(
 
 /** rct2: 0x008A4E4C */
 static void mini_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
@@ -4295,7 +4295,7 @@ static void mini_rc_track_left_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A4E6C */
 static void mini_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_quarter_turn_1_60_deg_up(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -4303,7 +4303,7 @@ static void mini_rc_track_right_quarter_turn_1_60_deg_down(
 
 /** rct2: 0x008A4E7C */
 static void mini_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4337,7 +4337,7 @@ static void mini_rc_track_brakes(
 
 /** rct2: 0x008A50CC */
 static void mini_rc_track_25_deg_up_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4396,7 +4396,7 @@ static void mini_rc_track_25_deg_up_left_banked(
 
 /** rct2: 0x008A50DC */
 static void mini_rc_track_25_deg_up_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4455,7 +4455,7 @@ static void mini_rc_track_25_deg_up_right_banked(
 
 /** rct2: 0x008A4E8C */
 static void mini_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -4505,7 +4505,7 @@ static void mini_rc_track_on_ride_photo(
 
 /** rct2: 0x008A50EC */
 static void mini_rc_track_25_deg_down_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_right_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4513,7 +4513,7 @@ static void mini_rc_track_25_deg_down_left_banked(
 
 /** rct2: 0x008A50FC */
 static void mini_rc_track_25_deg_down_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_left_banked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -4521,7 +4521,7 @@ static void mini_rc_track_25_deg_down_right_banked(
 
 /** rct2: 0x008A4EAC */
 static void mini_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4669,7 +4669,7 @@ static void mini_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A4EBC */
 static void mini_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4817,7 +4817,7 @@ static void mini_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A4ECC */
 static void mini_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4826,7 +4826,7 @@ static void mini_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A4EDC */
 static void mini_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -4835,7 +4835,7 @@ static void mini_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A4EEC */
 static void mini_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4983,7 +4983,7 @@ static void mini_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A4EFC */
 static void mini_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5131,7 +5131,7 @@ static void mini_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A4F0C */
 static void mini_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5140,7 +5140,7 @@ static void mini_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A4F1C */
 static void mini_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5149,7 +5149,7 @@ static void mini_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A4E9C */
 static void mini_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5295,7 +5295,7 @@ static void mini_rc_track_diag_flat(
 
 /** rct2: 0x008A4F4C */
 static void mini_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5441,7 +5441,7 @@ static void mini_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A4FAC */
 static void mini_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5517,7 +5517,7 @@ static void mini_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A4F2C */
 static void mini_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5663,7 +5663,7 @@ static void mini_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A4F8C */
 static void mini_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5739,7 +5739,7 @@ static void mini_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A4F9C */
 static void mini_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5815,7 +5815,7 @@ static void mini_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A4F3C */
 static void mini_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5961,7 +5961,7 @@ static void mini_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A4F7C */
 static void mini_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6107,7 +6107,7 @@ static void mini_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A4FDC */
 static void mini_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6183,7 +6183,7 @@ static void mini_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A4F5C */
 static void mini_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6327,7 +6327,7 @@ static void mini_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A4FBC */
 static void mini_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6403,7 +6403,7 @@ static void mini_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A4FCC */
 static void mini_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6479,7 +6479,7 @@ static void mini_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A4F6C */
 static void mini_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6625,7 +6625,7 @@ static void mini_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A500C */
 static void mini_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6702,7 +6702,7 @@ static void mini_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A501C */
 static void mini_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6779,7 +6779,7 @@ static void mini_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A502C */
 static void mini_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6856,7 +6856,7 @@ static void mini_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A503C */
 static void mini_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6933,7 +6933,7 @@ static void mini_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A506C */
 static void mini_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7010,7 +7010,7 @@ static void mini_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A507C */
 static void mini_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7087,7 +7087,7 @@ static void mini_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A504C */
 static void mini_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7166,7 +7166,7 @@ static void mini_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A505C */
 static void mini_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7245,7 +7245,7 @@ static void mini_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A508C */
 static void mini_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7322,7 +7322,7 @@ static void mini_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A509C */
 static void mini_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7399,7 +7399,7 @@ static void mini_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A50AC */
 static void mini_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7476,7 +7476,7 @@ static void mini_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A50BC */
 static void mini_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7553,7 +7553,7 @@ static void mini_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A4FEC */
 static void mini_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7627,7 +7627,7 @@ static void mini_rc_track_diag_left_bank(
 
 /** rct2: 0x008A4FFC */
 static void mini_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7701,7 +7701,7 @@ static void mini_rc_track_diag_right_bank(
 
 /** rct2: 0x008A530C */
 static void mini_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -7733,7 +7733,7 @@ static void mini_rc_track_block_brakes(
 
 /** rct2: 0x008A510C */
 static void mini_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7834,7 +7834,7 @@ static void mini_rc_track_left_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A511C */
 static void mini_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7935,7 +7935,7 @@ static void mini_rc_track_right_banked_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A512C */
 static void mini_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7945,7 +7945,7 @@ static void mini_rc_track_left_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A513C */
 static void mini_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7954,7 +7954,7 @@ static void mini_rc_track_right_banked_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A514C */
 static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8143,7 +8143,7 @@ static void mini_rc_track_left_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A515C */
 static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8332,7 +8332,7 @@ static void mini_rc_track_right_banked_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A516C */
 static void mini_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8342,7 +8342,7 @@ static void mini_rc_track_left_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A517C */
 static void mini_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8351,7 +8351,7 @@ static void mini_rc_track_right_banked_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A518C */
 static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8413,7 +8413,7 @@ static void mini_rc_track_25_deg_up_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A519C */
 static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8475,7 +8475,7 @@ static void mini_rc_track_25_deg_up_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A51AC */
 static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8537,7 +8537,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A51BC */
 static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8599,7 +8599,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A51CC */
 static void mini_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8607,7 +8607,7 @@ static void mini_rc_track_25_deg_down_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A51DC */
 static void mini_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_banked_25_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8615,7 +8615,7 @@ static void mini_rc_track_25_deg_down_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A51EC */
 static void mini_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8623,7 +8623,7 @@ static void mini_rc_track_left_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A51FC */
 static void mini_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_25_deg_up_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -8631,7 +8631,7 @@ static void mini_rc_track_right_banked_25_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A520C */
 static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8688,7 +8688,7 @@ static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A521C */
 static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8745,7 +8745,7 @@ static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A524C */
 static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8804,7 +8804,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 
 /** rct2: 0x008A525C */
 static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8863,7 +8863,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 
 /** rct2: 0x008A526C */
 static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_banked_25_deg_up_to_right_banked_flat(
@@ -8872,7 +8872,7 @@ static void mini_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A527C */
 static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_banked_25_deg_up_to_left_banked_flat(
@@ -8881,7 +8881,7 @@ static void mini_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A522C */
 static void mini_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_banked_flat_to_right_banked_25_deg_up(
@@ -8890,7 +8890,7 @@ static void mini_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 
 /** rct2: 0x008A523C */
 static void mini_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_banked_flat_to_left_banked_25_deg_up(
@@ -8899,7 +8899,7 @@ static void mini_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 
 /** rct2: 0x008A528C */
 static void mini_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -8959,7 +8959,7 @@ static void mini_rc_track_flat_to_left_banked_25_deg_up(
 
 /** rct2: 0x008A529C */
 static void mini_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9019,7 +9019,7 @@ static void mini_rc_track_flat_to_right_banked_25_deg_up(
 
 /** rct2: 0x008A52AC */
 static void mini_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9081,7 +9081,7 @@ static void mini_rc_track_left_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A52BC */
 static void mini_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -9143,7 +9143,7 @@ static void mini_rc_track_right_banked_25_deg_up_to_flat(
 
 /** rct2: 0x008A52CC */
 static void mini_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_right_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9151,7 +9151,7 @@ static void mini_rc_track_flat_to_left_banked_25_deg_down(
 
 /** rct2: 0x008A52DC */
 static void mini_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_left_banked_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9159,7 +9159,7 @@ static void mini_rc_track_flat_to_right_banked_25_deg_down(
 
 /** rct2: 0x008A52EC */
 static void mini_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_flat_to_right_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -9167,14 +9167,14 @@ static void mini_rc_track_left_banked_25_deg_down_to_flat(
 
 /** rct2: 0x008A52FC */
 static void mini_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_rc_track_flat_to_left_banked_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void mini_rc_track_left_curved_lift_hill(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9274,7 +9274,7 @@ static void mini_rc_track_left_curved_lift_hill(
 }
 
 static void mini_rc_track_right_curved_lift_hill(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9374,7 +9374,7 @@ static void mini_rc_track_right_curved_lift_hill(
 }
 
 static void mini_rc_track_booster(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     // These offsets could be moved to the g2.dat file when that supports offsets.

--- a/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008AFE9C */
 static void mini_suspended_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -85,7 +85,7 @@ static void mini_suspended_rc_track_flat(
 
 /** rct2: 0x008AFF4C, 0x008AFF5C, 0x008AFF6C */
 static void mini_suspended_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -113,7 +113,7 @@ static void mini_suspended_rc_track_station(
 
 /** rct2: 0x008AFEAC */
 static void mini_suspended_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -207,7 +207,7 @@ static void mini_suspended_rc_track_25_deg_up(
 
 /** rct2: 0x008AFEBC */
 static void mini_suspended_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -301,7 +301,7 @@ static void mini_suspended_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AFECC */
 static void mini_suspended_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -395,7 +395,7 @@ static void mini_suspended_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AFEDC */
 static void mini_suspended_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_suspended_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -403,7 +403,7 @@ static void mini_suspended_rc_track_25_deg_down(
 
 /** rct2: 0x008AFEEC */
 static void mini_suspended_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_suspended_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -411,7 +411,7 @@ static void mini_suspended_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AFEFC */
 static void mini_suspended_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     mini_suspended_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -419,7 +419,7 @@ static void mini_suspended_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008AFF0C */
 static void mini_suspended_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -624,7 +624,7 @@ static void mini_suspended_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008AFF1C */
 static void mini_suspended_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -633,7 +633,7 @@ static void mini_suspended_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008AFF2C */
 static void mini_suspended_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -828,7 +828,7 @@ static void mini_suspended_rc_track_s_bend_left(
 
 /** rct2: 0x008AFF3C */
 static void mini_suspended_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1023,7 +1023,7 @@ static void mini_suspended_rc_track_s_bend_right(
 
 /** rct2: 0x008AFF7C */
 static void mini_suspended_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1165,7 +1165,7 @@ static void mini_suspended_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008AFF8C */
 static void mini_suspended_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1174,7 +1174,7 @@ static void mini_suspended_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008AFFAC */
 static void mini_suspended_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1347,7 +1347,7 @@ static void mini_suspended_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008AFFBC */
 static void mini_suspended_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1520,7 +1520,7 @@ static void mini_suspended_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008AFFCC */
 static void mini_suspended_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1529,7 +1529,7 @@ static void mini_suspended_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008AFFDC */
 static void mini_suspended_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1538,7 +1538,7 @@ static void mini_suspended_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008AFF9C */
 static void mini_suspended_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1677,7 +1677,7 @@ static void mini_suspended_rc_track_diag_flat(
 
 /** rct2: 0x008B000C */
 static void mini_suspended_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1816,7 +1816,7 @@ static void mini_suspended_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008AFFEC */
 static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1955,7 +1955,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AFFFC */
 static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2094,7 +2094,7 @@ static void mini_suspended_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008B003C */
 static void mini_suspended_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2233,7 +2233,7 @@ static void mini_suspended_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008B001C */
 static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2369,7 +2369,7 @@ static void mini_suspended_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008B002C */
 static void mini_suspended_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/MultiDimensionRollerCoaster.cpp
@@ -35,7 +35,7 @@ static constexpr const uint32_t MULTI_DIM_INVERTED_BLOCK_BRAKE_NW_SE_CLOSED = 26
 
 /** rct2: 0x00792D88 */
 static void multi_dimension_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -123,7 +123,7 @@ static void multi_dimension_rc_track_flat(
 
 /** rct2: 0x00792F98, 0x00792FA8, 0x00792FB8 */
 static void multi_dimension_rc_track_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[NumOrthogonalDirections][3] = {
@@ -180,7 +180,7 @@ static void multi_dimension_rc_track_station(
 
 /** rct2: 0x00792D98 */
 static void multi_dimension_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -323,7 +323,7 @@ static void multi_dimension_rc_track_25_deg_up(
 
 /** rct2: 0x00792DA8 */
 static void multi_dimension_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -408,7 +408,7 @@ static void multi_dimension_rc_track_60_deg_up(
 
 /** rct2: 0x00792DB8 */
 static void multi_dimension_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -551,7 +551,7 @@ static void multi_dimension_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x00792DC8 */
 static void multi_dimension_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -648,7 +648,7 @@ static void multi_dimension_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x00792DD8 */
 static void multi_dimension_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -769,7 +769,7 @@ static void multi_dimension_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00792DE8 */
 static void multi_dimension_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -912,7 +912,7 @@ static void multi_dimension_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x00792DF8 */
 static void multi_dimension_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -920,7 +920,7 @@ static void multi_dimension_rc_track_25_deg_down(
 
 /** rct2: 0x00792E08 */
 static void multi_dimension_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -928,7 +928,7 @@ static void multi_dimension_rc_track_60_deg_down(
 
 /** rct2: 0x00792E18 */
 static void multi_dimension_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -936,7 +936,7 @@ static void multi_dimension_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x00792E28 */
 static void multi_dimension_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -944,7 +944,7 @@ static void multi_dimension_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x00792E38 */
 static void multi_dimension_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -952,7 +952,7 @@ static void multi_dimension_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x00792E48 */
 static void multi_dimension_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -960,7 +960,7 @@ static void multi_dimension_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x00792E58 */
 static void multi_dimension_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1322,7 +1322,7 @@ static void multi_dimension_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x00792E68 */
 static void multi_dimension_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1331,7 +1331,7 @@ static void multi_dimension_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x00792E78 */
 static void multi_dimension_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1417,7 +1417,7 @@ static void multi_dimension_rc_track_flat_to_left_bank(
 
 /** rct2: 0x00792E88 */
 static void multi_dimension_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1503,7 +1503,7 @@ static void multi_dimension_rc_track_flat_to_right_bank(
 
 /** rct2: 0x00792E98 */
 static void multi_dimension_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1589,7 +1589,7 @@ static void multi_dimension_rc_track_left_bank_to_flat(
 
 /** rct2: 0x00792EA8 */
 static void multi_dimension_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -1675,7 +1675,7 @@ static void multi_dimension_rc_track_right_bank_to_flat(
 
 /** rct2: 0x00792EB8 */
 static void multi_dimension_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2043,7 +2043,7 @@ static void multi_dimension_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x00792EC8 */
 static void multi_dimension_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2053,7 +2053,7 @@ static void multi_dimension_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x00792ED8 */
 static void multi_dimension_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2170,7 +2170,7 @@ static void multi_dimension_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x00792EE8 */
 static void multi_dimension_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2287,7 +2287,7 @@ static void multi_dimension_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x00792EF8 */
 static void multi_dimension_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2404,7 +2404,7 @@ static void multi_dimension_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x00792F08 */
 static void multi_dimension_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2521,7 +2521,7 @@ static void multi_dimension_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x00792F18 */
 static void multi_dimension_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2529,7 +2529,7 @@ static void multi_dimension_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x00792F28 */
 static void multi_dimension_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2537,7 +2537,7 @@ static void multi_dimension_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x00792F38 */
 static void multi_dimension_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2545,7 +2545,7 @@ static void multi_dimension_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x00792F48 */
 static void multi_dimension_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2553,7 +2553,7 @@ static void multi_dimension_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x00792F58 */
 static void multi_dimension_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2633,7 +2633,7 @@ static void multi_dimension_rc_track_left_bank(
 
 /** rct2: 0x00792F68 */
 static void multi_dimension_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2641,7 +2641,7 @@ static void multi_dimension_rc_track_right_bank(
 
 /** rct2: 0x00792F78 */
 static void multi_dimension_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -2958,7 +2958,7 @@ static void multi_dimension_rc_track_s_bend_left(
 
 /** rct2: 0x00792F88 */
 static void multi_dimension_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3275,7 +3275,7 @@ static void multi_dimension_rc_track_s_bend_right(
 
 /** rct2: 0x00792FC8 */
 static void multi_dimension_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3507,7 +3507,7 @@ static void multi_dimension_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x00792FD8 */
 static void multi_dimension_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3516,7 +3516,7 @@ static void multi_dimension_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x00792FE8 */
 static void multi_dimension_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -3754,7 +3754,7 @@ static void multi_dimension_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x00792FF8 */
 static void multi_dimension_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3763,7 +3763,7 @@ static void multi_dimension_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x00793008 */
 static void multi_dimension_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3991,7 +3991,7 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x00793018 */
 static void multi_dimension_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4219,7 +4219,7 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x00793028 */
 static void multi_dimension_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -4234,7 +4234,7 @@ static void multi_dimension_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x00793038 */
 static void multi_dimension_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -4249,7 +4249,7 @@ static void multi_dimension_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x00793048 */
 static void multi_dimension_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4603,7 +4603,7 @@ static void multi_dimension_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x00793058 */
 static void multi_dimension_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4957,7 +4957,7 @@ static void multi_dimension_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x00793068 */
 static void multi_dimension_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4972,7 +4972,7 @@ static void multi_dimension_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x00793078 */
 static void multi_dimension_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -4987,7 +4987,7 @@ static void multi_dimension_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x00793088 */
 static void multi_dimension_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5049,7 +5049,7 @@ static void multi_dimension_rc_track_brakes(
 
 /** rct2: 0x00793098 */
 static void multi_dimension_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5164,7 +5164,7 @@ static void multi_dimension_rc_track_on_ride_photo(
 
 /** rct2: 0x00793328 */
 static void multi_dimension_rc_track_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5245,7 +5245,7 @@ static void multi_dimension_rc_track_90_deg_up(
 
 /** rct2: 0x00793338 */
 static void multi_dimension_rc_track_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5253,7 +5253,7 @@ static void multi_dimension_rc_track_90_deg_down(
 
 /** rct2: 0x00793348 */
 static void multi_dimension_rc_track_60_deg_up_to_90_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5342,7 +5342,7 @@ static void multi_dimension_rc_track_60_deg_up_to_90_deg_up(
 
 /** rct2: 0x00793358 */
 static void multi_dimension_rc_track_90_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     multi_dimension_rc_track_60_deg_up_to_90_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -5350,7 +5350,7 @@ static void multi_dimension_rc_track_90_deg_down_to_60_deg_down(
 
 /** rct2: 0x00793368 */
 static void multi_dimension_rc_track_90_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5433,7 +5433,7 @@ static void multi_dimension_rc_track_90_deg_up_to_60_deg_up(
 
 /** rct2: 0x00793378 */
 static void multi_dimension_rc_track_60_deg_down_to_90_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5520,7 +5520,7 @@ static void multi_dimension_rc_track_60_deg_down_to_90_deg_down(
 
 /** rct2: 0x007930B8 */
 static void multi_dimension_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -5821,7 +5821,7 @@ static void multi_dimension_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x007930C8 */
 static void multi_dimension_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6122,7 +6122,7 @@ static void multi_dimension_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x007930D8 */
 static void multi_dimension_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6131,7 +6131,7 @@ static void multi_dimension_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x007930E8 */
 static void multi_dimension_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6140,7 +6140,7 @@ static void multi_dimension_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x007930F8 */
 static void multi_dimension_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6441,7 +6441,7 @@ static void multi_dimension_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x00793108 */
 static void multi_dimension_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -6742,7 +6742,7 @@ static void multi_dimension_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x00793118 */
 static void multi_dimension_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6751,7 +6751,7 @@ static void multi_dimension_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x00793128 */
 static void multi_dimension_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -6760,7 +6760,7 @@ static void multi_dimension_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x007930A8 */
 static void multi_dimension_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7044,7 +7044,7 @@ static void multi_dimension_rc_track_diag_flat(
 
 /** rct2: 0x00793158 */
 static void multi_dimension_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7328,7 +7328,7 @@ static void multi_dimension_rc_track_diag_25_deg_up(
 
 /** rct2: 0x007931B8 */
 static void multi_dimension_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7486,7 +7486,7 @@ static void multi_dimension_rc_track_diag_60_deg_up(
 
 /** rct2: 0x00793138 */
 static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7770,7 +7770,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x00793198 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -7928,7 +7928,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x007931A8 */
 static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8086,7 +8086,7 @@ static void multi_dimension_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x00793148 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8370,7 +8370,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x00793188 */
 static void multi_dimension_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8598,7 +8598,7 @@ static void multi_dimension_rc_track_diag_25_deg_down(
 
 /** rct2: 0x007931E8 */
 static void multi_dimension_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8756,7 +8756,7 @@ static void multi_dimension_rc_track_diag_60_deg_down(
 
 /** rct2: 0x00793168 */
 static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -8980,7 +8980,7 @@ static void multi_dimension_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x007931C8 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9138,7 +9138,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x007931D8 */
 static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9296,7 +9296,7 @@ static void multi_dimension_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x00793178 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9524,7 +9524,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x00793218 */
 static void multi_dimension_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9686,7 +9686,7 @@ static void multi_dimension_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x00793228 */
 static void multi_dimension_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -9848,7 +9848,7 @@ static void multi_dimension_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x00793238 */
 static void multi_dimension_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10010,7 +10010,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x00793248 */
 static void multi_dimension_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10172,7 +10172,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x00793278 */
 static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10333,7 +10333,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x00793288 */
 static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10494,7 +10494,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x00793258 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10655,7 +10655,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x00793268 */
 static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10816,7 +10816,7 @@ static void multi_dimension_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x00793298 */
 static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -10970,7 +10970,7 @@ static void multi_dimension_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x007932A8 */
 static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11124,7 +11124,7 @@ static void multi_dimension_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x007932B8 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11285,7 +11285,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x007932C8 */
 static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11446,7 +11446,7 @@ static void multi_dimension_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x007931F8 */
 static void multi_dimension_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11605,7 +11605,7 @@ static void multi_dimension_rc_track_diag_left_bank(
 
 /** rct2: 0x00793208 */
 static void multi_dimension_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -11764,7 +11764,7 @@ static void multi_dimension_rc_track_diag_right_bank(
 
 /** rct2: 0x007932D8 */
 static void multi_dimension_rc_track_left_flyer_twist_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11883,7 +11883,7 @@ static void multi_dimension_rc_track_left_flyer_twist_up(
 
 /** rct2: 0x007932E8 */
 static void multi_dimension_rc_track_right_flyer_twist_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12002,7 +12002,7 @@ static void multi_dimension_rc_track_right_flyer_twist_up(
 
 /** rct2: 0x007932F8 */
 static void multi_dimension_rc_track_left_flyer_twist_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12121,7 +12121,7 @@ static void multi_dimension_rc_track_left_flyer_twist_down(
 
 /** rct2: 0x00793308 */
 static void multi_dimension_rc_track_right_flyer_twist_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12240,7 +12240,7 @@ static void multi_dimension_rc_track_right_flyer_twist_down(
 
 /** rct2: 0x00793398 */
 static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12439,7 +12439,7 @@ static void multi_dimension_rc_track_multidim_inverted_flat_to_90_deg_quarter_lo
 
 /** rct2: 0x00793318 */
 static void multi_dimension_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();
@@ -12489,7 +12489,7 @@ static void multi_dimension_rc_track_block_brakes(
 
 /** rct2: 0x00793388 */
 static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12684,7 +12684,7 @@ static void multi_dimension_rc_track_multidim_90_deg_up_to_inverted_flat_quarter
 
 /** rct2: 0x00793398 */
 static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())
@@ -12883,7 +12883,7 @@ static void multi_dimension_rc_track_multidim_flat_to_90_deg_down_quarter_loop(
 
 /** rct2: 0x00793388 */
 static void multi_dimension_rc_track_multidim_inverted_90_deg_up_to_flat_quarter_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (!trackElement.IsInverted())

--- a/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
@@ -196,7 +196,7 @@ static constexpr const uint32_t reverse_freefall_rc_track_pieces_vertical_suppor
 };
 
 static void paint_reverse_freefall_rc_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction & 1)
@@ -218,7 +218,7 @@ static void paint_reverse_freefall_rc_flat(
 }
 
 static void paint_reverse_freefall_rc_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -257,7 +257,7 @@ static void paint_reverse_freefall_rc_station(
 }
 
 static void paint_reverse_freefall_rc_slope(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const int8_t bbHeights03[] = { 1, 6, 14, 37, 64 };
@@ -358,7 +358,7 @@ static void paint_reverse_freefall_rc_slope(
 }
 
 static void paint_reverse_freefall_rc_vertical(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId supportsImageId, trackImageId;
@@ -391,7 +391,7 @@ static void paint_reverse_freefall_rc_vertical(
 }
 
 static void paint_reverse_freefall_rc_onride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -27,7 +27,7 @@
  *  rct2: 0x006D4453
  */
 void vehicle_visual_reverser(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry)
 {
     Vehicle* v1 = GetEntity<Vehicle>(vehicle->prev_vehicle_on_ride);
@@ -47,7 +47,7 @@ void vehicle_visual_reverser(
 
 /** rct2: 0x0086E65C */
 static void reverser_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -96,7 +96,7 @@ static void reverser_rc_track_flat(
 }
 
 static void reverser_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -121,7 +121,7 @@ static void reverser_rc_track_station(
 
 /** rct2: 0x0086E66C */
 static void reverser_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -198,7 +198,7 @@ static void reverser_rc_track_25_deg_up(
 
 /** rct2: 0x0086E67C */
 static void reverser_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -275,7 +275,7 @@ static void reverser_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x0086E68C */
 static void reverser_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -352,7 +352,7 @@ static void reverser_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0086E69C */
 static void reverser_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     reverser_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -360,7 +360,7 @@ static void reverser_rc_track_25_deg_down(
 
 /** rct2: 0x0086E6AC */
 static void reverser_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     reverser_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -368,7 +368,7 @@ static void reverser_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x0086E6BC */
 static void reverser_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     reverser_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -376,7 +376,7 @@ static void reverser_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x0086E6CC */
 static void reverser_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -575,7 +575,7 @@ static void reverser_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x0086E6DC */
 static void reverser_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -584,7 +584,7 @@ static void reverser_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x0086E6EC */
 static void reverser_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -737,7 +737,7 @@ static void reverser_rc_track_s_bend_left(
 
 /** rct2: 0x0086E6FC */
 static void reverser_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -890,7 +890,7 @@ static void reverser_rc_track_s_bend_right(
 
 /** rct2: 0x0086E73C */
 static void reverser_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1006,7 +1006,7 @@ static void reverser_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x0086E74C */
 static void reverser_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1015,7 +1015,7 @@ static void reverser_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x0086E75C */
 static void reverser_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1042,7 +1042,7 @@ static void reverser_rc_track_brakes(
 
 /** rct2: 0x0086E76C */
 static void reverser_rc_track_left_reverser(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1251,7 +1251,7 @@ static void reverser_rc_track_left_reverser(
 
 /** rct2: 0x0086E77C */
 static void reverser_rc_track_right_reverser(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SideFrictionRollerCoaster.cpp
@@ -67,7 +67,7 @@ constexpr int32_t SPR_SIDE_FRICTION_DIAG_60_DEG_UP_TO_25_DEG_UP_DIR_3_A = 21879;
 
 /** rct2: 0x0077839C */
 static void side_friction_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -145,7 +145,7 @@ static void side_friction_rc_track_flat(
 
 /** rct2: 0x007784AC, 0x007784BC, 0x007784CC */
 static void side_friction_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -167,7 +167,7 @@ static void side_friction_rc_track_station(
 
 /** rct2: 0x007783AC */
 static void side_friction_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -268,7 +268,7 @@ static void side_friction_rc_track_25_deg_up(
 
 /** rct2: 0x007783CC */
 static void side_friction_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -369,7 +369,7 @@ static void side_friction_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x007783FC */
 static void side_friction_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -470,7 +470,7 @@ static void side_friction_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x0077840C */
 static void side_friction_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -478,7 +478,7 @@ static void side_friction_rc_track_25_deg_down(
 
 /** rct2: 0x0077842C */
 static void side_friction_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -486,7 +486,7 @@ static void side_friction_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x0077845C */
 static void side_friction_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -494,7 +494,7 @@ static void side_friction_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x0077846C */
 static void side_friction_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -753,7 +753,7 @@ static void side_friction_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x0077847C */
 static void side_friction_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -762,7 +762,7 @@ static void side_friction_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x0077848C */
 static void side_friction_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -963,7 +963,7 @@ static void side_friction_rc_track_s_bend_left(
 
 /** rct2: 0x0077849C */
 static void side_friction_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1164,7 +1164,7 @@ static void side_friction_rc_track_s_bend_right(
 
 /** rct2: 0x007784DC */
 static void side_friction_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1316,7 +1316,7 @@ static void side_friction_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x007784EC */
 static void side_friction_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1325,7 +1325,7 @@ static void side_friction_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x007784FC */
 static void side_friction_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1358,7 +1358,7 @@ static void side_friction_rc_track_brakes(
 
 /** rct2: 0x007785DC */
 static void side_friction_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1559,7 +1559,7 @@ static void side_friction_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x007785EC */
 static void side_friction_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1760,7 +1760,7 @@ static void side_friction_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x007785FC */
 static void side_friction_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1769,7 +1769,7 @@ static void side_friction_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x0077860C */
 static void side_friction_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1778,7 +1778,7 @@ static void side_friction_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x0077850C */
 static void side_friction_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1944,7 +1944,7 @@ static void side_friction_rc_track_diag_flat(
 
 /** rct2: 0x0077853C */
 static void side_friction_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2110,7 +2110,7 @@ static void side_friction_rc_track_diag_25_deg_up(
 
 /** rct2: 0x0077851C */
 static void side_friction_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2276,7 +2276,7 @@ static void side_friction_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x0077852C */
 static void side_friction_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2442,7 +2442,7 @@ static void side_friction_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x0077859C */
 static void side_friction_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2608,7 +2608,7 @@ static void side_friction_rc_track_diag_25_deg_down(
 
 /** rct2: 0x0077857C */
 static void side_friction_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2769,7 +2769,7 @@ static void side_friction_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x0077858C */
 static void side_friction_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2934,7 +2934,7 @@ static void side_friction_rc_track_diag_25_deg_down_to_flat(
 }
 
 static void side_friction_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -2993,14 +2993,14 @@ static void side_friction_rc_track_60_deg_up(
 }
 
 static void side_friction_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void side_friction_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3064,14 +3064,14 @@ static void side_friction_rc_track_25_deg_up_to_60_deg_up(
 }
 
 static void side_friction_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void side_friction_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -3135,14 +3135,14 @@ static void side_friction_rc_track_60_deg_up_to_25_deg_up(
 }
 
 static void side_friction_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void side_friction_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3233,14 +3233,14 @@ static void side_friction_rc_track_diag_60_deg_up(
 }
 
 static void side_friction_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_diag_60_deg_up(session, ride, 3 - trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3329,7 +3329,7 @@ static void side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
 }
 
 static void side_friction_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_diag_60_deg_up_to_25_deg_up(
@@ -3337,7 +3337,7 @@ static void side_friction_rc_track_diag_25_deg_down_to_60_deg_down(
 };
 
 static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3424,7 +3424,7 @@ static void side_friction_rc_track_diag_25_deg_up_to_60_deg_up(
 }
 
 static void side_friction_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     side_friction_rc_track_diag_25_deg_up_to_60_deg_up(

--- a/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/SingleRailRollerCoaster.cpp
@@ -27,7 +27,7 @@
 namespace SingleRailRC
 {
     static void TrackFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -93,7 +93,7 @@ namespace SingleRailRC
     }
 
     static void TrackStation(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         static constexpr const uint32_t imageIds[4][3] = {
@@ -126,7 +126,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -209,7 +209,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -290,7 +290,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -371,7 +371,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpTo60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -466,7 +466,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegUpTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -561,7 +561,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -642,49 +642,49 @@ namespace SingleRailRC
     }
 
     static void Track25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownTo60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDownTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpTo60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -728,14 +728,14 @@ namespace SingleRailRC
     }
 
     static void Track90DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegUpTo90DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -788,14 +788,14 @@ namespace SingleRailRC
     }
 
     static void Track90DegDownTo60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpTo90DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegUpTo60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -836,7 +836,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegDownTo90DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -883,7 +883,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1006,7 +1006,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1014,7 +1014,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1210,7 +1210,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1218,7 +1218,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftEighthToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1380,7 +1380,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightEighthToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1542,7 +1542,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftEighthToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1550,7 +1550,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightEighthToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1558,7 +1558,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1711,7 +1711,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -1868,7 +1868,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2025,7 +2025,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2182,7 +2182,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2339,7 +2339,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2494,7 +2494,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2651,7 +2651,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2808,7 +2808,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpTo60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -2965,7 +2965,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegUpTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3122,7 +3122,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3279,7 +3279,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownTo60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3436,7 +3436,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegDownTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -3593,7 +3593,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3642,7 +3642,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3691,21 +3691,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3761,7 +3761,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3817,7 +3817,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3873,7 +3873,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3929,35 +3929,35 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToRightBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBankTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -3998,14 +3998,14 @@ namespace SingleRailRC
     }
 
     static void TrackRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackDiagFlatToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4093,7 +4093,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4181,7 +4181,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBankToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4269,7 +4269,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBankToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4357,7 +4357,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4445,7 +4445,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBankTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4533,7 +4533,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4621,7 +4621,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegUpToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4709,7 +4709,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4795,7 +4795,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBankTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4881,7 +4881,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -4969,7 +4969,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag25DegDownToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5057,7 +5057,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5140,7 +5140,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5223,7 +5223,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Bank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5354,7 +5354,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Bank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -5362,7 +5362,7 @@ namespace SingleRailRC
     }
 
     static void TrackBankedLeftQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5566,7 +5566,7 @@ namespace SingleRailRC
     }
 
     static void TrackBankedRightQuarterTurn5(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -5574,7 +5574,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftEighthBankToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5736,7 +5736,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightEighthBankToDiag(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -5898,7 +5898,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftEighthBankToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5906,7 +5906,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightEighthBankToOrthogonal(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5914,7 +5914,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6008,7 +6008,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6109,7 +6109,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -6117,7 +6117,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -6125,7 +6125,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn525DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6321,7 +6321,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn525DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6517,7 +6517,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn525DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -6525,7 +6525,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn525DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -6533,7 +6533,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn160DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6585,7 +6585,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn160DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6637,21 +6637,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn160DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightQuarterTurn160DegUp(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightQuarterTurn160DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftQuarterTurn160DegUp(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
     }
 
     static void TrackLeftQuarterTurn190DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6703,7 +6703,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn190DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -6755,21 +6755,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn190DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightQuarterTurn190DegUp(session, ride, trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightQuarterTurn190DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftQuarterTurn190DegUp(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
     }
 
     static void Track25DegUpToLeftBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6821,7 +6821,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpToRightBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6873,7 +6873,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegUpTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6925,7 +6925,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBanked25DegUpTo25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -6977,35 +6977,35 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegDownTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownTo25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToLeftBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownToRightBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7053,7 +7053,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedFlatToRightBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7101,7 +7101,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegUpToLeftBankedFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7149,7 +7149,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBanked25DegUpToRightBankedFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7197,35 +7197,35 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedFlatToLeftBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpToRightBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBankedFlatToRightBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpToLeftBankedFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBanked25DegDownToLeftBankedFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBankedFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownToRightBankedFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBankedFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegUpLeftBanked(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7273,7 +7273,7 @@ namespace SingleRailRC
     }
 
     static void Track25DegUpRightBanked(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7321,21 +7321,21 @@ namespace SingleRailRC
     }
 
     static void Track25DegDownLeftBanked(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpRightBanked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track25DegDownRightBanked(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track25DegUpLeftBanked(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatToLeftBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7387,7 +7387,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToRightBanked25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7439,7 +7439,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBanked25DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7491,7 +7491,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBanked25DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -7543,35 +7543,35 @@ namespace SingleRailRC
     }
 
     static void TrackFlatToLeftBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackFlatToRightBanked25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBanked25DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBanked25DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToRightBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBanked25DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatToLeftBanked25DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7673,7 +7673,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -7782,7 +7782,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedQuarterTurn3Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7790,7 +7790,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedQuarterTurn3Tile25DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -7798,7 +7798,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedQuarterTurn525DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8014,7 +8014,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedQuarterTurn525DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8230,7 +8230,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBankedQuarterTurn525DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8238,7 +8238,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankedQuarterTurn525DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -8246,7 +8246,7 @@ namespace SingleRailRC
     }
 
     static void TrackSBendLeft(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8412,7 +8412,7 @@ namespace SingleRailRC
     }
 
     static void TrackSBendRight(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8578,7 +8578,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixUpSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -8835,7 +8835,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightHalfBankedHelixUpSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9092,7 +9092,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixDownSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 4)
@@ -9105,7 +9105,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightHalfBankedHelixDownSmall(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 4)
@@ -9118,7 +9118,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixUpLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9520,7 +9520,7 @@ namespace SingleRailRC
         }
     }
     static void TrackRightHalfBankedHelixUpLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -9937,7 +9937,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftHalfBankedHelixDownLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 7)
@@ -9950,7 +9950,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightHalfBankedHelixDownLarge(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackSequence >= 7)
@@ -9963,7 +9963,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBarrelRollUpToDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10142,7 +10142,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBarrelRollUpToDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10321,21 +10321,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftBarrelRollDownToUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightBarrelRollDownToUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightBarrelRollUpToDown(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackHalfLoopUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10491,14 +10491,14 @@ namespace SingleRailRC
     }
 
     static void TrackHalfLoopDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackHalfLoopUp(session, ride, 3 - trackSequence, direction, height, trackElement);
     }
 
     static void TrackBrakes(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -10527,7 +10527,7 @@ namespace SingleRailRC
     }
 
     static void TrackOnRidePhoto(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -10576,7 +10576,7 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo60DegUpLongBase(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10745,7 +10745,7 @@ namespace SingleRailRC
         }
     }
     static void Track60DegUpToFlatLongBase(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -10915,21 +10915,21 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo60DegDownLongBase(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpToFlatLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDownToFlatLongBase(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo60DegUpLongBase(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackBlockBrakes(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (direction)
@@ -10960,7 +10960,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftCorkscrewUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11086,7 +11086,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightCorkscrewUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11210,21 +11210,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftCorkscrewDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightCorkscrewUp(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightCorkscrewDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftCorkscrewUp(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
     }
 
     static void TrackLeftLargeCorkscrewUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11440,7 +11440,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightLargeCorkscrewUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11655,14 +11655,14 @@ namespace SingleRailRC
     }
 
     static void TrackLeftLargeCorkscrewDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightLargeCorkscrewUp(session, ride, 5 - trackSequence, (direction + 1) & 3, height, trackElement);
     }
 
     static void TrackRightLargeCorkscrewDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftLargeCorkscrewUp(session, ride, 5 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -11685,7 +11685,7 @@ namespace SingleRailRC
     // 8756
 
     static void TrackLeftMediumHalfLoopUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -11882,7 +11882,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightMediumHalfLoopUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -12079,21 +12079,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftMediumHalfLoopDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightMediumHalfLoopUp(session, ride, 4 - trackSequence, direction, height, trackElement);
     }
 
     static void TrackRightMediumHalfLoopDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftMediumHalfLoopUp(session, ride, 4 - trackSequence, direction, height, trackElement);
     }
 
     static void TrackLeftZeroGRollUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -12244,7 +12244,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightZeroGRollUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -12394,21 +12394,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftZeroGRollDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftZeroGRollUp(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightZeroGRollDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightZeroGRollUp(session, ride, 2 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackLeftLargeZeroGRollUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -12589,7 +12589,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightLargeZeroGRollUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -12771,21 +12771,21 @@ namespace SingleRailRC
     }
 
     static void TrackLeftLargeZeroGRollDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftLargeZeroGRollUp(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackRightLargeZeroGRollDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightLargeZeroGRollUp(session, ride, 3 - trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track90DegToInvertedFlatQuarterLoopUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -12894,14 +12894,14 @@ namespace SingleRailRC
     }
 
     static void TrackInvertedFlatTo90DegQuarterLoopDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track90DegToInvertedFlatQuarterLoopUp(session, ride, 2 - trackSequence, direction, height, trackElement);
     }
 
     static void TrackLeftBankToLeftQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -13000,7 +13000,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightBankToRightQuarterTurn3Tile25DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -13099,7 +13099,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftQuarterTurn3Tile25DegDownToLeftBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -13198,7 +13198,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightQuarterTurn3Tile25DegDownToRightBank(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -13297,7 +13297,7 @@ namespace SingleRailRC
     }
 
     static void TrackLeftLargeHalfLoopUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -13567,7 +13567,7 @@ namespace SingleRailRC
     }
 
     static void TrackRightLargeHalfLoopUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -13837,21 +13837,21 @@ namespace SingleRailRC
     }
 
     static void TrackRightLargeHalfLoopDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackRightLargeHalfLoopUp(session, ride, 6 - trackSequence, direction, height, trackElement);
     }
 
     static void TrackLeftLargeHalfLoopDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackLeftLargeHalfLoopUp(session, ride, 6 - trackSequence, direction, height, trackElement);
     }
 
     static void TrackFlatTo60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -13960,7 +13960,7 @@ namespace SingleRailRC
     }
 
     static void Track60DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         if (trackElement.HasChain())
@@ -14055,21 +14055,21 @@ namespace SingleRailRC
     }
 
     static void TrackFlatTo60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         Track60DegUpToFlat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void Track60DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         TrackFlatTo60DegUp(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
     }
 
     static void TrackDiagFlatTo60DegUp(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -14230,7 +14230,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegUpToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -14391,7 +14391,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiagFlatTo60DegDown(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)
@@ -14552,7 +14552,7 @@ namespace SingleRailRC
     }
 
     static void TrackDiag60DegDownToFlat(
-        paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+        PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
         const TrackElement& trackElement)
     {
         switch (trackSequence)

--- a/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/StandUpRollerCoaster.cpp
@@ -32,7 +32,7 @@ static constexpr const uint32_t _StandUpBlockBrakeImages[NumOrthogonalDirections
 
 /** rct2: 0x008A7114 */
 static void stand_up_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -89,7 +89,7 @@ static void stand_up_rc_track_flat(
 
 /** rct2: 0x008A7384, 0x008A7394, 0x008A73A4 */
 static void stand_up_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -124,7 +124,7 @@ static void stand_up_rc_track_station(
 
 /** rct2: 0x008A7124 */
 static void stand_up_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -194,7 +194,7 @@ static void stand_up_rc_track_25_deg_up(
 
 /** rct2: 0x008A7134 */
 static void stand_up_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -268,7 +268,7 @@ static void stand_up_rc_track_60_deg_up(
 
 /** rct2: 0x008A7144 */
 static void stand_up_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -338,7 +338,7 @@ static void stand_up_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A7154 */
 static void stand_up_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -424,7 +424,7 @@ static void stand_up_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A7164 */
 static void stand_up_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -510,7 +510,7 @@ static void stand_up_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7174 */
 static void stand_up_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -580,7 +580,7 @@ static void stand_up_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A7184 */
 static void stand_up_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -588,7 +588,7 @@ static void stand_up_rc_track_25_deg_down(
 
 /** rct2: 0x008A7194 */
 static void stand_up_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -596,7 +596,7 @@ static void stand_up_rc_track_60_deg_down(
 
 /** rct2: 0x008A71A4 */
 static void stand_up_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -604,7 +604,7 @@ static void stand_up_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A71B4 */
 static void stand_up_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -612,7 +612,7 @@ static void stand_up_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A71C4 */
 static void stand_up_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -620,7 +620,7 @@ static void stand_up_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A71D4 */
 static void stand_up_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -628,7 +628,7 @@ static void stand_up_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A71E4 */
 static void stand_up_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -803,7 +803,7 @@ static void stand_up_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A71F4 */
 static void stand_up_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -812,7 +812,7 @@ static void stand_up_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A7204 */
 static void stand_up_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -846,7 +846,7 @@ static void stand_up_rc_track_flat_to_left_bank(
 
 /** rct2: 0x008A7214 */
 static void stand_up_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -880,7 +880,7 @@ static void stand_up_rc_track_flat_to_right_bank(
 
 /** rct2: 0x008A7224 */
 static void stand_up_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -914,7 +914,7 @@ static void stand_up_rc_track_left_bank_to_flat(
 
 /** rct2: 0x008A7234 */
 static void stand_up_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -948,7 +948,7 @@ static void stand_up_rc_track_right_bank_to_flat(
 
 /** rct2: 0x008A7244 */
 static void stand_up_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1129,7 +1129,7 @@ static void stand_up_rc_track_banked_left_quarter_turn_5(
 
 /** rct2: 0x008A7254 */
 static void stand_up_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1138,7 +1138,7 @@ static void stand_up_rc_track_banked_right_quarter_turn_5(
 
 /** rct2: 0x008A7264 */
 static void stand_up_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1179,7 +1179,7 @@ static void stand_up_rc_track_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A7274 */
 static void stand_up_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1220,7 +1220,7 @@ static void stand_up_rc_track_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A7284 */
 static void stand_up_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1261,7 +1261,7 @@ static void stand_up_rc_track_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A7294 */
 static void stand_up_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1302,7 +1302,7 @@ static void stand_up_rc_track_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A72A4 */
 static void stand_up_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_25_deg_up_to_right_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1310,7 +1310,7 @@ static void stand_up_rc_track_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A72B4 */
 static void stand_up_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_25_deg_up_to_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1318,7 +1318,7 @@ static void stand_up_rc_track_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A72C4 */
 static void stand_up_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_right_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1326,7 +1326,7 @@ static void stand_up_rc_track_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A72D4 */
 static void stand_up_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_left_bank_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1334,7 +1334,7 @@ static void stand_up_rc_track_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A72E4 */
 static void stand_up_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1368,7 +1368,7 @@ static void stand_up_rc_track_left_bank(
 
 /** rct2: 0x008A72F4 */
 static void stand_up_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_left_bank(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1376,7 +1376,7 @@ static void stand_up_rc_track_right_bank(
 
 /** rct2: 0x008A7304 */
 static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1698,7 +1698,7 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7314 */
 static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2020,7 +2020,7 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A7324 */
 static void stand_up_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2029,7 +2029,7 @@ static void stand_up_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A7334 */
 static void stand_up_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2038,7 +2038,7 @@ static void stand_up_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A7344 */
 static void stand_up_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2187,7 +2187,7 @@ static void stand_up_rc_track_s_bend_left(
 
 /** rct2: 0x008A7354 */
 static void stand_up_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2336,7 +2336,7 @@ static void stand_up_rc_track_s_bend_right(
 
 /** rct2: 0x008A7364 */
 static void stand_up_rc_track_left_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2619,7 +2619,7 @@ static void stand_up_rc_track_left_vertical_loop(
 
 /** rct2: 0x008A7374 */
 static void stand_up_rc_track_right_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2876,7 +2876,7 @@ static void stand_up_rc_track_right_vertical_loop(
 
 /** rct2: 0x008A73B4 */
 static void stand_up_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2988,7 +2988,7 @@ static void stand_up_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A73C4 */
 static void stand_up_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -2997,7 +2997,7 @@ static void stand_up_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A73D4 */
 static void stand_up_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3115,7 +3115,7 @@ static void stand_up_rc_track_left_quarter_turn_3_bank(
 
 /** rct2: 0x008A73E4 */
 static void stand_up_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3124,7 +3124,7 @@ static void stand_up_rc_track_right_quarter_turn_3_bank(
 
 /** rct2: 0x008A73F4 */
 static void stand_up_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3271,7 +3271,7 @@ static void stand_up_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7404 */
 static void stand_up_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3432,7 +3432,7 @@ static void stand_up_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A7414 */
 static void stand_up_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3441,7 +3441,7 @@ static void stand_up_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A7424 */
 static void stand_up_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -3450,7 +3450,7 @@ static void stand_up_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A7434 */
 static void stand_up_rc_track_half_loop_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3590,7 +3590,7 @@ static void stand_up_rc_track_half_loop_up(
 
 /** rct2: 0x008A7444 */
 static void stand_up_rc_track_half_loop_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_half_loop_up(session, ride, 3 - trackSequence, direction, height, trackElement);
@@ -3598,7 +3598,7 @@ static void stand_up_rc_track_half_loop_down(
 
 /** rct2: 0x008A7454 */
 static void stand_up_rc_track_left_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3709,7 +3709,7 @@ static void stand_up_rc_track_left_corkscrew_up(
 
 /** rct2: 0x008A7464 */
 static void stand_up_rc_track_right_corkscrew_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3821,7 +3821,7 @@ static void stand_up_rc_track_right_corkscrew_up(
 
 /** rct2: 0x008A7474 */
 static void stand_up_rc_track_left_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_right_corkscrew_up(session, ride, 2 - trackSequence, (direction + 1) & 3, height, trackElement);
@@ -3829,7 +3829,7 @@ static void stand_up_rc_track_left_corkscrew_down(
 
 /** rct2: 0x008A7484 */
 static void stand_up_rc_track_right_corkscrew_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     stand_up_rc_track_left_corkscrew_up(session, ride, 2 - trackSequence, (direction - 1) & 3, height, trackElement);
@@ -3837,7 +3837,7 @@ static void stand_up_rc_track_right_corkscrew_down(
 
 /** rct2: 0x008A7734 */
 static void stand_up_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4067,7 +4067,7 @@ static void stand_up_rc_track_left_half_banked_helix_up_small(
 
 /** rct2: 0x008A7744 */
 static void stand_up_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4297,7 +4297,7 @@ static void stand_up_rc_track_right_half_banked_helix_up_small(
 
 /** rct2: 0x008A7754 */
 static void stand_up_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -4311,7 +4311,7 @@ static void stand_up_rc_track_left_half_banked_helix_down_small(
 
 /** rct2: 0x008A7764 */
 static void stand_up_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -4325,7 +4325,7 @@ static void stand_up_rc_track_right_half_banked_helix_down_small(
 
 /** rct2: 0x008A76F4 */
 static void stand_up_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4681,7 +4681,7 @@ static void stand_up_rc_track_left_half_banked_helix_up_large(
 
 /** rct2: 0x008A7704 */
 static void stand_up_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5037,7 +5037,7 @@ static void stand_up_rc_track_right_half_banked_helix_up_large(
 
 /** rct2: 0x008A7714 */
 static void stand_up_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -5051,7 +5051,7 @@ static void stand_up_rc_track_left_half_banked_helix_down_large(
 
 /** rct2: 0x008A7724 */
 static void stand_up_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -5065,7 +5065,7 @@ static void stand_up_rc_track_right_half_banked_helix_down_large(
 
 /** rct2: 0x008A7494 */
 static void stand_up_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5093,7 +5093,7 @@ static void stand_up_rc_track_brakes(
 
 /** rct2: 0x008A74A4 */
 static void stand_up_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -5143,7 +5143,7 @@ static void stand_up_rc_track_on_ride_photo(
 
 /** rct2: 0x008A74B4 */
 static void stand_up_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5288,7 +5288,7 @@ static void stand_up_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A74C4 */
 static void stand_up_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5433,7 +5433,7 @@ static void stand_up_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A74D4 */
 static void stand_up_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5442,7 +5442,7 @@ static void stand_up_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A74E4 */
 static void stand_up_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5451,7 +5451,7 @@ static void stand_up_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A76A4 */
 static void stand_up_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5596,7 +5596,7 @@ static void stand_up_rc_track_left_eighth_bank_to_diag(
 
 /** rct2: 0x008A76B4 */
 static void stand_up_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5741,7 +5741,7 @@ static void stand_up_rc_track_right_eighth_bank_to_diag(
 
 /** rct2: 0x008A76C4 */
 static void stand_up_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5750,7 +5750,7 @@ static void stand_up_rc_track_left_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A76D4 */
 static void stand_up_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -5759,7 +5759,7 @@ static void stand_up_rc_track_right_eighth_bank_to_orthogonal(
 
 /** rct2: 0x008A74F4 */
 static void stand_up_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5905,7 +5905,7 @@ static void stand_up_rc_track_diag_flat(
 
 /** rct2: 0x008A7524 */
 static void stand_up_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6051,7 +6051,7 @@ static void stand_up_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A7584 */
 static void stand_up_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6197,7 +6197,7 @@ static void stand_up_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A7504 */
 static void stand_up_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6343,7 +6343,7 @@ static void stand_up_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A7564 */
 static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6489,7 +6489,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A7574 */
 static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6635,7 +6635,7 @@ static void stand_up_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A7514 */
 static void stand_up_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6781,7 +6781,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A7554 */
 static void stand_up_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6927,7 +6927,7 @@ static void stand_up_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A75B4 */
 static void stand_up_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7073,7 +7073,7 @@ static void stand_up_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A7534 */
 static void stand_up_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7217,7 +7217,7 @@ static void stand_up_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A7594 */
 static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7363,7 +7363,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A75A4 */
 static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7509,7 +7509,7 @@ static void stand_up_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A7544 */
 static void stand_up_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7655,7 +7655,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A75E4 */
 static void stand_up_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7734,7 +7734,7 @@ static void stand_up_rc_track_diag_flat_to_left_bank(
 
 /** rct2: 0x008A75F4 */
 static void stand_up_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7813,7 +7813,7 @@ static void stand_up_rc_track_diag_flat_to_right_bank(
 
 /** rct2: 0x008A7604 */
 static void stand_up_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7892,7 +7892,7 @@ static void stand_up_rc_track_diag_left_bank_to_flat(
 
 /** rct2: 0x008A7614 */
 static void stand_up_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7971,7 +7971,7 @@ static void stand_up_rc_track_diag_right_bank_to_flat(
 
 /** rct2: 0x008A7644 */
 static void stand_up_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8050,7 +8050,7 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_up(
 
 /** rct2: 0x008A7654 */
 static void stand_up_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8129,7 +8129,7 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_up(
 
 /** rct2: 0x008A7624 */
 static void stand_up_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8208,7 +8208,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_left_bank(
 
 /** rct2: 0x008A7634 */
 static void stand_up_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8287,7 +8287,7 @@ static void stand_up_rc_track_diag_25_deg_up_to_right_bank(
 
 /** rct2: 0x008A7664 */
 static void stand_up_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8364,7 +8364,7 @@ static void stand_up_rc_track_diag_left_bank_to_25_deg_down(
 
 /** rct2: 0x008A7674 */
 static void stand_up_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8441,7 +8441,7 @@ static void stand_up_rc_track_diag_right_bank_to_25_deg_down(
 
 /** rct2: 0x008A7684 */
 static void stand_up_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8520,7 +8520,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_left_bank(
 
 /** rct2: 0x008A7694 */
 static void stand_up_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8599,7 +8599,7 @@ static void stand_up_rc_track_diag_25_deg_down_to_right_bank(
 
 /** rct2: 0x008A75C4 */
 static void stand_up_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8675,7 +8675,7 @@ static void stand_up_rc_track_diag_left_bank(
 
 /** rct2: 0x008A75D4 */
 static void stand_up_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8751,7 +8751,7 @@ static void stand_up_rc_track_diag_right_bank(
 
 /** rct2: 0x008A76E4 */
 static void stand_up_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008A59A8 */
 static void steeplechase_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -68,7 +68,7 @@ static void steeplechase_track_flat(
 }
 
 static void steeplechase_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -93,7 +93,7 @@ static void steeplechase_track_station(
 
 /** rct2: 0x008A59B8 */
 static void steeplechase_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -167,7 +167,7 @@ static void steeplechase_track_25_deg_up(
 
 /** rct2: 0x008A59C8 */
 static void steeplechase_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -241,7 +241,7 @@ static void steeplechase_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A59D8 */
 static void steeplechase_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -315,7 +315,7 @@ static void steeplechase_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A59E8 */
 static void steeplechase_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     steeplechase_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -323,7 +323,7 @@ static void steeplechase_track_25_deg_down(
 
 /** rct2: 0x008A59F8 */
 static void steeplechase_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     steeplechase_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -331,7 +331,7 @@ static void steeplechase_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A5A08 */
 static void steeplechase_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     steeplechase_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -339,7 +339,7 @@ static void steeplechase_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A5A18 */
 static void steeplechase_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -528,7 +528,7 @@ static void steeplechase_track_left_quarter_turn_5(
 
 /** rct2: 0x008A5A28 */
 static void steeplechase_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -537,7 +537,7 @@ static void steeplechase_track_right_quarter_turn_5(
 
 /** rct2: 0x008A5A38 */
 static void steeplechase_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -700,7 +700,7 @@ static void steeplechase_track_s_bend_left(
 
 /** rct2: 0x008A5A48 */
 static void steeplechase_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -863,7 +863,7 @@ static void steeplechase_track_s_bend_right(
 
 /** rct2: 0x008A5A88 */
 static void steeplechase_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -989,7 +989,7 @@ static void steeplechase_track_left_quarter_turn_3(
 
 /** rct2: 0x008A5A98 */
 static void steeplechase_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -998,7 +998,7 @@ static void steeplechase_track_right_quarter_turn_3(
 
 /** rct2: 0x008A5AA8 */
 static void steeplechase_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1024,7 +1024,7 @@ static void steeplechase_track_brakes(
 
 /** rct2: 0x008A5AD8 */
 static void steeplechase_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1176,7 +1176,7 @@ static void steeplechase_track_left_eighth_to_diag(
 
 /** rct2: 0x008A5AE8 */
 static void steeplechase_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1328,7 +1328,7 @@ static void steeplechase_track_right_eighth_to_diag(
 
 /** rct2: 0x008A5AF8 */
 static void steeplechase_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1337,7 +1337,7 @@ static void steeplechase_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A5B08 */
 static void steeplechase_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1346,7 +1346,7 @@ static void steeplechase_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A5AC8 */
 static void steeplechase_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1492,7 +1492,7 @@ static void steeplechase_track_diag_flat(
 
 /** rct2: 0x008A5B38 */
 static void steeplechase_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1638,7 +1638,7 @@ static void steeplechase_track_diag_25_deg_up(
 
 /** rct2: 0x008A5B18 */
 static void steeplechase_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1784,7 +1784,7 @@ static void steeplechase_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A5B28 */
 static void steeplechase_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1930,7 +1930,7 @@ static void steeplechase_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A5B68 */
 static void steeplechase_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2076,7 +2076,7 @@ static void steeplechase_track_diag_25_deg_down(
 
 /** rct2: 0x008A5B48 */
 static void steeplechase_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2220,7 +2220,7 @@ static void steeplechase_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A5B58 */
 static void steeplechase_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2366,7 +2366,7 @@ static void steeplechase_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A5AB8 */
 static void steeplechase_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
@@ -20,7 +20,7 @@
 
 /** rct2: 0x008A8958 */
 static void suspended_swinging_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -73,7 +73,7 @@ static void suspended_swinging_rc_track_flat(
 
 /** rct2: 0x008A8AA8, 0x008A8AB8, 0x008A8AC8 */
 static void suspended_swinging_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -101,7 +101,7 @@ static void suspended_swinging_rc_track_station(
 
 /** rct2: 0x008A8968 */
 static void suspended_swinging_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -195,7 +195,7 @@ static void suspended_swinging_rc_track_25_deg_up(
 
 /** rct2: 0x008A8978 */
 static void suspended_swinging_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -236,7 +236,7 @@ static void suspended_swinging_rc_track_60_deg_up(
 
 /** rct2: 0x008A8988 */
 static void suspended_swinging_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -330,7 +330,7 @@ static void suspended_swinging_rc_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A8998 */
 static void suspended_swinging_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -377,7 +377,7 @@ static void suspended_swinging_rc_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A89A8 */
 static void suspended_swinging_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -483,7 +483,7 @@ static void suspended_swinging_rc_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A89B8 */
 static void suspended_swinging_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackElement.HasChain())
@@ -577,7 +577,7 @@ static void suspended_swinging_rc_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A89C8 */
 static void suspended_swinging_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -585,7 +585,7 @@ static void suspended_swinging_rc_track_25_deg_down(
 
 /** rct2: 0x008A89D8 */
 static void suspended_swinging_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -593,7 +593,7 @@ static void suspended_swinging_rc_track_60_deg_down(
 
 /** rct2: 0x008A89E8 */
 static void suspended_swinging_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -601,7 +601,7 @@ static void suspended_swinging_rc_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A89F8 */
 static void suspended_swinging_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -609,7 +609,7 @@ static void suspended_swinging_rc_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A8A08 */
 static void suspended_swinging_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -617,7 +617,7 @@ static void suspended_swinging_rc_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A8A18 */
 static void suspended_swinging_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_swinging_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -625,7 +625,7 @@ static void suspended_swinging_rc_track_25_deg_down_to_flat(
 
 /** rct2: 0x008A8A28 */
 static void suspended_swinging_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -806,7 +806,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_5(
 
 /** rct2: 0x008A8A38 */
 static void suspended_swinging_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -815,7 +815,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_5(
 
 /** rct2: 0x008A8A48 */
 static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -996,7 +996,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A8A58 */
 static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1177,7 +1177,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_up(
 
 /** rct2: 0x008A8A68 */
 static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1187,7 +1187,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A8A78 */
 static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1197,7 +1197,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_5_25_deg_down(
 
 /** rct2: 0x008A8A88 */
 static void suspended_swinging_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1368,7 +1368,7 @@ static void suspended_swinging_rc_track_s_bend_left(
 
 /** rct2: 0x008A8A98 */
 static void suspended_swinging_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1539,7 +1539,7 @@ static void suspended_swinging_rc_track_s_bend_right(
 
 /** rct2: 0x008A8AD8 */
 static void suspended_swinging_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1657,7 +1657,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_3(
 
 /** rct2: 0x008A8AE8 */
 static void suspended_swinging_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1666,7 +1666,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_3(
 
 /** rct2: 0x008A8AF8 */
 static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1759,7 +1759,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A8B08 */
 static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1852,7 +1852,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x008A8B18 */
 static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1862,7 +1862,7 @@ static void suspended_swinging_rc_track_left_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A8B28 */
 static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1872,7 +1872,7 @@ static void suspended_swinging_rc_track_right_quarter_turn_3_25_deg_down(
 
 /** rct2: 0x008A8B38 */
 static void suspended_swinging_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1904,7 +1904,7 @@ static void suspended_swinging_rc_track_brakes(
 
 /** rct2: 0x008A8B48 */
 static void suspended_swinging_rc_track_left_quarter_helix_large_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2085,7 +2085,7 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_up(
 
 /** rct2: 0x008A8B58 */
 static void suspended_swinging_rc_track_right_quarter_helix_large_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2266,7 +2266,7 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_up(
 
 /** rct2: 0x008A8B68 */
 static void suspended_swinging_rc_track_left_quarter_helix_large_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2447,7 +2447,7 @@ static void suspended_swinging_rc_track_left_quarter_helix_large_down(
 
 /** rct2: 0x008A8B78 */
 static void suspended_swinging_rc_track_right_quarter_helix_large_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2628,7 +2628,7 @@ static void suspended_swinging_rc_track_right_quarter_helix_large_down(
 
 /** rct2: 0x008A8B88 */
 static void suspended_swinging_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2789,7 +2789,7 @@ static void suspended_swinging_rc_track_left_eighth_to_diag(
 
 /** rct2: 0x008A8B98 */
 static void suspended_swinging_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2950,7 +2950,7 @@ static void suspended_swinging_rc_track_right_eighth_to_diag(
 
 /** rct2: 0x008A8BA8 */
 static void suspended_swinging_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -2959,7 +2959,7 @@ static void suspended_swinging_rc_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008A8BB8 */
 static void suspended_swinging_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -2968,7 +2968,7 @@ static void suspended_swinging_rc_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008A8BC8 */
 static void suspended_swinging_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3107,7 +3107,7 @@ static void suspended_swinging_rc_track_diag_flat(
 
 /** rct2: 0x008A8BF8 */
 static void suspended_swinging_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3246,7 +3246,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up(
 
 /** rct2: 0x008A8C58 */
 static void suspended_swinging_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3329,7 +3329,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up(
 
 /** rct2: 0x008A8BD8 */
 static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3468,7 +3468,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008A8C38 */
 static void suspended_swinging_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3551,7 +3551,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x008A8C48 */
 static void suspended_swinging_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3634,7 +3634,7 @@ static void suspended_swinging_rc_track_diag_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x008A8BE8 */
 static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3773,7 +3773,7 @@ static void suspended_swinging_rc_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008A8C28 */
 static void suspended_swinging_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3912,7 +3912,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down(
 
 /** rct2: 0x008A8C88 */
 static void suspended_swinging_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3974,7 +3974,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down(
 
 /** rct2: 0x008A8C08 */
 static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4110,7 +4110,7 @@ static void suspended_swinging_rc_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008A8C68 */
 static void suspended_swinging_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4193,7 +4193,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A8C78 */
 static void suspended_swinging_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4276,7 +4276,7 @@ static void suspended_swinging_rc_track_diag_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A8C18 */
 static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4415,7 +4415,7 @@ static void suspended_swinging_rc_track_diag_25_deg_down_to_flat(
 
 /** rct2: 0x008A8B38 */
 static void suspended_swinging_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)

--- a/src/openrct2/ride/coaster/VirginiaReel.cpp
+++ b/src/openrct2/ride/coaster/VirginiaReel.cpp
@@ -164,7 +164,7 @@ static constexpr const uint32_t virginia_reel_track_pieces_flat_quarter_turn_1_t
  *  rct2: 0x006D5B48
  */
 void vehicle_visual_virginia_reel(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry)
 {
     imageDirection = OpenRCT2::Entity::Yaw::YawTo32(imageDirection);
@@ -223,7 +223,7 @@ void vehicle_visual_virginia_reel(
 
 /** rct2: 0x00811264 */
 static void paint_virginia_reel_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_flat;
@@ -252,7 +252,7 @@ static void paint_virginia_reel_track_flat(
 
 /** rct2: 0x00811274 */
 static void paint_virginia_reel_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_25_deg_up;
@@ -262,7 +262,7 @@ static void paint_virginia_reel_track_25_deg_up(
     }
 
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction]);
-    paint_struct* ps;
+    PaintStruct* ps;
 
     if (direction & 1)
     {
@@ -304,7 +304,7 @@ static void paint_virginia_reel_track_25_deg_up(
 
 /** rct2: 0x00811294 */
 static void paint_virginia_reel_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_flat_to_25_deg_up;
@@ -314,7 +314,7 @@ static void paint_virginia_reel_track_flat_to_25_deg_up(
     }
 
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction]);
-    paint_struct* ps;
+    PaintStruct* ps;
     switch (direction)
     {
         case 0:
@@ -351,7 +351,7 @@ static void paint_virginia_reel_track_flat_to_25_deg_up(
 
 /** rct2: 0x00811294 */
 static void paint_virginia_reel_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const uint32_t* sprites = virginia_reel_track_pieces_25_deg_up_to_flat;
@@ -361,7 +361,7 @@ static void paint_virginia_reel_track_25_deg_up_to_flat(
     }
 
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction]);
-    paint_struct* ps;
+    PaintStruct* ps;
 
     if (direction & 1)
     {
@@ -403,7 +403,7 @@ static void paint_virginia_reel_track_25_deg_up_to_flat(
 
 /** rct2: 0x008112A4 */
 static void paint_virginia_reel_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_virginia_reel_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -411,7 +411,7 @@ static void paint_virginia_reel_track_25_deg_down(
 
 /** rct2: 0x008112B4 */
 static void paint_virginia_reel_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_virginia_reel_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -419,7 +419,7 @@ static void paint_virginia_reel_track_flat_to_25_deg_down(
 
 /** rct2: 0x008112C4 */
 static void paint_virginia_reel_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_virginia_reel_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -427,7 +427,7 @@ static void paint_virginia_reel_track_25_deg_down_to_flat(
 
 /** rct2: 0x008112D4, 0x008112E4, 0x008112F4 */
 static void paint_virginia_reel_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -469,7 +469,7 @@ static constexpr const uint8_t virginia_reel_left_quarter_turn_supports[] = {
 
 /** rct2: 0x00811304 */
 static void paint_virginia_reel_track_left_quarter_turn_3_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -503,7 +503,7 @@ static constexpr const uint8_t virginia_reel_right_quarter_turn_3_tiles_to_left_
 
 /** rct2: 0x00811314 */
 static void paint_virginia_reel_track_right_quarter_turn_3_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = virginia_reel_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
@@ -513,7 +513,7 @@ static void paint_virginia_reel_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x00811324 */
 static void paint_virginia_reel_track_left_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
@@ -546,7 +546,7 @@ static void paint_virginia_reel_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x00811334 */
 static void paint_virginia_reel_track_right_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_virginia_reel_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);

--- a/src/openrct2/ride/coaster/WildMouse.cpp
+++ b/src/openrct2/ride/coaster/WildMouse.cpp
@@ -165,7 +165,7 @@ static constexpr const uint32_t _wild_mouse_block_brakes_image_ids[NumOrthogonal
 
 /** rct2: 0x0078B1E4 */
 static void wild_mouse_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -189,7 +189,7 @@ static void wild_mouse_track_flat(
 }
 
 static void wild_mouse_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t baseImageIds[4] = {
@@ -226,7 +226,7 @@ static void wild_mouse_track_station(
 
 /** rct2: 0x0078B1F4 */
 static void wild_mouse_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -258,7 +258,7 @@ static void wild_mouse_track_25_deg_up(
 
 /** rct2: 0x0078B204 */
 static void wild_mouse_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -304,7 +304,7 @@ static void wild_mouse_track_60_deg_up(
 
 /** rct2: 0x0078B214 */
 static void wild_mouse_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -336,7 +336,7 @@ static void wild_mouse_track_flat_to_25_deg_up(
 
 /** rct2: 0x0078B224 */
 static void wild_mouse_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -383,7 +383,7 @@ static void wild_mouse_track_25_deg_up_to_60_deg_up(
 
 /** rct2: 0x0078B234 */
 static void wild_mouse_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -430,7 +430,7 @@ static void wild_mouse_track_60_deg_up_to_25_deg_up(
 
 /** rct2: 0x0078B244 */
 static void wild_mouse_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -462,7 +462,7 @@ static void wild_mouse_track_25_deg_up_to_flat(
 
 /** rct2: 0x0078B254 */
 static void wild_mouse_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -470,7 +470,7 @@ static void wild_mouse_track_25_deg_down(
 
 /** rct2: 0x0078B264 */
 static void wild_mouse_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -478,7 +478,7 @@ static void wild_mouse_track_60_deg_down(
 
 /** rct2: 0x0078B274 */
 static void wild_mouse_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -486,7 +486,7 @@ static void wild_mouse_track_flat_to_25_deg_down(
 
 /** rct2: 0x0078B284 */
 static void wild_mouse_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -494,7 +494,7 @@ static void wild_mouse_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x0078B294 */
 static void wild_mouse_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -502,17 +502,17 @@ static void wild_mouse_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x0078B2A4 */
 static void wild_mouse_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void wild_mouse_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    static constexpr const sprite_bb imageIds[4][3] = {
+    static constexpr const SpriteBb imageIds[4][3] = {
         {
             { SPR_WILD_MOUSE_QUARTER_TURN_3_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 3 } },
             { SPR_WILD_MOUSE_QUARTER_TURN_3_SW_SE_PART_1, { 0, 0, 0 }, { 16, 16, 0 }, { 16, 16, 3 } },
@@ -565,10 +565,10 @@ static void wild_mouse_track_right_quarter_turn_3(
 }
 
 static void wild_mouse_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    static constexpr const sprite_bb imageIds[4][2] = {
+    static constexpr const SpriteBb imageIds[4][2] = {
         {
             { SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_DOWN_SW_SE_PART_0, { 0, 6, 0 }, { 0, 0, 0 }, { 32, 20, 3 } },
             { SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_DOWN_SW_SE_PART_1, { 6, 0, 0 }, { 0, 0, 0 }, { 20, 32, 3 } },
@@ -591,7 +591,7 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_down(
     if (trackSequence == 0 || trackSequence == 3)
     {
         int32_t part = trackSequence == 0 ? 0 : 1;
-        const sprite_bb* sbb = &imageIds[direction][part];
+        const SpriteBb* sbb = &imageIds[direction][part];
         const auto& offset = sbb->offset;
         PaintAddImageAsParent(
             session, session.TrackColours[SCHEME_TRACK].WithIndex(sbb->sprite_id), { offset.x, offset.y, height + offset.z },
@@ -624,7 +624,7 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_down(
 }
 
 static void wild_mouse_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -633,10 +633,10 @@ static void wild_mouse_track_left_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0078B314 */
 static void wild_mouse_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    static constexpr const sprite_bb imageIds[4][2] = {
+    static constexpr const SpriteBb imageIds[4][2] = {
         {
             { SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_UP_SW_SE_PART_0, { 0, 6, 0 }, { 0, 0, 0 }, { 32, 20, 3 } },
             { SPR_WILD_MOUSE_QUARTER_TURN_3_25_DEG_UP_SW_SE_PART_1, { 6, 0, 0 }, { 0, 0, 0 }, { 20, 32, 3 } },
@@ -659,7 +659,7 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_up(
     if (trackSequence == 0 || trackSequence == 3)
     {
         int32_t part = trackSequence == 0 ? 0 : 1;
-        const sprite_bb* sbb = &imageIds[direction][part];
+        const SpriteBb* sbb = &imageIds[direction][part];
         PaintAddImageAsParent(
             session, session.TrackColours[SCHEME_TRACK].WithIndex(sbb->sprite_id),
             { sbb->offset.x, sbb->offset.y, height + sbb->offset.z }, sbb->bb_size);
@@ -700,7 +700,7 @@ static void wild_mouse_track_right_quarter_turn_3_25_deg_up(
 
 /** rct2: 0x0078B324 */
 static void wild_mouse_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -708,7 +708,7 @@ static void wild_mouse_track_left_quarter_turn_3_25_deg_down(
 }
 
 static void wild_mouse_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -717,7 +717,7 @@ static void wild_mouse_track_left_quarter_turn_3(
 
 /** rct2: 0x0078B394 */
 static void wild_mouse_track_left_quarter_turn_1(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -752,7 +752,7 @@ static void wild_mouse_track_left_quarter_turn_1(
 
 /** rct2: 0x0078B3A4 */
 static void wild_mouse_track_right_quarter_turn_1(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_left_quarter_turn_1(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -760,7 +760,7 @@ static void wild_mouse_track_right_quarter_turn_1(
 
 /** rct2: 0x0078B354 */
 static void wild_mouse_track_flat_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -807,7 +807,7 @@ static void wild_mouse_track_flat_to_60_deg_up(
 
 /** rct2: 0x0078B364 */
 static void wild_mouse_track_60_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -861,7 +861,7 @@ static void wild_mouse_track_60_deg_up_to_flat(
 
 /** rct2: 0x0078B374 */
 static void wild_mouse_track_flat_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_60_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -869,7 +869,7 @@ static void wild_mouse_track_flat_to_60_deg_down(
 
 /** rct2: 0x0078B384 */
 static void wild_mouse_track_60_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wild_mouse_track_flat_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -877,7 +877,7 @@ static void wild_mouse_track_60_deg_down_to_flat(
 
 /** rct2: 0x0078B344 */
 static void wild_mouse_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(_wild_mouse_brakes_image_ids[direction]);
@@ -894,7 +894,7 @@ static void wild_mouse_track_brakes(
 
 /** rct2: 0x0078B3C4 */
 static void wild_mouse_track_rotation_control_toggle(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -918,7 +918,7 @@ static void wild_mouse_track_rotation_control_toggle(
 
 /** rct2: 0x0078B3B4 */
 static void wild_mouse_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isClosed = trackElement.BlockBrakeClosed();

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -448,7 +448,7 @@ static constexpr const uint32_t _wooden_rc_station_block_brakes_image_ids[4][2] 
     { SPR_G2_WOODEN_RC_STATION_BLOCK_BRAKE_OPEN_NW_SE, SPR_G2_WOODEN_RC_STATION_BLOCK_BRAKE_CLOSED_NW_SE },
 };
 
-ImageId wooden_rc_get_rails_colour(paint_session& session)
+ImageId wooden_rc_get_rails_colour(PaintSession& session)
 {
     return session.TrackColours[SCHEME_TRACK];
 }
@@ -456,7 +456,7 @@ ImageId wooden_rc_get_rails_colour(paint_session& session)
 /** rct2: 0x008AC568 */
 template<bool isClassic>
 static void wooden_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -484,7 +484,7 @@ static void wooden_rc_track_flat(
 
 template<bool isClassic>
 static void wooden_rc_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t stationImageIds[4][2] = {
@@ -517,7 +517,7 @@ static void wooden_rc_track_station(
 /** rct2: 0x008AC578 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][4] = {
@@ -603,7 +603,7 @@ static void wooden_rc_track_25_deg_up(
 /** rct2: 0x008AC588 */
 template<bool isClassic>
 static void wooden_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -641,7 +641,7 @@ static void wooden_rc_track_60_deg_up(
 /** rct2: 0x008AC598 */
 template<bool isClassic>
 static void wooden_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][4] = {
@@ -727,7 +727,7 @@ static void wooden_rc_track_flat_to_25_deg_up(
 /** rct2: 0x008AC5A8 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -787,7 +787,7 @@ static void wooden_rc_track_25_deg_up_to_60_deg_up(
 /** rct2: 0x008AC5B8 */
 template<bool isClassic>
 static void wooden_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -847,7 +847,7 @@ static void wooden_rc_track_60_deg_up_to_25_deg_up(
 /** rct2: 0x008AC5C8 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][4] = {
@@ -933,7 +933,7 @@ static void wooden_rc_track_25_deg_up_to_flat(
 /** rct2: 0x008AC5D8 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -942,7 +942,7 @@ static void wooden_rc_track_25_deg_down(
 /** rct2: 0x008AC5E8 */
 template<bool isClassic>
 static void wooden_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_60_deg_up<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -951,7 +951,7 @@ static void wooden_rc_track_60_deg_down(
 /** rct2: 0x008AC5F8 */
 template<bool isClassic>
 static void wooden_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_flat<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -960,7 +960,7 @@ static void wooden_rc_track_flat_to_25_deg_down(
 /** rct2: 0x008AC608 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_60_deg_up_to_25_deg_up<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -969,7 +969,7 @@ static void wooden_rc_track_25_deg_down_to_60_deg_down(
 /** rct2: 0x008AC618 */
 template<bool isClassic>
 static void wooden_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_60_deg_up<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -978,7 +978,7 @@ static void wooden_rc_track_60_deg_down_to_25_deg_down(
 /** rct2: 0x008AC628 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_flat_to_25_deg_up<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -986,7 +986,7 @@ static void wooden_rc_track_25_deg_down_to_flat(
 
 template<bool isClassic>
 static void wooden_rc_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[2][4][7] = {
@@ -1369,7 +1369,7 @@ static void wooden_rc_track_right_quarter_turn_5(
 
 template<bool isClassic>
 static void wooden_rc_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1379,7 +1379,7 @@ static void wooden_rc_track_left_quarter_turn_5(
 /** rct2: 0x008AC658 */
 template<bool isClassic>
 static void wooden_rc_track_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1425,7 +1425,7 @@ static void wooden_rc_track_flat_to_left_bank(
 /** rct2: 0x008AC668 */
 template<bool isClassic>
 static void wooden_rc_track_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1471,7 +1471,7 @@ static void wooden_rc_track_flat_to_right_bank(
 /** rct2: 0x008AC678 */
 template<bool isClassic>
 static void wooden_rc_track_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_flat_to_right_bank<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1480,7 +1480,7 @@ static void wooden_rc_track_left_bank_to_flat(
 /** rct2: 0x008AC688 */
 template<bool isClassic>
 static void wooden_rc_track_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_flat_to_left_bank<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -1488,7 +1488,7 @@ static void wooden_rc_track_right_bank_to_flat(
 
 template<bool isClassic>
 static void wooden_rc_track_banked_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const sprite_bb_2 imageIds[2][4][7] = {
@@ -1871,7 +1871,7 @@ static void wooden_rc_track_banked_right_quarter_turn_5(
 
 template<bool isClassic>
 static void wooden_rc_track_banked_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1882,7 +1882,7 @@ static void wooden_rc_track_banked_left_quarter_turn_5(
 /** rct2: 0x008AC6B8 */
 template<bool isClassic>
 static void wooden_rc_track_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1935,7 +1935,7 @@ static void wooden_rc_track_left_bank_to_25_deg_up(
 /** rct2: 0x008AC6C8 */
 template<bool isClassic>
 static void wooden_rc_track_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -1988,7 +1988,7 @@ static void wooden_rc_track_right_bank_to_25_deg_up(
 /** rct2: 0x008AC6D8 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -2041,7 +2041,7 @@ static void wooden_rc_track_25_deg_up_to_left_bank(
 /** rct2: 0x008AC6E8 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4] = {
@@ -2094,7 +2094,7 @@ static void wooden_rc_track_25_deg_up_to_right_bank(
 /** rct2: 0x008AC6F8 */
 template<bool isClassic>
 static void wooden_rc_track_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_right_bank<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2103,7 +2103,7 @@ static void wooden_rc_track_left_bank_to_25_deg_down(
 /** rct2: 0x008AC708 */
 template<bool isClassic>
 static void wooden_rc_track_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_left_bank<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2112,7 +2112,7 @@ static void wooden_rc_track_right_bank_to_25_deg_down(
 /** rct2: 0x008AC718 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_bank_to_25_deg_up<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2121,7 +2121,7 @@ static void wooden_rc_track_25_deg_down_to_left_bank(
 /** rct2: 0x008AC728 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_bank_to_25_deg_up<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2130,7 +2130,7 @@ static void wooden_rc_track_25_deg_down_to_right_bank(
 /** rct2: 0x008AC738 */
 template<bool isClassic>
 static void wooden_rc_track_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -2151,7 +2151,7 @@ static void wooden_rc_track_left_bank(
 /** rct2: 0x008AC748 */
 template<bool isClassic>
 static void wooden_rc_track_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_bank<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -2160,7 +2160,7 @@ static void wooden_rc_track_right_bank(
 /** rct2: 0x008AC758 */
 template<bool isClassic>
 static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2486,7 +2486,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
 /** rct2: 0x008AC768 */
 template<bool isClassic>
 static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -2812,7 +2812,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
 /** rct2: 0x008AC778 */
 template<bool isClassic>
 static void wooden_rc_track_left_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2823,7 +2823,7 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_down(
 /** rct2: 0x008AC788 */
 template<bool isClassic>
 static void wooden_rc_track_right_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -2834,7 +2834,7 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_down(
 /** rct2: 0x008AC798 */
 template<bool isClassic>
 static void wooden_rc_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3084,7 +3084,7 @@ static void wooden_rc_track_s_bend_left(
 /** rct2: 0x008AC7A8 */
 template<bool isClassic>
 static void wooden_rc_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3334,7 +3334,7 @@ static void wooden_rc_track_s_bend_right(
 /** rct2: 0x008ACE18 */
 template<bool isClassic>
 static void wooden_rc_track_left_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3618,7 +3618,7 @@ static void wooden_rc_track_left_vertical_loop(
 /** rct2: 0x008ACE28 */
 template<bool isClassic>
 static void wooden_rc_track_right_vertical_loop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -3876,7 +3876,7 @@ static void wooden_rc_track_right_vertical_loop(
 /** rct2: 0x008AC7E8 */
 template<bool isClassic>
 static void wooden_rc_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4065,7 +4065,7 @@ static void wooden_rc_track_left_quarter_turn_3(
 /** rct2: 0x008AC7F8 */
 template<bool isClassic>
 static void wooden_rc_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4075,7 +4075,7 @@ static void wooden_rc_track_right_quarter_turn_3(
 /** rct2: 0x008AC808 */
 template<bool isClassic>
 static void wooden_rc_track_left_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4282,7 +4282,7 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
 /** rct2: 0x008AC818 */
 template<bool isClassic>
 static void wooden_rc_track_right_quarter_turn_3_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4293,7 +4293,7 @@ static void wooden_rc_track_right_quarter_turn_3_bank(
 /** rct2: 0x008AC828 */
 template<bool isClassic>
 static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4441,7 +4441,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
 /** rct2: 0x008AC838 */
 template<bool isClassic>
 static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -4589,7 +4589,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
 /** rct2: 0x008AC848 */
 template<bool isClassic>
 static void wooden_rc_track_left_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4600,7 +4600,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down(
 /** rct2: 0x008AC858 */
 template<bool isClassic>
 static void wooden_rc_track_right_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -4611,7 +4611,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down(
 /** rct2: 0x008ACAB8 */
 template<bool isClassic>
 static void wooden_rc_track_left_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5060,7 +5060,7 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
 /** rct2: 0x008ACAC8 */
 template<bool isClassic>
 static void wooden_rc_track_right_half_banked_helix_up_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -5508,7 +5508,7 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
 /** rct2: 0x008ACAD8 */
 template<bool isClassic>
 static void wooden_rc_track_left_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -5524,7 +5524,7 @@ static void wooden_rc_track_left_half_banked_helix_down_small(
 /** rct2: 0x008ACAE8 */
 template<bool isClassic>
 static void wooden_rc_track_right_half_banked_helix_down_small(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 4)
@@ -5540,7 +5540,7 @@ static void wooden_rc_track_right_half_banked_helix_down_small(
 /** rct2: 0x008ACAF8 */
 template<bool isClassic>
 static void wooden_rc_track_left_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6181,7 +6181,7 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
 /** rct2: 0x008ACB08 */
 template<bool isClassic>
 static void wooden_rc_track_right_half_banked_helix_up_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -6822,7 +6822,7 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
 /** rct2: 0x008ACB18 */
 template<bool isClassic>
 static void wooden_rc_track_left_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6838,7 +6838,7 @@ static void wooden_rc_track_left_half_banked_helix_down_large(
 /** rct2: 0x008ACB28 */
 template<bool isClassic>
 static void wooden_rc_track_right_half_banked_helix_down_large(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence >= 7)
@@ -6854,7 +6854,7 @@ static void wooden_rc_track_right_half_banked_helix_down_large(
 /** rct2: 0x008ACB98 */
 template<bool isClassic>
 static void wooden_rc_track_left_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -6924,7 +6924,7 @@ static void wooden_rc_track_left_quarter_turn_1_60_deg_up(
 /** rct2: 0x008ACB78 */
 template<bool isClassic>
 static void wooden_rc_track_right_quarter_turn_1_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -6994,7 +6994,7 @@ static void wooden_rc_track_right_quarter_turn_1_60_deg_up(
 /** rct2: 0x008ACB88 */
 template<bool isClassic>
 static void wooden_rc_track_left_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_quarter_turn_1_60_deg_up<isClassic>(
@@ -7004,7 +7004,7 @@ static void wooden_rc_track_left_quarter_turn_1_60_deg_down(
 /** rct2: 0x008ACBA8 */
 template<bool isClassic>
 static void wooden_rc_track_right_quarter_turn_1_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_quarter_turn_1_60_deg_up<isClassic>(
@@ -7014,7 +7014,7 @@ static void wooden_rc_track_right_quarter_turn_1_60_deg_down(
 /** rct2: 0x008AC868 */
 template<bool isClassic>
 static void wooden_rc_track_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -7035,7 +7035,7 @@ static void wooden_rc_track_brakes(
 /** rct2: 0x008ACC78 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_up_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -7104,7 +7104,7 @@ static void wooden_rc_track_25_deg_up_left_banked(
 /** rct2: 0x008ACC88 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_up_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -7173,7 +7173,7 @@ static void wooden_rc_track_25_deg_up_right_banked(
 /** rct2: 0x008AC878 */
 template<bool isClassic>
 static void wooden_rc_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -7221,7 +7221,7 @@ static void wooden_rc_track_on_ride_photo(
 /** rct2: 0x008ACC98 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_down_left_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_right_banked<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -7230,7 +7230,7 @@ static void wooden_rc_track_25_deg_down_left_banked(
 /** rct2: 0x008ACCA8 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_down_right_banked(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_left_banked<isClassic>(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -7239,7 +7239,7 @@ static void wooden_rc_track_25_deg_down_right_banked(
 /** rct2: 0x008ACE08 */
 template<bool isClassic>
 static void wooden_rc_track_water_splash(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const bool transparent = gConfigGeneral.transparent_water || (session.ViewFlags & VIEWPORT_FLAG_UNDERGROUND_INSIDE);
@@ -7730,7 +7730,7 @@ static void wooden_rc_track_water_splash(
 /** rct2: 0x008AC958 */
 template<bool isClassic>
 static void wooden_rc_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -7980,7 +7980,7 @@ static void wooden_rc_track_left_eighth_to_diag(
 /** rct2: 0x008AC968 */
 template<bool isClassic>
 static void wooden_rc_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8230,7 +8230,7 @@ static void wooden_rc_track_right_eighth_to_diag(
 /** rct2: 0x008AC978 */
 template<bool isClassic>
 static void wooden_rc_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8240,7 +8240,7 @@ static void wooden_rc_track_left_eighth_to_orthogonal(
 /** rct2: 0x008AC988 */
 template<bool isClassic>
 static void wooden_rc_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8250,7 +8250,7 @@ static void wooden_rc_track_right_eighth_to_orthogonal(
 /** rct2: 0x008AC998 */
 template<bool isClassic>
 static void wooden_rc_track_left_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8500,7 +8500,7 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
 /** rct2: 0x008AC9A8 */
 template<bool isClassic>
 static void wooden_rc_track_right_eighth_bank_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8750,7 +8750,7 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
 /** rct2: 0x008AC9B8 */
 template<bool isClassic>
 static void wooden_rc_track_left_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8761,7 +8761,7 @@ static void wooden_rc_track_left_eighth_bank_to_orthogonal(
 /** rct2: 0x008AC9C8 */
 template<bool isClassic>
 static void wooden_rc_track_right_eighth_bank_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -8772,7 +8772,7 @@ static void wooden_rc_track_right_eighth_bank_to_orthogonal(
 /** rct2: 0x008AC888 */
 template<bool isClassic>
 static void wooden_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -8975,7 +8975,7 @@ static void wooden_rc_track_diag_flat(
 /** rct2: 0x008AC8B8 */
 template<bool isClassic>
 static void wooden_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9178,7 +9178,7 @@ static void wooden_rc_track_diag_25_deg_up(
 /** rct2: 0x008AC8E8 */
 template<bool isClassic>
 static void wooden_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9281,7 +9281,7 @@ static void wooden_rc_track_diag_60_deg_up(
 /** rct2: 0x008AC898 */
 template<bool isClassic>
 static void wooden_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9484,7 +9484,7 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
 /** rct2: 0x008AC8C8 */
 template<bool isClassic>
 static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9587,7 +9587,7 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
 /** rct2: 0x008AC8D8 */
 template<bool isClassic>
 static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9690,7 +9690,7 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
 /** rct2: 0x008AC8A8 */
 template<bool isClassic>
 static void wooden_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -9893,7 +9893,7 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
 /** rct2: 0x008AC918 */
 template<bool isClassic>
 static void wooden_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10096,7 +10096,7 @@ static void wooden_rc_track_diag_25_deg_down(
 /** rct2: 0x008AC948 */
 template<bool isClassic>
 static void wooden_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10199,7 +10199,7 @@ static void wooden_rc_track_diag_60_deg_down(
 /** rct2: 0x008AC8F8 */
 template<bool isClassic>
 static void wooden_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10397,7 +10397,7 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
 /** rct2: 0x008AC928 */
 template<bool isClassic>
 static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10500,7 +10500,7 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
 /** rct2: 0x008AC938 */
 template<bool isClassic>
 static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10603,7 +10603,7 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
 /** rct2: 0x008AC908 */
 template<bool isClassic>
 static void wooden_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10806,7 +10806,7 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
 /** rct2: 0x008ACA18 */
 template<bool isClassic>
 static void wooden_rc_track_diag_flat_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -10909,7 +10909,7 @@ static void wooden_rc_track_diag_flat_to_left_bank(
 /** rct2: 0x008AC9F8 */
 template<bool isClassic>
 static void wooden_rc_track_diag_flat_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11012,7 +11012,7 @@ static void wooden_rc_track_diag_flat_to_right_bank(
 /** rct2: 0x008ACA08 */
 template<bool isClassic>
 static void wooden_rc_track_diag_left_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11115,7 +11115,7 @@ static void wooden_rc_track_diag_left_bank_to_flat(
 /** rct2: 0x008ACA28 */
 template<bool isClassic>
 static void wooden_rc_track_diag_right_bank_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11218,7 +11218,7 @@ static void wooden_rc_track_diag_right_bank_to_flat(
 /** rct2: 0x008ACA58 */
 template<bool isClassic>
 static void wooden_rc_track_diag_left_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11321,7 +11321,7 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
 /** rct2: 0x008ACA68 */
 template<bool isClassic>
 static void wooden_rc_track_diag_right_bank_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11424,7 +11424,7 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
 /** rct2: 0x008ACA38 */
 template<bool isClassic>
 static void wooden_rc_track_diag_25_deg_up_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11527,7 +11527,7 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
 /** rct2: 0x008ACA48 */
 template<bool isClassic>
 static void wooden_rc_track_diag_25_deg_up_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11630,7 +11630,7 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
 /** rct2: 0x008ACA78 */
 template<bool isClassic>
 static void wooden_rc_track_diag_left_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11728,7 +11728,7 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
 /** rct2: 0x008ACA88 */
 template<bool isClassic>
 static void wooden_rc_track_diag_right_bank_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11826,7 +11826,7 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
 /** rct2: 0x008ACA98 */
 template<bool isClassic>
 static void wooden_rc_track_diag_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -11929,7 +11929,7 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
 /** rct2: 0x008ACAA8 */
 template<bool isClassic>
 static void wooden_rc_track_diag_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12032,7 +12032,7 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
 /** rct2: 0x008AC9D8 */
 template<bool isClassic>
 static void wooden_rc_track_diag_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12135,7 +12135,7 @@ static void wooden_rc_track_diag_left_bank(
 /** rct2: 0x008AC9E8 */
 template<bool isClassic>
 static void wooden_rc_track_diag_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12238,7 +12238,7 @@ static void wooden_rc_track_diag_right_bank(
 /** rct2: 0x008ACB38 */
 template<bool isClassic>
 static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12386,7 +12386,7 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
 /** rct2: 0x008ACB48 */
 template<bool isClassic>
 static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12534,7 +12534,7 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
 /** rct2: 0x008ACB58 */
 template<bool isClassic>
 static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12682,7 +12682,7 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
 /** rct2: 0x008ACB68 */
 template<bool isClassic>
 static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12830,7 +12830,7 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
 /** rct2: 0x008ACDF8 */
 template<bool isClassic>
 static void wooden_rc_track_block_brakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const auto brakeImg = trackElement.BlockBrakeClosed() ? _wooden_rc_block_brakes_image_ids[direction][1]
@@ -12846,7 +12846,7 @@ static void wooden_rc_track_block_brakes(
 /** rct2: 0x008ACCB8 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -12994,7 +12994,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
 /** rct2: 0x008ACCC8 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -13142,7 +13142,7 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
 /** rct2: 0x008ACCD8 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -13153,7 +13153,7 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_down(
 /** rct2: 0x008ACCE8 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -13164,7 +13164,7 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_down(
 /** rct2: 0x008ACC38 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -13490,7 +13490,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
 /** rct2: 0x008ACC48 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -13816,7 +13816,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
 /** rct2: 0x008ACC58 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -13827,7 +13827,7 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_down(
 /** rct2: 0x008ACC68 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -13838,7 +13838,7 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_down(
 /** rct2: 0x008ACCF8 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13895,7 +13895,7 @@ static void wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(
 /** rct2: 0x008ACD08 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -13952,7 +13952,7 @@ static void wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
 /** rct2: 0x008ACD18 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -14009,7 +14009,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(
 /** rct2: 0x008ACD28 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -14066,7 +14066,7 @@ static void wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
 /** rct2: 0x008ACD38 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_down_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_banked_25_deg_up_to_25_deg_up<isClassic>(
@@ -14076,7 +14076,7 @@ static void wooden_rc_track_25_deg_down_to_left_banked_25_deg_down(
 /** rct2: 0x008ACD48 */
 template<bool isClassic>
 static void wooden_rc_track_25_deg_down_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_banked_25_deg_up_to_25_deg_up<isClassic>(
@@ -14086,7 +14086,7 @@ static void wooden_rc_track_25_deg_down_to_right_banked_25_deg_down(
 /** rct2: 0x008ACD58 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_right_banked_25_deg_up<isClassic>(
@@ -14096,7 +14096,7 @@ static void wooden_rc_track_left_banked_25_deg_down_to_25_deg_down(
 /** rct2: 0x008ACD68 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_25_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_25_deg_up_to_left_banked_25_deg_up<isClassic>(
@@ -14106,7 +14106,7 @@ static void wooden_rc_track_right_banked_25_deg_down_to_25_deg_down(
 /** rct2: 0x008ACD78 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -14175,7 +14175,7 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
 /** rct2: 0x008ACD88 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -14244,7 +14244,7 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
 /** rct2: 0x008ACD98 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -14313,7 +14313,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
 /** rct2: 0x008ACDA8 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -14382,7 +14382,7 @@ static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
 /** rct2: 0x008ACDB8 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat<isClassic>(
@@ -14392,7 +14392,7 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_down(
 /** rct2: 0x008ACDC8 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat<isClassic>(
@@ -14402,7 +14402,7 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_down(
 /** rct2: 0x008ACDD8 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_25_deg_down_to_left_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up<isClassic>(
@@ -14412,7 +14412,7 @@ static void wooden_rc_track_left_banked_25_deg_down_to_left_banked_flat(
 /** rct2: 0x008ACDE8 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_25_deg_down_to_right_banked_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up<isClassic>(
@@ -14422,7 +14422,7 @@ static void wooden_rc_track_right_banked_25_deg_down_to_right_banked_flat(
 /** rct2: 0x008ACBB8 */
 template<bool isClassic>
 static void wooden_rc_track_flat_to_left_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -14491,7 +14491,7 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_up(
 /** rct2: 0x008ACBC8 */
 template<bool isClassic>
 static void wooden_rc_track_flat_to_right_banked_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -14560,7 +14560,7 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_up(
 /** rct2: 0x008ACBD8 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -14629,7 +14629,7 @@ static void wooden_rc_track_left_banked_25_deg_up_to_flat(
 /** rct2: 0x008ACBE8 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -14698,7 +14698,7 @@ static void wooden_rc_track_right_banked_25_deg_up_to_flat(
 /** rct2: 0x008ACBF8 */
 template<bool isClassic>
 static void wooden_rc_track_flat_to_left_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_right_banked_25_deg_up_to_flat<isClassic>(
@@ -14708,7 +14708,7 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_down(
 /** rct2: 0x008ACC08 */
 template<bool isClassic>
 static void wooden_rc_track_flat_to_right_banked_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_left_banked_25_deg_up_to_flat<isClassic>(
@@ -14718,7 +14718,7 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_down(
 /** rct2: 0x008ACC18 */
 template<bool isClassic>
 static void wooden_rc_track_left_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_flat_to_right_banked_25_deg_up<isClassic>(
@@ -14728,7 +14728,7 @@ static void wooden_rc_track_left_banked_25_deg_down_to_flat(
 /** rct2: 0x008ACC28 */
 template<bool isClassic>
 static void wooden_rc_track_right_banked_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_rc_track_flat_to_left_banked_25_deg_up<isClassic>(
@@ -14737,7 +14737,7 @@ static void wooden_rc_track_right_banked_25_deg_down_to_flat(
 
 template<bool isClassic>
 static void wooden_rc_track_booster(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.h
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.h
@@ -24,7 +24,7 @@ struct sprite_bb_2
     CoordsXYZ bb_size;
 };
 
-template<bool isClassic> ImageId wooden_rc_get_track_colour(const paint_session& session)
+template<bool isClassic> ImageId wooden_rc_get_track_colour(const PaintSession& session)
 {
     if (isClassic)
         return session.TrackColours[SCHEME_TRACK];
@@ -34,11 +34,11 @@ template<bool isClassic> ImageId wooden_rc_get_track_colour(const paint_session&
             : session.TrackColours[SCHEME_TRACK].WithPrimary(session.TrackColours[SCHEME_SUPPORTS].GetPrimary());
 }
 
-ImageId wooden_rc_get_rails_colour(paint_session& session);
+ImageId wooden_rc_get_rails_colour(PaintSession& session);
 
 template<bool isClassic>
-paint_struct* wooden_rc_track_paint(
-    paint_session& session, uint32_t imageIdTrack, uint32_t imageIdRails, uint8_t direction, int8_t x_offset, int8_t y_offset,
+PaintStruct* wooden_rc_track_paint(
+    PaintSession& session, uint32_t imageIdTrack, uint32_t imageIdRails, uint8_t direction, int8_t x_offset, int8_t y_offset,
     int16_t bound_box_length_x, int16_t bound_box_length_y, int8_t bound_box_length_z, int16_t z_offset,
     int16_t bound_box_offset_x, int16_t bound_box_offset_y, int16_t bound_box_offset_z)
 {
@@ -55,7 +55,7 @@ paint_struct* wooden_rc_track_paint(
         { bound_box_offset_x, bound_box_offset_y, bound_box_offset_z });
 }
 
-template<bool isClassic> void wooden_rc_track_paint_bb(paint_session& session, const sprite_bb_2* bb, int16_t height)
+template<bool isClassic> void wooden_rc_track_paint_bb(PaintSession& session, const sprite_bb_2* bb, int16_t height)
 {
     if (bb->sprite_id_a == 0)
         return;

--- a/src/openrct2/ride/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/ride/coaster/WoodenWildMouse.cpp
@@ -122,7 +122,7 @@ enum
 
 /** rct2: 0x008A5464 */
 static void wooden_wild_mouse_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -146,7 +146,7 @@ static void wooden_wild_mouse_track_flat(
 }
 
 static void wooden_wild_mouse_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -171,7 +171,7 @@ static void wooden_wild_mouse_track_station(
 
 /** rct2: 0x008A5474 */
 static void wooden_wild_mouse_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -210,7 +210,7 @@ static void wooden_wild_mouse_track_25_deg_up(
 
 /** rct2: 0x008A5484 */
 static void wooden_wild_mouse_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -257,7 +257,7 @@ static void wooden_wild_mouse_track_60_deg_up(
 
 /** rct2: 0x008A5494 */
 static void wooden_wild_mouse_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -296,7 +296,7 @@ static void wooden_wild_mouse_track_flat_to_25_deg_up(
 
 /** rct2: 0x008A54A4 */
 static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -346,7 +346,7 @@ static void wooden_wild_mouse_track_25_deg_up_to_60_deg_up(
 }
 
 static void wooden_wild_mouse_track_60_deg_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -397,7 +397,7 @@ static void wooden_wild_mouse_track_60_deg_to_25_deg_up(
 
 /** rct2: 0x008A54C4 */
 static void wooden_wild_mouse_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4] = {
@@ -436,7 +436,7 @@ static void wooden_wild_mouse_track_25_deg_up_to_flat(
 
 /** rct2: 0x008A54D4 */
 static void wooden_wild_mouse_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -444,7 +444,7 @@ static void wooden_wild_mouse_track_25_deg_down(
 
 /** rct2: 0x008A54E4 */
 static void wooden_wild_mouse_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -452,7 +452,7 @@ static void wooden_wild_mouse_track_60_deg_down(
 
 /** rct2: 0x008A54F4 */
 static void wooden_wild_mouse_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -460,7 +460,7 @@ static void wooden_wild_mouse_track_flat_to_25_deg_down(
 
 /** rct2: 0x008A5504 */
 static void wooden_wild_mouse_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_60_deg_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -468,7 +468,7 @@ static void wooden_wild_mouse_track_25_deg_down_to_60_deg_down(
 
 /** rct2: 0x008A5514 */
 static void wooden_wild_mouse_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -476,17 +476,17 @@ static void wooden_wild_mouse_track_60_deg_down_to_25_deg_down(
 
 /** rct2: 0x008A5524 */
 static void wooden_wild_mouse_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void wooden_wild_mouse_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    static constexpr const sprite_bb imageIds[4][3] = {
+    static constexpr const SpriteBb imageIds[4][3] = {
         {
             { SPR_WOODEN_WILD_MOUSE_QUARTER_TURN_3_SW_SE_PART_0, { 0, 6, 0 }, { 0, 0, 0 }, { 32, 20, 1 } },
             { SPR_WOODEN_WILD_MOUSE_QUARTER_TURN_3_SW_SE_PART_1, { 16, 16, 0 }, { 0, 0, 0 }, { 16, 16, 1 } },
@@ -540,7 +540,7 @@ static void wooden_wild_mouse_track_right_quarter_turn_3(
 }
 
 static void wooden_wild_mouse_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -548,7 +548,7 @@ static void wooden_wild_mouse_track_left_quarter_turn_3(
 }
 
 static void wooden_wild_mouse_track_left_quarter_turn_1(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4] = {
@@ -583,7 +583,7 @@ static void wooden_wild_mouse_track_left_quarter_turn_1(
 
 /** rct2: 0x008A55D4 */
 static void wooden_wild_mouse_track_right_quarter_turn_1(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_left_quarter_turn_1(session, ride, trackSequence, (direction - 1) & 3, height, trackElement);
@@ -591,7 +591,7 @@ static void wooden_wild_mouse_track_right_quarter_turn_1(
 
 /** rct2: 0x008A55E4 */
 static void wooden_wild_mouse_track_flat_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -641,7 +641,7 @@ static void wooden_wild_mouse_track_flat_to_60_deg_up(
 
 /** rct2: 0x008A55F4 */
 static void wooden_wild_mouse_track_60_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -691,7 +691,7 @@ static void wooden_wild_mouse_track_60_deg_up_to_flat(
 
 /** rct2: 0x008A5604 */
 static void wooden_wild_mouse_track_flat_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_60_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -699,7 +699,7 @@ static void wooden_wild_mouse_track_flat_to_60_deg_down(
 
 /** rct2: 0x008A5614 */
 static void wooden_wild_mouse_track_60_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     wooden_wild_mouse_track_flat_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);

--- a/src/openrct2/ride/gentle/CarRide.cpp
+++ b/src/openrct2/ride/gentle/CarRide.cpp
@@ -157,7 +157,7 @@ static constexpr const uint32_t CarRideTrackPiecesQuarterTurn3Tiles[4][3] = {
 
 /** rct2: 0x006F72C8 */
 static void PaintCarRideTrackFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(CarRideTrackPiecesFlat[direction]);
@@ -188,7 +188,7 @@ static void PaintCarRideTrackFlat(
 
 /** rct2: 0x006F72D8 */
 static void PaintCarRideTrack25DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(CarRideTrackPieces25DegUp[direction]);
@@ -226,7 +226,7 @@ static void PaintCarRideTrack25DegUp(
 
 /** rct2: 0x006F72E8 */
 static void PaintCarRideTrackFlatTo25DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(CarRideTrackPiecesFlatTo25DegUp[direction]);
@@ -264,7 +264,7 @@ static void PaintCarRideTrackFlatTo25DegUp(
 
 /** rct2: 0x006F72F8 */
 static void PaintCarRideTrack25DegUpToFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(CarRideTrackPieces25DegUpToFlat[direction]);
@@ -302,7 +302,7 @@ static void PaintCarRideTrack25DegUpToFlat(
 
 /** rct2: 0x006F7308 */
 static void PaintCarRideTrack25DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintCarRideTrack25DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -310,7 +310,7 @@ static void PaintCarRideTrack25DegDown(
 
 /** rct2: 0x006F7318 */
 static void PaintCarRideTrackFlatTo25DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintCarRideTrack25DegUpToFlat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -318,7 +318,7 @@ static void PaintCarRideTrackFlatTo25DegDown(
 
 /** rct2: 0x006F7328 */
 static void PaintCarRideTrack25DegDownToFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintCarRideTrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -326,7 +326,7 @@ static void PaintCarRideTrack25DegDownToFlat(
 
 /** rct2: 0x006F7338, 0x006F7348, 0x006F7358 */
 static void PaintCarRideStation(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -380,7 +380,7 @@ static void PaintCarRideStation(
 
 /** rct2: 0x006F7378 */
 static void PaintCarRideTrackRightQuarterTurn3Tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -416,7 +416,7 @@ static void PaintCarRideTrackRightQuarterTurn3Tiles(
 
 /** rct2: 0x006F7368 */
 static void PaintCarRideTrackLeftQuarterTurn3Tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -425,7 +425,7 @@ static void PaintCarRideTrackLeftQuarterTurn3Tiles(
 
 /** rct2: 0x006F7388 */
 static void PaintCarRideTrackLeftQuarterTurn1Tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(CarRideTrackPiecesLeftQuarterTurn1Tile[direction]);
@@ -456,7 +456,7 @@ static void PaintCarRideTrackLeftQuarterTurn1Tile(
 
 /** rct2: 0x006F7398 */
 static void PaintCarRideTrackRightQuarterTurn1Tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintCarRideTrackLeftQuarterTurn1Tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);
@@ -464,7 +464,7 @@ static void PaintCarRideTrackRightQuarterTurn1Tile(
 
 /** rct2: 0x006F73A8 */
 static void PaintCarRideTrackSpinningTunnel(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(CarRideTrackPiecesFlat[direction]);
@@ -497,7 +497,7 @@ static void PaintCarRideTrackSpinningTunnel(
 
 /** rct2: 0x006F73B8 */
 static void PaintCarRideTrack60DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(CarRideTrackPieces60DegUp[direction]);
@@ -546,7 +546,7 @@ static void PaintCarRideTrack60DegUp(
 
 /** rct2: 0x006F73C8 */
 static void PaintCarRideTrack25DegUpTo60DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(CarRideTrackPieces25DegUpTo60DegUp[direction][0]);
@@ -602,7 +602,7 @@ static void PaintCarRideTrack25DegUpTo60DegUp(
 
 /** rct2: 0x006F73D8 */
 static void PaintCarRideTrack60DegUpTo25DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(CarRideTrackPieces60DegUpTo25DegUp[direction][0]);
@@ -658,7 +658,7 @@ static void PaintCarRideTrack60DegUpTo25DegUp(
 
 /** rct2: 0x006F73E8 */
 static void PaintCarRideTrack60DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintCarRideTrack60DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -666,7 +666,7 @@ static void PaintCarRideTrack60DegDown(
 
 /** rct2: 0x006F73F8 */
 static void PaintCarRideTrack25DegDownTo60DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintCarRideTrack60DegUpTo25DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -674,7 +674,7 @@ static void PaintCarRideTrack25DegDownTo60DegDown(
 
 /** rct2: 0x006F7408 */
 static void PaintCarRideTrack60DegDownTo25DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintCarRideTrack25DegUpTo60DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -682,7 +682,7 @@ static void PaintCarRideTrack60DegDownTo25DegDown(
 
 /** rct2: 0x006F7418 */
 static void PaintCarRideTrackLogBumps(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(CarRideTrackPiecesLogBumps[direction]);

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -17,7 +17,7 @@
 #include "../Track.h"
 #include "../TrackPaint.h"
 
-static void PaintCircusTent(paint_session& session, const Ride& ride, uint8_t direction, int8_t al, int8_t cl, uint16_t height)
+static void PaintCircusTent(PaintSession& session, const Ride& ride, uint8_t direction, int8_t al, int8_t cl, uint16_t height)
 {
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -46,7 +46,7 @@ static void PaintCircusTent(paint_session& session, const Ride& ride, uint8_t di
 }
 
 static void PaintCircus(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];

--- a/src/openrct2/ride/gentle/CrookedHouse.cpp
+++ b/src/openrct2/ride/gentle/CrookedHouse.cpp
@@ -46,7 +46,7 @@ static constexpr const BoundBoxXY CrookedHouseData[] = {
  *  rct2: 0x0088ABA4
  */
 static void PaintCrookedHouseStructure(
-    paint_session& session, uint8_t direction, int32_t x_offset, int32_t y_offset, uint32_t segment, int32_t height)
+    PaintSession& session, uint8_t direction, int32_t x_offset, int32_t y_offset, uint32_t segment, int32_t height)
 {
     const auto* tileElement = session.CurrentlyDrawnTileElement;
     if (tileElement == nullptr)
@@ -81,7 +81,7 @@ static void PaintCrookedHouseStructure(
 }
 
 static void PaintCrookedHouse(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];

--- a/src/openrct2/ride/gentle/Dodgems.cpp
+++ b/src/openrct2/ride/gentle/Dodgems.cpp
@@ -34,7 +34,7 @@ static constexpr const uint32_t DodgemsFenceSprites[] = {
     SprDodgemsFenceTopLeft,
 };
 
-static void PaintDodgemsRoof(paint_session& session, int32_t height, int32_t offset)
+static void PaintDodgemsRoof(PaintSession& session, int32_t height, int32_t offset)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex((SprDodgemsRoofFrame + offset));
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { 32, 32, 2 });
@@ -44,7 +44,7 @@ static void PaintDodgemsRoof(paint_session& session, int32_t height, int32_t off
 }
 
 static void PaintDodgems(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_4x4[direction][trackSequence];

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -42,7 +42,7 @@ static constexpr BoundBoxXY FerrisWheelData[] = {
 };
 
 static void PaintFerrisWheelRiders(
-    paint_session& session, const rct_ride_entry& rideEntry, const Vehicle& vehicle, uint8_t direction, const CoordsXYZ offset,
+    PaintSession& session, const rct_ride_entry& rideEntry, const Vehicle& vehicle, uint8_t direction, const CoordsXYZ offset,
     const BoundBoxXYZ& bb)
 {
     for (int32_t i = 0; i < 32; i += 2)
@@ -59,7 +59,7 @@ static void PaintFerrisWheelRiders(
 }
 
 static void PaintFerrisWheelStructure(
-    paint_session& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
 {
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -102,7 +102,7 @@ static void PaintFerrisWheelStructure(
 }
 
 static void PaintFerrisWheel(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];

--- a/src/openrct2/ride/gentle/FlyingSaucers.cpp
+++ b/src/openrct2/ride/gentle/FlyingSaucers.cpp
@@ -35,7 +35,7 @@ static constexpr const uint32_t FlyingSaucersFenceSprites[] = {
  * rct2: 0x008873D8
  */
 static void paint_flying_saucers(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_4x4[direction][trackSequence];

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -177,7 +177,7 @@ static uint8_t GetTunnelDoorsImageStraightFlat(const TrackElement& trackElement,
 
 /** rct2: 0x00770BEC */
 static void PaintGhostTrainTrackFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(GhostTrainTrackPiecesFlat[direction]);
@@ -199,7 +199,7 @@ static void PaintGhostTrainTrackFlat(
 
 /** rct2: 0x00770BFC */
 static void PaintGhostTrainTrack25DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(GhostTrainTrackPieces25DegUp[direction][0]);
@@ -236,7 +236,7 @@ static void PaintGhostTrainTrack25DegUp(
 
 /** rct2: 0x00770C0C */
 static void PaintGhostTrainTrackFlatTo25DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isBackwards = trackElement.GetTrackType() == TrackElemType::Down25ToFlat;
@@ -283,7 +283,7 @@ static void PaintGhostTrainTrackFlatTo25DegUp(
 }
 
 static void PaintGhostTrainTrack25DegUpToFlatShared(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(GhostTrainTrackPieces25DegUpToFlat[direction][0]);
@@ -304,7 +304,7 @@ static void PaintGhostTrainTrack25DegUpToFlatShared(
 
 /** rct2: 0x00770C1C */
 static void PaintGhostTrainTrack25DegUpToFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintGhostTrainTrack25DegUpToFlatShared(session, ride, trackSequence, direction, height, trackElement);
@@ -328,7 +328,7 @@ static void PaintGhostTrainTrack25DegUpToFlat(
 
 /** rct2: 0x00770C2C */
 static void PaintGhostTrainTrack25DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintGhostTrainTrack25DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -336,7 +336,7 @@ static void PaintGhostTrainTrack25DegDown(
 
 /** rct2: 0x00770C3C */
 static void PaintGhostTrainTrackFlatTo25DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintGhostTrainTrack25DegUpToFlatShared(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -360,7 +360,7 @@ static void PaintGhostTrainTrackFlatTo25DegDown(
 
 /** rct2: 0x00770C4C */
 static void PaintGhostTrainTrack25DegDownToFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintGhostTrainTrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -368,7 +368,7 @@ static void PaintGhostTrainTrack25DegDownToFlat(
 
 /** rct2: 0x00770C5C, 0x00770C6C, 0x00770C7C */
 static void PaintGhostTrainStation(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -407,7 +407,7 @@ static void PaintGhostTrainStation(
 
 /** rct2: 0x00770C9C */
 static void PaintGhostTrainTrackRightQuarterTurn3Tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -448,7 +448,7 @@ static void PaintGhostTrainTrackRightQuarterTurn3Tiles(
 
 /** rct2: 0x00770CAC */
 static void PaintGhostTrainTrackLeftQuarterTurn3Tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -457,7 +457,7 @@ static void PaintGhostTrainTrackLeftQuarterTurn3Tiles(
 
 /** rct2: 0x00770CAC */
 static void PaintGhostTrainTrackLeftQuarterTurn1Tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isBackwards = trackElement.GetTrackType() == TrackElemType::RightQuarterTurn1Tile;
@@ -484,7 +484,7 @@ static void PaintGhostTrainTrackLeftQuarterTurn1Tile(
 
 /** rct2: 0x00770CBC */
 static void PaintGhostTrainTrackRightQuarterTurn1Tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintGhostTrainTrackLeftQuarterTurn1Tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);
@@ -492,7 +492,7 @@ static void PaintGhostTrainTrackRightQuarterTurn1Tile(
 
 /** rct2: 0x00770CCC */
 static void PaintGhostTrainTrackSpinningTunnel(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(ghost_train_track_pieces_spinning_tunnel_track[direction]);
@@ -512,7 +512,7 @@ static void PaintGhostTrainTrackSpinningTunnel(
 
 /** rct2: 0x00770CDC */
 static void PaintGhostTrainTrackBrakes(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(GhostTrainTrackPiecesBrakes[direction]);

--- a/src/openrct2/ride/gentle/HauntedHouse.cpp
+++ b/src/openrct2/ride/gentle/HauntedHouse.cpp
@@ -24,7 +24,7 @@ static constexpr BoundBoxXY HauntedHouseData[] = {
 };
 
 static void PaintHauntedHouseStructure(
-    paint_session& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint8_t part, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint8_t part, uint16_t height)
 {
     uint8_t frameNum = 0;
 
@@ -61,7 +61,7 @@ static void PaintHauntedHouseStructure(
 }
 
 static void PaintHauntedHouse(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];

--- a/src/openrct2/ride/gentle/Maze.cpp
+++ b/src/openrct2/ride/gentle/Maze.cpp
@@ -53,7 +53,7 @@ enum
  * rct: 0x004ACF4A
  */
 static void MazePaintSetup(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint16_t mazeEntry = trackElement.GetMazeEntry();

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -26,7 +26,7 @@ static constexpr const uint16_t MerryGoRoundBreakdownVibration[] = {
 };
 
 static void PaintRiders(
-    paint_session& session, const Ride& ride, const rct_ride_entry& rideEntry, const Vehicle& vehicle, int32_t rotationOffset,
+    PaintSession& session, const Ride& ride, const rct_ride_entry& rideEntry, const Vehicle& vehicle, int32_t rotationOffset,
     const CoordsXYZ& offset, const BoundBoxXYZ& bb)
 {
     if (session.DPI.zoom_level > ZoomLevel{ 0 })
@@ -51,7 +51,7 @@ static void PaintRiders(
 }
 
 static void PaintCarousel(
-    paint_session& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
 {
     height += 7;
 
@@ -99,7 +99,7 @@ static void PaintCarousel(
 }
 
 static void PaintMerryGoRound(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -443,8 +443,8 @@ const size_t MiniGolfPeepAnimationLengths[] = {
 };
 // clang-format on
 
-static paint_struct* MiniGolfPaintUtil7C(
-    paint_session& session, uint8_t direction, ImageId imageId, int8_t x_offset, int8_t yOffset, int16_t boundBoxLengthX,
+static PaintStruct* MiniGolfPaintUtil7C(
+    PaintSession& session, uint8_t direction, ImageId imageId, int8_t x_offset, int8_t yOffset, int16_t boundBoxLengthX,
     int16_t boundBoxLengthY, int8_t boundBoxLengthZ, int16_t zOffset, int16_t boundBoxOffsetX, int16_t boundBoxOffsetY,
     int16_t boundBoxOffsetZ, uint32_t rotation)
 {
@@ -460,7 +460,7 @@ static paint_struct* MiniGolfPaintUtil7C(
         { boundBoxOffsetX, boundBoxOffsetY, boundBoxOffsetZ });
 }
 
-static bool MiniGolfPaintUtilShouldDrawFence(paint_session& session, const TrackElement& trackElement)
+static bool MiniGolfPaintUtilShouldDrawFence(PaintSession& session, const TrackElement& trackElement)
 {
     if (!(session.Flags & PaintSessionFlags::PassedSurface))
     {
@@ -484,7 +484,7 @@ static bool MiniGolfPaintUtilShouldDrawFence(paint_session& session, const Track
 
 /** rct2: 0x0087F10C */
 static void PaintMiniGolfTrackFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -531,7 +531,7 @@ static void PaintMiniGolfTrackFlat(
 
 /** rct2: 0x0087F11C */
 static void PaintMiniGolfTrack25DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -570,7 +570,7 @@ static void PaintMiniGolfTrack25DegUp(
 
 /** rct2: 0x0087F12C */
 static void PaintMiniGolfTrackFlatTo25DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -609,7 +609,7 @@ static void PaintMiniGolfTrackFlatTo25DegUp(
 
 /** rct2: 0x0087F13C */
 static void PaintMiniGolfTrack25DegUpToFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -648,7 +648,7 @@ static void PaintMiniGolfTrack25DegUpToFlat(
 
 /** rct2: 0x0087F14C */
 static void PaintMiniGolfTrack25DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintMiniGolfTrack25DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -656,7 +656,7 @@ static void PaintMiniGolfTrack25DegDown(
 
 /** rct2: 0x0087F15C */
 static void PaintMiniGolfTrackFlatTo25DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintMiniGolfTrack25DegUpToFlat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -664,7 +664,7 @@ static void PaintMiniGolfTrackFlatTo25DegDown(
 
 /** rct2: 0x0087F16C */
 static void PaintMiniGolfTrack25DegDownToFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintMiniGolfTrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -672,7 +672,7 @@ static void PaintMiniGolfTrack25DegDownToFlat(
 
 /** rct2: 0x0087F17C, 0x0087F18C, 0x0087F19C */
 static void PaintMiniGolfStation(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const auto* stationObj = ride.GetStationObject();
@@ -734,7 +734,7 @@ static void PaintMiniGolfStation(
 
 /** rct2: 0x0087F1AC */
 static void PaintMiniGolfTrackLeftQuarterTurn1Tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -814,14 +814,14 @@ static void PaintMiniGolfTrackLeftQuarterTurn1Tile(
 
 /** rct2: 0x0087F1BC */
 static void PaintMiniGolfTrackRightQuarterTurn1Tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintMiniGolfTrackLeftQuarterTurn1Tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);
 }
 
 static void PaintMiniGolfHoleAb(
-    paint_session& session, uint8_t trackSequence, uint8_t direction, int32_t height, const uint32_t sprites[4][2][2])
+    PaintSession& session, uint8_t trackSequence, uint8_t direction, int32_t height, const uint32_t sprites[4][2][2])
 {
     ImageId imageId;
     CoordsXY boundBox, boundBoxOffset;
@@ -876,7 +876,7 @@ static void PaintMiniGolfHoleAb(
 
 /** rct2: 0x0087F1CC */
 static void PaintMiniGolfHoleA(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintMiniGolfHoleAb(session, trackSequence, direction, height, MiniGolfTrackSpritesHoleA);
@@ -884,7 +884,7 @@ static void PaintMiniGolfHoleA(
 
 /** rct2: 0x0087F1DC */
 static void PaintMiniGolfHoleB(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintMiniGolfHoleAb(session, trackSequence, direction, height, MiniGolfTrackSpritesHoleB);
@@ -892,7 +892,7 @@ static void PaintMiniGolfHoleB(
 
 /** rct2: 0x0087F1EC */
 static void PaintMiniGolfHoleC(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -963,7 +963,7 @@ static void PaintMiniGolfHoleC(
 
 /** rct2: 0x0087F1FC */
 static void PaintMiniGolfHoleD(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -1057,7 +1057,7 @@ static void PaintMiniGolfHoleD(
 
 /** rct2: 0x0087F1FC */
 static void PaintMiniGolfHoleE(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -1202,7 +1202,7 @@ TRACK_PAINT_FUNCTION GetTrackPaintFunctionMiniGolf(int32_t trackType)
  * rct2: 0x006D42F0
  */
 void vehicle_visual_mini_golf_player(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle)
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle)
 {
     if (vehicle->num_peeps == 0)
     {
@@ -1239,7 +1239,7 @@ void vehicle_visual_mini_golf_player(
  * rct2: 0x006D43C6
  */
 void VehicleVisualMiniGolfBall(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle)
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle)
 {
     if (vehicle->mini_golf_current_animation != MiniGolfAnimation::PlaceBallDown)
     {

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -18,7 +18,7 @@
 
 /** rct2: 0x */
 static void PaintMiniHelicoptersTrackStation(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -56,7 +56,7 @@ static void PaintMiniHelicoptersTrackStation(
 
 /** rct2: 0x0081F348 */
 static void PaintMiniHelicoptersTrackFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -88,7 +88,7 @@ static void PaintMiniHelicoptersTrackFlat(
 
 /** rct2: 0x0081F368 */
 static void PaintMiniHelicoptersTrackFlatTo25DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -133,7 +133,7 @@ static void PaintMiniHelicoptersTrackFlatTo25DegUp(
 
 /** rct2: 0x0081F358 */
 static void PaintMiniHelicoptersTrack25DegUp(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -174,7 +174,7 @@ static void PaintMiniHelicoptersTrack25DegUp(
 
 /** rct2: 0x0081F378 */
 static void PaintMiniHelicoptersTrack25DegUpToFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -219,7 +219,7 @@ static void PaintMiniHelicoptersTrack25DegUpToFlat(
 
 /** rct2: 0x */
 static void PaintMiniHelicoptersTrackFlatTo25DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintMiniHelicoptersTrack25DegUpToFlat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -227,7 +227,7 @@ static void PaintMiniHelicoptersTrackFlatTo25DegDown(
 
 /** rct2: 0x0081F388 */
 static void PaintMiniHelicoptersTrack25DegDown(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintMiniHelicoptersTrack25DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -235,7 +235,7 @@ static void PaintMiniHelicoptersTrack25DegDown(
 
 /** rct2: 0x0081F3A8 */
 static void PaintMiniHelicoptersTrack25DegDownToFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintMiniHelicoptersTrackFlatTo25DegUp(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -243,7 +243,7 @@ static void PaintMiniHelicoptersTrack25DegDownToFlat(
 
 /** rct2: 0x0081F3E8 */
 static void PaintMiniHelicoptersTrackLeftQuarterTurn3Tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -281,7 +281,7 @@ static constexpr const uint8_t MiniHelicoptersRightQuarterTurn3TilesToLeftTurnMa
 
 /** rct2: 0x0081F3F8 */
 static void PaintMiniHelicoptersTrackRightQuarterTurn3Tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = MiniHelicoptersRightQuarterTurn3TilesToLeftTurnMap[trackSequence];
@@ -290,7 +290,7 @@ static void PaintMiniHelicoptersTrackRightQuarterTurn3Tiles(
 
 /** rct2: 0x0081F408 */
 static void PaintMiniHelicoptersTrackLeftQuarterTurn1Tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
@@ -305,7 +305,7 @@ static void PaintMiniHelicoptersTrackLeftQuarterTurn1Tile(
 
 /** rct2: 0x0081F418 */
 static void PaintMiniHelicoptersTrackRightQuarterTurn1Tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintMiniHelicoptersTrackLeftQuarterTurn1Tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);

--- a/src/openrct2/ride/gentle/MonorailCycles.cpp
+++ b/src/openrct2/ride/gentle/MonorailCycles.cpp
@@ -159,8 +159,8 @@ static constexpr const uint32_t MonorailCyclesTrackPiecesFlatQuarterTurn3Tiles[4
     },
 };
 
-static paint_struct* PaintMonorailCyclesUtil7C(
-    paint_session& session, bool flip, ImageId imageId, int8_t xOffset, int8_t yOffset, int16_t boundBoxLengthX,
+static PaintStruct* PaintMonorailCyclesUtil7C(
+    PaintSession& session, bool flip, ImageId imageId, int8_t xOffset, int8_t yOffset, int16_t boundBoxLengthX,
     int16_t boundBoxLengthY, int8_t boundBoxLengthZ, int16_t zOffset, int16_t boundBoxOffsetX, int16_t boundBoxOffsetY,
     int16_t boundBoxOffsetZ, uint32_t rotation)
 {
@@ -178,7 +178,7 @@ static paint_struct* PaintMonorailCyclesUtil7C(
 
 /** rct2: 0x0088AD48 */
 static void PaintMonorailCyclesTrackFlat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(MonorailCyclesTrackPiecesFlat[(direction & 1)]);
@@ -205,7 +205,7 @@ static void PaintMonorailCyclesTrackFlat(
 
 /** rct2: 0x0088ADD8 */
 static void PaintMonorailCyclesStation(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -243,7 +243,7 @@ static void PaintMonorailCyclesStation(
 
 /** rct2: 0x0088AD88 */
 static void PaintMonorailCyclesTrackLeftQuarterTurn3Tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -281,7 +281,7 @@ static constexpr const uint8_t monorail_cycles_right_quarter_turn_3_tiles_to_lef
 
 /** rct2: 0x0088AD98 */
 static void PaintMonorailCyclesTrackRightQuarterTurn3Tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = monorail_cycles_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
@@ -304,7 +304,7 @@ static constexpr const int8_t MonorailCyclesTrackRightQuarterTurn5TilesSupportSp
 
 /** rct2: 0x0088ADB8 */
 static void PaintMonorailCyclesTrackRightQuarterTurn5Tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -417,7 +417,7 @@ static void PaintMonorailCyclesTrackRightQuarterTurn5Tiles(
 
 /** rct2: 0x0088ADA8 */
 static void PaintMonorailCyclesTrackLeftQuarterTurn5Tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -426,7 +426,7 @@ static void PaintMonorailCyclesTrackLeftQuarterTurn5Tiles(
 
 /** rct2: 0x0088ADC8 */
 static void PaintMonorailCyclesTrackSBendLeft(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -530,7 +530,7 @@ static void PaintMonorailCyclesTrackSBendLeft(
 
 /** rct2: 0x*/
 static void PaintMonorailCyclesTrackSBendRight(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)

--- a/src/openrct2/ride/gentle/ObservationTower.cpp
+++ b/src/openrct2/ride/gentle/ObservationTower.cpp
@@ -61,7 +61,7 @@ static uint32_t GetObservationTowerVehicleBaseImageId(const Vehicle* vehicle, co
  *  rct2: 0x006D6258
  */
 void VehicleVisualObservationTower(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry)
 {
     auto baseImageId = GetObservationTowerVehicleBaseImageId(vehicle, carEntry, imageDirection);
@@ -80,7 +80,7 @@ void VehicleVisualObservationTower(
 
 /** rct2: 0x0070DD6C */
 static void PaintObservationTowerBase(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -153,7 +153,7 @@ static void PaintObservationTowerBase(
 
 /** rct2: 0x0070DD7C */
 static void PaintObservationTowerSection(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -34,7 +34,7 @@ static constexpr const uint32_t SpaceRingsFenceSprites[] = {
 
 /** rct2: 0x00768A3B */
 static void PaintSpaceRingsStructure(
-    paint_session& session, const Ride& ride, uint8_t direction, uint32_t segment, int32_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, uint32_t segment, int32_t height)
 {
     uint32_t vehicleIndex = (segment - direction) & 0x3;
 
@@ -85,7 +85,7 @@ static void PaintSpaceRingsStructure(
 
 /** rct2: 0x00767C40 */
 static void PaintSpaceRings(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -49,7 +49,7 @@ enum
 };
 
 static void SpiralSlidePaintTileRight(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto rideEntry = ride.GetRideEntry();
@@ -71,7 +71,7 @@ static void SpiralSlidePaintTileRight(
 }
 
 static void SpiralSlidePaintTileLeft(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto rideEntry = ride.GetRideEntry();
@@ -93,7 +93,7 @@ static void SpiralSlidePaintTileLeft(
 }
 
 static void SpiralSlidePaintTileFront(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto rideEntry = ride.GetRideEntry();
@@ -194,7 +194,7 @@ static void SpiralSlidePaintTileFront(
  * rct: 0x007485C8
  */
 static void PaintSpiralSlide(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto rideEntry = ride.GetRideEntry();

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -19,7 +19,7 @@
 #include "../TrackPaint.h"
 
 static void PaintFacility(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool hasSupports = WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_3]);

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -19,7 +19,7 @@
 #include "../TrackPaint.h"
 
 static void PaintShop(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool hasSupports = WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_3]);

--- a/src/openrct2/ride/thrill/3dCinema.cpp
+++ b/src/openrct2/ride/thrill/3dCinema.cpp
@@ -18,7 +18,7 @@
 #include "../Vehicle.h"
 
 static void Paint3dCinemaDome(
-    paint_session& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
 {
     auto rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -49,7 +49,7 @@ static void Paint3dCinemaDome(
  * rct2: 0x0076574C
  */
 static void Paint3dCinema(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -20,7 +20,7 @@
 #include "../Vehicle.h"
 
 static void PaintEnterpriseRiders(
-    paint_session& session, const rct_ride_entry& rideEntry, Vehicle& vehicle, uint32_t imageOffset, const CoordsXYZ& offset,
+    PaintSession& session, const rct_ride_entry& rideEntry, Vehicle& vehicle, uint32_t imageOffset, const CoordsXYZ& offset,
     const BoundBoxXYZ& bb)
 {
     if (session.DPI.zoom_level > ZoomLevel{ 0 })
@@ -43,7 +43,7 @@ static void PaintEnterpriseRiders(
 }
 
 static void PaintEnterpriseStructure(
-    paint_session& session, const Ride& ride, int8_t xOffset, int8_t yOffset, uint16_t height, const TrackElement& trackElement)
+    PaintSession& session, const Ride& ride, int8_t xOffset, int8_t yOffset, uint16_t height, const TrackElement& trackElement)
 {
     const auto* rideEntry = get_ride_entry(ride.subtype);
     if (rideEntry == nullptr)
@@ -88,7 +88,7 @@ static void PaintEnterpriseStructure(
 }
 
 static void PaintEnterprise(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_4x4[direction][trackSequence];

--- a/src/openrct2/ride/thrill/GoKarts.cpp
+++ b/src/openrct2/ride/thrill/GoKarts.cpp
@@ -126,7 +126,7 @@ static constexpr const uint32_t go_karts_track_pieces_25_deg_up_to_flat[4][2] = 
 
 /** rct2: 0x0074A748 */
 static void paint_go_karts_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -159,11 +159,11 @@ static void paint_go_karts_track_flat(
 
 /** rct2: 0x0074A758 */
 static void paint_go_karts_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
-    paint_struct* ps;
+    PaintStruct* ps;
 
     imageId = session.TrackColours[SCHEME_TRACK].WithIndex(go_karts_track_pieces_25_deg_up[direction][0]);
     if (direction == 0 || direction == 2)
@@ -213,11 +213,11 @@ static void paint_go_karts_track_25_deg_up(
 
 /** rct2: 0x0074A768 */
 static void paint_go_karts_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
-    paint_struct* ps;
+    PaintStruct* ps;
 
     imageId = session.TrackColours[SCHEME_TRACK].WithIndex(go_karts_track_pieces_flat_to_25_deg_up[direction][0]);
     if (direction == 0 || direction == 2)
@@ -267,11 +267,11 @@ static void paint_go_karts_track_flat_to_25_deg_up(
 
 /** rct2: 0x */
 static void paint_go_karts_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
-    paint_struct* ps;
+    PaintStruct* ps;
 
     imageId = session.TrackColours[SCHEME_TRACK].WithIndex(go_karts_track_pieces_25_deg_up_to_flat[direction][0]);
     if (direction == 0 || direction == 2)
@@ -321,7 +321,7 @@ static void paint_go_karts_track_25_deg_up_to_flat(
 
 /** rct2: 0x0074A788 */
 static void paint_go_karts_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_go_karts_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -329,7 +329,7 @@ static void paint_go_karts_track_25_deg_down(
 
 /** rct2: 0x0074A798 */
 static void paint_go_karts_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_go_karts_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -337,7 +337,7 @@ static void paint_go_karts_track_flat_to_25_deg_down(
 
 /** rct2: 0x0074A7A8 */
 static void paint_go_karts_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_go_karts_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -345,7 +345,7 @@ static void paint_go_karts_track_25_deg_down_to_flat(
 
 /** rct2: 0x */
 static void paint_go_karts_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const auto* stationObj = ride.GetStationObject();
@@ -454,7 +454,7 @@ static void paint_go_karts_station(
 
 /** rct2: 0x0074A7E8 */
 static void paint_go_karts_track_left_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -524,7 +524,7 @@ static void paint_go_karts_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x0074A7F8 */
 static void paint_go_karts_track_right_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_go_karts_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);

--- a/src/openrct2/ride/thrill/LaunchedFreefall.cpp
+++ b/src/openrct2/ride/thrill/LaunchedFreefall.cpp
@@ -30,7 +30,7 @@ enum
  *  rct2: 0x006D5FAB
  */
 void vehicle_visual_launched_freefall(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry)
 {
     auto imageFlags = ImageId(0, vehicle->colours.Body, vehicle->colours.Trim);
@@ -88,7 +88,7 @@ void vehicle_visual_launched_freefall(
 
 /** rct2: 0x006FD1F8 */
 static void paint_launched_freefall_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -162,7 +162,7 @@ static void paint_launched_freefall_base(
 
 /** rct2: 0x006FD208 */
 static void paint_launched_freefall_tower_section(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/thrill/MagicCarpet.cpp
+++ b/src/openrct2/ride/thrill/MagicCarpet.cpp
@@ -97,7 +97,7 @@ static Vehicle* GetFirstVehicle(const Ride& ride)
 }
 
 static void PaintMagicCarpetRiders(
-    paint_session& session, const rct_ride_entry& rideEntry, const Vehicle& vehicle, Direction direction,
+    PaintSession& session, const rct_ride_entry& rideEntry, const Vehicle& vehicle, Direction direction,
     const CoordsXYZ& offset, const BoundBoxXYZ& bb)
 {
     if (session.DPI.zoom_level > ZoomLevel{ 1 })
@@ -114,7 +114,7 @@ static void PaintMagicCarpetRiders(
 }
 
 static void PaintMagicCarpetFrame(
-    paint_session& session, Plane plane, Direction direction, const CoordsXYZ& offset, const BoundBoxXYZ& bb)
+    PaintSession& session, Plane plane, Direction direction, const CoordsXYZ& offset, const BoundBoxXYZ& bb)
 {
     auto imageIndex = GetMagicCarpetFrameImage(plane, direction);
     auto imageTemplate = session.TrackColours[SCHEME_TRACK];
@@ -130,7 +130,7 @@ static void PaintMagicCarpetFrame(
 }
 
 static void PaintMagicCarpetPendulum(
-    paint_session& session, Plane plane, int32_t swing, Direction direction, const CoordsXYZ& offset, const BoundBoxXYZ& bb)
+    PaintSession& session, Plane plane, int32_t swing, Direction direction, const CoordsXYZ& offset, const BoundBoxXYZ& bb)
 {
     auto imageIndex = GetMagicCarpetPendulumImage(plane, direction, swing);
     auto imageTemplate = session.TrackColours[SCHEME_TRACK];
@@ -139,7 +139,7 @@ static void PaintMagicCarpetPendulum(
 }
 
 static void PaintMagicCarpetVehicle(
-    paint_session& session, const Ride& ride, uint8_t direction, int32_t swing, CoordsXYZ offset, const BoundBoxXYZ& bb)
+    PaintSession& session, const Ride& ride, uint8_t direction, int32_t swing, CoordsXYZ offset, const BoundBoxXYZ& bb)
 {
     const auto* rideEntry = ride.GetRideEntry();
     if (rideEntry == nullptr)
@@ -181,7 +181,7 @@ static void PaintMagicCarpetVehicle(
 }
 
 static void PaintMagicCarpetStructure(
-    paint_session& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
 {
     auto swing = 0;
     auto* vehicle = GetFirstVehicle(ride);
@@ -210,7 +210,7 @@ static void PaintMagicCarpetStructure(
 }
 
 static void PaintMagicCarpet(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];

--- a/src/openrct2/ride/thrill/MotionSimulator.cpp
+++ b/src/openrct2/ride/thrill/MotionSimulator.cpp
@@ -31,7 +31,7 @@ enum
 };
 
 static void PaintMotionSimulatorVehicle(
-    paint_session& session, const Ride& ride, int8_t offsetX, int8_t offsetY, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, int8_t offsetX, int8_t offsetY, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto rideEntry = ride.GetRideEntry();
@@ -102,7 +102,7 @@ static void PaintMotionSimulatorVehicle(
 }
 
 static void PaintMotionSimulator(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_2x2[direction][trackSequence];

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -34,7 +34,7 @@ enum
  *  rct2: 0x006D5DA9
  */
 void vehicle_visual_roto_drop(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry)
 {
     imageDirection = OpenRCT2::Entity::Yaw::YawTo32(imageDirection);
@@ -100,7 +100,7 @@ void vehicle_visual_roto_drop(
 
 /** rct2: 0x00886194 */
 static void paint_roto_drop_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -175,7 +175,7 @@ static void paint_roto_drop_base(
 
 /** rct2: 0x008861A4 */
 static void paint_roto_drop_tower_section(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -59,7 +59,7 @@ static constexpr const uint32_t SwingingInverterShipFrameSprites[] = {
 };
 
 static void PaintSwingingInverterShipStructure(
-    paint_session& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
 {
     rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
     if (rideEntry == nullptr)
@@ -125,7 +125,7 @@ static void PaintSwingingInverterShipStructure(
 }
 
 static void PaintSwingingInverterShip(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_1x4[direction][trackSequence];

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -56,7 +56,7 @@ static constexpr const uint32_t SwingingShipFrameSprites[][2] = {
 };
 
 static void PaintSwingingShipRiders(
-    paint_session& session, const Ride& ride, const Vehicle& vehicle, ImageIndex baseImageIndex, Direction direction,
+    PaintSession& session, const Ride& ride, const Vehicle& vehicle, ImageIndex baseImageIndex, Direction direction,
     const CoordsXYZ& offset, const BoundBoxXYZ& bb)
 {
     if (session.DPI.zoom_level > ZoomLevel{ 1 })
@@ -84,7 +84,7 @@ static void PaintSwingingShipRiders(
 }
 
 static void PaintSwingingShipStructure(
-    paint_session& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
 {
     rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
     if (rideEntry == nullptr)
@@ -151,7 +151,7 @@ static void PaintSwingingShipStructure(
 }
 
 static void PaintSwingingShip(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     uint8_t relativeTrackSequence = track_map_1x5[direction][trackSequence];

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -35,7 +35,7 @@ static int8_t TopSpinSeatPositionOffset[] = {
 };
 
 static void PaintTopSpinRiders(
-    paint_session& session, const Vehicle& vehicle, ImageIndex seatImageIndex, const CoordsXYZ& seatCoords,
+    PaintSession& session, const Vehicle& vehicle, ImageIndex seatImageIndex, const CoordsXYZ& seatCoords,
     const BoundBoxXYZ& bb)
 {
     if (session.DPI.zoom_level >= ZoomLevel{ 2 })
@@ -59,7 +59,7 @@ static void PaintTopSpinRiders(
 }
 
 static void PaintTopSpinSeat(
-    paint_session& session, const Ride& ride, const rct_ride_entry& rideEntry, const Vehicle* vehicle, Direction direction,
+    PaintSession& session, const Ride& ride, const rct_ride_entry& rideEntry, const Vehicle* vehicle, Direction direction,
     uint32_t armRotation, uint32_t seatRotation, const CoordsXYZ& offset, const BoundBoxXYZ& bb)
 {
     if (armRotation >= std::size(TopSpinSeatHeightOffset))
@@ -116,7 +116,7 @@ static void PaintTopSpinSeat(
 }
 
 static void PaintTopSpinVehicle(
-    paint_session& session, int32_t al, int32_t cl, const Ride& ride, uint8_t direction, int32_t height,
+    PaintSession& session, int32_t al, int32_t cl, const Ride& ride, uint8_t direction, int32_t height,
     const TrackElement& tileElement)
 {
     const auto* rideEntry = get_ride_entry(ride.subtype);
@@ -182,7 +182,7 @@ static void PaintTopSpinVehicle(
 }
 
 static void PaintTopSpin(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -21,7 +21,7 @@
 
 /** rct2: 0x0076E5C9 */
 static void paint_twist_structure(
-    paint_session& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
+    PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
 {
     rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
     Vehicle* vehicle = nullptr;
@@ -82,7 +82,7 @@ static void paint_twist_structure(
 
 /** rct2: 0x0076D858 */
 static void paint_twist(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];

--- a/src/openrct2/ride/transport/Chairlift.cpp
+++ b/src/openrct2/ride/transport/Chairlift.cpp
@@ -75,7 +75,7 @@ const uint32_t chairlift_bullwheel_frames[] = {
     SPR_CHAIRLIFT_BULLWHEEL_FRAME_4,
 };
 
-static void chairlift_paint_util_draw_supports(paint_session& session, int32_t segments, uint16_t height)
+static void chairlift_paint_util_draw_supports(PaintSession& session, int32_t segments, uint16_t height)
 {
     bool success = false;
 
@@ -97,7 +97,7 @@ static void chairlift_paint_util_draw_supports(paint_session& session, int32_t s
         return;
     }
 
-    support_height* supportSegments = session.SupportSegments;
+    SupportHeight* supportSegments = session.SupportSegments;
     for (int32_t s = 0; s < 9; s++)
     {
         if (!(segments & segment_offsets[s]))
@@ -176,7 +176,7 @@ static bool chairlift_paint_util_is_last_track(
 }
 
 static void chairlift_paint_station_ne_sw(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const CoordsXY pos = session.MapPosition;
@@ -268,7 +268,7 @@ static void chairlift_paint_station_ne_sw(
 }
 
 static void chairlift_paint_station_se_nw(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const CoordsXY pos = session.MapPosition;
@@ -362,7 +362,7 @@ static void chairlift_paint_station_se_nw(
 
 /** rct2: 0x00744068 */
 static void chairlift_paint_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction % 2)
@@ -376,7 +376,7 @@ static void chairlift_paint_station(
 }
 
 static void chairlift_paint_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -399,7 +399,7 @@ static void chairlift_paint_flat(
 
 /** rct2: 0x00743FD8 */
 static void chairlift_paint_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -437,7 +437,7 @@ static void chairlift_paint_25_deg_up(
 
 /** rct2: 0x00743FD8 */
 static void chairlift_paint_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -492,7 +492,7 @@ static void chairlift_paint_flat_to_25_deg_up(
 
 /** rct2: 0x00743FF8 */
 static void chairlift_paint_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -547,7 +547,7 @@ static void chairlift_paint_25_deg_up_to_flat(
 
 /** rct2: 0x00744008 */
 static void chairlift_paint_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     chairlift_paint_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -555,7 +555,7 @@ static void chairlift_paint_25_deg_down(
 
 /** rct2: 0x00744018 */
 static void chairlift_paint_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     chairlift_paint_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -563,7 +563,7 @@ static void chairlift_paint_flat_to_25_deg_down(
 
 /** rct2: 0x00744028 */
 static void chairlift_paint_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     chairlift_paint_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -571,7 +571,7 @@ static void chairlift_paint_25_deg_down_to_flat(
 
 /** rct2: 0x00744038 */
 static void chairlift_paint_left_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -638,7 +638,7 @@ static void chairlift_paint_left_quarter_turn_1_tile(
 
 /** rct2: 0x00744048 */
 static void chairlift_paint_right_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     chairlift_paint_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);

--- a/src/openrct2/ride/transport/Lift.cpp
+++ b/src/openrct2/ride/transport/Lift.cpp
@@ -34,7 +34,7 @@ static constexpr const uint32_t lift_cage_sprites[][2] = {
     { SPR_LIFT_CAGE_NW_BACK, SPR_LIFT_CAGE_NW_FRONT },
 };
 
-static void paint_lift_cage(paint_session& session, int8_t index, ImageId colourFlags, int32_t height, uint8_t rotation)
+static void paint_lift_cage(PaintSession& session, int8_t index, ImageId colourFlags, int32_t height, uint8_t rotation)
 {
     ImageId imageId;
 
@@ -47,7 +47,7 @@ static void paint_lift_cage(paint_session& session, int8_t index, ImageId colour
 
 /** rct2: 0x0076C6CC */
 static void paint_lift_base(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = track_map_3x3[direction][trackSequence];
@@ -112,7 +112,7 @@ static void paint_lift_base(
 
 /** rct2: 0x0076C6DC */
 static void paint_lift_tower_section(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (trackSequence == 1)

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -623,7 +623,7 @@ static ImageId miniature_railway_track_to_grooved_indent(const TileElement* path
 
 /** rct2: 0x008AD0C0 */
 static void paint_miniature_railway_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool paintAsGravel = false;
@@ -698,7 +698,7 @@ static void paint_miniature_railway_track_flat(
 
 /** rct2: 0x008AD170, 0x008AD180, 0x008AD190 */
 static void paint_miniature_railway_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -722,7 +722,7 @@ static void paint_miniature_railway_station(
 
 /** rct2: 0x008AD0D0 */
 static void paint_miniature_railway_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_25_deg_up[direction]);
@@ -753,7 +753,7 @@ static void paint_miniature_railway_track_25_deg_up(
 
 /** rct2: 0x008AD0E0 */
 static void paint_miniature_railway_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_flat_to_25_deg_up[direction]);
@@ -784,7 +784,7 @@ static void paint_miniature_railway_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AD0F0 */
 static void paint_miniature_railway_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_25_deg_up_to_flat[direction]);
@@ -815,7 +815,7 @@ static void paint_miniature_railway_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AD100 */
 static void paint_miniature_railway_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_miniature_railway_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -823,7 +823,7 @@ static void paint_miniature_railway_track_25_deg_down(
 
 /** rct2: 0x008AD110 */
 static void paint_miniature_railway_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_miniature_railway_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -831,7 +831,7 @@ static void paint_miniature_railway_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AD120 */
 static void paint_miniature_railway_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_miniature_railway_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -974,7 +974,7 @@ static constexpr const int8_t miniature_railway_right_quarter_turn_5_tiles_sprit
 
 /** rct2: 0x008AD140 */
 static void paint_miniature_railway_track_right_quarter_turn_5_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (right_quarter_turn_5_supports_type[direction][trackSequence] != -1)
@@ -1063,7 +1063,7 @@ static void paint_miniature_railway_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x008AD130 */
 static void paint_miniature_railway_track_left_quarter_turn_5_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1095,7 +1095,7 @@ static constexpr const uint32_t miniature_railway_s_bend_left_tiles_track_floor[
 
 /** rct2: 0x8AD150 */
 static void paint_miniature_railway_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -1204,7 +1204,7 @@ static constexpr const uint32_t miniature_railway_s_bend_right_tiles_track_floor
 
 /** rct2: 0x008AD160 */
 static void paint_miniature_railway_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -1337,7 +1337,7 @@ static constexpr const CoordsXYZ miniature_railway_right_quarter_turn_3_tile_bou
 
 /** rct2: 0x008AD1B0 */
 static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isSupported = false;
@@ -1404,7 +1404,7 @@ static void paint_miniature_railway_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x008AD1A0 */
 static void paint_miniature_railway_track_left_quarter_turn_3_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1511,7 +1511,7 @@ static constexpr const CoordsXY miniature_railway_track_floor_pieces_left_eight_
 
 /** rct2: 0x008AD1C0 */
 static void paint_miniature_railway_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t supportType[4][5] = {
@@ -1675,7 +1675,7 @@ static constexpr const CoordsXY miniature_railway_track_floor_pieces_right_eight
 
 /** rct2: 0x008AD1D0 */
 static void paint_miniature_railway_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t supportType[4][5] = {
@@ -1747,7 +1747,7 @@ static void paint_miniature_railway_track_right_eighth_to_diag(
 
 /** rct2: 0x008AD1E0 */
 static void paint_miniature_railway_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1756,7 +1756,7 @@ static void paint_miniature_railway_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008AD1F0 */
 static void paint_miniature_railway_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1805,7 +1805,7 @@ static constexpr const floor_desc floors[] = {
 
 /** rct2: 0x008AD200 */
 static void miniature_railway_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isSupported = false;
@@ -1861,7 +1861,7 @@ enum
 };
 
 static bool wooden_supports_paint_setup(
-    paint_session& session, int32_t woodType, int32_t supportType, int32_t special, int32_t height, ImageId imageColourFlags)
+    PaintSession& session, int32_t woodType, int32_t supportType, int32_t special, int32_t height, ImageId imageColourFlags)
 {
     switch (woodType)
     {
@@ -1877,7 +1877,7 @@ static bool wooden_supports_paint_setup(
 
 /** rct2: 0x008AD230 */
 static void miniature_railway_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     // TODO: The supports are inconsistent for different rotations
@@ -1957,7 +1957,7 @@ static void miniature_railway_track_diag_25_deg_up(
 
 /** rct2: 0x008AD210 */
 static void miniature_railway_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool hasSupports = false;
@@ -2008,7 +2008,7 @@ static void miniature_railway_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AD220 */
 static void miniature_railway_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t supportOffsets[][4] = {
@@ -2084,7 +2084,7 @@ static void miniature_railway_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AD260 */
 static void miniature_railway_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t supportOffsets[][4] = {
@@ -2159,7 +2159,7 @@ static void miniature_railway_track_diag_25_deg_down(
 
 /** rct2: 0x008AD240 */
 static void miniature_railway_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr int8_t supportOffsets[][4] = {
@@ -2232,7 +2232,7 @@ static void miniature_railway_track_diag_flat_to_25_deg_down(
 }
 
 static void miniature_railway_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool hasSupports = false;

--- a/src/openrct2/ride/transport/Monorail.cpp
+++ b/src/openrct2/ride/transport/Monorail.cpp
@@ -385,7 +385,7 @@ static constexpr const uint32_t monorail_track_pieces_diag_25_deg_up[4] = {
 
 /** rct2: 0x008AE1AC */
 static void paint_monorail_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_flat[direction]);
@@ -420,7 +420,7 @@ static void paint_monorail_track_flat(
 
 /** rct2: 0x008AE25C, 0x008AE26C, 0x008AE27C */
 static void paint_monorail_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -480,7 +480,7 @@ static void paint_monorail_station(
 
 /** rct2: 0x008AE1BC */
 static void paint_monorail_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_25_deg_up[direction]);
@@ -522,7 +522,7 @@ static void paint_monorail_track_25_deg_up(
 
 /** rct2: 0x008AE1CC */
 static void paint_monorail_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_flat_to_25_deg_up[direction]);
@@ -564,7 +564,7 @@ static void paint_monorail_track_flat_to_25_deg_up(
 
 /** rct2: 0x008AE1DC */
 static void paint_monorail_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(monorail_track_pieces_25_deg_up_to_flat[direction]);
@@ -606,7 +606,7 @@ static void paint_monorail_track_25_deg_up_to_flat(
 
 /** rct2: 0x008AE1EC */
 static void paint_monorail_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_monorail_track_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -614,7 +614,7 @@ static void paint_monorail_track_25_deg_down(
 
 /** rct2: 0x008AE1FC */
 static void paint_monorail_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_monorail_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -622,7 +622,7 @@ static void paint_monorail_track_flat_to_25_deg_down(
 
 /** rct2: 0x008AE20C */
 static void paint_monorail_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_monorail_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -630,7 +630,7 @@ static void paint_monorail_track_25_deg_down_to_flat(
 
 /** rct2: 0x008AE22C */
 static void paint_monorail_track_right_quarter_turn_5_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint(
@@ -693,7 +693,7 @@ static void paint_monorail_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x008AE21C */
 static void paint_monorail_track_left_quarter_turn_5_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -702,7 +702,7 @@ static void paint_monorail_track_left_quarter_turn_5_tiles(
 
 /** rct2: 0x */
 static void paint_monorail_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -794,7 +794,7 @@ static void paint_monorail_track_s_bend_left(
 
 /** rct2: 0x008AE24C */
 static void paint_monorail_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction == 2 || direction == 3)
@@ -883,7 +883,7 @@ static void paint_monorail_track_s_bend_right(
 
 /** rct2: 0x008AE29C */
 static void paint_monorail_track_right_quarter_turn_3_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_3_tiles_paint(
@@ -920,7 +920,7 @@ static void paint_monorail_track_right_quarter_turn_3_tiles(
 
 /** rct2: 0x008AE28C */
 static void paint_monorail_track_left_quarter_turn_3_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -933,7 +933,7 @@ static constexpr const int8_t paint_monorail_eighth_to_diag_index[] = {
 
 /** rct2: 0x008AE31C */
 static void paint_monorail_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     int8_t index = paint_monorail_eighth_to_diag_index[trackSequence];
@@ -998,7 +998,7 @@ static void paint_monorail_track_left_eighth_to_diag(
 
 /** rct2: 0x008AE32C */
 static void paint_monorail_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     int8_t index = paint_monorail_eighth_to_diag_index[trackSequence];
@@ -1063,7 +1063,7 @@ static void paint_monorail_track_right_eighth_to_diag(
 
 /** rct2: 0x008AE33C */
 static void paint_monorail_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -1073,7 +1073,7 @@ static void paint_monorail_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x008AE34C */
 static void paint_monorail_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr uint8_t map[] = { 4, 2, 3, 1, 0 };
@@ -1104,7 +1104,7 @@ static constexpr const int32_t monorail_diag_blocked_segments[] = {
 
 /** rct2: 0x008AE2AC */
 static void paint_monorail_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1127,7 +1127,7 @@ static void paint_monorail_track_diag_flat(
 
 /** rct2: 0x008AE2DC */
 static void paint_monorail_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1150,7 +1150,7 @@ static void paint_monorail_track_diag_25_deg_up(
 
 /** rct2: 0x008AE2BC */
 static void paint_monorail_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1173,7 +1173,7 @@ static void paint_monorail_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x008AE2CC */
 static void paint_monorail_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1196,7 +1196,7 @@ static void paint_monorail_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x008AE30C */
 static void paint_monorail_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1219,7 +1219,7 @@ static void paint_monorail_track_diag_25_deg_down(
 
 /** rct2: 0x008AE2EC */
 static void paint_monorail_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])
@@ -1243,7 +1243,7 @@ static void paint_monorail_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x008AE2FC */
 static void paint_monorail_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (monorail_diag_image_segment[direction][trackSequence])

--- a/src/openrct2/ride/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/ride/transport/SuspendedMonorail.cpp
@@ -21,7 +21,7 @@
 
 /** rct2: 0x008636F4 */
 static void suspended_monorail_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -53,7 +53,7 @@ static void suspended_monorail_track_flat(
 
 /** rct2: 0x008637A4, 0x008637B4, 0x008637C4 */
 static void suspended_monorail_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -81,7 +81,7 @@ static void suspended_monorail_track_station(
 
 /** rct2: 0x00863704 */
 static void suspended_monorail_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -146,7 +146,7 @@ static void suspended_monorail_track_25_deg_up(
 
 /** rct2: 0x00863714 */
 static void suspended_monorail_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -211,7 +211,7 @@ static void suspended_monorail_track_flat_to_25_deg_up(
 
 /** rct2: 0x00863724 */
 static void suspended_monorail_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -276,7 +276,7 @@ static void suspended_monorail_track_25_deg_up_to_flat(
 
 /** rct2: 0x00863734 */
 static void suspended_monorail_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_monorail_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -284,7 +284,7 @@ static void suspended_monorail_track_25_deg_down(
 
 /** rct2: 0x00863744 */
 static void suspended_monorail_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_monorail_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -292,7 +292,7 @@ static void suspended_monorail_track_flat_to_25_deg_down(
 
 /** rct2: 0x00863754 */
 static void suspended_monorail_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     suspended_monorail_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
@@ -300,7 +300,7 @@ static void suspended_monorail_track_25_deg_down_to_flat(
 
 /** rct2: 0x00863764 */
 static void suspended_monorail_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -481,7 +481,7 @@ static void suspended_monorail_track_left_quarter_turn_5(
 
 /** rct2: 0x00863774 */
 static void suspended_monorail_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -490,7 +490,7 @@ static void suspended_monorail_track_right_quarter_turn_5(
 
 /** rct2: 0x00863784 */
 static void suspended_monorail_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -661,7 +661,7 @@ static void suspended_monorail_track_s_bend_left(
 
 /** rct2: 0x00863794 */
 static void suspended_monorail_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -832,7 +832,7 @@ static void suspended_monorail_track_s_bend_right(
 
 /** rct2: 0x008637D4 */
 static void suspended_monorail_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -950,7 +950,7 @@ static void suspended_monorail_track_left_quarter_turn_3(
 
 /** rct2: 0x008637E4 */
 static void suspended_monorail_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -959,7 +959,7 @@ static void suspended_monorail_track_right_quarter_turn_3(
 
 /** rct2: 0x00863864 */
 static void suspended_monorail_track_left_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1119,7 +1119,7 @@ static void suspended_monorail_track_left_eighth_to_diag(
 
 /** rct2: 0x00863874 */
 static void suspended_monorail_track_right_eighth_to_diag(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1279,7 +1279,7 @@ static void suspended_monorail_track_right_eighth_to_diag(
 
 /** rct2: 0x00863884 */
 static void suspended_monorail_track_left_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1288,7 +1288,7 @@ static void suspended_monorail_track_left_eighth_to_orthogonal(
 
 /** rct2: 0x00863894 */
 static void suspended_monorail_track_right_eighth_to_orthogonal(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftEighthTurnToOrthogonal[trackSequence];
@@ -1297,7 +1297,7 @@ static void suspended_monorail_track_right_eighth_to_orthogonal(
 
 /** rct2: 0x008637F4 */
 static void suspended_monorail_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1380,7 +1380,7 @@ static void suspended_monorail_track_diag_flat(
 
 /** rct2: 0x00863824 */
 static void suspended_monorail_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1463,7 +1463,7 @@ static void suspended_monorail_track_diag_25_deg_up(
 
 /** rct2: 0x00863804 */
 static void suspended_monorail_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1546,7 +1546,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_up(
 
 /** rct2: 0x00863814 */
 static void suspended_monorail_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1629,7 +1629,7 @@ static void suspended_monorail_track_diag_25_deg_up_to_flat(
 
 /** rct2: 0x00863854 */
 static void suspended_monorail_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1712,7 +1712,7 @@ static void suspended_monorail_track_diag_25_deg_down(
 
 /** rct2: 0x00863834 */
 static void suspended_monorail_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)
@@ -1792,7 +1792,7 @@ static void suspended_monorail_track_diag_flat_to_25_deg_down(
 
 /** rct2: 0x00863844 */
 static void suspended_monorail_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (trackSequence)

--- a/src/openrct2/ride/water/BoatHire.cpp
+++ b/src/openrct2/ride/water/BoatHire.cpp
@@ -32,7 +32,7 @@ enum
 
 /** rct2: 0x008B0E40 */
 static void paint_boat_hire_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -62,7 +62,7 @@ static void paint_boat_hire_track_flat(
 
 /** rct2: 0x008B0E50 */
 static void paint_boat_hire_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const auto* stationObj = ride.GetStationObject();
@@ -86,7 +86,7 @@ static void paint_boat_hire_station(
 
 /** rct2: 0x008B0E80 */
 static void paint_boat_hire_track_left_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -130,7 +130,7 @@ static void paint_boat_hire_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x008B0E90 */
 static void paint_boat_hire_track_right_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_boat_hire_track_left_quarter_turn_1_tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);

--- a/src/openrct2/ride/water/DingySlide.cpp
+++ b/src/openrct2/ride/water/DingySlide.cpp
@@ -349,7 +349,7 @@ enum
 };
 
 static void dinghy_slide_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -387,7 +387,7 @@ static void dinghy_slide_track_flat(
 }
 
 static void dinghy_slide_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -418,7 +418,7 @@ static void dinghy_slide_track_station(
 }
 
 static void dinghy_slide_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -463,7 +463,7 @@ static void dinghy_slide_track_25_deg_up(
 }
 
 static void dinghy_slide_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -499,7 +499,7 @@ static void dinghy_slide_track_60_deg_up(
 }
 
 static void dinghy_slide_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -544,7 +544,7 @@ static void dinghy_slide_track_flat_to_25_deg_up(
 }
 
 static void dinghy_slide_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -580,7 +580,7 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up(
 }
 
 static void dinghy_slide_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -616,7 +616,7 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up(
 }
 
 static void dinghy_slide_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[2][4][2] = {
@@ -661,45 +661,45 @@ static void dinghy_slide_track_25_deg_up_to_flat(
 }
 
 static void dinghy_slide_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_right_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    static constexpr const sprite_bb imageIds[4][5] = {
+    static constexpr const SpriteBb imageIds[4][5] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_SW_SE_PART_0, { 0, 2, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_SW_SE_PART_1, { 0, 16, 0 }, { 0, 16, 0 }, { 32, 16, 2 } },
@@ -729,7 +729,7 @@ static void dinghy_slide_track_right_quarter_turn_5(
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_SE_NE_PART_4, { 0, 2, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
         },
     };
-    static constexpr const sprite_bb frontImageIds[4][5] = {
+    static constexpr const SpriteBb frontImageIds[4][5] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_FRONT_SW_SE_PART_0, { 0, 2, 0 }, { 0, 6, 27 }, { 32, 30, 0 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_FRONT_SW_SE_PART_1, { 0, 16, 0 }, { 0, 16, 27 }, { 32, 16, 0 } },
@@ -822,7 +822,7 @@ static void dinghy_slide_track_right_quarter_turn_5(
 }
 
 static void dinghy_slide_track_left_quarter_turn_5(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -830,14 +830,14 @@ static void dinghy_slide_track_left_quarter_turn_5(
 }
 
 static void dinghy_slide_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -942,7 +942,7 @@ static void dinghy_slide_track_s_bend_left(
 }
 
 static void dinghy_slide_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1045,10 +1045,10 @@ static void dinghy_slide_track_s_bend_right(
 }
 
 static void dinghy_slide_track_right_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    static constexpr const sprite_bb imageIds[4][3] = {
+    static constexpr const SpriteBb imageIds[4][3] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_SW_SE_PART_1, { 0, 0, 0 }, { 16, 16, 0 }, { 16, 16, 2 } },
@@ -1070,7 +1070,7 @@ static void dinghy_slide_track_right_quarter_turn_3(
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_SE_NE_PART_2, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
         },
     };
-    static constexpr const sprite_bb frontImageIds[4][3] = {
+    static constexpr const SpriteBb frontImageIds[4][3] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_FRONT_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 27 }, { 32, 20, 0 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_FRONT_SW_SE_PART_1, { 0, 0, 0 }, { 16, 16, 27 }, { 16, 16, 0 } },
@@ -1126,7 +1126,7 @@ static void dinghy_slide_track_right_quarter_turn_3(
 }
 
 static void dinghy_slide_track_left_quarter_turn_3(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1134,7 +1134,7 @@ static void dinghy_slide_track_left_quarter_turn_3(
 }
 
 static void dinghy_slide_track_flat_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1163,7 +1163,7 @@ static void dinghy_slide_track_flat_covered(
 }
 
 static void dinghy_slide_track_25_deg_up_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1199,7 +1199,7 @@ static void dinghy_slide_track_25_deg_up_covered(
 }
 
 static void dinghy_slide_track_60_deg_up_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1235,7 +1235,7 @@ static void dinghy_slide_track_60_deg_up_covered(
 }
 
 static void dinghy_slide_track_flat_to_25_deg_up_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1271,7 +1271,7 @@ static void dinghy_slide_track_flat_to_25_deg_up_covered(
 }
 
 static void dinghy_slide_track_25_deg_up_to_60_deg_up_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1307,7 +1307,7 @@ static void dinghy_slide_track_25_deg_up_to_60_deg_up_covered(
 }
 
 static void dinghy_slide_track_60_deg_up_to_25_deg_up_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1343,7 +1343,7 @@ static void dinghy_slide_track_60_deg_up_to_25_deg_up_covered(
 }
 
 static void dinghy_slide_track_25_deg_up_to_flat_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -1379,45 +1379,45 @@ static void dinghy_slide_track_25_deg_up_to_flat_covered(
 }
 
 static void dinghy_slide_track_25_deg_down_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_60_deg_down_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_60_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_flat_to_25_deg_down_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up_to_flat_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_60_deg_down_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_60_deg_up_to_25_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_25_deg_down_to_flat_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_flat_to_25_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void dinghy_slide_track_right_quarter_turn_5_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    static constexpr const sprite_bb imageIds[4][5] = {
+    static constexpr const SpriteBb imageIds[4][5] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_COVERED_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_COVERED_SW_SE_PART_1, { 0, 0, 0 }, { 0, 16, 0 }, { 32, 16, 2 } },
@@ -1447,7 +1447,7 @@ static void dinghy_slide_track_right_quarter_turn_5_covered(
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_COVERED_SE_NE_PART_4, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
         },
     };
-    static constexpr const sprite_bb frontImageIds[4][5] = {
+    static constexpr const SpriteBb frontImageIds[4][5] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_COVERED_FRONT_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 27 }, { 32, 30, 0 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_5_COVERED_FRONT_SW_SE_PART_1, { 0, 0, 0 }, { 0, 16, 27 }, { 32, 16, 0 } },
@@ -1540,7 +1540,7 @@ static void dinghy_slide_track_right_quarter_turn_5_covered(
 }
 
 static void dinghy_slide_track_left_quarter_turn_5_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn5TilesToRightQuarterTurn5Tiles[trackSequence];
@@ -1548,7 +1548,7 @@ static void dinghy_slide_track_left_quarter_turn_5_covered(
 }
 
 static void dinghy_slide_track_s_bend_left_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1653,7 +1653,7 @@ static void dinghy_slide_track_s_bend_left_covered(
 }
 
 static void dinghy_slide_track_s_bend_right_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1756,10 +1756,10 @@ static void dinghy_slide_track_s_bend_right_covered(
 }
 
 static void dinghy_slide_track_right_quarter_turn_3_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    static constexpr const sprite_bb imageIds[4][3] = {
+    static constexpr const SpriteBb imageIds[4][3] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_COVERED_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_COVERED_SW_SE_PART_1, { 0, 0, 0 }, { 16, 16, 0 }, { 16, 16, 2 } },
@@ -1781,7 +1781,7 @@ static void dinghy_slide_track_right_quarter_turn_3_covered(
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_COVERED_SE_NE_PART_2, { 0, 0, 0 }, { 0, 6, 0 }, { 32, 20, 2 } },
         },
     };
-    static constexpr const sprite_bb frontImageIds[4][3] = {
+    static constexpr const SpriteBb frontImageIds[4][3] = {
         {
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_COVERED_FRONT_SW_SE_PART_0, { 0, 0, 0 }, { 0, 6, 27 }, { 32, 20, 0 } },
             { SPR_DINGHY_SLIDE_QUARTER_TURN_3_COVERED_FRONT_SW_SE_PART_1, { 0, 0, 0 }, { 16, 16, 27 }, { 16, 16, 0 } },
@@ -1837,7 +1837,7 @@ static void dinghy_slide_track_right_quarter_turn_3_covered(
 }
 
 static void dinghy_slide_track_left_quarter_turn_3_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = mapLeftQuarterTurn3TilesToRightQuarterTurn3Tiles[trackSequence];
@@ -1845,7 +1845,7 @@ static void dinghy_slide_track_left_quarter_turn_3_covered(
 }
 
 static void dinghy_slide_track_60_deg_down_to_25_deg_down_covered(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     dinghy_slide_track_25_deg_up_to_60_deg_up_covered(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);

--- a/src/openrct2/ride/water/LogFlume.cpp
+++ b/src/openrct2/ride/water/LogFlume.cpp
@@ -161,7 +161,7 @@ static constexpr const uint32_t LogFlumeTrackFlatImageIds[4][2] = {
 };
 
 static void paint_log_flume_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(LogFlumeTrackFlatImageIds[direction][0]);
@@ -182,7 +182,7 @@ static void paint_log_flume_track_flat(
 }
 
 static void paint_log_flume_track_station(
-    paint_session& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(LogFlumeTrackFlatImageIds[direction][0]);
@@ -219,7 +219,7 @@ static void paint_log_flume_track_station(
 }
 
 static void paint_log_flume_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -254,7 +254,7 @@ static void paint_log_flume_track_25_deg_up(
 }
 
 static void paint_log_flume_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -289,7 +289,7 @@ static void paint_log_flume_track_flat_to_25_deg_up(
 }
 
 static void paint_log_flume_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -324,7 +324,7 @@ static void paint_log_flume_track_25_deg_up_to_flat(
 }
 
 static void paint_log_flume_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -359,7 +359,7 @@ static void paint_log_flume_track_25_deg_down(
 }
 
 static void paint_log_flume_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -394,7 +394,7 @@ static void paint_log_flume_track_flat_to_25_deg_down(
 }
 
 static void paint_log_flume_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {
@@ -429,7 +429,7 @@ static void paint_log_flume_track_25_deg_down_to_flat(
 }
 
 static void paint_log_flume_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -534,7 +534,7 @@ static void paint_log_flume_track_s_bend_left(
 }
 
 static void paint_log_flume_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -637,7 +637,7 @@ static void paint_log_flume_track_s_bend_right(
 }
 
 static void paint_log_flume_track_left_quarter_turn_3_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -716,7 +716,7 @@ static void paint_log_flume_track_left_quarter_turn_3_tiles(
 }
 
 static void paint_log_flume_track_right_quarter_turn_3_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][3] = {
@@ -795,7 +795,7 @@ static void paint_log_flume_track_right_quarter_turn_3_tiles(
 }
 
 static void paint_log_flume_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     PaintAddImageAsParent(session, ImageId(SPR_STATION_BASE_D, COLOUR_BLACK), { 0, 0, height }, { 32, 32, 1 });
@@ -825,7 +825,7 @@ static void paint_log_flume_track_on_ride_photo(
 }
 
 static void paint_log_flume_track_reverser(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][2] = {

--- a/src/openrct2/ride/water/RiverRapids.cpp
+++ b/src/openrct2/ride/water/RiverRapids.cpp
@@ -178,7 +178,7 @@ static constexpr const uint32_t river_rapids_track_pieces_25_deg_down_to_flat[][
  *  rct2: 0x006D5889
  */
 void vehicle_visual_river_rapids(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry)
 {
     imageDirection = OpenRCT2::Entity::Yaw::YawTo32(imageDirection);
@@ -277,7 +277,7 @@ void vehicle_visual_river_rapids(
 
 /** rct2: 0x00757650 */
 static void paint_river_rapids_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -320,7 +320,7 @@ static void paint_river_rapids_track_flat(
 
 /** rct2: 0x007576C0 */
 static void paint_river_rapids_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_flat(session, ride, trackSequence, direction, height, trackElement);
@@ -329,10 +329,10 @@ static void paint_river_rapids_station(
 }
 
 static void paint_river_rapids_track_25_deg(
-    paint_session& session, uint8_t direction, int32_t height, const uint32_t sprites[4][2])
+    PaintSession& session, uint8_t direction, int32_t height, const uint32_t sprites[4][2])
 {
     ImageId imageId;
-    paint_struct* ps;
+    PaintStruct* ps;
 
     switch (direction)
     {
@@ -388,10 +388,10 @@ static void paint_river_rapids_track_25_deg(
 }
 
 static void paint_river_rapids_track_25_deg_to_flat_a(
-    paint_session& session, uint8_t direction, int32_t height, const uint32_t sprites[4][2])
+    PaintSession& session, uint8_t direction, int32_t height, const uint32_t sprites[4][2])
 {
     ImageId imageId;
-    paint_struct* ps;
+    PaintStruct* ps;
 
     switch (direction)
     {
@@ -448,10 +448,10 @@ static void paint_river_rapids_track_25_deg_to_flat_a(
 }
 
 static void paint_river_rapids_track_25_deg_to_flat_b(
-    paint_session& session, uint8_t direction, int32_t height, const uint32_t sprites[4][2])
+    PaintSession& session, uint8_t direction, int32_t height, const uint32_t sprites[4][2])
 {
     ImageId imageId;
-    paint_struct* ps;
+    PaintStruct* ps;
 
     switch (direction)
     {
@@ -508,7 +508,7 @@ static void paint_river_rapids_track_25_deg_to_flat_b(
 
 /** rct2: 0x00757660 */
 static void paint_river_rapids_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg(session, direction, height, river_rapids_track_pieces_25_deg_up);
@@ -516,7 +516,7 @@ static void paint_river_rapids_track_25_deg_up(
 
 /** rct2: 0x00757670 */
 static void paint_river_rapids_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg_to_flat_b(session, direction, height, river_rapids_track_pieces_flat_to_25_deg_up);
@@ -524,7 +524,7 @@ static void paint_river_rapids_track_flat_to_25_deg_up(
 
 /** rct2: 0x00757680 */
 static void paint_river_rapids_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg_to_flat_a(session, direction, height, river_rapids_track_pieces_25_deg_up_to_flat);
@@ -532,7 +532,7 @@ static void paint_river_rapids_track_25_deg_up_to_flat(
 
 /** rct2: 0x00757690 */
 static void paint_river_rapids_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg(session, (direction + 2) % 4, height, river_rapids_track_pieces_25_deg_down);
@@ -540,7 +540,7 @@ static void paint_river_rapids_track_25_deg_down(
 
 /** rct2: 0x007576A0 */
 static void paint_river_rapids_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg_to_flat_a(
@@ -549,7 +549,7 @@ static void paint_river_rapids_track_flat_to_25_deg_down(
 
 /** rct2: 0x007576B0 */
 static void paint_river_rapids_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_25_deg_to_flat_b(
@@ -558,7 +558,7 @@ static void paint_river_rapids_track_25_deg_down_to_flat(
 
 /** rct2: 0x007576F0 */
 static void paint_river_rapids_track_left_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -614,7 +614,7 @@ static void paint_river_rapids_track_left_quarter_turn_1_tile(
 
 /** rct2: 0x00757700 */
 static void paint_river_rapids_track_right_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -671,7 +671,7 @@ static void paint_river_rapids_track_right_quarter_turn_1_tile(
 
 /** rct2: 0x00757710 */
 static void paint_river_rapids_track_waterfall(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -734,7 +734,7 @@ static void paint_river_rapids_track_waterfall(
 
 /** rct2: 0x00757720 */
 static void paint_river_rapids_track_rapids(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -775,7 +775,7 @@ static void paint_river_rapids_track_rapids(
 
 /** rct2: 0x00757740 */
 static void paint_river_rapids_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_river_rapids_track_flat(session, ride, trackSequence, direction, height, trackElement);
@@ -785,7 +785,7 @@ static void paint_river_rapids_track_on_ride_photo(
 
 /** rct2: 0x */
 static void paint_river_rapids_track_whirlpool(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -350,7 +350,7 @@ static constexpr const uint32_t SplashBoats25DegDownToFlatFrontImageId[4] = {
     SPR_SPLASH_BOATS_FLAT_TO_25_DEG_UP_FRONT_NW_SE,
 };
 
-static constexpr const sprite_bb RiverRaftsLeftQuarterTurn5_Top[4][5] = {
+static constexpr const SpriteBb RiverRaftsLeftQuarterTurn5_Top[4][5] = {
     {
         SPR_SPLASH_BOATS_TURN_LEFT_5_TOP_SW_NW_SEQ_0, { 0, 0, 0 }, { 0, 2, 0 },  { 32, 27, 2 },
         SPR_SPLASH_BOATS_TURN_LEFT_5_TOP_SW_NW_SEQ_2, { 0, 0, 0 }, { 0, 0, 0 },  { 32, 16, 2 },
@@ -381,7 +381,7 @@ static constexpr const sprite_bb RiverRaftsLeftQuarterTurn5_Top[4][5] = {
     },
 };
 
-static constexpr const sprite_bb RiverRaftsLeftQuarterTurn5_Side[4][5] = {
+static constexpr const SpriteBb RiverRaftsLeftQuarterTurn5_Side[4][5] = {
     {
         SPR_SPLASH_BOATS_TURN_LEFT_5_SIDE_SW_NW_SEQ_0, { 0, 0, 0 }, { 0, 2, 27 },  { 32, 27, 0 },
         SPR_SPLASH_BOATS_TURN_LEFT_5_SIDE_SW_NW_SEQ_2, { 0, 0, 0 }, { 0, 0, 27 },  { 32, 16, 0 },
@@ -412,7 +412,7 @@ static constexpr const sprite_bb RiverRaftsLeftQuarterTurn5_Side[4][5] = {
     },
 };
 
-static constexpr const sprite_bb RiverRaftsRightQuarterTurn5_Top[4][5] = {
+static constexpr const SpriteBb RiverRaftsRightQuarterTurn5_Top[4][5] = {
     {
         SPR_SPLASH_BOATS_TURN_RIGHT_5_TOP_SW_SE_SEQ_0, { 0, 0, 0 }, { 0, 2, 0 },  { 32, 32, 2 },
         SPR_SPLASH_BOATS_TURN_RIGHT_5_TOP_SW_SE_SEQ_2, { 0, 0, 0 }, { 0, 16, 0 }, { 32, 16, 2 },
@@ -443,7 +443,7 @@ static constexpr const sprite_bb RiverRaftsRightQuarterTurn5_Top[4][5] = {
     },
 };
 
-static constexpr const sprite_bb RiverRaftsRightQuarterTurn5_Side[4][5] = {
+static constexpr const SpriteBb RiverRaftsRightQuarterTurn5_Side[4][5] = {
     {
         SPR_SPLASH_BOATS_TURN_RIGHT_5_SIDE_SW_SE_SEQ_0, { 0, 0, 0 }, { 0, 2, 27 },  { 32, 32, 0 },
         SPR_SPLASH_BOATS_TURN_RIGHT_5_SIDE_SW_SE_SEQ_2, { 0, 0, 0 }, { 0, 16, 27 }, { 32, 16, 0 },
@@ -475,7 +475,7 @@ static constexpr const sprite_bb RiverRaftsRightQuarterTurn5_Side[4][5] = {
 };
 
 static void paint_splash_boats_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegUpImageId[direction]);
@@ -499,7 +499,7 @@ static void paint_splash_boats_track_25_deg_up(
 }
 
 static void paint_splash_boats_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats60DegUpImageId[direction]);
@@ -524,7 +524,7 @@ static void paint_splash_boats_track_60_deg_up(
 }
 
 static void paint_splash_boats_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoatsFlatTo25DegUpImageId[direction]);
@@ -548,7 +548,7 @@ static void paint_splash_boats_track_flat_to_25_deg_up(
 }
 
 static void paint_splash_boats_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegUpToFlatImageId[direction]);
@@ -572,7 +572,7 @@ static void paint_splash_boats_track_25_deg_up_to_flat(
 }
 
 static void paint_splash_boats_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegUpTo60DegUpImageId[direction]);
@@ -597,7 +597,7 @@ static void paint_splash_boats_track_25_deg_up_to_60_deg_up(
 }
 
 static void paint_splash_boats_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats60DegUpTo25DegUpImageId[direction]);
@@ -622,7 +622,7 @@ static void paint_splash_boats_track_60_deg_up_to_25_deg_up(
 }
 
 static void paint_splash_boats_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegDownImageId[direction]);
@@ -648,14 +648,14 @@ static void paint_splash_boats_track_25_deg_down(
 }
 
 static void paint_splash_boats_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_splash_boats_track_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void paint_splash_boats_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoatsFlatTo25DegDownImageId[direction]);
@@ -681,21 +681,21 @@ static void paint_splash_boats_track_flat_to_25_deg_down(
 }
 
 static void paint_splash_boats_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_splash_boats_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void paint_splash_boats_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     paint_splash_boats_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void paint_splash_boats_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     auto imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SplashBoats25DegDownToFlatImageId[direction]);
@@ -723,7 +723,7 @@ static void paint_splash_boats_track_25_deg_down_to_flat(
 /** Start of elements originally from River Rafts */
 /** rct2: 0x0089B170 */
 static void paint_splash_boats_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     ImageId imageId;
@@ -766,7 +766,7 @@ static void paint_splash_boats_track_flat(
 
 /** rct2: 0x0089B1A0 */
 static void paint_splash_boats_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     if (direction & 1)
@@ -800,7 +800,7 @@ static void paint_splash_boats_station(
 
 /** rct2: 0x0089B1D0 */
 static void paint_splash_boats_track_left_quarter_turn_5_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
@@ -879,7 +879,7 @@ static void paint_splash_boats_track_left_quarter_turn_5_tiles(
 
 /** rct2: 0x0089B1D0 */
 static void paint_splash_boats_track_right_quarter_turn_5_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_right_quarter_turn_5_tiles_paint_2(
@@ -958,7 +958,7 @@ static void paint_splash_boats_track_right_quarter_turn_5_tiles(
 
 /** rct2: 0x0089B180 */
 static void paint_splash_boats_track_s_bend_left(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1058,7 +1058,7 @@ static void paint_splash_boats_track_s_bend_left(
 
 /** rct2: 0x0089B190 */
 static void paint_splash_boats_track_s_bend_right(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     static constexpr const uint32_t imageIds[4][4][2] = {
@@ -1157,7 +1157,7 @@ static void paint_splash_boats_track_s_bend_right(
 }
 
 static void paint_splash_boats_track_on_ride_photo(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     switch (direction)
@@ -1247,7 +1247,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_splash_boats(int32_t trackType)
  *  rct2: 0x006D4295
  */
 void vehicle_visual_splash_boats_or_water_coaster(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry)
 {
     auto* vehicleToPaint = vehicle->IsHead() ? GetEntity<Vehicle>(vehicle->next_vehicle_on_ride)

--- a/src/openrct2/ride/water/SubmarineRide.cpp
+++ b/src/openrct2/ride/water/SubmarineRide.cpp
@@ -42,7 +42,7 @@ static uint32_t SubmarineVehicleGetBaseImageId(const Vehicle* vehicle, const Car
  *  rct2: 0x006D44D5
  */
 void vehicle_visual_submarine(
-    paint_session& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
+    PaintSession& session, int32_t x, int32_t imageDirection, int32_t y, int32_t z, const Vehicle* vehicle,
     const CarEntry* carEntry)
 {
     auto baseImageId = SubmarineVehicleGetBaseImageId(vehicle, carEntry, imageDirection);
@@ -64,7 +64,7 @@ void vehicle_visual_submarine(
 }
 
 static void submarine_ride_paint_track_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     const auto* stationObj = ride.GetStationObject();
@@ -95,7 +95,7 @@ static void submarine_ride_paint_track_station(
 }
 
 static void submarine_ride_paint_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     int32_t heightLower = height - 16;
@@ -127,7 +127,7 @@ static void submarine_ride_paint_track_flat(
 }
 
 static void submarine_ride_paint_track_left_quarter_turn_3_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_3_tiles_paint(
@@ -163,7 +163,7 @@ static constexpr const uint8_t submarine_ride_right_quarter_turn_3_tiles_to_left
     0,
 };
 static void submarine_ride_paint_track_right_quarter_turn_3_tiles(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = submarine_ride_right_quarter_turn_3_tiles_to_left_turn_map[trackSequence];
@@ -172,7 +172,7 @@ static void submarine_ride_paint_track_right_quarter_turn_3_tiles(
 }
 
 static void submarine_ride_paint_track_left_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     track_paint_util_left_quarter_turn_1_tile_paint(
@@ -186,7 +186,7 @@ static void submarine_ride_paint_track_left_quarter_turn_1_tile(
 }
 
 static void submarine_ride_paint_track_right_quarter_turn_1_tile(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     submarine_ride_paint_track_left_quarter_turn_1_tile(

--- a/src/openrct2/ride/water/WaterCoaster.cpp
+++ b/src/openrct2/ride/water/WaterCoaster.cpp
@@ -14,7 +14,7 @@
 #include "../coaster/JuniorRollerCoaster.h"
 
 static void water_rc_track_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -24,7 +24,7 @@ static void water_rc_track_flat(
 }
 
 static void water_rc_track_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -34,7 +34,7 @@ static void water_rc_track_25_deg_up(
 }
 
 static void water_rc_track_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -44,7 +44,7 @@ static void water_rc_track_flat_to_25_deg_up(
 }
 
 static void water_rc_track_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -54,28 +54,28 @@ static void water_rc_track_25_deg_up_to_flat(
 }
 
 static void water_rc_track_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void water_rc_track_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_25_deg_up_to_flat(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void water_rc_track_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_flat_to_25_deg_up(session, ride, trackSequence, (direction + 2) & 3, height, trackElement);
 }
 
 static void water_rc_track_diag_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -85,7 +85,7 @@ static void water_rc_track_diag_flat(
 }
 
 static void water_rc_track_diag_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -95,7 +95,7 @@ static void water_rc_track_diag_25_deg_up(
 }
 
 static void water_rc_track_diag_flat_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -105,7 +105,7 @@ static void water_rc_track_diag_flat_to_25_deg_up(
 }
 
 static void water_rc_track_diag_25_deg_up_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -115,7 +115,7 @@ static void water_rc_track_diag_25_deg_up_to_flat(
 }
 
 static void water_rc_track_diag_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -125,7 +125,7 @@ static void water_rc_track_diag_25_deg_down(
 }
 
 static void water_rc_track_diag_flat_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -135,7 +135,7 @@ static void water_rc_track_diag_flat_to_25_deg_down(
 }
 
 static void water_rc_track_diag_25_deg_down_to_flat(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
@@ -145,21 +145,21 @@ static void water_rc_track_diag_25_deg_down_to_flat(
 }
 
 static void water_rc_track_station(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_station(session, ride, trackSequence, direction, height, trackElement, false);
 }
 
 static void water_rc_track_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_60_deg_up(session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_25_deg_up_to_60_deg_up(
@@ -167,7 +167,7 @@ static void water_rc_track_25_deg_up_to_60_deg_up(
 }
 
 static void water_rc_track_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_60_deg_up_to_25_deg_up(
@@ -175,21 +175,21 @@ static void water_rc_track_60_deg_up_to_25_deg_up(
 }
 
 static void water_rc_track_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void water_rc_track_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_60_deg_up_to_25_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
 static void water_rc_track_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_25_deg_up_to_60_deg_up(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
@@ -198,7 +198,7 @@ static void water_rc_track_60_deg_down_to_25_deg_down(
 // 5 tile turns
 
 static void water_rc_track_left_quarter_turn_5_tiles_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
@@ -206,7 +206,7 @@ static void water_rc_track_left_quarter_turn_5_tiles_25_deg_up(
 }
 
 static void water_rc_track_right_quarter_turn_5_tiles_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
@@ -218,7 +218,7 @@ static constexpr const uint8_t water_rc_left_quarter_turn_5_tiles_to_right_turn_
 };
 
 static void water_rc_track_left_quarter_turn_5_tiles_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_right_quarter_turn_5_tiles_25_deg_up(
@@ -227,7 +227,7 @@ static void water_rc_track_left_quarter_turn_5_tiles_25_deg_down(
 }
 
 static void water_rc_track_right_quarter_turn_5_tiles_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     water_rc_track_left_quarter_turn_5_tiles_25_deg_up(
@@ -238,7 +238,7 @@ static void water_rc_track_right_quarter_turn_5_tiles_25_deg_down(
 // 3 tile turns
 
 static void water_rc_track_right_quarter_turn_3_tiles_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
@@ -246,7 +246,7 @@ static void water_rc_track_right_quarter_turn_3_tiles_25_deg_up(
 }
 
 static void water_rc_track_right_quarter_turn_3_tiles_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
@@ -261,7 +261,7 @@ static constexpr const uint8_t water_rc_left_quarter_turn_3_tiles_to_right_turn_
 };
 
 static void water_rc_track_left_quarter_turn_3_tiles_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = water_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
@@ -270,7 +270,7 @@ static void water_rc_track_left_quarter_turn_3_tiles_25_deg_up(
 }
 
 static void water_rc_track_left_quarter_turn_3_tiles_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     trackSequence = water_rc_left_quarter_turn_3_tiles_to_right_turn_map[trackSequence];
@@ -279,7 +279,7 @@ static void water_rc_track_left_quarter_turn_3_tiles_25_deg_down(
 }
 
 static void water_rc_track_diag_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_60_deg_up(
@@ -287,7 +287,7 @@ static void water_rc_track_diag_60_deg_up(
 }
 
 static void water_rc_track_diag_25_deg_up_to_60_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
@@ -295,7 +295,7 @@ static void water_rc_track_diag_25_deg_up_to_60_deg_up(
 }
 
 static void water_rc_track_diag_60_deg_up_to_25_deg_up(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
@@ -303,7 +303,7 @@ static void water_rc_track_diag_60_deg_up_to_25_deg_up(
 }
 
 static void water_rc_track_diag_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_60_deg_down(
@@ -311,7 +311,7 @@ static void water_rc_track_diag_60_deg_down(
 }
 
 static void water_rc_track_diag_25_deg_down_to_60_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
@@ -319,7 +319,7 @@ static void water_rc_track_diag_25_deg_down_to_60_deg_down(
 }
 
 static void water_rc_track_diag_60_deg_down_to_25_deg_down(
-    paint_session& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
     junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(


### PR DESCRIPTION
This is quite big again, but that's impossible to avoid when renaming `paint_session`. I also renamed the other structs in `Paint.h` which didn't have as much of an impact.