### PR TITLE
Change scenery calculation

### DIFF
--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2959,10 +2959,17 @@ static PeepThoughtType peep_assess_surroundings(int16_t centre_x, int16_t centre
                         if (tileElement->AsPath()->IsBroken())
                         {
                             num_rubbish++;
+                            break;
+                        }
+                        if (pathAddEntry->flags & (PATH_BIT_FLAG_LAMP))
+                        {
+                            num_scenery++;
                         }
                         break;
                     }
                     case TileElementType::LargeScenery:
+                        num_scenery += 2;
+                        break;
                     case TileElementType::SmallScenery:
                         num_scenery++;
                         break;


### PR DESCRIPTION
It would take quite a lot of scenery before guests could start starting: 'Great scenery!'. By changing some quirks, this has been adjusted a bit.

Firstly, extra value is added to large scenery, so it isn't handled exactly the same as small scenery.  Relatively, small scenery still counts for more, which makes sense since it's also a more work to place which would be appreciated by guests too.

Secondly, lamps currently have no function other than make parks look pretty. They didn't count towards this though.  Now, they add the same amount of value as small scenery.

**Note: this PR is intended to facilitate a discussion about this proposed change.** I'll personally continue testing with this build whilst playing the game. So far, it makes guests appreciate the scenery a bit faster but not excessively - you'll still have to put work into your scenery. So I'm quite happy with it, but have to test a bit more in any case.