### PR TITLE
Fix #18552: Trains clipping through helixes

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -43,6 +43,7 @@
 - Fix: [#18449] [Plugin] Change type of listview widgets from 'scroll_view' to 'listview'.
 - Fix: [#18453] Slow walking guests don't get across level crossings in time.
 - Fix: [#18459] ‘Highlight path issues’ hides fences for paths with additions.
+- Fix: [#18552] Trains clipping through helixes.
 - Fix: [#18606] JSON objects do not take priority over the DAT files they supersede.
 - Fix: [#18620] [Plugin] Crash when reading widget properties from windows that have both static and tab widgets.
 

--- a/src/openrct2/ride/TrackPaint.cpp
+++ b/src/openrct2/ride/TrackPaint.cpp
@@ -975,12 +975,12 @@ constexpr CoordsXY defaultRightHelixUpSmallQuarterBoundLengths[4][3][2] = {
 
 constexpr CoordsXYZ defaultRightHelixUpSmallQuarterBoundOffsets[4][3][2] = {
     {
-        { { 0, 6, 8 }, { 0, 0, 0 } },
+        { { 0, 6, 0 }, { 0, 0, 0 } },
         { { 16, 16, 0 }, { 0, 0, 0 } },
-        { { 6, 0, 8 }, { 0, 0, 0 } },
+        { { 6, 0, 0 }, { 0, 0, 0 } },
     },
     {
-        { { 6, 0, 8 }, { 0, 0, 0 } },
+        { { 6, 0, 0 }, { 0, 0, 0 } },
         { { 16, 0, 0 }, { 0, 0, 0 } },
         { { 0, 6, 0 }, { 0, 27, 0 } },
     },
@@ -990,7 +990,7 @@ constexpr CoordsXYZ defaultRightHelixUpSmallQuarterBoundOffsets[4][3][2] = {
         { { 0, 0, 0 }, { 27, 0, 0 } },
     },
     {
-        { { 6, 0, 8 }, { 27, 0, 0 } },
+        { { 6, 0, 0 }, { 27, 0, 0 } },
         { { 0, 16, 0 }, { 0, 0, 0 } },
         { { 0, 6, 0 }, { 0, 0, 0 } },
     },
@@ -1040,14 +1040,14 @@ void track_paint_util_right_helix_up_small_quarter_tiles_paint(
 
 constexpr CoordsXYZ defaultRightHelixUpLargeQuarterBoundOffsets[4][5][2] = {
     {
-        { { 0, 6, 8 }, { 0, 0, 0 } },
+        { { 0, 6, 0 }, { 0, 0, 0 } },
         { { 0, 16, 0 }, { 0, 0, 0 } },
         { { 0, 0, 0 }, { 0, 0, 0 } },
         { { 16, 0, 0 }, { 0, 0, 0 } },
-        { { 6, 0, 8 }, { 0, 0, 0 } },
+        { { 6, 0, 0 }, { 0, 0, 0 } },
     },
     {
-        { { 6, 0, 8 }, { 0, 0, 0 } },
+        { { 6, 0, 0 }, { 0, 0, 0 } },
         { { 16, 0, 0 }, { 0, 0, 0 } },
         { { 0, 16, 0 }, { 0, 0, 0 } },
         { { 0, 0, 0 }, { 0, 0, 0 } },
@@ -1061,7 +1061,7 @@ constexpr CoordsXYZ defaultRightHelixUpLargeQuarterBoundOffsets[4][5][2] = {
         { { 0, 0, 0 }, { 27, 0, 0 } },
     },
     {
-        { { 6, 0, 8 }, { 27, 0, 0 } },
+        { { 6, 0, 0 }, { 27, 0, 0 } },
         { { 0, 0, 0 }, { 0, 0, 0 } },
         { { 16, 0, 0 }, { 0, 0, 0 } },
         { { 0, 16, 0 }, { 0, 0, 0 } },


### PR DESCRIPTION
Trains would clip through helixes, both upwards and downwards, on the Junior Coaster, Classic Mini Coaster and the Water Coaster. Adjusting the bounding box offsets resolves this. Demo time!

**Left downwards before & after:**
![Left down before](https://user-images.githubusercontent.com/30838294/202706983-92d26b5c-ad3d-41eb-8c14-c86c7e4a460a.gif)
![Left down after](https://user-images.githubusercontent.com/30838294/202707011-68931e57-bf1a-4447-8a69-ae7862e5bc6b.gif)

**Right downwards before & after:**
![Right down before](https://user-images.githubusercontent.com/30838294/202707133-4865321f-e905-443e-9327-d2183b9c21d6.gif)
![Right down after](https://user-images.githubusercontent.com/30838294/202707142-6d855eeb-e2b6-42d9-92a8-867ba0919d85.gif)

**Right upwards before & after:**
![Right up before](https://user-images.githubusercontent.com/30838294/202707197-ca98731e-d1bb-43de-a72f-653f152d2934.gif)
![Right up after](https://user-images.githubusercontent.com/30838294/202707223-4e5e7fc6-3167-4547-acea-25912c00ec27.gif)

**Left upwards before & after (with Water Coaster):**
![Water coaster before](https://user-images.githubusercontent.com/30838294/202707382-979865da-c24f-4aa7-9129-ae3b44f5ba53.gif)
![Water coaster after](https://user-images.githubusercontent.com/30838294/202707406-05b59630-26d2-47bc-bd48-c63507420c72.gif)

**Note:** This PR basically reverts the changes introduced in #17312 for these coaster types. This does mean another z-fighting issue regarding helixes entering/exiting at tunnels for these coaster types will return, but unfortunately that might be a harder fix and this issue is more prevalent. 