### PR TITLE
Changed ride vehicle list to have less padding

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#18214] Competition scenarios have received their own section.
 - Improved: [#18250] Added modern style file and folder pickers on Windows.
 - Improved: [#18332] Allow Inverted Roller Coaster to draw boosters.
+- Improved: [#18350] Changed ride vehicle list to have less padding.
 - Improved: [#18422] Allow adding images to music objects.
 - Improved: [#18428] [Plugin] Add widget description interfaces to documentation.
 - Change: [#17998] Show cursor when using inverted mouse dragging.

--- a/src/openrct2-ui/interface/Dropdown.h
+++ b/src/openrct2-ui/interface/Dropdown.h
@@ -56,6 +56,7 @@ void WindowDropdownShowColour(rct_window* w, rct_widget* widget, uint8_t dropdow
 void WindowDropdownShowColourAvailable(
     rct_window* w, rct_widget* widget, uint8_t dropdownColour, uint8_t selectedColour, uint32_t availableColours);
 uint32_t DropdownGetAppropriateImageDropdownItemsPerRow(uint32_t numItems);
+bool WindowDropDownHasMultipleColumns(size_t numItems);
 
 namespace Dropdown
 {

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -473,3 +473,8 @@ uint32_t DropdownGetAppropriateImageDropdownItemsPerRow(uint32_t numItems)
 {
     return numItems < std::size(_appropriateImageDropdownItemsPerRow) ? _appropriateImageDropdownItemsPerRow[numItems] : 8;
 }
+
+bool WindowDropDownHasMultipleColumns(size_t numItems)
+{
+    return numItems > DROPDOWN_TEXT_MAX_ROWS;
+}

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2075,7 +2075,7 @@ static void WindowRideShowVehicleTypeDropdown(rct_window* w, rct_widget* widget)
     rct_widget* dropdownWidget = widget - 1;
     WindowDropdownShowTextCustomWidth(
         { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-        w->colours[1], 0, Dropdown::Flag::StayOpen, numItems, widget->right - dropdownWidget->left - 96);
+        w->colours[1], 0, Dropdown::Flag::StayOpen, numItems, widget->right - dropdownWidget->left - 30);
 
     // Find the current vehicle type in the ordered list.
     int32_t pos = 0;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2075,7 +2075,7 @@ static void WindowRideShowVehicleTypeDropdown(rct_window* w, rct_widget* widget)
     rct_widget* dropdownWidget = widget - 1;
     WindowDropdownShowTextCustomWidth(
         { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-        w->colours[1], 0, Dropdown::Flag::StayOpen, numItems, widget->right - dropdownWidget->left);
+        w->colours[1], 0, Dropdown::Flag::StayOpen, numItems, widget->right - dropdownWidget->left - 96);
 
     // Find the current vehicle type in the ordered list.
     int32_t pos = 0;

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2073,9 +2073,10 @@ static void WindowRideShowVehicleTypeDropdown(rct_window* w, rct_widget* widget)
     }
 
     rct_widget* dropdownWidget = widget - 1;
+    auto width = WindowDropDownHasMultipleColumns(numItems) ? dropdownWidget->width() - 24 : dropdownWidget->width();
     WindowDropdownShowTextCustomWidth(
         { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-        w->colours[1], 0, Dropdown::Flag::StayOpen, numItems, widget->right - dropdownWidget->left - 30);
+        w->colours[1], 0, Dropdown::Flag::StayOpen, numItems, width);
 
     // Find the current vehicle type in the ordered list.
     int32_t pos = 0;


### PR DESCRIPTION
changes value of integer in ride.cpp in order to prevent the ride list from being cut off when allow ride vehicles from other track types is turned on at reasonable scaling levels
https://github.com/OpenRCT2/OpenRCT2/issues/18132

before
<img width="1926" alt="before" src="https://user-images.githubusercontent.com/94884086/196017607-2c372942-22a2-4400-b1f6-0ded4c9871b7.png">
after
<img width="1919" alt="after3" src="https://user-images.githubusercontent.com/94884086/197928012-27dbbd44-eb65-4556-bae3-ed07a7a84e1d.png">


