### PR TITLE
Fix #11679: Facilities clipping issues

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Change: [#17998] Show cursor when using inverted mouse dragging.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.
 - Change: [#18381] Convert custom invisible paths to the built-in ones.
+- Fix: [#11679] Facilities clipping issues.
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#14425] Ride ratings do not skip unallocated ride ids.
 - Fix: [#15969] Guests heading for ride use vanilla behaviour

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -32,10 +32,10 @@ static void PaintFacility(
     if (firstCarEntry == nullptr)
         return;
 
-    auto lengthX = (direction & 1) == 0 ? 28 : 2;
-    auto lengthY = (direction & 1) == 0 ? 2 : 28;
+    auto lengthX = direction == 1 ? 2 : 28;
+    auto lengthY = direction == 2 ? 2 : 28;
     CoordsXYZ offset(0, 0, height);
-    BoundBoxXYZ bb = { { direction == 3 ? 28 : 2, direction == 0 ? 28 : 2, height }, { lengthX, lengthY, 29 } };
+    BoundBoxXYZ bb = { { 2, 2, height }, { lengthX, lengthY, 29 } };
 
     auto imageTemplate = session.TrackColours[SCHEME_TRACK];
     auto imageIndex = firstCarEntry->base_image_id + ((direction + 2) & 3);


### PR DESCRIPTION
Adjust the bounding boxes to prevent clipping issues as shown in linked issue. I also didn't notice any regression when testing in busy parks with facilities.

Resolves #11679.