### PR TITLE
Fill out TrackSegment API

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1984,8 +1984,7 @@ declare global {
         readonly endY: number;
 
         /**
-         * The relative ending Z position. Negative numbers indicate
-         * that the track ends upside down.
+         * The relative ending Z position.
          */
         readonly endZ: number;
 
@@ -2018,37 +2017,37 @@ declare global {
         readonly elements: TrackSegmentElement[];
 
         /**
-         * The curve direction of the suggested following piece, or if the suggested following piece is a TrackElement
+         * The curve direction of the suggested following piece, or if the suggested following piece is a track segment
          */
         readonly chainNextCurve: TrackCurveType;
 
         /**
-         * The curve direction of the suggested preceding piece, or if the suggested preceding piece is a TrackElement
+         * The curve direction of the suggested preceding piece, or if the suggested preceding piece is a track segment
          */
         readonly chainPrevCurve: TrackCurveType;
 
         /**
-         * The track element for the following piece. Only valid if chainNextCurve is trackElement.
+         * The track segment for the following piece. Only valid if chainNextCurve is trackSegment.
          */
         readonly chainNextElement: number | null;
 
         /**
-         * The track element for the preceding piece. Only valid if chainPrevCurve is trackElement.
+         * The track segment for the preceding piece. Only valid if chainPrevCurve is trackSegment.
          */
         readonly chainPrevElement: number | null;
 
         /**
-         * The base price of the track element.
+         * The base price of the track segment.
          */
         readonly priceModifier: number;
 
         /**
-         * Track element representing the mirror image of the track element.
+         * Track segment representing the mirror image of the track segment.
          */
         readonly mirrorElement: number | null;
 
         /**
-         * Track element representing the covered/flume variant of the track element.
+         * Track segment representing the covered/flume variant of the track segment.
          */
         readonly alternateType: number | null;
 

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2017,26 +2017,15 @@ declare global {
         readonly elements: TrackSegmentElement[];
 
         /**
-         * The curve direction of the suggested following piece, or if the suggested following piece
+         * The curve direction of the suggested following piece, or track segment if it is specified.
          * is a track segment
          */
-        readonly nextCurve: TrackCurveType;
+        readonly nextSuggestedSegment: TrackCurveType | number;
 
         /**
-         * The curve direction of the suggested preceding piece, or if the suggested preceding piece
-         * is a track segment
+         * The curve direction of the suggested preceding piece, or track segment if it is specified.
          */
-        readonly previousCurve: TrackCurveType;
-
-        /**
-         * The track segment for the following piece. Only valid if chainEndCurve is trackSegment.
-         */
-        readonly nextElement: number | null;
-
-        /**
-         * The track segment for the preceding piece. Only valid if chainBeginCurve is trackSegment.
-         */
-        readonly previousElement: number | null;
+        readonly previousSuggestedSegment: TrackCurveType | number;
 
         /**
          * The base price of the track segment.
@@ -2046,12 +2035,18 @@ declare global {
         /**
          * Track segment representing the mirror image of the track segment.
          */
-        readonly mirrorElement: number | null;
+        readonly mirrorSegment: number | null;
 
         /**
          * Track segment representing the covered/flume variant of the track segment.
          */
-        readonly alternateType: number | null;
+        readonly alternateTypeSegment: number | null;
+
+        /**
+         * The group the track element belongs to. Ride types allow or disallow track groups to limit the
+         * buildable track segments.
+         */
+        readonly trackGroup: number;
 
         /**
          * Which direction the track curves towards.
@@ -2103,7 +2098,7 @@ declare global {
         UpsideDown = 15
     }
 
-    type TrackCurveType = "straight" | "left" | "right" | "trackElement";
+    type TrackCurveType = "straight" | "left" | "right";
     type TrackSlopeType = "flat" | "up" | "down";
 
     interface TrackSegmentElement extends Readonly<CoordsXYZ> {

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1988,12 +1988,12 @@ declare global {
         /**
          * The slope angle the segment starts with.
          */
-        readonly beginPitch: TrackSlope;
+        readonly beginSlope: TrackSlope;
 
         /**
          * The slope angle the segment ends with.
          */
-        readonly endPitch: TrackSlope;
+        readonly endSlope: TrackSlope;
 
         /**
          * The kind of banking the segment starts with.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1968,7 +1968,7 @@ declare global {
         /**
          * The slope angle the segment starts with.
          */
-        readonly beginAngle: TrackSlope;
+        readonly beginSlope: TrackSlope;
 
         /**
          * The kind of banking the segment starts with.
@@ -1995,11 +1995,10 @@ declare global {
          */
         readonly endDirection: Direction8;
 
-
         /**
          * The slope angle the segment ends with.
          */
-        readonly endAngle: TrackSlope;
+        readonly endSlope: TrackSlope;
 
         /**
          * The kind of banking the segment ends with.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1960,35 +1960,25 @@ declare global {
         readonly beginZ: number;
 
         /**
-        * The relative starting direction. Usually 0, but will be 4
-        * for diagonal segments.
-        */
-        readonly beginDirection: Direction8;
-
-        /**
-         * The slope angle the segment starts with.
+         * The relative ending Z position from the base of the first track sequence block.
          */
-        readonly beginSlope: TrackSlope;
+        readonly endZ: number;
 
         /**
-         * The kind of banking the segment starts with.
-         */
-        readonly beginBank: TrackBanking;
-
-        /**
-         * The relative ending X position.
+         * The relative ending X position. BeginX is always 0.
          */
         readonly endX: number;
 
         /**
-         * The relative ending Y position.
+         * The relative ending Y position. BeginY is always 0.
          */
         readonly endY: number;
 
         /**
-         * The relative ending Z position from the base of the first track sequence block.
-         */
-        readonly endZ: number;
+        * The relative starting direction. Usually 0, but will be 4
+        * for diagonal segments.
+        */
+        readonly beginDirection: Direction8;
 
         /**
          * The relative ending direction.
@@ -1996,9 +1986,19 @@ declare global {
         readonly endDirection: Direction8;
 
         /**
+         * The slope angle the segment starts with.
+         */
+        readonly beginSlope: TrackSlope;
+
+        /**
          * The slope angle the segment ends with.
          */
         readonly endSlope: TrackSlope;
+
+        /**
+         * The kind of banking the segment starts with.
+         */
+        readonly beginBank: TrackBanking;
 
         /**
          * The kind of banking the segment ends with.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2064,12 +2064,12 @@ declare global {
         /**
          * The track segment counts as banked for vehicles with "no banked track" behaviour.
          */
-        readonly segmentBanks: boolean;
+        readonly isBanked: boolean;
 
         /**
          * The track segment counts as an inversion for vehicles with "no inversions" behaviour.
          */
-        readonly segmentInverts: boolean;
+        readonly isInversion: boolean;
 
         /**
          * Pevents steep forward chainlifts but allows steep reverse chainlifts for reverse incline
@@ -2085,7 +2085,7 @@ declare global {
         /**
          * The track segment adds to golf hole counter.
          */
-        readonly isGolfHole: boolean;
+        readonly countsAsGolfHole: boolean;
 
         /**
          * The track segment adds to banked turn counter.
@@ -2105,7 +2105,7 @@ declare global {
         /**
          * The track segment adds to inversion counter. Usually applied to the first half of inversions.
          */
-        readonly isInversion: boolean;
+        readonly countsAsInversion: boolean;
         
         /**
          * Gets a length of the subpositions list for this track segment.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1988,12 +1988,12 @@ declare global {
         /**
          * The slope angle the segment starts with.
          */
-        readonly beginSlope: TrackSlope;
+        readonly beginPitch: TrackSlope;
 
         /**
          * The slope angle the segment ends with.
          */
-        readonly endSlope: TrackSlope;
+        readonly endPitch: TrackSlope;
 
         /**
          * The kind of banking the segment starts with.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2060,8 +2060,16 @@ declare global {
         readonly onlyAllowedUnderwater: boolean;
         readonly onlyAllowedAboveGround: boolean;
         readonly allowsChainLift: boolean;
-        readonly isBanked: boolean;
-        readonly isInversion: boolean;
+
+        /**
+         * The track segment counts as banked for vehicles with "no banked track" behaviour.
+         */
+        readonly segmentBanks: boolean;
+
+        /**
+         * The track segment counts as an inversion for vehicles with "no inversions" behaviour.
+         */
+        readonly segmentInverts: boolean;
 
         /**
          * Pevents steep forward chainlifts but allows steep reverse chainlifts for reverse incline
@@ -2077,27 +2085,27 @@ declare global {
         /**
          * The track segment adds to golf hole counter.
          */
-        readonly countsAsGolfHole: boolean;
+        readonly isGolfHole: boolean;
 
         /**
          * The track segment adds to banked turn counter.
          */
-        readonly countsAsBankedTurn: boolean;
+        readonly isBankedTurn: boolean;
 
         /**
          * The track segment adds to sloped turn counter.
          */
-        readonly countsAsSlopedTurn: boolean;
+        readonly isSlopedTurn: boolean;
 
         /**
          * The track segment adds to helix counter.
          */
-        readonly countsAsHelix: boolean;
+        readonly isHelix: boolean;
 
         /**
          * The track segment adds to inversion counter. Usually applied to the first half of inversions.
          */
-        readonly countsAsInversion: boolean;
+        readonly isInversion: boolean;
         
         /**
          * Gets a length of the subpositions list for this track segment.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2018,7 +2018,6 @@ declare global {
 
         /**
          * The curve direction of the suggested following piece, or track segment if it is specified.
-         * is a track segment
          */
         readonly nextSuggestedSegment: TrackCurveType | number;
 
@@ -2101,8 +2100,7 @@ declare global {
         readonly countsAsInversion: boolean;
         
         /**
-         * Gets a length of the subpositions list for this track segment. Note that subpositions
-         * are not rotated and are not equal length.
+         * Gets a length of the subpositions list for this track segment.
          */
         getSubpositionLength(subpositionType: number, direction: Direction): number;
 

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2062,16 +2062,43 @@ declare global {
         readonly onlyAllowedAboveGround: boolean;
         readonly allowsChainLift: boolean;
         readonly isBanked: boolean;
-        readonly isGolfHole: boolean;
-        readonly isHelix: boolean;
-        readonly startsHalfHeightUp: boolean;
         readonly isInversion: boolean;
 
         /**
-         * Used to prevent steep forward chainlifts but allows steep reverse chainlifts for
-         * reverse incline shuttle mode for ride types which do not normally allow steep chainlifts.
+         * Pevents steep forward chainlifts but allows steep reverse chainlifts for reverse incline
+         * shuttle mode for ride types which do not normally allow steep chainlifts.
          */
         readonly isSteepUp: boolean;
+
+        /**
+         * The track segment begins one height unit above normal track height units.
+         */
+        readonly startsHalfHeightUp: boolean;
+
+        /**
+         * The track segment adds to golf hole counter.
+         */
+        readonly countsAsGolfHole: boolean;
+
+        /**
+         * The track segment adds to banked turn counter.
+         */
+        readonly countsAsBankedTurn: boolean;
+
+        /**
+         * The track segment adds to sloped turn counter.
+         */
+        readonly countsAsSlopedTurn: boolean;
+
+        /**
+         * The track segment adds to helix counter.
+         */
+        readonly countsAsHelix: boolean;
+
+        /**
+         * The track segment adds to inversion counter. Usually applied to the first half of inversions.
+         */
+        readonly countsAsInversion: boolean;
         
         /**
          * Gets a length of the subpositions list for this track segment. Note that subpositions

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2018,6 +2018,61 @@ declare global {
         readonly elements: TrackSegmentElement[];
 
         /**
+         * The curve direction of the suggested following piece, or if the suggested following piece is a TrackElement
+         */
+        readonly chainNextCurve: TrackCurveType;
+
+        /**
+         * The curve direction of the suggested preceding piece, or if the suggested preceding piece is a TrackElement
+         */
+        readonly chainPrevCurve: TrackCurveType;
+
+        /**
+         * The track element for the following piece. Only valid if chainNextCurve is trackElement.
+         */
+        readonly chainNextElement: number | null;
+
+        /**
+         * The track element for the preceding piece. Only valid if chainPrevCurve is trackElement.
+         */
+        readonly chainPrevElement: number | null;
+
+        /**
+         * The base price of the track element.
+         */
+        readonly priceModifier: number;
+
+        /**
+         * Track element representing the mirror image of the track element.
+         */
+        readonly mirrorElement: number | null;
+
+        /**
+         * Track element representing the covered/flume variant of the track element.
+         */
+        readonly alternateType: number | null;
+
+        /**
+         * Which direction the track curves
+         */
+        readonly turnDirection: TrackCurveType;
+
+        /**
+         * Which way the track slopes
+         */
+        readonly slopeDirection: TrackSlopeType;
+
+        readonly onlyAllowedUnderwater: boolean;
+        readonly onlyAllowedAboveGround: boolean;
+        readonly allowsChainLift: boolean;
+        readonly isBanked: boolean;
+        readonly isGolfHole: boolean;
+        readonly isHelix: boolean;
+        readonly startsHalfHeightUp: boolean;
+        readonly isSteepUp: boolean;
+        readonly isInversion: boolean;
+        
+        /**
          * Gets a length of the subpositions list for this track segment.
          */
         getSubpositionLength(subpositionType: number, direction: Direction): number;
@@ -2045,6 +2100,9 @@ declare global {
         Right = 4,
         UpsideDown = 15
     }
+
+    type TrackCurveType = "straight" | "left" | "right" | "trackElement";
+    type TrackSlopeType = "flat" | "up" | "down";
 
     interface TrackSegmentElement extends Readonly<CoordsXYZ> {
     }

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -234,6 +234,8 @@ declare global {
          */
         getTrackSegment(type: number): TrackSegment | null;
 
+        getAllTrackSegments(): TrackSegment[];
+
         /**
          * Gets the image number for the given icon.
          * @param iconName The name of the icon.
@@ -1953,7 +1955,7 @@ declare global {
         readonly description: string;
 
         /**
-         * The relative starting Z position.
+         * The relative starting Z position from the base of the first track sequence block.
          */
         readonly beginZ: number;
 
@@ -1984,7 +1986,7 @@ declare global {
         readonly endY: number;
 
         /**
-         * The relative ending Z position.
+         * The relative ending Z position from the base of the first track sequence block.
          */
         readonly endZ: number;
 
@@ -2005,9 +2007,7 @@ declare global {
         readonly endBank: TrackBanking;
 
         /**
-         * The length of the segment in RCT track length units.
-         *
-         * *1 metre = 1 / (2 ^ 16)*
+         * The rough length of the segment.
          */
         readonly length: number;
 

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2065,8 +2065,13 @@ declare global {
         readonly isGolfHole: boolean;
         readonly isHelix: boolean;
         readonly startsHalfHeightUp: boolean;
-        readonly isSteepUp: boolean;
         readonly isInversion: boolean;
+
+        /**
+         * Used to prevent steep forward chainlifts but allows steep reverse chainlifts for
+         * reverse incline shuttle mode for ride types which do not normally allow steep chainlifts.
+         */
+        readonly isSteepUp: boolean;
         
         /**
          * Gets a length of the subpositions list for this track segment. Note that subpositions

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2017,24 +2017,26 @@ declare global {
         readonly elements: TrackSegmentElement[];
 
         /**
-         * The curve direction of the suggested following piece, or if the suggested following piece is a track segment
+         * The curve direction of the suggested following piece, or if the suggested following piece
+         * is a track segment
          */
-        readonly chainNextCurve: TrackCurveType;
+        readonly nextCurve: TrackCurveType;
 
         /**
-         * The curve direction of the suggested preceding piece, or if the suggested preceding piece is a track segment
+         * The curve direction of the suggested preceding piece, or if the suggested preceding piece
+         * is a track segment
          */
-        readonly chainPrevCurve: TrackCurveType;
+        readonly previousCurve: TrackCurveType;
 
         /**
-         * The track segment for the following piece. Only valid if chainNextCurve is trackSegment.
+         * The track segment for the following piece. Only valid if chainEndCurve is trackSegment.
          */
-        readonly chainNextElement: number | null;
+        readonly nextElement: number | null;
 
         /**
-         * The track segment for the preceding piece. Only valid if chainPrevCurve is trackSegment.
+         * The track segment for the preceding piece. Only valid if chainBeginCurve is trackSegment.
          */
-        readonly chainPrevElement: number | null;
+        readonly previousElement: number | null;
 
         /**
          * The base price of the track segment.
@@ -2052,12 +2054,12 @@ declare global {
         readonly alternateType: number | null;
 
         /**
-         * Which direction the track curves
+         * Which direction the track curves towards.
          */
         readonly turnDirection: TrackCurveType;
 
         /**
-         * Which way the track slopes
+         * Which direction the track slopes towards.
          */
         readonly slopeDirection: TrackSlopeType;
 
@@ -2072,7 +2074,8 @@ declare global {
         readonly isInversion: boolean;
         
         /**
-         * Gets a length of the subpositions list for this track segment.
+         * Gets a length of the subpositions list for this track segment. Note that subpositions
+         * are not rotated and are not equal length.
          */
         getSubpositionLength(subpositionType: number, direction: Direction): number;
 

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 69;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 70;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -233,7 +233,7 @@ namespace OpenRCT2::Scripting
             }
         }
 
-        std::vector<DukValue> getTrackSegments()
+        std::vector<DukValue> getAllTrackSegments()
         {
             auto ctx = GetContext()->GetScriptEngine().GetContext();
 
@@ -243,7 +243,7 @@ namespace OpenRCT2::Scripting
                 auto obj = std::make_shared<ScTrackSegment>(type);
                 if (obj != nullptr)
                 {
-                    result.push_back(GetObjectAsDukValue(ctx, std::make_shared<ScTrackSegment>(type)));
+                    result.push_back(GetObjectAsDukValue(ctx, obj));
                 }
             }
             return result;
@@ -471,7 +471,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_method(ctx, &ScContext::getObject, "getObject");
             dukglue_register_method(ctx, &ScContext::getAllObjects, "getAllObjects");
             dukglue_register_method(ctx, &ScContext::getTrackSegment, "getTrackSegment");
-            dukglue_register_method(ctx, &ScContext::getTrackSegments, "getTrackSegments");
+            dukglue_register_method(ctx, &ScContext::getAllTrackSegments, "getAllTrackSegments");
             dukglue_register_method(ctx, &ScContext::getRandom, "getRandom");
             dukglue_register_method_varargs(ctx, &ScContext::formatString, "formatString");
             dukglue_register_method(ctx, &ScContext::subscribe, "subscribe");

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -233,6 +233,22 @@ namespace OpenRCT2::Scripting
             }
         }
 
+        std::vector<DukValue> getTrackSegments()
+        {
+            auto ctx = GetContext()->GetScriptEngine().GetContext();
+
+            std::vector<DukValue> result;
+            for (track_type_t type = 0; type < TrackElemType::Count; type++)
+            {
+                auto obj = std::make_shared<ScTrackSegment>(type);
+                if (obj != nullptr)
+                {
+                    result.push_back(GetObjectAsDukValue(ctx, std::make_shared<ScTrackSegment>(type)));
+                }
+            }
+            return result;
+        }
+
         int32_t getRandom(int32_t min, int32_t max)
         {
             ThrowIfGameStateNotMutable();
@@ -455,6 +471,7 @@ namespace OpenRCT2::Scripting
             dukglue_register_method(ctx, &ScContext::getObject, "getObject");
             dukglue_register_method(ctx, &ScContext::getAllObjects, "getAllObjects");
             dukglue_register_method(ctx, &ScContext::getTrackSegment, "getTrackSegment");
+            dukglue_register_method(ctx, &ScContext::getTrackSegments, "getTrackSegments");
             dukglue_register_method(ctx, &ScContext::getRandom, "getRandom");
             dukglue_register_method_varargs(ctx, &ScContext::formatString, "formatString");
             dukglue_register_method(ctx, &ScContext::subscribe, "subscribe");

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -54,13 +54,12 @@ void ScTrackSegment::Register(duk_context* ctx)
     dukglue_register_property(
         ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_ONLY_ABOVE_GROUND>, nullptr, "onlyAllowedAboveGround");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_ALLOW_LIFT_HILL>, nullptr, "allowsChainLift");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_BANKED>, nullptr, "segmentBanks");
-    dukglue_register_property(
-        ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_INVERSION_TO_NORMAL>, nullptr, "segmentInverts");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_BANKED>, nullptr, "isBanked");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_INVERSION_TO_NORMAL>, nullptr, "isInversion");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_IS_STEEP_UP>, nullptr, "isSteepUp");
     dukglue_register_property(
         ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT>, nullptr, "startsHalfHeightUp");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_IS_GOLF_HOLE>, nullptr, "isGolfHole");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_IS_GOLF_HOLE>, nullptr, "countsAsInversion");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_TURN_BANKED>, nullptr, "isBankedTurn");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_TURN_SLOPED>, nullptr, "isSlopedTurn");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_HELIX>, nullptr, "isHelix");

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -31,8 +31,8 @@ void ScTrackSegment::Register(duk_context* ctx)
     dukglue_register_property(ctx, &ScTrackSegment::elements_get, nullptr, "elements");
     dukglue_register_property(ctx, &ScTrackSegment::beginDirection_get, nullptr, "beginDirection");
     dukglue_register_property(ctx, &ScTrackSegment::endDirection_get, nullptr, "endDirection");
-    dukglue_register_property(ctx, &ScTrackSegment::beginSlope_get, nullptr, "beginSlope");
-    dukglue_register_property(ctx, &ScTrackSegment::endSlope_get, nullptr, "endSlope");
+    dukglue_register_property(ctx, &ScTrackSegment::beginPitch_get, nullptr, "beginPitch");
+    dukglue_register_property(ctx, &ScTrackSegment::endPitch_get, nullptr, "endPitch");
     dukglue_register_property(ctx, &ScTrackSegment::beginBank_get, nullptr, "beginBank");
     dukglue_register_property(ctx, &ScTrackSegment::endBank_get, nullptr, "endBank");
     dukglue_register_property(ctx, &ScTrackSegment::beginZ_get, nullptr, "beginZ");
@@ -93,7 +93,7 @@ int32_t ScTrackSegment::beginDirection_get() const
     return ted.Coordinates.rotation_begin;
 }
 
-int32_t ScTrackSegment::beginSlope_get() const
+int32_t ScTrackSegment::beginPitch_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Definition.vangle_start;
@@ -129,7 +129,7 @@ int32_t ScTrackSegment::endDirection_get() const
     return ted.Coordinates.rotation_end;
 }
 
-int32_t ScTrackSegment::endSlope_get() const
+int32_t ScTrackSegment::endPitch_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Definition.vangle_end;

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -55,19 +55,16 @@ void ScTrackSegment::Register(duk_context* ctx)
         ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_ONLY_ABOVE_GROUND>, nullptr, "onlyAllowedAboveGround");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_ALLOW_LIFT_HILL>, nullptr, "allowsChainLift");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_BANKED>, nullptr, "isBanked");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_IS_GOLF_HOLE>, nullptr, "isGolfHole");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_HELIX>, nullptr, "isHelix");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_INVERSION_TO_NORMAL>, nullptr, "isInversion");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_IS_STEEP_UP>, nullptr, "isSteepUp");
     dukglue_register_property(
         ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT>, nullptr, "startsHalfHeightUp");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_IS_STEEP_UP>, nullptr, "isSteepUp");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_INVERSION_TO_NORMAL>, nullptr, "isInversion");
-    /*
-    Flags not included:
-    TRACK_ELEM_FLAG_NORMAL_TO_INVERSION -> adds to inversion counter, implies TRACK_ELEM_FLAG_INVERSION_TO_NORMAL
-    TRACK_ELEM_FLAG_TURN_BANKED -> counts as banked turn (implied by turn field and banked flag)
-    TRACK_ELEM_FLAG_TURN_SLOPED -> counts as sloped turn (implied by turn field and slope field)
-    TRACK_ELEM_FLAG_CURVE_ALLOWS_LIFT -> implied by turn field and chain flag
-    */
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_IS_GOLF_HOLE>, nullptr, "countsAsGolfHole");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_TURN_BANKED>, nullptr, "countsAsBankedTurn");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_TURN_SLOPED>, nullptr, "countsAsSlopedTurn");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_HELIX>, nullptr, "isHelix");
+    dukglue_register_property(
+        ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_NORMAL_TO_INVERSION>, nullptr, "countsAsInversion");
 
     dukglue_register_method(ctx, &ScTrackSegment::getSubpositionLength, "getSubpositionLength");
     dukglue_register_method(ctx, &ScTrackSegment::getSubpositions, "getSubpositions");

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -31,8 +31,8 @@ void ScTrackSegment::Register(duk_context* ctx)
     dukglue_register_property(ctx, &ScTrackSegment::elements_get, nullptr, "elements");
     dukglue_register_property(ctx, &ScTrackSegment::beginDirection_get, nullptr, "beginDirection");
     dukglue_register_property(ctx, &ScTrackSegment::endDirection_get, nullptr, "endDirection");
-    dukglue_register_property(ctx, &ScTrackSegment::beginAngle_get, nullptr, "beginAngle");
-    dukglue_register_property(ctx, &ScTrackSegment::endAngle_get, nullptr, "endAngle");
+    dukglue_register_property(ctx, &ScTrackSegment::beginSlope_get, nullptr, "beginSlope");
+    dukglue_register_property(ctx, &ScTrackSegment::endSlope_get, nullptr, "endSlope");
     dukglue_register_property(ctx, &ScTrackSegment::beginBank_get, nullptr, "beginBank");
     dukglue_register_property(ctx, &ScTrackSegment::endBank_get, nullptr, "endBank");
     dukglue_register_property(ctx, &ScTrackSegment::beginZ_get, nullptr, "beginZ");
@@ -93,7 +93,7 @@ int32_t ScTrackSegment::beginDirection_get() const
     return ted.Coordinates.rotation_begin;
 }
 
-int32_t ScTrackSegment::beginAngle_get() const
+int32_t ScTrackSegment::beginSlope_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Definition.vangle_start;
@@ -129,7 +129,7 @@ int32_t ScTrackSegment::endDirection_get() const
     return ted.Coordinates.rotation_end;
 }
 
-int32_t ScTrackSegment::endAngle_get() const
+int32_t ScTrackSegment::endSlope_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Definition.vangle_end;

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -31,8 +31,8 @@ void ScTrackSegment::Register(duk_context* ctx)
     dukglue_register_property(ctx, &ScTrackSegment::elements_get, nullptr, "elements");
     dukglue_register_property(ctx, &ScTrackSegment::beginDirection_get, nullptr, "beginDirection");
     dukglue_register_property(ctx, &ScTrackSegment::endDirection_get, nullptr, "endDirection");
-    dukglue_register_property(ctx, &ScTrackSegment::beginPitch_get, nullptr, "beginPitch");
-    dukglue_register_property(ctx, &ScTrackSegment::endPitch_get, nullptr, "endPitch");
+    dukglue_register_property(ctx, &ScTrackSegment::beginSlope_get, nullptr, "beginSlope");
+    dukglue_register_property(ctx, &ScTrackSegment::endSlope_get, nullptr, "endSlope");
     dukglue_register_property(ctx, &ScTrackSegment::beginBank_get, nullptr, "beginBank");
     dukglue_register_property(ctx, &ScTrackSegment::endBank_get, nullptr, "endBank");
     dukglue_register_property(ctx, &ScTrackSegment::beginZ_get, nullptr, "beginZ");
@@ -93,7 +93,7 @@ int32_t ScTrackSegment::beginDirection_get() const
     return ted.Coordinates.rotation_begin;
 }
 
-int32_t ScTrackSegment::beginPitch_get() const
+int32_t ScTrackSegment::beginSlope_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Definition.vangle_start;
@@ -129,7 +129,7 @@ int32_t ScTrackSegment::endDirection_get() const
     return ted.Coordinates.rotation_end;
 }
 
-int32_t ScTrackSegment::endPitch_get() const
+int32_t ScTrackSegment::endSlope_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
     return ted.Definition.vangle_end;

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -54,14 +54,15 @@ void ScTrackSegment::Register(duk_context* ctx)
     dukglue_register_property(
         ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_ONLY_ABOVE_GROUND>, nullptr, "onlyAllowedAboveGround");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_ALLOW_LIFT_HILL>, nullptr, "allowsChainLift");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_BANKED>, nullptr, "isBanked");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_INVERSION_TO_NORMAL>, nullptr, "isInversion");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_BANKED>, nullptr, "segmentBanks");
+    dukglue_register_property(
+        ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_INVERSION_TO_NORMAL>, nullptr, "segmentInverts");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_IS_STEEP_UP>, nullptr, "isSteepUp");
     dukglue_register_property(
         ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_STARTS_AT_HALF_HEIGHT>, nullptr, "startsHalfHeightUp");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_IS_GOLF_HOLE>, nullptr, "countsAsGolfHole");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_TURN_BANKED>, nullptr, "countsAsBankedTurn");
-    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_TURN_SLOPED>, nullptr, "countsAsSlopedTurn");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_IS_GOLF_HOLE>, nullptr, "isGolfHole");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_TURN_BANKED>, nullptr, "isBankedTurn");
+    dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_TURN_SLOPED>, nullptr, "isSlopedTurn");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_HELIX>, nullptr, "isHelix");
     dukglue_register_property(
         ctx, &ScTrackSegment::getTrackFlag<TRACK_ELEM_FLAG_NORMAL_TO_INVERSION>, nullptr, "countsAsInversion");

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -40,12 +40,10 @@ void ScTrackSegment::Register(duk_context* ctx)
     dukglue_register_property(ctx, &ScTrackSegment::endX_get, nullptr, "endX");
     dukglue_register_property(ctx, &ScTrackSegment::endY_get, nullptr, "endY");
     dukglue_register_property(ctx, &ScTrackSegment::length_get, nullptr, "length");
-    dukglue_register_property(ctx, &ScTrackSegment::nextCurveDirection_get, nullptr, "nextCurve");
-    dukglue_register_property(ctx, &ScTrackSegment::previousCurveDirection_get, nullptr, "previousCurve");
-    dukglue_register_property(ctx, &ScTrackSegment::nextCurveElement_get, nullptr, "nextElement");
-    dukglue_register_property(ctx, &ScTrackSegment::previousCurveElement_get, nullptr, "previousElement");
-    dukglue_register_property(ctx, &ScTrackSegment::getMirrorElement, nullptr, "mirrorElement");
-    dukglue_register_property(ctx, &ScTrackSegment::getAlternativeElement, nullptr, "alternateType");
+    dukglue_register_property(ctx, &ScTrackSegment::nextCurveElement_get, nullptr, "nextSuggestedSegment");
+    dukglue_register_property(ctx, &ScTrackSegment::previousCurveElement_get, nullptr, "previousSuggestedSegment");
+    dukglue_register_property(ctx, &ScTrackSegment::getMirrorElement, nullptr, "mirrorSegment");
+    dukglue_register_property(ctx, &ScTrackSegment::getAlternativeElement, nullptr, "alternateTypeSegment");
     dukglue_register_property(ctx, &ScTrackSegment::getPriceModifier, nullptr, "priceModifier");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackGroup, nullptr, "trackGroup");
     dukglue_register_property(ctx, &ScTrackSegment::getTrackCurvature, nullptr, "turnDirection");
@@ -200,45 +198,6 @@ std::vector<DukValue> ScTrackSegment::getSubpositions(uint8_t trackSubposition, 
     return result;
 }
 
-std::string ScTrackSegment::nextCurveDirection_get() const
-{
-    const auto& ted = GetTrackElementDescriptor(_type);
-
-    int32_t curve = ted.CurveChain.next;
-    if (curve & RideConstructionSpecialPieceSelected)
-    {
-        return "trackElement";
-    }
-    switch (curve)
-    {
-        case 1:
-            return "left";
-        case 2:
-            return "right";
-        default:
-            return "straight";
-    }
-}
-std::string ScTrackSegment::previousCurveDirection_get() const
-{
-    const auto& ted = GetTrackElementDescriptor(_type);
-
-    int32_t curve = ted.CurveChain.previous;
-    if (curve & RideConstructionSpecialPieceSelected)
-    {
-        return "trackElement";
-    }
-    switch (curve)
-    {
-        case 1:
-            return "left";
-        case 2:
-            return "right";
-        default:
-            return "straight";
-    }
-}
-
 DukValue ScTrackSegment::nextCurveElement_get() const
 {
     const auto ctx = GetContext()->GetScriptEngine().GetContext();
@@ -247,7 +206,15 @@ DukValue ScTrackSegment::nextCurveElement_get() const
     int32_t curve = ted.CurveChain.next;
     if (curve & RideConstructionSpecialPieceSelected)
         return ToDuk<int32_t>(ctx, curve & (~RideConstructionSpecialPieceSelected));
-    return ToDuk(ctx, nullptr);
+    switch (curve)
+    {
+        case 1:
+            return ToDuk<std::string>(ctx, "left");
+        case 2:
+            return ToDuk<std::string>(ctx, "right");
+        default:
+            return ToDuk<std::string>(ctx, "straight");
+    }
 }
 
 DukValue ScTrackSegment::previousCurveElement_get() const
@@ -258,7 +225,15 @@ DukValue ScTrackSegment::previousCurveElement_get() const
     int32_t curve = ted.CurveChain.previous;
     if (curve & RideConstructionSpecialPieceSelected)
         return ToDuk<int32_t>(ctx, curve & (~RideConstructionSpecialPieceSelected));
-    return ToDuk(ctx, nullptr);
+    switch (curve)
+    {
+        case 1:
+            return ToDuk<std::string>(ctx, "left");
+        case 2:
+            return ToDuk<std::string>(ctx, "right");
+        default:
+            return ToDuk<std::string>(ctx, "straight");
+    }
 }
 
 DukValue ScTrackSegment::getMirrorElement() const

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -58,6 +58,16 @@ namespace OpenRCT2::Scripting
         DukValue elements_get() const;
         uint16_t getSubpositionLength(uint8_t trackSubposition, uint8_t direction) const;
         std::vector<DukValue> getSubpositions(uint8_t trackSubposition, uint8_t direction) const;
+        template<uint8_t position> std::string trackCurveType() const;
+        template<uint8_t position> DukValue trackCurveElement() const;
+        DukValue getMirrorElement() const;
+        DukValue getAlternativeElement() const;
+        int32_t getPriceModifier() const;
+        int32_t getPreviewZOffset() const;
+        int32_t getTrackGroup() const;
+        template<uint16_t flag> bool getTrackFlag() const;
+        std::string getTrackCurvature() const;
+        std::string getTrackSlopeDirection() const;
     };
 
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -46,13 +46,13 @@ namespace OpenRCT2::Scripting
         std::string description_get() const;
         int32_t beginZ_get() const;
         int32_t beginDirection_get() const;
-        int32_t beginPitch_get() const;
+        int32_t beginSlope_get() const;
         int32_t beginBank_get() const;
         int32_t endX_get() const;
         int32_t endY_get() const;
         int32_t endZ_get() const;
         int32_t endDirection_get() const;
-        int32_t endPitch_get() const;
+        int32_t endSlope_get() const;
         int32_t endBank_get() const;
         int32_t length_get() const;
         DukValue elements_get() const;

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -46,13 +46,13 @@ namespace OpenRCT2::Scripting
         std::string description_get() const;
         int32_t beginZ_get() const;
         int32_t beginDirection_get() const;
-        int32_t beginAngle_get() const;
+        int32_t beginSlope_get() const;
         int32_t beginBank_get() const;
         int32_t endX_get() const;
         int32_t endY_get() const;
         int32_t endZ_get() const;
         int32_t endDirection_get() const;
-        int32_t endAngle_get() const;
+        int32_t endSlope_get() const;
         int32_t endBank_get() const;
         int32_t length_get() const;
         DukValue elements_get() const;

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -58,8 +58,6 @@ namespace OpenRCT2::Scripting
         DukValue elements_get() const;
         uint16_t getSubpositionLength(uint8_t trackSubposition, uint8_t direction) const;
         std::vector<DukValue> getSubpositions(uint8_t trackSubposition, uint8_t direction) const;
-        std::string nextCurveDirection_get() const;
-        std::string previousCurveDirection_get() const;
         DukValue nextCurveElement_get() const;
         DukValue previousCurveElement_get() const;
         DukValue getMirrorElement() const;

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -46,13 +46,13 @@ namespace OpenRCT2::Scripting
         std::string description_get() const;
         int32_t beginZ_get() const;
         int32_t beginDirection_get() const;
-        int32_t beginSlope_get() const;
+        int32_t beginPitch_get() const;
         int32_t beginBank_get() const;
         int32_t endX_get() const;
         int32_t endY_get() const;
         int32_t endZ_get() const;
         int32_t endDirection_get() const;
-        int32_t endSlope_get() const;
+        int32_t endPitch_get() const;
         int32_t endBank_get() const;
         int32_t length_get() const;
         DukValue elements_get() const;

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.h
@@ -58,8 +58,10 @@ namespace OpenRCT2::Scripting
         DukValue elements_get() const;
         uint16_t getSubpositionLength(uint8_t trackSubposition, uint8_t direction) const;
         std::vector<DukValue> getSubpositions(uint8_t trackSubposition, uint8_t direction) const;
-        template<uint8_t position> std::string trackCurveType() const;
-        template<uint8_t position> DukValue trackCurveElement() const;
+        std::string nextCurveDirection_get() const;
+        std::string previousCurveDirection_get() const;
+        DukValue nextCurveElement_get() const;
+        DukValue previousCurveElement_get() const;
         DukValue getMirrorElement() const;
         DukValue getAlternativeElement() const;
         int32_t getPriceModifier() const;


### PR DESCRIPTION
Exposes track properties of TED to scripting API.

I would like feedback on the implementation of TrackCurveType and TrackSlopeType.

I thought about exposing gTrackDescriptors but I changed my mind - plugin makers can decide for themselves how best to look up track elements to build.

I could add sequence specific data (allowed walls, entrance hut directions, if a height marker is shown), but I don't see a use for it at this time.