### PR TITLE
Fix #18199 Save gamefile's name with many dots is truncated when it is saved

### DIFF
--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -605,8 +605,13 @@ static void WindowLoadsaveTextinput(rct_window* w, WidgetIndex widgetIndex, char
 
         case WIDX_NEW_FILE:
         {
-            const u8string path = Path::WithExtension(
-                Path::Combine(_directory, text), RemovePatternWildcard(_extensionPattern));
+            const auto extension = Path::GetExtension(text);
+            const auto newExtension = RemovePatternWildcard(_extensionPattern);
+            u8string path = Path::Combine(_directory, text);
+            if (!String::Equals(extension, newExtension, true))
+            {
+                path += newExtension;
+            }
 
             overwrite = false;
             for (auto& item : _listItems)
@@ -1088,7 +1093,12 @@ static void WindowLoadsaveSelect(rct_window* w, const char* path)
         {
             SetAndSaveConfigPath(gConfigGeneral.last_save_track_directory, pathBuffer);
 
-            const auto withExtension = Path::WithExtension(pathBuffer, "td6");
+            u8string withExtension = pathBuffer;
+            if (!String::Equals(Path::GetExtension(pathBuffer), "td6", true))
+            {
+                withExtension = Path::WithExtension(pathBuffer, "td6");
+            }
+
             String::Set(pathBuffer, sizeof(pathBuffer), withExtension.c_str());
 
             RCT2::T6Exporter t6Export{ _trackDesign };

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -565,7 +565,12 @@ void save_game()
 {
     if (!gFirstTimeSaving && !gIsAutosaveLoaded)
     {
-        const auto savePath = Path::WithExtension(gScenarioSavePath, ".park");
+        u8string savePath = gScenarioSavePath;
+        if (!String::Equals(Path::GetExtension(gScenarioSavePath), ".park", true))
+        {
+            savePath = Path::WithExtension(gScenarioSavePath, ".park");
+        }
+
         save_game_with_name(savePath);
     }
     else
@@ -578,14 +583,23 @@ void save_game_cmd(u8string_view name /* = {} */)
 {
     if (name.empty())
     {
-        const auto savePath = Path::WithExtension(gScenarioSavePath, ".park");
+        u8string savePath = gScenarioSavePath;
+        if (!String::Equals(Path::GetExtension(gScenarioSavePath), ".park", true))
+        {
+            savePath = Path::WithExtension(gScenarioSavePath, ".park");
+        }
 
         save_game_with_name(savePath);
     }
     else
     {
         auto env = GetContext()->GetPlatformEnvironment();
-        auto savePath = Path::Combine(env->GetDirectoryPath(DIRBASE::USER, DIRID::SAVE), u8string(name) + u8".park");
+        u8string saveName = u8string(name);
+        if (!String::Equals(Path::GetExtension(name), ".park", true))
+        {
+            saveName += ".park";
+        }
+        auto savePath = Path::Combine(env->GetDirectoryPath(DIRBASE::USER, DIRID::SAVE), saveName);
         save_game_with_name(savePath);
     }
 }


### PR DESCRIPTION
I'm compare old and new extension here

https://github.com/OpenRCT2/OpenRCT2/blob/9d3da730e9274c86149aa77f3af13b2d3930111f/src/openrct2-ui/windows/LoadSave.cpp#L606-L615

and ones in `save_game_cmd` as well

https://github.com/OpenRCT2/OpenRCT2/blob/9d3da730e9274c86149aa77f3af13b2d3930111f/src/openrct2/Game.cpp#L597-L602

---

Check like this is for when file is not lower case (`.PARK`) I want to keep the extension. but it will replace the other extension like `.sv4`.  From my test the input for these checks always has extension, so it's fine to replace.

https://github.com/OpenRCT2/OpenRCT2/blob/9d3da730e9274c86149aa77f3af13b2d3930111f/src/openrct2/Game.cpp#L568-L572

Fix #18199