### PR TITLE
Revert "Fix #11679: Facilities clipping issues"

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -20,7 +20,6 @@
 - Change: [#18381] Convert custom invisible paths to the built-in ones.
 - Change: [OpenSFX#11, OpenMusic#19] First implementation of official replacement asset packs for sound effects & music. 
 - Fix: [#1519] “See-through rides” doesn't affect all rides (original bug).
-- Fix: [#11679] Facilities clipping issues.
 - Fix: [#14312] Research ride type message incorrect.
 - Fix: [#14425] Ride ratings do not skip unallocated ride ids.
 - Fix: [#15969] Guests heading for ride use vanilla behaviour

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -32,10 +32,10 @@ static void PaintFacility(
     if (firstCarEntry == nullptr)
         return;
 
-    auto lengthX = direction == 1 ? 2 : 28;
-    auto lengthY = direction == 2 ? 2 : 28;
+    auto lengthX = (direction & 1) == 0 ? 28 : 2;
+    auto lengthY = (direction & 1) == 0 ? 2 : 28;
     CoordsXYZ offset(0, 0, height);
-    BoundBoxXYZ bb = { { 2, 2, height }, { lengthX, lengthY, 29 } };
+    BoundBoxXYZ bb = { { direction == 3 ? 28 : 2, direction == 0 ? 28 : 2, height }, { lengthX, lengthY, 29 } };
 
     auto imageTemplate = session.TrackColours[SCHEME_TRACK];
     auto imageIndex = firstCarEntry->base_image_id + ((direction + 2) & 3);


### PR DESCRIPTION
This reverts commit c9b6292b88a9bd212d088f1c19e23f4906057919.

Unfortunately #11679 had side effects more serious than the problem it set out to solve. So unfortunately we’ll have to revert it, unless @rik-smeets has another solution.

See here: https://github.com/OpenRCT2/OpenRCT2/pull/18358#issuecomment-1304615840