### PR TITLE
Fix #18324: Refactor TitleOptions to class

### DIFF
--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -19,49 +19,48 @@ enum WindowTitleOptionsWidgetIdx {
     WIDX_OPTIONS,
 };
 
-static rct_widget window_title_options_widgets[] = {
+static rct_widget _windowTitleOptionsWidgets[] = {
     MakeWidget({0, 0}, {80, 15}, WindowWidgetType::Button, WindowColour::Tertiary, STR_OPTIONS, STR_OPTIONS_TIP),
     WIDGETS_END,
 };
-
-static void WindowTitleOptionsMouseup(rct_window *w, WidgetIndex widgetIndex);
-static void WindowTitleOptionsPaint(rct_window *w, rct_drawpixelinfo *dpi);
-
-static WindowEventList window_title_options_events([](auto& events)
-{
-    events.mouse_up = &WindowTitleOptionsMouseup;
-    events.paint = &WindowTitleOptionsPaint;
-});
 // clang-format on
+
+class TitleOptionsWindow final : public Window
+{
+public:
+    void OnOpen() override
+    {
+        widgets = _windowTitleOptionsWidgets;
+        WindowInitScrollWidgets(*this);
+    }
+
+    void OnMouseUp(WidgetIndex widgetIndex) override
+    {
+        switch (widgetIndex)
+        {
+            case WIDX_OPTIONS:
+                context_open_window(WindowClass::Options);
+                break;
+        }
+    }
+
+    void OnDraw(rct_drawpixelinfo& dpi) override
+    {
+        DrawWidgets(dpi);
+    }
+};
 
 /**
  * Creates the window containing the options button on the title screen.
  */
 rct_window* WindowTitleOptionsOpen()
 {
-    rct_window* window = WindowCreate(
-        ScreenCoordsXY(context_get_width() - 80, 0), 80, 15, &window_title_options_events, WindowClass::TitleOptions,
-        WF_STICK_TO_BACK | WF_TRANSPARENT);
-    window->widgets = window_title_options_widgets;
-    WindowInitScrollWidgets(*window);
+    auto* window = window_bring_to_front_by_class(WindowClass::TitleOptions);
+    if (window == nullptr)
+    {
+        window = WindowCreate<TitleOptionsWindow>(
+            WindowClass::TitleOptions, ScreenCoordsXY(context_get_width() - 80, 0), 80, 15, WF_STICK_TO_BACK | WF_TRANSPARENT);
+    }
 
     return window;
-}
-
-static void WindowTitleOptionsMouseup(rct_window* w, WidgetIndex widgetIndex)
-{
-    if (gIntroState != IntroState::None)
-        return;
-
-    switch (widgetIndex)
-    {
-        case WIDX_OPTIONS:
-            context_open_window(WindowClass::Options);
-            break;
-    }
-}
-
-static void WindowTitleOptionsPaint(rct_window* w, rct_drawpixelinfo* dpi)
-{
-    WindowDrawWidgets(*w, dpi);
 }


### PR DESCRIPTION
Updated TileOptions.cpp to be class-based and use current convention for local statics.