### PR TITLE
Fix #18379 : Mini Golf doesn't render Special E track's tunnel correctly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -16,6 +16,7 @@
 - Fix: [#18122] Ghosts count towards “Great scenery!” guest thought.
 - Fix: [#18134] Underground on-ride photo section partially clips through adjacent terrain edge.
 - Fix: [#18257] Guests ‘waiting’ on extended railway crossings.
+- Fix: [#18379] Tunnel entrances for underground Mini Golf Hole E are not rendered correctly.
 
 0.4.2 (2022-10-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -1073,13 +1073,13 @@ static void PaintMiniGolfHoleE(
 
     switch ((direction << 4) | trackSequence)
     {
-        case 0x00:
-        case 0x32:
+        case (0 << 4 | 0):
+        case (3 << 4 | 2):
             PaintUtilPushTunnelLeft(session, height, TUNNEL_PATH_AND_MINI_GOLF);
             break;
 
-        case 0x22:
-        case 0x30:
+        case (2 << 4 | 2):
+        case (3 << 4 | 0):
             PaintUtilPushTunnelRight(session, height, TUNNEL_PATH_AND_MINI_GOLF);
             break;
     }

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -1074,11 +1074,11 @@ static void PaintMiniGolfHoleE(
     switch ((direction << 4) | trackSequence)
     {
         case 0x00:
-        case 0x12:
+        case 0x32:
             PaintUtilPushTunnelLeft(session, height, TUNNEL_PATH_AND_MINI_GOLF);
             break;
 
-        case 0x02:
+        case 0x22:
         case 0x30:
             PaintUtilPushTunnelRight(session, height, TUNNEL_PATH_AND_MINI_GOLF);
             break;


### PR DESCRIPTION
Resolves #18379 

After
![image](https://user-images.githubusercontent.com/12020398/197134626-c9439d57-3460-4f66-a587-96418ef29597.png)