### PR TITLE
Pass ImageId by value instead by const-ref

### DIFF
--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -104,11 +104,11 @@ public:
     void FilterRect(
         rct_drawpixelinfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
     void DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, const ScreenLine& line) override;
-    void DrawSprite(rct_drawpixelinfo* dpi, const ImageId& imageId, int32_t x, int32_t y) override;
+    void DrawSprite(rct_drawpixelinfo* dpi, const ImageId imageId, int32_t x, int32_t y) override;
     void DrawSpriteRawMasked(
-        rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId& maskImage, const ImageId& colourImage) override;
-    void DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, uint8_t colour) override;
-    void DrawGlyph(rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, const PaletteMap& palette) override;
+        rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
+    void DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
+    void DrawGlyph(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) override;
     void DrawBitmap(
         rct_drawpixelinfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
         int32_t y) override;
@@ -587,7 +587,7 @@ void OpenGLDrawingContext::DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, con
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawSprite(rct_drawpixelinfo* dpi, const ImageId& imageId, int32_t x, int32_t y)
+void OpenGLDrawingContext::DrawSprite(rct_drawpixelinfo* dpi, const ImageId imageId, int32_t x, int32_t y)
 {
     CalculcateClipping(dpi);
 
@@ -738,7 +738,7 @@ void OpenGLDrawingContext::DrawSprite(rct_drawpixelinfo* dpi, const ImageId& ima
 }
 
 void OpenGLDrawingContext::DrawSpriteRawMasked(
-    rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId& maskImage, const ImageId& colourImage)
+    rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
 {
     CalculcateClipping(dpi);
 
@@ -800,7 +800,7 @@ void OpenGLDrawingContext::DrawSpriteRawMasked(
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, uint8_t colour)
+void OpenGLDrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
 {
     CalculcateClipping(dpi);
 
@@ -853,7 +853,7 @@ void OpenGLDrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId
 }
 
 void OpenGLDrawingContext::DrawGlyph(
-    rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, const PaletteMap& palette)
+    rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette)
 {
     CalculcateClipping(dpi);
 

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -64,7 +64,7 @@ void TextureCache::InvalidateImage(ImageIndex image)
 }
 
 // Note: for performance reasons, this returns a BasicTextureInfo over an AtlasTextureInfo (also to not expose the cache)
-BasicTextureInfo TextureCache::GetOrLoadImageTexture(const ImageId& imageId)
+BasicTextureInfo TextureCache::GetOrLoadImageTexture(const ImageId imageId)
 {
     uint32_t index;
 
@@ -96,7 +96,7 @@ BasicTextureInfo TextureCache::GetOrLoadImageTexture(const ImageId& imageId)
     return info;
 }
 
-BasicTextureInfo TextureCache::GetOrLoadGlyphTexture(const ImageId& imageId, const PaletteMap& paletteMap)
+BasicTextureInfo TextureCache::GetOrLoadGlyphTexture(const ImageId imageId, const PaletteMap& paletteMap)
 {
     GlyphId glyphId{};
     glyphId.Image = imageId.GetIndex();
@@ -266,7 +266,7 @@ void TextureCache::EnlargeAtlasesTexture(GLuint newEntries)
     _atlasesTextureIndices = newIndices;
 }
 
-AtlasTextureInfo TextureCache::LoadImageTexture(const ImageId& imageId)
+AtlasTextureInfo TextureCache::LoadImageTexture(const ImageId imageId)
 {
     rct_drawpixelinfo dpi = GetImageAsDPI(ImageId(imageId.GetIndex()));
 
@@ -283,7 +283,7 @@ AtlasTextureInfo TextureCache::LoadImageTexture(const ImageId& imageId)
     return cacheInfo;
 }
 
-AtlasTextureInfo TextureCache::LoadGlyphTexture(const ImageId& imageId, const PaletteMap& paletteMap)
+AtlasTextureInfo TextureCache::LoadGlyphTexture(const ImageId imageId, const PaletteMap& paletteMap)
 {
     rct_drawpixelinfo dpi = GetGlyphAsDPI(imageId, paletteMap);
 
@@ -347,7 +347,7 @@ AtlasTextureInfo TextureCache::AllocateImage(int32_t imageWidth, int32_t imageHe
     return _atlases.back().Allocate(imageWidth, imageHeight);
 }
 
-rct_drawpixelinfo TextureCache::GetImageAsDPI(const ImageId& imageId)
+rct_drawpixelinfo TextureCache::GetImageAsDPI(const ImageId imageId)
 {
     auto g1Element = gfx_get_g1_element(imageId);
     int32_t width = g1Element->width;
@@ -358,7 +358,7 @@ rct_drawpixelinfo TextureCache::GetImageAsDPI(const ImageId& imageId)
     return dpi;
 }
 
-rct_drawpixelinfo TextureCache::GetGlyphAsDPI(const ImageId& imageId, const PaletteMap& palette)
+rct_drawpixelinfo TextureCache::GetGlyphAsDPI(const ImageId imageId, const PaletteMap& palette)
 {
     auto g1Element = gfx_get_g1_element(imageId);
     int32_t width = g1Element->width;

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -221,8 +221,8 @@ public:
     TextureCache();
     ~TextureCache();
     void InvalidateImage(ImageIndex image);
-    BasicTextureInfo GetOrLoadImageTexture(const ImageId& imageId);
-    BasicTextureInfo GetOrLoadGlyphTexture(const ImageId& imageId, const PaletteMap& paletteMap);
+    BasicTextureInfo GetOrLoadImageTexture(const ImageId imageId);
+    BasicTextureInfo GetOrLoadGlyphTexture(const ImageId imageId, const PaletteMap& paletteMap);
     BasicTextureInfo GetOrLoadBitmapTexture(ImageIndex image, const void* pixels, size_t width, size_t height);
 
     GLuint GetAtlasesTexture();
@@ -233,12 +233,12 @@ private:
     void CreateTextures();
     void GeneratePaletteTexture();
     void EnlargeAtlasesTexture(GLuint newEntries);
-    AtlasTextureInfo LoadImageTexture(const ImageId& image);
-    AtlasTextureInfo LoadGlyphTexture(const ImageId& image, const PaletteMap& paletteMap);
+    AtlasTextureInfo LoadImageTexture(const ImageId image);
+    AtlasTextureInfo LoadGlyphTexture(const ImageId image, const PaletteMap& paletteMap);
     AtlasTextureInfo AllocateImage(int32_t imageWidth, int32_t imageHeight);
     AtlasTextureInfo LoadBitmapTexture(ImageIndex image, const void* pixels, size_t width, size_t height);
-    static rct_drawpixelinfo GetImageAsDPI(const ImageId& imageId);
-    static rct_drawpixelinfo GetGlyphAsDPI(const ImageId& imageId, const PaletteMap& paletteMap);
+    static rct_drawpixelinfo GetImageAsDPI(const ImageId imageId);
+    static rct_drawpixelinfo GetGlyphAsDPI(const ImageId imageId, const PaletteMap& paletteMap);
     void FreeTextures();
 
     static rct_drawpixelinfo CreateDPI(int32_t width, int32_t height);

--- a/src/openrct2/drawing/Drawing.Sprite.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.cpp
@@ -444,7 +444,7 @@ static std::optional<PaletteMap> FASTCALL gfx_draw_sprite_get_palette(ImageId im
     return paletteMap;
 }
 
-void FASTCALL gfx_draw_sprite_software(rct_drawpixelinfo* dpi, const ImageId& imageId, const ScreenCoordsXY& spriteCoords)
+void FASTCALL gfx_draw_sprite_software(rct_drawpixelinfo* dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords)
 {
     if (imageId.HasValue())
     {
@@ -467,7 +467,7 @@ void FASTCALL gfx_draw_sprite_software(rct_drawpixelinfo* dpi, const ImageId& im
  * y (dx)
  */
 void FASTCALL gfx_draw_sprite_palette_set_software(
-    rct_drawpixelinfo* dpi, const ImageId& imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+    rct_drawpixelinfo* dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
     int32_t x = coords.x;
     int32_t y = coords.y;
@@ -639,7 +639,7 @@ void FASTCALL gfx_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs&
  *  rct2: 0x00681DE2
  */
 void FASTCALL gfx_draw_sprite_raw_masked_software(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& scrCoords, const ImageId& maskImage, const ImageId& colourImage)
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage)
 {
     int32_t left, top, right, bottom, width, height;
     auto imgMask = gfx_get_g1_element(maskImage);
@@ -692,7 +692,7 @@ void FASTCALL gfx_draw_sprite_raw_masked_software(
     mask_fn(width, height, maskSrc, colourSrc, dst, maskWrap, colourWrap, dstWrap);
 }
 
-const rct_g1_element* gfx_get_g1_element(const ImageId& imageId)
+const rct_g1_element* gfx_get_g1_element(const ImageId imageId)
 {
     return gfx_get_g1_element(imageId.GetIndex());
 }

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -517,7 +517,7 @@ bool gfx_load_csg();
 void gfx_unload_g1();
 void gfx_unload_g2();
 void gfx_unload_csg();
-const rct_g1_element* gfx_get_g1_element(const ImageId& imageId);
+const rct_g1_element* gfx_get_g1_element(const ImageId imageId);
 const rct_g1_element* gfx_get_g1_element(ImageIndex image_id);
 void gfx_set_g1_element(ImageIndex imageId, const rct_g1_element* g1);
 std::optional<rct_gx> GfxLoadGx(const std::vector<uint8_t>& buffer);
@@ -525,17 +525,17 @@ bool is_csg_loaded();
 void FASTCALL gfx_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL gfx_bmp_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL gfx_rle_sprite_to_buffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
-void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, const ImageId& image_id, const ScreenCoordsXY& coords);
+void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, const ImageId image_id, const ScreenCoordsXY& coords);
 void FASTCALL
-    gfx_draw_glyph(rct_drawpixelinfo* dpi, const ImageId& image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
-void FASTCALL gfx_draw_sprite_solid(rct_drawpixelinfo* dpi, const ImageId& image, const ScreenCoordsXY& coords, uint8_t colour);
+    gfx_draw_glyph(rct_drawpixelinfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+void FASTCALL gfx_draw_sprite_solid(rct_drawpixelinfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
 void FASTCALL gfx_draw_sprite_raw_masked(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const ImageId& maskImage, const ImageId& colourImage);
-void FASTCALL gfx_draw_sprite_software(rct_drawpixelinfo* dpi, const ImageId& imageId, const ScreenCoordsXY& spriteCoords);
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
+void FASTCALL gfx_draw_sprite_software(rct_drawpixelinfo* dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
 void FASTCALL gfx_draw_sprite_palette_set_software(
-    rct_drawpixelinfo* dpi, const ImageId& imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+    rct_drawpixelinfo* dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
 void FASTCALL gfx_draw_sprite_raw_masked_software(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& scrCoords, const ImageId& maskImage, const ImageId& colourImage);
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage);
 
 // string
 void gfx_draw_string(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint = {});

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -26,13 +26,13 @@ namespace OpenRCT2::Drawing
         virtual void FilterRect(
             rct_drawpixelinfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) abstract;
         virtual void DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, const ScreenLine& line) abstract;
-        virtual void DrawSprite(rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y) abstract;
+        virtual void DrawSprite(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y) abstract;
         virtual void DrawSpriteRawMasked(
-            rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId& maskImage, const ImageId& colourImage) abstract;
+            rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) abstract;
         virtual void DrawSpriteSolid(
-            rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, uint8_t colour) abstract;
+            rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) abstract;
         virtual void DrawGlyph(
-            rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, const PaletteMap& palette) abstract;
+            rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) abstract;
         virtual void DrawBitmap(
             rct_drawpixelinfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
             int32_t y) abstract;

--- a/src/openrct2/drawing/ImageId.hpp
+++ b/src/openrct2/drawing/ImageId.hpp
@@ -288,4 +288,4 @@ public:
         return result;
     }
 };
-static_assert(sizeof(ImageId) == 8);
+static_assert(sizeof(ImageId) == 8, "The size of this struct is expected to fit in 64 bits for perfomance reasons. See #18555");

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -233,7 +233,7 @@ void gfx_draw_dashed_line(
     }
 }
 
-void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, const ImageId& imageId, const ScreenCoordsXY& coords)
+void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, const ImageId imageId, const ScreenCoordsXY& coords)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -244,7 +244,7 @@ void FASTCALL gfx_draw_sprite(rct_drawpixelinfo* dpi, const ImageId& imageId, co
 }
 
 void FASTCALL
-    gfx_draw_glyph(rct_drawpixelinfo* dpi, const ImageId& image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+    gfx_draw_glyph(rct_drawpixelinfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -255,7 +255,7 @@ void FASTCALL
 }
 
 void FASTCALL gfx_draw_sprite_raw_masked(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const ImageId& maskImage, const ImageId& colourImage)
+    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -265,7 +265,7 @@ void FASTCALL gfx_draw_sprite_raw_masked(
     }
 }
 
-void FASTCALL gfx_draw_sprite_solid(rct_drawpixelinfo* dpi, const ImageId& image, const ScreenCoordsXY& coords, uint8_t colour)
+void FASTCALL gfx_draw_sprite_solid(rct_drawpixelinfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -708,18 +708,18 @@ void X8DrawingContext::DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, const S
     gfx_draw_line_software(dpi, line, colour);
 }
 
-void X8DrawingContext::DrawSprite(rct_drawpixelinfo* dpi, const ImageId& imageId, int32_t x, int32_t y)
+void X8DrawingContext::DrawSprite(rct_drawpixelinfo* dpi, const ImageId imageId, int32_t x, int32_t y)
 {
     gfx_draw_sprite_software(dpi, imageId, { x, y });
 }
 
 void X8DrawingContext::DrawSpriteRawMasked(
-    rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId& maskImage, const ImageId& colourImage)
+    rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
 {
     gfx_draw_sprite_raw_masked_software(dpi, { x, y }, maskImage, colourImage);
 }
 
-void X8DrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, uint8_t colour)
+void X8DrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
 {
     uint8_t palette[256];
     std::fill_n(palette, sizeof(palette), colour);
@@ -730,7 +730,7 @@ void X8DrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId& im
 }
 
 void X8DrawingContext::DrawGlyph(
-    rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, const PaletteMap& paletteMap)
+    rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap)
 {
     gfx_draw_sprite_palette_set_software(dpi, image, { x, y }, paletteMap);
 }

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -142,12 +142,12 @@ namespace OpenRCT2
                 rct_drawpixelinfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right,
                 int32_t bottom) override;
             void DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, const ScreenLine& line) override;
-            void DrawSprite(rct_drawpixelinfo* dpi, const ImageId& imageId, int32_t x, int32_t y) override;
+            void DrawSprite(rct_drawpixelinfo* dpi, const ImageId imageId, int32_t x, int32_t y) override;
             void DrawSpriteRawMasked(
-                rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId& maskImage, const ImageId& colourImage) override;
-            void DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, uint8_t colour) override;
+                rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
+            void DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
             void DrawGlyph(
-                rct_drawpixelinfo* dpi, const ImageId& image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
+                rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
             void DrawBitmap(
                 rct_drawpixelinfo* dpi, uint32_t image, const void* pixels, int32_t width, int32_t height, int32_t x,
                 int32_t y) override

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -687,13 +687,13 @@ void PaintSessionFree([[maybe_unused]] PaintSession* session)
  * @return (ebp) PaintStruct on success (CF == 0), nullptr on failure (CF == 1)
  */
 PaintStruct* PaintAddImageAsParent(
-    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize)
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize)
 {
     return PaintAddImageAsParent(session, image_id, offset, { offset, boundBoxSize });
 }
 
 PaintStruct* PaintAddImageAsParent(
-    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize,
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize,
     const CoordsXYZ& boundBoxOffset)
 {
     return PaintAddImageAsParent(session, image_id, offset, { boundBoxOffset, boundBoxSize });
@@ -716,7 +716,7 @@ PaintStruct* PaintAddImageAsParent(
  */
 // Track Pieces, Shops.
 PaintStruct* PaintAddImageAsParent(
-    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
 {
     session.LastPS = nullptr;
     session.LastAttachedPS = nullptr;
@@ -750,7 +750,7 @@ PaintStruct* PaintAddImageAsParent(
  * Creates a paint struct but does not allocate to a paint quadrant. Result cannot be ignored!
  */
 [[nodiscard]] PaintStruct* PaintAddImageAsOrphan(
-    PaintSession& session, const ImageId& imageId, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
+    PaintSession& session, const ImageId imageId, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
 {
     session.LastPS = nullptr;
     session.LastAttachedPS = nullptr;
@@ -758,7 +758,7 @@ PaintStruct* PaintAddImageAsParent(
 }
 
 PaintStruct* PaintAddImageAsChild(
-    PaintSession& session, const ImageId& imageId, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
+    PaintSession& session, const ImageId imageId, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
     const CoordsXYZ& boundBoxOffset)
 {
     return PaintAddImageAsChild(session, imageId, offset, { boundBoxOffset, boundBoxLength });
@@ -782,7 +782,7 @@ PaintStruct* PaintAddImageAsChild(
  * If there is no parent paint struct then image is added as a parent
  */
 PaintStruct* PaintAddImageAsChild(
-    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
 {
     PaintStruct* parentPS = session.LastPS;
     if (parentPS == nullptr)
@@ -809,7 +809,7 @@ PaintStruct* PaintAddImageAsChild(
  * @param y (cx)
  * @return (!CF) success
  */
-bool PaintAttachToPreviousAttach(PaintSession& session, const ImageId& imageId, int32_t x, int32_t y)
+bool PaintAttachToPreviousAttach(PaintSession& session, const ImageId imageId, int32_t x, int32_t y)
 {
     auto* previousAttachedPS = session.LastAttachedPS;
     if (previousAttachedPS == nullptr)
@@ -842,7 +842,7 @@ bool PaintAttachToPreviousAttach(PaintSession& session, const ImageId& imageId, 
  * @param y (cx)
  * @return (!CF) success
  */
-bool PaintAttachToPreviousPS(PaintSession& session, const ImageId& image_id, int32_t x, int32_t y)
+bool PaintAttachToPreviousPS(PaintSession& session, const ImageId image_id, int32_t x, int32_t y)
 {
     auto* masterPs = session.LastPS;
     if (masterPs == nullptr)

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -295,34 +295,34 @@ extern bool gPaintBlockedTiles;
 extern bool gPaintWidePathsAsGhost;
 
 PaintStruct* PaintAddImageAsParent(
-    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize);
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize);
 PaintStruct* PaintAddImageAsParent(
-    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize,
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize,
     const CoordsXYZ& boundBoxOffset);
 PaintStruct* PaintAddImageAsParent(
-    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 [[nodiscard]] PaintStruct* PaintAddImageAsOrphan(
-    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 PaintStruct* PaintAddImageAsChild(
-    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxLength,
     const CoordsXYZ& boundBoxOffset);
 PaintStruct* PaintAddImageAsChild(
-    PaintSession& session, const ImageId& image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox);
 
 PaintStruct* PaintAddImageAsChildRotated(
-    PaintSession& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
+    PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset);
 PaintStruct* PaintAddImageAsParentRotated(
-    PaintSession& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
+    PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize);
 PaintStruct* PaintAddImageAsParentRotated(
-    PaintSession& session, const uint8_t direction, const ImageId& imageId, const CoordsXYZ& offset,
+    PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset);
 
 void PaintUtilPushTunnelRotated(PaintSession& session, uint8_t direction, uint16_t height, uint8_t type);
 
-bool PaintAttachToPreviousAttach(PaintSession& session, const ImageId& imageId, int32_t x, int32_t y);
-bool PaintAttachToPreviousPS(PaintSession& session, const ImageId& image_id, int32_t x, int32_t y);
+bool PaintAttachToPreviousAttach(PaintSession& session, const ImageId imageId, int32_t x, int32_t y);
+bool PaintAttachToPreviousPS(PaintSession& session, const ImageId image_id, int32_t x, int32_t y);
 void PaintFloatingMoneyEffect(
     PaintSession& session, money64 amount, StringId string_id, int32_t y, int32_t z, int8_t y_offsets[], int32_t offset_x,
     uint32_t rotation);

--- a/src/openrct2/paint/PaintHelpers.cpp
+++ b/src/openrct2/paint/PaintHelpers.cpp
@@ -12,7 +12,7 @@
 #include "Paint.h"
 
 PaintStruct* PaintAddImageAsParentRotated(
-    PaintSession& session, const uint8_t direction, const ImageId& imageId, const CoordsXYZ& offset,
+    PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
 {
     if (direction & 1)
@@ -26,7 +26,7 @@ PaintStruct* PaintAddImageAsParentRotated(
 }
 
 PaintStruct* PaintAddImageAsParentRotated(
-    PaintSession& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
+    PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize)
 {
     if (direction & 1)
@@ -39,7 +39,7 @@ PaintStruct* PaintAddImageAsParentRotated(
 }
 
 PaintStruct* PaintAddImageAsChildRotated(
-    PaintSession& session, const uint8_t direction, const ImageId& image_id, const CoordsXYZ& offset,
+    PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
 {
     if (direction & 1)

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -293,7 +293,7 @@ void track_paint_util_paint_floor(
 
 void track_paint_util_paint_fences(
     PaintSession& session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
-    const ImageId& colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation)
+    const ImageId colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation)
 {
     if (edges & EDGE_NW && track_paint_util_has_fence(EDGE_NW, position, trackElement, ride, rotation))
     {
@@ -1005,7 +1005,7 @@ static constexpr const int8_t right_helix_up_small_quarter_tiles_sprite_map[] = 
 
 void track_paint_util_right_helix_up_small_quarter_tiles_paint(
     PaintSession& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
+    const ImageId colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
     const CoordsXY boundsLengths[4][3][2], const CoordsXYZ boundsOffsets[4][3][2])
 {
     int32_t index = right_helix_up_small_quarter_tiles_sprite_map[trackSequence];
@@ -1105,7 +1105,7 @@ static constexpr const int8_t right_helix_up_large_quarter_sprite_map[] = {
 };
 void track_paint_util_right_helix_up_large_quarter_tiles_paint(
     PaintSession& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
+    const ImageId colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
     const CoordsXY boundsLengths[4][5][2], const CoordsXYZ boundsOffsets[4][5][2])
 {
     int32_t index = right_helix_up_large_quarter_sprite_map[trackSequence];
@@ -1282,7 +1282,7 @@ static constexpr const int8_t eighth_to_diag_sprite_map[] = {
 };
 void track_paint_util_eighth_to_diag_tiles_paint(
     PaintSession& session, const int8_t thickness[4][4], int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
+    const ImageId colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
     const CoordsXYZ boundsOffsets[4][4])
 {
     int32_t index = eighth_to_diag_sprite_map[trackSequence];
@@ -1324,7 +1324,7 @@ static constexpr const int8_t diag_sprite_map[4][4] = {
 
 void track_paint_util_diag_tiles_paint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4],
+    const ImageId colourFlags, const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4],
     const CoordsXYZ boundsOffsets[4])
 {
     int32_t index = diag_sprite_map[direction][trackSequence];
@@ -1446,7 +1446,7 @@ static constexpr const int8_t right_quarter_turn_5_tiles_sprite_map[] = {
 
 void track_paint_util_right_quarter_turn_5_tiles_paint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
+    const ImageId colourFlags, const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
     const CoordsXYZ boundsOffsets[4][5])
 {
     int32_t index = right_quarter_turn_5_tiles_sprite_map[trackSequence];
@@ -1466,7 +1466,7 @@ void track_paint_util_right_quarter_turn_5_tiles_paint(
 }
 
 void track_paint_util_right_quarter_turn_5_tiles_paint_2(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
     const SpriteBb sprites[][5])
 {
     int8_t sprite = right_quarter_turn_5_tiles_sprite_map[trackSequence];
@@ -1485,7 +1485,7 @@ void track_paint_util_right_quarter_turn_5_tiles_paint_2(
 }
 
 void track_paint_util_right_quarter_turn_5_tiles_paint_3(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
     const SpriteBb sprites[][5])
 {
     int8_t sprite = right_quarter_turn_5_tiles_sprite_map[trackSequence];
@@ -1622,7 +1622,7 @@ static constexpr const int8_t right_quarter_turn_3_tiles_sprite_map[] = {
 
 void track_paint_util_right_quarter_turn_3_tiles_paint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
+    const ImageId colourFlags, const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
     const CoordsXYZ boundsOffsets[4][3])
 {
     int32_t index = right_quarter_turn_3_tiles_sprite_map[trackSequence];
@@ -1643,7 +1643,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint(
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_2(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3])
+    const ImageId colourFlags, const uint32_t sprites[4][3])
 {
     track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
         session, thickness, height, direction, trackSequence, colourFlags, sprites, 0);
@@ -1651,7 +1651,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_2(
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset)
+    const ImageId colourFlags, const uint32_t sprites[4][3], int32_t heightOffset)
 {
     int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1738,7 +1738,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_3(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
     const SpriteBb sprites[4][3])
 {
     int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
@@ -1755,7 +1755,7 @@ void track_paint_util_right_quarter_turn_3_tiles_paint_3(
 }
 
 void track_paint_util_right_quarter_turn_3_tiles_paint_4(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
     const SpriteBb sprites[4][3])
 {
     int8_t sprite = right_quarter_turn_3_tiles_sprite_map[trackSequence];
@@ -1845,7 +1845,7 @@ static constexpr const int8_t left_quarter_turn_3_tiles_sprite_map[] = {
 
 void track_paint_util_left_quarter_turn_3_tiles_paint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3])
+    const ImageId colourFlags, const uint32_t sprites[4][3])
 {
     track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
         session, thickness, height, direction, trackSequence, colourFlags, sprites, 0);
@@ -1853,7 +1853,7 @@ void track_paint_util_left_quarter_turn_3_tiles_paint(
 
 void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset)
+    const ImageId colourFlags, const uint32_t sprites[4][3], int32_t heightOffset)
 {
     int8_t sprite = left_quarter_turn_3_tiles_sprite_map[trackSequence];
     if (sprite < 0)
@@ -1965,7 +1965,7 @@ void track_paint_util_left_quarter_turn_3_tiles_tunnel(
 
 void track_paint_util_left_quarter_turn_1_tile_paint(
     PaintSession& session, int8_t thickness, int16_t height, int16_t boundBoxZOffset, Direction direction,
-    const ImageId& colourFlags, const uint32_t* sprites)
+    const ImageId colourFlags, const uint32_t* sprites)
 {
     auto imageId = colourFlags.WithIndex(sprites[direction]);
 

--- a/src/openrct2/ride/TrackPaint.h
+++ b/src/openrct2/ride/TrackPaint.h
@@ -286,7 +286,7 @@ void track_paint_util_paint_floor(
     const StationObject* stationStyle);
 void track_paint_util_paint_fences(
     PaintSession& session, uint8_t edges, const CoordsXY& position, const TrackElement& trackElement, const Ride& ride,
-    const ImageId& colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation);
+    const ImageId colourFlags, uint16_t height, const uint32_t fenceSprites[4], uint8_t rotation);
 bool track_paint_util_draw_station_covers(
     PaintSession& session, enum edge_t edge, bool hasFence, const StationObject* stationObject, uint16_t height);
 bool track_paint_util_draw_station_covers_2(
@@ -316,13 +316,13 @@ void track_paint_util_draw_station_metal_supports_2(
 
 void track_paint_util_right_quarter_turn_5_tiles_paint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
+    const ImageId colourFlags, const uint32_t sprites[4][5], const CoordsXY offsets[4][5], const CoordsXY boundsLengths[4][5],
     const CoordsXYZ boundsOffsets[4][5]);
 void track_paint_util_right_quarter_turn_5_tiles_paint_2(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
     const SpriteBb sprites[][5]);
 void track_paint_util_right_quarter_turn_5_tiles_paint_3(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
     const SpriteBb sprites[][5]);
 void track_paint_util_right_quarter_turn_5_tiles_tunnel(
     PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType);
@@ -336,33 +336,33 @@ void track_paint_util_right_quarter_turn_3_tiles_25_deg_down_tunnel(
     uint8_t tunnelType3);
 void track_paint_util_right_quarter_turn_3_tiles_paint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
+    const ImageId colourFlags, const uint32_t sprites[4][3], const CoordsXY offsets[4][3], const CoordsXY boundsLengths[4][3],
     const CoordsXYZ boundsOffsets[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_paint_2(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3]);
+    const ImageId colourFlags, const uint32_t sprites[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_paint_2_with_height_offset(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset);
+    const ImageId colourFlags, const uint32_t sprites[4][3], int32_t heightOffset);
 void track_paint_util_right_quarter_turn_3_tiles_paint_3(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
     const SpriteBb sprites[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_paint_4(
-    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId& colourFlags,
+    PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, const ImageId colourFlags,
     const SpriteBb sprites[4][3]);
 void track_paint_util_right_quarter_turn_3_tiles_tunnel(
     PaintSession& session, int16_t height, Direction direction, uint8_t trackSequence, uint8_t tunnelType);
 void track_paint_util_left_quarter_turn_3_tiles_paint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3]);
+    const ImageId colourFlags, const uint32_t sprites[4][3]);
 void track_paint_util_left_quarter_turn_3_tiles_paint_with_height_offset(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3], int32_t heightOffset);
+    const ImageId colourFlags, const uint32_t sprites[4][3], int32_t heightOffset);
 void track_paint_util_left_quarter_turn_3_tiles_tunnel(
     PaintSession& session, int16_t height, uint8_t tunnelType, Direction direction, uint8_t trackSequence);
 void track_paint_util_left_quarter_turn_1_tile_paint(
     PaintSession& session, int8_t thickness, int16_t height, int16_t boundBoxZOffset, Direction direction,
-    const ImageId& colourFlags, const uint32_t* sprites);
+    const ImageId colourFlags, const uint32_t* sprites);
 void track_paint_util_spinning_tunnel_paint(PaintSession& session, int8_t thickness, int16_t height, Direction direction);
 void track_paint_util_onride_photo_small_paint(
     PaintSession& session, Direction direction, int32_t height, const TrackElement& trackElement);
@@ -370,19 +370,19 @@ void track_paint_util_onride_photo_paint(
     PaintSession& session, Direction direction, int32_t height, const TrackElement& trackElement);
 void track_paint_util_right_helix_up_small_quarter_tiles_paint(
     PaintSession& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
+    const ImageId colourFlags, const uint32_t sprites[4][3][2], const CoordsXY offsets[4][3][2],
     const CoordsXY boundsLengths[4][3][2], const CoordsXYZ boundsOffsets[4][3][2]);
 void track_paint_util_right_helix_up_large_quarter_tiles_paint(
     PaintSession& session, const int8_t thickness[2], int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
+    const ImageId colourFlags, const uint32_t sprites[4][5][2], const CoordsXY offsets[4][5][2],
     const CoordsXY boundsLengths[4][5][2], const CoordsXYZ boundsOffsets[4][5][2]);
 void track_paint_util_eighth_to_diag_tiles_paint(
     PaintSession& session, const int8_t thickness[4][4], int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
+    const ImageId colourFlags, const uint32_t sprites[4][4], const CoordsXY offsets[4][4], const CoordsXY boundsLengths[4][4],
     const CoordsXYZ boundsOffsets[4][4]);
 void track_paint_util_diag_tiles_paint(
     PaintSession& session, int8_t thickness, int16_t height, Direction direction, uint8_t trackSequence,
-    const ImageId& colourFlags, const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4],
+    const ImageId colourFlags, const uint32_t sprites[4], const CoordsXY offsets[4], const CoordsXY boundsLengths[4],
     const CoordsXYZ boundsOffsets[4]);
 
 void track_paint_util_left_quarter_turn_1_tile_tunnel(


### PR DESCRIPTION
ImageId struct is 8-bytes large and can fit in CPU register. Passing it by value lets compiler pass it in register instead of forcing to reference it from memory.

In my tests this brings [dome park](https://github.com/OpenRCT2/OpenRCT2/files/6134362/dome-export.zip) benchgfx results from 42.16s down to 41.08s, or by 2.5%.