### PR TITLE
Allow adding images to MusicObjects

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Improved: [#18192] Tycoon Park has been added Extras tab.
 - Improved: [#18214] Competition scenarios have received their own section.
 - Improved: [#18250] Added modern style file and folder pickers on Windows.
+- Improved: [#18422] Allow adding images to music objects.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.
 - Change: [#18381] Convert custom invisible paths to the built-in ones.
 - Fix: [#14312] Research ride type message incorrect.

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -18,6 +18,7 @@
 #include "../core/IStream.hpp"
 #include "../core/Json.hpp"
 #include "../core/Path.hpp"
+#include "../drawing/Image.h"
 #include "../localisation/StringIds.h"
 #include "../ride/Ride.h"
 #include "RideObject.h"
@@ -71,6 +72,9 @@ void MusicObject::Load()
             track.Size = track.Asset.GetSize();
         }
     }
+
+    _hasPreview = !!GetImageTable().GetCount();
+    _previewImageId = gfx_object_allocate_images(GetImageTable().GetImages(), GetImageTable().GetCount());
 }
 
 void MusicObject::Unload()
@@ -84,7 +88,10 @@ void MusicObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t hei
     // Write (no image)
     int32_t x = width / 2;
     int32_t y = height / 2;
-    DrawTextBasic(dpi, { x, y }, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::CENTRE });
+    if (_hasPreview)
+        gfx_draw_sprite(dpi, ImageId(_previewImageId), { 0, 0 });
+    else
+        DrawTextBasic(dpi, { x, y }, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::CENTRE });
 }
 
 void MusicObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/MusicObject.h
+++ b/src/openrct2/object/MusicObject.h
@@ -49,6 +49,8 @@ private:
     MusicNiceFactor _niceFactor;
     AudioSampleTable _sampleTable;
     AudioSampleTable _loadedSampleTable;
+    bool _hasPreview{};
+    uint32_t _previewImageId{};
 
 public:
     StringId NameStringId{};


### PR DESCRIPTION
This allows object creators to add an image to their music objects. This can be stuff like album art or a suggestion which scenery their style may be a good fit for.

![afbeelding](https://user-images.githubusercontent.com/1478678/197414390-cab4dabb-11c2-4b97-8266-91931f5f7aaa.png)
