### PR TITLE
Convert PATHINVS, PATHCLR , PAT25MKY, JAINVSFP (in SV6 parks) to Invisible Path

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,7 +5,7 @@
 - Improved: [#18214] Competition scenarios have received their own section.
 - Improved: [#18250] Added modern style file and folder pickers on Windows.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.
-- Change: [#00000] Convert custom paths to invisible path: PATHINVS, PATHCLR , PAT25MKY, JAINVSFP.
+- Change: [#18381] Convert custom paths to invisible path, when converting from SV6: PATHINVS, PATHCLR , PAT25MKY, JAINVSFP.
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#17316] Sides of River Rapids’ corners overlay other parts of the track.
 - Fix: [#17763] Missing validation on invalid characters in file name.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Improved: [#18214] Competition scenarios have received their own section.
 - Improved: [#18250] Added modern style file and folder pickers on Windows.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.
+- Change: [#00000] Convert custom paths to invisible path: PATHINVS, PATHCLR , PAT25MKY, JAINVSFP.
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#17316] Sides of River Rapids’ corners overlay other parts of the track.
 - Fix: [#17763] Missing validation on invalid characters in file name.

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,7 +5,7 @@
 - Improved: [#18214] Competition scenarios have received their own section.
 - Improved: [#18250] Added modern style file and folder pickers on Windows.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.
-- Change: [#18381] Convert custom paths to invisible path, when converting from SV6: PATHINVS, PATHCLR , PAT25MKY, JAINVSFP.
+- Change: [#18381] Convert custom invisible paths to the built-in ones.
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#17316] Sides of River Rapids’ corners overlay other parts of the track.
 - Fix: [#17763] Missing validation on invalid characters in file name.

--- a/src/openrct2/rct2/RCT2.cpp
+++ b/src/openrct2/rct2/RCT2.cpp
@@ -216,6 +216,16 @@ namespace RCT2
           "rct2.footpath_railings.concrete" },
         { "PATHCRZY", "rct1ll.footpath_surface.tiles_green", "rct1aa.footpath_surface.queue_green",
           "rct2.footpath_railings.concrete" },
+
+        // Custom path mapping
+        { "PATHINVS", "openrct2.footpath_surface.invisible", "openrct2.footpath_surface.queue_invisible",
+          "openrct2.footpath_railings.invisible" },
+        { "PATHCLR ", "openrct2.footpath_surface.invisible", "openrct2.footpath_surface.queue_invisible",
+          "openrct2.footpath_railings.invisible" },
+        { "PAT25MKY", "openrct2.footpath_surface.invisible", "openrct2.footpath_surface.queue_invisible",
+          "openrct2.footpath_railings.invisible" },
+        { "JAINVSFP", "openrct2.footpath_surface.invisible", "openrct2.footpath_surface.queue_invisible",
+          "openrct2.footpath_railings.invisible" },
     };
 
     const FootpathMapping* GetFootpathSurfaceId(const ObjectEntryDescriptor& desc, bool ideallyLoaded, bool isQueue)


### PR DESCRIPTION
This is currently only available when converting from `.SV6`. A different PR will need to prevent `PATHINVS`, `PATHCLR `, `PAT25MKY` and `JAINVSFP` from being selectable in general and converting all objects in `.park` files aswell.

Farewell to this beautiful preview
![image](https://user-images.githubusercontent.com/1516893/196700956-dc1dc423-2a2b-4348-811c-648b841a5fe4.png)

[Test park](https://github.com/OpenRCT2/OpenRCT2/files/9820853/Invis.path.conversion.test.zip)

