### PR TITLE
Fix #18469: Land rights window issues

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -42,6 +42,7 @@
 - Fix: [#18442] About window background is clickable.
 - Fix: [#18449] [Plugin] Change type of listview widgets from 'scroll_view' to 'listview'.
 - Fix: [#18453] Slow walking guests don't get across level crossings in time.
+- Fix: [#18469] Land rights window buttons incorrectly disabled and markers remain visible indefinitely.
 - Fix: [#18459] ‘Highlight path issues’ hides fences for paths with additions.
 - Fix: [#18606] JSON objects do not take priority over the DAT files they supersede.
 - Fix: [#18620] [Plugin] Crash when reading widget properties from windows that have both static and tab widgets.

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -453,6 +453,8 @@ void game_fix_save_vars()
     ParkEntranceFixLocations();
 
     UpdateConsolidatedPatrolAreas();
+
+    MapCountRemainingLandRights();
 }
 
 void game_load_init()

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -196,7 +196,6 @@ namespace RCT1
             SetDefaultNames();
             determine_ride_entrance_and_exit_locations();
 
-            MapCountRemainingLandRights();
             research_determine_first_of_type();
 
             CheatsReset();

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -501,7 +501,6 @@ namespace RCT2
             // Fix and set dynamic variables
             MapStripGhostFlagFromElements();
             ConvertScenarioStringsToUTF8();
-            MapCountRemainingLandRights();
             determine_ride_entrance_and_exit_locations();
 
             park.Name = GetUserString(_s6.park_name);


### PR DESCRIPTION
Global variables regarding land ownership weren't initialized upon loading a `.park` file. This would lead to different bugs when using the 'Land rights' window, like markers remaining visible indefinitely and not being able to select the type of land rights to buy.

The `MapCountRemainingLandRights` method to initialize these variables is now called in the `game_fix_save_vars` method, which is called after the `Import` function of the save file importer has been called. The calls to said method have therefore been removed from the S4 and S6 importers.