### PR TITLE
allow mini helicopters to draw spinning tunnel

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -8,6 +8,7 @@
 - Improved: [#18350] Changed ride vehicle list to have less padding.
 - Improved: [#18422] Allow adding images to music objects.
 - Improved: [#18428] [Plugin] Add widget description interfaces to documentation.
+- Improved: [#18487] Mini Helicopters track can now draw spinning tunnels.
 - Improved: [#18514] Add colour preset to Spiral Slide.
 - Change: [#17998] Show cursor when using inverted mouse dragging.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -311,6 +311,31 @@ static void PaintMiniHelicoptersTrackRightQuarterTurn1Tile(
     PaintMiniHelicoptersTrackLeftQuarterTurn1Tile(session, ride, trackSequence, (direction + 3) % 4, height, trackElement);
 }
 
+static void PaintMiniHelicoptersTrackSpinningTunnel(
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
+    const TrackElement& trackElement)
+{
+    const uint32_t sprites[NumOrthogonalDirections][2] = {
+        { SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW, 28773 },
+        { SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW, 28774 },
+        { SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_NE_SW, 28773 },
+        { SPR_TRACK_SUBMARINE_RIDE_MINI_HELICOPTERS_FLAT_SE_NW, 28774 },
+    };
+
+    ImageId imageId = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][0]);
+    ImageId underlay = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
+
+    PaintAddImageAsParentRotated(session, direction, underlay, { 0, 6, height - 2 }, { 32, 20, 1 }, { 0, 6, height });
+    PaintAddImageAsChildRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+    track_paint_util_spinning_tunnel_paint(session, 1, height, direction);
+    PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
+
+    WoodenASupportsPaintSetup(session, (direction & 1), 0, height, session.TrackColours[SCHEME_MISC]);
+
+    PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
+    PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
+}
+
 /**
  * rct2: 0x0081F268
  */
@@ -349,6 +374,9 @@ TRACK_PAINT_FUNCTION GetTrackPaintFunctionMiniHelicopters(int32_t trackType)
             return PaintMiniHelicoptersTrackLeftQuarterTurn1Tile;
         case TrackElemType::RightQuarterTurn1Tile:
             return PaintMiniHelicoptersTrackRightQuarterTurn1Tile;
+
+        case TrackElemType::SpinningTunnel:
+            return PaintMiniHelicoptersTrackSpinningTunnel;
     }
 
     return nullptr;

--- a/src/openrct2/ride/gentle/meta/MiniHelicopters.h
+++ b/src/openrct2/ride/gentle/meta/MiniHelicopters.h
@@ -21,7 +21,7 @@ constexpr const RideTypeDescriptor MiniHelicoptersRTD =
     SET_FIELD(AlternateType, RIDE_TYPE_NULL),
     SET_FIELD(Category, RIDE_CATEGORY_GENTLE),
     SET_FIELD(EnabledTrackPieces, {TRACK_STRAIGHT, TRACK_STATION_END, TRACK_SLOPE, TRACK_CURVE_VERY_SMALL, TRACK_CURVE_SMALL}),
-    SET_FIELD(ExtraTrackPieces, {}),
+    SET_FIELD(ExtraTrackPieces, {TRACK_SPINNING_TUNNEL}),
     SET_FIELD(CoveredTrackPieces, {}),
     SET_FIELD(StartTrackPiece, TrackElemType::EndStation),
     SET_FIELD(TrackPaintFunction, GetTrackPaintFunctionMiniHelicopters),


### PR DESCRIPTION
this will allow mini helicopters to draw spinning tunnel, but it will not add spinning tunnel to the special drop down list
![rawrrrrr](https://user-images.githubusercontent.com/94884086/199501716-19502276-4d5f-4333-a0c1-6481bb77f44e.png)
