### PR TITLE
Close #18323: Refactor TitleMenu window to class

### DIFF
--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -54,66 +54,7 @@ static rct_widget window_title_menu_widgets[] = {
     MakeWidget({0,                       0}, UpdateButtonDims, WindowWidgetType::Empty,  WindowColour::Secondary, STR_UPDATE_AVAILABLE),
     WIDGETS_END,
 };
-
-static void WindowTitleMenuMouseup(rct_window *w, WidgetIndex widgetIndex);
-static void WindowTitleMenuMousedown(rct_window *w, WidgetIndex widgetIndex, rct_widget* widget);
-static void WindowTitleMenuDropdown(rct_window *w, WidgetIndex widgetIndex, int32_t dropdownIndex);
-static void WindowTitleMenuCursor(rct_window *w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID *cursorId);
-static void WindowTitleMenuInvalidate(rct_window *w);
-static void WindowTitleMenuPaint(rct_window *w, rct_drawpixelinfo *dpi);
-
-static WindowEventList window_title_menu_events([](auto& events)
-{
-    events.mouse_up = &WindowTitleMenuMouseup;
-    events.mouse_down = &WindowTitleMenuMousedown;
-    events.dropdown = &WindowTitleMenuDropdown;
-    events.cursor = &WindowTitleMenuCursor;
-    events.invalidate = &WindowTitleMenuInvalidate;
-    events.paint = &WindowTitleMenuPaint;
-});
 // clang-format on
-
-/**
- * Creates the window containing the menu buttons on the title screen.
- *  rct2: 0x0066B5C0 (part of 0x0066B3E8)
- */
-rct_window* WindowTitleMenuOpen()
-{
-    rct_window* window;
-
-    const uint16_t windowHeight = MenuButtonDims.height + UpdateButtonDims.height;
-    window = WindowCreate(
-        ScreenCoordsXY(0, context_get_height() - 182), 0, windowHeight, &window_title_menu_events, WindowClass::TitleMenu,
-        WF_STICK_TO_BACK | WF_TRANSPARENT | WF_NO_BACKGROUND);
-
-    window->widgets = window_title_menu_widgets;
-
-#ifdef DISABLE_NETWORK
-    window->widgets[WIDX_MULTIPLAYER].type = WindowWidgetType::Empty;
-#endif
-
-    WidgetIndex i = 0;
-    int32_t x = 0;
-    for (rct_widget* widget = window->widgets; widget != &window->widgets[WIDX_NEW_VERSION]; widget++)
-    {
-        if (widget->type != WindowWidgetType::Empty)
-        {
-            widget->left = x;
-            widget->right = x + MenuButtonDims.width - 1;
-
-            x += MenuButtonDims.width;
-        }
-        i++;
-    }
-    window->width = x;
-    window->widgets[WIDX_NEW_VERSION].right = window->width;
-    window->windowPos.x = (context_get_width() - window->width) / 2;
-    window->colours[1] = TRANSLUCENT(COLOUR_LIGHT_ORANGE);
-
-    WindowInitScrollWidgets(*window);
-
-    return window;
-}
 
 static void WindowTitleMenuScenarioselectCallback(const utf8* path)
 {
@@ -121,106 +62,6 @@ static void WindowTitleMenuScenarioselectCallback(const utf8* path)
     OpenRCT2::GetContext()->LoadParkFromFile(path, false, true);
     game_load_scripts();
     game_notify_map_changed();
-}
-
-static void WindowTitleMenuMouseup(rct_window* w, WidgetIndex widgetIndex)
-{
-    rct_window* windowToOpen = nullptr;
-
-    switch (widgetIndex)
-    {
-        case WIDX_START_NEW_GAME:
-            windowToOpen = window_find_by_class(WindowClass::ScenarioSelect);
-            if (windowToOpen != nullptr)
-            {
-                window_bring_to_front(*windowToOpen);
-            }
-            else
-            {
-                window_close_by_class(WindowClass::Loadsave);
-                window_close_by_class(WindowClass::ServerList);
-                WindowScenarioselectOpen(WindowTitleMenuScenarioselectCallback, false);
-            }
-            break;
-        case WIDX_CONTINUE_SAVED_GAME:
-            windowToOpen = window_find_by_class(WindowClass::Loadsave);
-            if (windowToOpen != nullptr)
-            {
-                window_bring_to_front(*windowToOpen);
-            }
-            else
-            {
-                window_close_by_class(WindowClass::ScenarioSelect);
-                window_close_by_class(WindowClass::ServerList);
-                auto loadOrQuitAction = LoadOrQuitAction(LoadOrQuitModes::OpenSavePrompt);
-                GameActions::Execute(&loadOrQuitAction);
-            }
-            break;
-        case WIDX_MULTIPLAYER:
-            windowToOpen = window_find_by_class(WindowClass::ServerList);
-            if (windowToOpen != nullptr)
-            {
-                window_bring_to_front(*windowToOpen);
-            }
-            else
-            {
-                window_close_by_class(WindowClass::ScenarioSelect);
-                window_close_by_class(WindowClass::Loadsave);
-                context_open_window(WindowClass::ServerList);
-            }
-            break;
-        case WIDX_NEW_VERSION:
-            context_open_window_view(WV_NEW_VERSION_INFO);
-            break;
-    }
-}
-
-static void WindowTitleMenuMousedown(rct_window* w, WidgetIndex widgetIndex, rct_widget* widget)
-{
-    if (widgetIndex == WIDX_GAME_TOOLS)
-    {
-        int32_t i = 0;
-        gDropdownItems[i++].Format = STR_SCENARIO_EDITOR;
-        gDropdownItems[i++].Format = STR_CONVERT_SAVED_GAME_TO_SCENARIO;
-        gDropdownItems[i++].Format = STR_ROLLER_COASTER_DESIGNER;
-        gDropdownItems[i++].Format = STR_TRACK_DESIGNS_MANAGER;
-        gDropdownItems[i++].Format = STR_OPEN_USER_CONTENT_FOLDER;
-
-#ifdef ENABLE_SCRIPTING
-        auto hasCustomItems = false;
-        const auto& customMenuItems = OpenRCT2::Scripting::CustomMenuItems;
-        if (!customMenuItems.empty())
-        {
-            for (const auto& item : customMenuItems)
-            {
-                if (item.Kind == OpenRCT2::Scripting::CustomToolbarMenuItemKind::Toolbox)
-                {
-                    // Add seperator
-                    if (!hasCustomItems)
-                    {
-                        hasCustomItems = true;
-                        gDropdownItems[i++].Format = STR_EMPTY;
-                    }
-
-                    gDropdownItems[i].Format = STR_STRING;
-                    auto sz = item.Text.c_str();
-                    std::memcpy(&gDropdownItems[i].Args, &sz, sizeof(const char*));
-                    i++;
-                }
-            }
-        }
-#endif
-
-        int32_t yOffset = 0;
-        if (i > 5)
-        {
-            yOffset = -(widget->height() + 5 + (i * 12));
-        }
-
-        WindowDropdownShowText(
-            { w->windowPos.x + widget->left, w->windowPos.y + widget->top + yOffset }, widget->height() + 1,
-            TRANSLUCENT(w->colours[0]), Dropdown::Flag::StayOpen, i);
-    }
 }
 
 static void InvokeCustomToolboxMenuItem(size_t index)
@@ -243,58 +84,203 @@ static void InvokeCustomToolboxMenuItem(size_t index)
 #endif
 }
 
-static void WindowTitleMenuDropdown(rct_window* w, WidgetIndex widgetIndex, int32_t dropdownIndex)
-{
-    if (widgetIndex == WIDX_GAME_TOOLS)
-    {
-        switch (dropdownIndex)
+class TitleMenuWindow final : public Window {
+public:
+    void OnOpen() override {
+        widgets = window_title_menu_widgets;
+
+    #ifdef DISABLE_NETWORK
+        widgets[WIDX_MULTIPLAYER].type = WindowWidgetType::Empty;
+    #endif
+
+        WidgetIndex i = 0;
+        int32_t x = 0;
+        for (rct_widget* widget = widgets; widget != &widgets[WIDX_NEW_VERSION]; widget++)
         {
-            case DDIDX_SCENARIO_EDITOR:
-                Editor::Load();
-                break;
-            case DDIDX_CONVERT_SAVED_GAME:
-                Editor::ConvertSaveToScenario();
-                break;
-            case DDIDX_TRACK_DESIGNER:
-                Editor::LoadTrackDesigner();
-                break;
-            case DDIDX_TRACK_MANAGER:
-                Editor::LoadTrackManager();
-                break;
-            case DDIDX_OPEN_CONTENT_FOLDER:
+            if (widget->type != WindowWidgetType::Empty)
             {
-                auto context = OpenRCT2::GetContext();
-                auto env = context->GetPlatformEnvironment();
-                auto uiContext = context->GetUiContext();
-                uiContext->OpenFolder(env->GetDirectoryPath(OpenRCT2::DIRBASE::USER));
-                break;
+                widget->left = x;
+                widget->right = x + MenuButtonDims.width - 1;
+
+                x += MenuButtonDims.width;
             }
-            default:
-                InvokeCustomToolboxMenuItem(dropdownIndex - DDIDX_CUSTOM_BEGIN);
+            i++;
+        }
+        width = x;
+        widgets[WIDX_NEW_VERSION].right = width;
+        windowPos.x = (context_get_width() - width) / 2;
+        colours[1] = TRANSLUCENT(COLOUR_LIGHT_ORANGE);
+
+        InitScrollWidgets();
+    }
+
+    void OnMouseUp(WidgetIndex widgetIndex) override
+    {
+        rct_window* windowToOpen = nullptr;
+
+        switch (widgetIndex)
+        {
+            case WIDX_START_NEW_GAME:
+                windowToOpen = window_find_by_class(WindowClass::ScenarioSelect);
+                if (windowToOpen != nullptr)
+                {
+                    window_bring_to_front(*windowToOpen);
+                }
+                else
+                {
+                    window_close_by_class(WindowClass::Loadsave);
+                    window_close_by_class(WindowClass::ServerList);
+                    WindowScenarioselectOpen(WindowTitleMenuScenarioselectCallback, false);
+                }
+                break;
+            case WIDX_CONTINUE_SAVED_GAME:
+                windowToOpen = window_find_by_class(WindowClass::Loadsave);
+                if (windowToOpen != nullptr)
+                {
+                    window_bring_to_front(*windowToOpen);
+                }
+                else
+                {
+                    window_close_by_class(WindowClass::ScenarioSelect);
+                    window_close_by_class(WindowClass::ServerList);
+                    auto loadOrQuitAction = LoadOrQuitAction(LoadOrQuitModes::OpenSavePrompt);
+                    GameActions::Execute(&loadOrQuitAction);
+                }
+                break;
+            case WIDX_MULTIPLAYER:
+                windowToOpen = window_find_by_class(WindowClass::ServerList);
+                if (windowToOpen != nullptr)
+                {
+                    window_bring_to_front(*windowToOpen);
+                }
+                else
+                {
+                    window_close_by_class(WindowClass::ScenarioSelect);
+                    window_close_by_class(WindowClass::Loadsave);
+                    context_open_window(WindowClass::ServerList);
+                }
+                break;
+            case WIDX_NEW_VERSION:
+                context_open_window_view(WV_NEW_VERSION_INFO);
                 break;
         }
     }
-}
 
-static void WindowTitleMenuCursor(
-    rct_window* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID* cursorId)
-{
-    gTooltipTimeout = 2000;
-}
-
-static void WindowTitleMenuInvalidate(rct_window* w)
-{
-    _filterRect = { w->windowPos.x, w->windowPos.y + UpdateButtonDims.height, w->windowPos.x + w->width - 1,
-                    w->windowPos.y + MenuButtonDims.height + UpdateButtonDims.height - 1 };
-    if (OpenRCT2::GetContext()->HasNewVersionInfo())
+    void OnMouseDown(WidgetIndex widgetIndex) override
     {
-        w->widgets[WIDX_NEW_VERSION].type = WindowWidgetType::Button;
-        _filterRect.Point1.y = w->windowPos.y;
-    }
-}
+        if (widgetIndex == WIDX_GAME_TOOLS)
+        {
+            rct_widget* widget = &widgets[widgetIndex];
+            int32_t i = 0;
+            gDropdownItems[i++].Format = STR_SCENARIO_EDITOR;
+            gDropdownItems[i++].Format = STR_CONVERT_SAVED_GAME_TO_SCENARIO;
+            gDropdownItems[i++].Format = STR_ROLLER_COASTER_DESIGNER;
+            gDropdownItems[i++].Format = STR_TRACK_DESIGNS_MANAGER;
+            gDropdownItems[i++].Format = STR_OPEN_USER_CONTENT_FOLDER;
 
-static void WindowTitleMenuPaint(rct_window* w, rct_drawpixelinfo* dpi)
+    #ifdef ENABLE_SCRIPTING
+            auto hasCustomItems = false;
+            const auto& customMenuItems = OpenRCT2::Scripting::CustomMenuItems;
+            if (!customMenuItems.empty())
+            {
+                for (const auto& item : customMenuItems)
+                {
+                    if (item.Kind == OpenRCT2::Scripting::CustomToolbarMenuItemKind::Toolbox)
+                    {
+                        // Add seperator
+                        if (!hasCustomItems)
+                        {
+                            hasCustomItems = true;
+                            gDropdownItems[i++].Format = STR_EMPTY;
+                        }
+
+                        gDropdownItems[i].Format = STR_STRING;
+                        auto sz = item.Text.c_str();
+                        std::memcpy(&gDropdownItems[i].Args, &sz, sizeof(const char*));
+                        i++;
+                    }
+                }
+            }
+    #endif
+
+            int32_t yOffset = 0;
+            if (i > 5)
+            {
+                yOffset = -(widget->height() + 5 + (i * 12));
+            }
+
+            WindowDropdownShowText(
+                { windowPos.x + widget->left, windowPos.y + widget->top + yOffset }, widget->height() + 1,
+                TRANSLUCENT(colours[0]), Dropdown::Flag::StayOpen, i);
+        }
+    }
+
+    void OnDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override
+    {
+        if (widgetIndex == WIDX_GAME_TOOLS)
+        {
+            switch (selectedIndex)
+            {
+                case DDIDX_SCENARIO_EDITOR:
+                    Editor::Load();
+                    break;
+                case DDIDX_CONVERT_SAVED_GAME:
+                    Editor::ConvertSaveToScenario();
+                    break;
+                case DDIDX_TRACK_DESIGNER:
+                    Editor::LoadTrackDesigner();
+                    break;
+                case DDIDX_TRACK_MANAGER:
+                    Editor::LoadTrackManager();
+                    break;
+                case DDIDX_OPEN_CONTENT_FOLDER:
+                {
+                    auto context = OpenRCT2::GetContext();
+                    auto env = context->GetPlatformEnvironment();
+                    auto uiContext = context->GetUiContext();
+                    uiContext->OpenFolder(env->GetDirectoryPath(OpenRCT2::DIRBASE::USER));
+                    break;
+                }
+                default:
+                    InvokeCustomToolboxMenuItem(selectedIndex - DDIDX_CUSTOM_BEGIN);
+                    break;
+            }
+        }
+    }
+
+    CursorID OnCursor(
+        WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID cursorId) override
+    {
+        gTooltipTimeout = 2000;
+        return cursorId;
+    }   
+
+    void OnUpdate() override
+    {
+        _filterRect = { windowPos.x, windowPos.y + UpdateButtonDims.height, windowPos.x + width - 1,
+                        windowPos.y + MenuButtonDims.height + UpdateButtonDims.height - 1 };
+        if (OpenRCT2::GetContext()->HasNewVersionInfo())
+        {
+            widgets[WIDX_NEW_VERSION].type = WindowWidgetType::Button;
+            _filterRect.Point1.y = windowPos.y;
+        }
+    }
+
+    void OnDraw(rct_drawpixelinfo& dpi) override
+    {
+        gfx_filter_rect(&dpi, _filterRect, FilterPaletteID::Palette51);
+        DrawWidgets(dpi);
+    }
+};
+
+/**
+ * Creates the window containing the menu buttons on the title screen.
+ *  rct2: 0x0066B5C0 (part of 0x0066B3E8)
+ */
+rct_window* WindowTitleMenuOpen()
 {
-    gfx_filter_rect(dpi, _filterRect, FilterPaletteID::Palette51);
-    WindowDrawWidgets(*w, dpi);
+    const uint16_t windowHeight = MenuButtonDims.height + UpdateButtonDims.height;
+    return WindowCreate<TitleMenuWindow>(
+        WindowClass::TitleMenu, ScreenCoordsXY(0, context_get_height() - 182), 0, windowHeight,
+        WF_STICK_TO_BACK | WF_TRANSPARENT | WF_NO_BACKGROUND);
 }

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -174,7 +174,6 @@ public:
     {
         if (widgetIndex == WIDX_GAME_TOOLS)
         {
-            rct_widget* widget = &widgets[widgetIndex];
             int32_t i = 0;
             gDropdownItems[i++].Format = STR_SCENARIO_EDITOR;
             gDropdownItems[i++].Format = STR_CONVERT_SAVED_GAME_TO_SCENARIO;
@@ -207,6 +206,7 @@ public:
             }
 #endif
 
+            rct_widget* widget = &widgets[widgetIndex];
             int32_t yOffset = 0;
             if (i > 5)
             {
@@ -214,7 +214,7 @@ public:
             }
 
             WindowDropdownShowText(
-                { windowPos.x + widget->left, windowPos.y + widget->top + yOffset }, widget->height() + 1,
+                windowPos + ScreenCoordsXY{ widget->left, widget->top + yOffset }, widget->height() + 1,
                 TRANSLUCENT(colours[0]), Dropdown::Flag::StayOpen, i);
         }
     }
@@ -252,7 +252,7 @@ public:
         }
     }
 
-    CursorID OnCursor(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID cursorId) override
+    CursorID OnCursor(WidgetIndex, const ScreenCoordsXY&, CursorID cursorId) override
     {
         gTooltipTimeout = 2000;
         return cursorId;
@@ -260,8 +260,8 @@ public:
 
     void OnPrepareDraw() override
     {
-        _filterRect = { windowPos.x, windowPos.y + UpdateButtonDims.height, windowPos.x + width - 1,
-                        windowPos.y + MenuButtonDims.height + UpdateButtonDims.height - 1 };
+        _filterRect = { windowPos + ScreenCoordsXY{ 0, UpdateButtonDims.height },
+                        windowPos + ScreenCoordsXY{ width - 1, MenuButtonDims.height + UpdateButtonDims.height - 1 } };
         if (OpenRCT2::GetContext()->HasNewVersionInfo())
         {
             widgets[WIDX_NEW_VERSION].type = WindowWidgetType::Button;
@@ -278,7 +278,6 @@ public:
 
 /**
  * Creates the window containing the menu buttons on the title screen.
- *  rct2: 0x0066B5C0 (part of 0x0066B3E8)
  */
 rct_window* WindowTitleMenuOpen()
 {

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -256,7 +256,7 @@ public:
         return cursorId;
     }
 
-    void OnUpdate() override
+    void OnPrepareDraw() override
     {
         _filterRect = { windowPos.x, windowPos.y + UpdateButtonDims.height, windowPos.x + width - 1,
                         windowPos.y + MenuButtonDims.height + UpdateButtonDims.height - 1 };

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -42,7 +42,6 @@ enum
     DDIDX_CUSTOM_BEGIN = 6,
 };
 
-static ScreenRect _filterRect;
 static constexpr ScreenSize MenuButtonDims = { 82, 82 };
 static constexpr ScreenSize UpdateButtonDims = { MenuButtonDims.width * 4, 28 };
 
@@ -86,6 +85,9 @@ static void InvokeCustomToolboxMenuItem(size_t index)
 
 class TitleMenuWindow final : public Window
 {
+private:
+    ScreenRect _filterRect;
+
 public:
     void OnOpen() override
     {

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -84,14 +84,16 @@ static void InvokeCustomToolboxMenuItem(size_t index)
 #endif
 }
 
-class TitleMenuWindow final : public Window {
+class TitleMenuWindow final : public Window
+{
 public:
-    void OnOpen() override {
+    void OnOpen() override
+    {
         widgets = window_title_menu_widgets;
 
-    #ifdef DISABLE_NETWORK
+#ifdef DISABLE_NETWORK
         widgets[WIDX_MULTIPLAYER].type = WindowWidgetType::Empty;
-    #endif
+#endif
 
         WidgetIndex i = 0;
         int32_t x = 0;
@@ -178,7 +180,7 @@ public:
             gDropdownItems[i++].Format = STR_TRACK_DESIGNS_MANAGER;
             gDropdownItems[i++].Format = STR_OPEN_USER_CONTENT_FOLDER;
 
-    #ifdef ENABLE_SCRIPTING
+#ifdef ENABLE_SCRIPTING
             auto hasCustomItems = false;
             const auto& customMenuItems = OpenRCT2::Scripting::CustomMenuItems;
             if (!customMenuItems.empty())
@@ -201,7 +203,7 @@ public:
                     }
                 }
             }
-    #endif
+#endif
 
             int32_t yOffset = 0;
             if (i > 5)
@@ -248,12 +250,11 @@ public:
         }
     }
 
-    CursorID OnCursor(
-        WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID cursorId) override
+    CursorID OnCursor(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID cursorId) override
     {
         gTooltipTimeout = 2000;
         return cursorId;
-    }   
+    }
 
     void OnUpdate() override
     {


### PR DESCRIPTION
Fixes https://github.com/OpenRCT2/OpenRCT2/issues/18323

TODO:
- [x] Does `WindowTitleMenuInvalidate` translate to `OnUpdate`, or should it be `OnPrepareDraw`?
- [x] Quitting out of the track designer manager seems slower than normal. Confirm whether this change causes that regression.