### PR TITLE
[Plugin] Fix crash when reading widget property on window that has both static and tab content

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -43,6 +43,7 @@
 - Fix: [#18453] Slow walking guests don't get across level crossings in time.
 - Fix: [#18459] ‘Highlight path issues’ hides fences for paths with additions.
 - Fix: [#18606] JSON objects do not take priority over the DAT files they supersede.
+- Fix: [#18620] [Plugin] Crash when reading widget properties from windows that have both static and tab widgets.
 
 0.4.2 (2022-10-05)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -365,7 +365,7 @@ namespace OpenRCT2::Ui::Windows
                     auto tabWidgetIndex = widgetDescIndex - Desc.Widgets.size();
                     if (tabWidgetIndex < widgets.size())
                     {
-                        return &widgets[widgetDescIndex];
+                        return &widgets[tabWidgetIndex];
                     }
                 }
             }


### PR DESCRIPTION
Hey all,

Hereby a one-liner fix for a crash that occurs when a plugin-created window uses both static content and widgets on a tab, and then tries to read a property (e.g. name) from a widget on the currently opened tab. This causes an out-of-bound assert in the widgets-vector, presumed to be because the wrong variable was used to index said vector.

If a plugin sample is preferred for testing purposes, please let me know, though I think the fix could speak for itself. :)

Thank you for your time.