### PR TITLE
Add button to show contributors.md

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3281,8 +3281,8 @@ STR_6133    :Access rides and scenery that have not yet been invented
 STR_6134    :Clear Scenery
 STR_6135    :Client sent invalid request
 STR_6136    :Server sent invalid request
-STR_6137    :OpenRCT2, a free and open source clone of Roller Coaster Tycoon 2.
-STR_6138    :OpenRCT2 is the work of many authors, a full list can be found in “contributors.md”. For more information, visit http://github.com/OpenRCT2/OpenRCT2
+STR_6137    :A free and open source recreation of and expansion to Roller Coaster Tycoon 2.
+STR_6138    :For more information, visit http://github.com/OpenRCT2/OpenRCT2
 STR_6139    :All product and company names belong to their respective holders. Use of them does not imply any affiliation with or endorsement by them.
 STR_6140    :Changelog…
 STR_6141    :RCT1 Bottom Toolbar
@@ -3644,6 +3644,7 @@ STR_6538    :Shows regular paths in the queues dropdown of the Footpaths window.
 STR_6539    :Brake Closed
 STR_6540    :{WINDOW_COLOUR_2}Special thanks to the following companies for allowing their likeness:
 STR_6541    :{WINDOW_COLOUR_2}Rocky Mountain Construction Group, Josef Wiegand GmbH & Co. KG
+STR_6542    :{WINDOW_COLOUR_2}Contributors
 
 #############
 # Scenarios #

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3281,8 +3281,8 @@ STR_6133    :Access rides and scenery that have not yet been invented
 STR_6134    :Clear Scenery
 STR_6135    :Client sent invalid request
 STR_6136    :Server sent invalid request
-STR_6137    :A free and open source recreation of and expansion to Roller Coaster Tycoon 2.
-STR_6138    :For more information, visit http://github.com/OpenRCT2/OpenRCT2
+STR_6137    :OpenRCT2, a free and open source recreation of and expansion to Roller Coaster Tycoon 2.
+STR_6138    :OpenRCT2 is the work of many authors, a full list can be found under the “Contributors” button. For more information, visit http://github.com/OpenRCT2/OpenRCT2
 STR_6139    :All product and company names belong to their respective holders. Use of them does not imply any affiliation with or endorsement by them.
 STR_6140    :Changelog…
 STR_6141    :RCT1 Bottom Toolbar
@@ -3644,7 +3644,8 @@ STR_6538    :Shows regular paths in the queues dropdown of the Footpaths window.
 STR_6539    :Brake Closed
 STR_6540    :{WINDOW_COLOUR_2}Special thanks to the following companies for allowing their likeness:
 STR_6541    :{WINDOW_COLOUR_2}Rocky Mountain Construction Group, Josef Wiegand GmbH & Co. KG
-STR_6542    :{WINDOW_COLOUR_2}Contributors
+STR_6542    :Contributors
+STR_6543    :Contributors…
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/CMakeLists.txt
+++ b/src/openrct2-ui/CMakeLists.txt
@@ -182,6 +182,7 @@ if(MACOS_BUNDLE)
     target_sources(${PROJECT_NAME}
         PUBLIC ${ROOT_DIR}/distribution/readme.txt
         PUBLIC ${ROOT_DIR}/distribution/changelog.txt
+        PUBLIC ${ROOT_DIR}/contributors.md
         PUBLIC ${ROOT_DIR}/resources/mac/openrct2.icns
         )
 
@@ -189,6 +190,7 @@ if(MACOS_BUNDLE)
     set(BUNDLE_RESOURCES
         ${ROOT_DIR}/distribution/readme.txt
         ${ROOT_DIR}/distribution/changelog.txt
+        ${ROOT_DIR}/contributors.md
         ${ROOT_DIR}/resources/mac/openrct2.icns
         )
 

--- a/src/openrct2-ui/WindowManager.cpp
+++ b/src/openrct2-ui/WindowManager.cpp
@@ -174,6 +174,8 @@ public:
                 return WindowChangelogOpen(WV_CHANGELOG);
             case WV_NEW_VERSION_INFO:
                 return WindowChangelogOpen(WV_NEW_VERSION_INFO);
+            case WV_CONTRIBUTORS:
+                return WindowChangelogOpen(WV_CONTRIBUTORS);
             case WV_FINANCE_MARKETING:
                 return WindowFinancesMarketingOpen();
             default:

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -6,16 +6,12 @@
  *
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
-
 #include <SDL_clipboard.h>
-#include <fstream>
 #include <openrct2-ui/interface/Widget.h>
 #include <openrct2-ui/windows/Window.h>
 #include <openrct2/Context.h>
 #include <openrct2/OpenRCT2.h>
-#include <openrct2/PlatformEnvironment.h>
 #include <openrct2/Version.h>
-#include <openrct2/core/FileSystem.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
@@ -35,7 +31,6 @@ enum
 {
     WINDOW_ABOUT_PAGE_OPENRCT2,
     WINDOW_ABOUT_PAGE_RCT2,
-    WINDOW_ABOUT_PAGE_CONTRIBUTORS,
 };
 
 enum WindowAboutWidgetIdx {
@@ -45,7 +40,6 @@ enum WindowAboutWidgetIdx {
     WIDX_PAGE_BACKGROUND,
     WIDX_TAB_ABOUT_OPENRCT2,
     WIDX_TAB_ABOUT_RCT2,
-    WIDX_TAB_ABOUT_CONTRIBUTORS,
 
     WIDX_PAGE_START,
 
@@ -59,14 +53,16 @@ enum WindowAboutWidgetIdx {
     WIDX_JOIN_DISCORD,
     WIDX_CONTRIBUTORS,
     WIDX_COPYRIGHT,
+    WIDX_SPECIAL_THANKS,
+    WIDX_COMPANY_NAMES,
+    WIDX_CONTRIBUTORS_BUTTON,
 };
 
 #define WIDGETS_MAIN \
     WINDOW_SHIM(WINDOW_TITLE, WW, WH), \
     MakeWidget     ({ 0, TABHEIGHT}, {WW, WH - TABHEIGHT}, WindowWidgetType::Frame,  WindowColour::Secondary               ), /* page background */       \
     MakeRemapWidget({ 3,        17}, {91, TABHEIGHT - 16}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_TAB_LARGE), /* about OpenRCT2 button */ \
-    MakeRemapWidget({94,        17}, {91, TABHEIGHT - 16}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_TAB_LARGE),  /* about RCT2 button */ \
-    MakeRemapWidget({185,       17}, {91, TABHEIGHT - 16}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_TAB_LARGE)  /* Contributors button */
+    MakeRemapWidget({94,        17}, {91, TABHEIGHT - 16}, WindowWidgetType::Tab,    WindowColour::Secondary, SPR_TAB_LARGE)  /* about RCT2 button */ \
 
 static Widget _windowAboutOpenRCT2Widgets[] = {
     WIDGETS_MAIN,
@@ -74,13 +70,14 @@ static Widget _windowAboutOpenRCT2Widgets[] = {
     MakeWidget({30, 90},        {128, 128},    WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_NONE), // OpenRCT2 Logo
     MakeWidget({168, 100},      {173, 24},     WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_NONE), // Build version
     MakeWidget({344, 100 },     {24, 24},      WindowWidgetType::ImgBtn,       WindowColour::Secondary, ImageId(SPR_G2_COPY), STR_COPY_BUILD_HASH   ), // "Copy build info" button
-    MakeWidget({168, 115 + 24}, {200, 14},     WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_UPDATE_AVAILABLE  ), // "new version" button
-    MakeWidget({168, 115 + 48}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CHANGELOG_ELLIPSIS), // changelog button
-    MakeWidget({168, 115 + 72}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_JOIN_DISCORD      ), // "join discord" button
+    MakeWidget({168, 115 + 20}, {200, 14},     WindowWidgetType::Placeholder,  WindowColour::Secondary, STR_UPDATE_AVAILABLE  ), // "new version" button
+    MakeWidget({168, 115 + 40}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CHANGELOG_ELLIPSIS), // changelog button
+    MakeWidget({168, 115 + 60}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_JOIN_DISCORD      ), // "join discord" button
     MakeWidget({10, 250},       {WW - 20, 50}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_OPENRCT2_DESCRIPTION_2), // More info
     MakeWidget({10, 300},       {WW - 20, 50}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_OPENRCT2_DESCRIPTION_3), // Copyright
     MakeWidget({10, 350},       {WW - 20, 50}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_SPECIAL_THANKS_1), // Special Thanks
     MakeWidget({10, 375},       {WW - 20, 50}, WindowWidgetType::LabelCentred, WindowColour::Secondary, STR_ABOUT_SPECIAL_THANKS_2), // Company names
+    MakeWidget({168, 115 + 80}, {200, 14},     WindowWidgetType::Button,       WindowColour::Secondary, STR_CONTRIBUTORS_WINDOW_BUTTON), // "contributors" button
     WIDGETS_END,
 };
 
@@ -89,36 +86,12 @@ static Widget _windowAboutRCT2Widgets[] = {
     WIDGETS_END,
 };
 
-static Widget _windowAboutContributorsWidgets[] = {
-    WIDGETS_MAIN,
-    MakeWidget({10,  60}, {WW - 20, 282}, WindowWidgetType::Scroll,      WindowColour::Secondary, SCROLL_BOTH                  ), // scroll area
-    WIDGETS_END,
-};
-
 static Widget *_windowAboutPageWidgets[] = {
     _windowAboutOpenRCT2Widgets,
     _windowAboutRCT2Widgets,
-    _windowAboutContributorsWidgets,
 };
 
 // clang-format on
-
-static std::string GetContributorsPath()
-{
-    auto env = GetContext()->GetPlatformEnvironment();
-    return env->GetFilePath(PATHID::CONTRIBUTORS);
-}
-
-static const std::string GetContributorsText()
-{
-    auto path = GetContributorsPath();
-    auto fs = std::ifstream(fs::u8path(path), std::ios::in);
-    if (!fs.is_open())
-    {
-        throw std::runtime_error("Unable to open " + path);
-    }
-    return std::string((std::istreambuf_iterator<char>(fs)), std::istreambuf_iterator<char>());
-}
 
 class AboutWindow final : public Window
 {
@@ -140,7 +113,6 @@ public:
                 break;
             case WIDX_TAB_ABOUT_OPENRCT2:
             case WIDX_TAB_ABOUT_RCT2:
-            case WIDX_TAB_ABOUT_CONTRIBUTORS:
                 SetPage(widgetIndex - WIDX_TAB_ABOUT_OPENRCT2);
                 break;
             case WIDX_JOIN_DISCORD:
@@ -155,6 +127,9 @@ public:
             case WIDX_COPY_BUILD_INFO:
                 SDL_SetClipboardText(gVersionInfoFull);
                 break;
+            case WIDX_CONTRIBUTORS_BUTTON:
+                ContextOpenWindowView(WV_CONTRIBUTORS);
+                break;
         }
     }
 
@@ -164,12 +139,10 @@ public:
 
         const auto& aboutOpenRCT2 = widgets[WIDX_TAB_ABOUT_OPENRCT2];
         const auto& aboutRCT2 = widgets[WIDX_TAB_ABOUT_RCT2];
-        const auto& aboutContributors = widgets[WIDX_TAB_ABOUT_CONTRIBUTORS];
 
         int32_t y = windowPos.y + aboutOpenRCT2.midY() - 3;
         ScreenCoordsXY aboutOpenRCT2Coords(windowPos.x + aboutOpenRCT2.left + 45, y);
         ScreenCoordsXY aboutRCT2Coords(windowPos.x + aboutRCT2.left + 45, y);
-        ScreenCoordsXY aboutContributorsCoords(windowPos.x + aboutContributors.left + 45, y);
 
         // Draw tab names
         {
@@ -184,13 +157,6 @@ public:
             DrawTextWrapped(
                 &dpi, aboutRCT2Coords, 87, STR_WINDOW_COLOUR_2_STRINGID, ft, { COLOUR_AQUAMARINE, TextAlignment::CENTRE });
         }
-        {
-            auto ft = Formatter();
-            ft.Add<StringId>(STR_TAB_CONTRIBUTORS);
-            DrawTextWrapped(
-                &dpi, aboutContributorsCoords, 87, STR_WINDOW_COLOUR_2_STRINGID, ft,
-                { COLOUR_AQUAMARINE, TextAlignment::CENTRE });
-        }
 
         if (page == WINDOW_ABOUT_PAGE_OPENRCT2)
         {
@@ -199,10 +165,6 @@ public:
         else if (page == WINDOW_ABOUT_PAGE_RCT2)
         {
             DrawRCT2Info(dpi);
-        }
-        else if (page == WINDOW_ABOUT_PAGE_CONTRIBUTORS)
-        {
-            DrawContributorsInfo(dpi);
         }
     }
 
@@ -224,9 +186,6 @@ private:
                 break;
             case WINDOW_ABOUT_PAGE_RCT2:
                 pressed_widgets |= (1uLL << WIDX_TAB_ABOUT_RCT2);
-                break;
-            case WINDOW_ABOUT_PAGE_CONTRIBUTORS:
-                pressed_widgets |= (1uLL << WIDX_TAB_ABOUT_CONTRIBUTORS);
                 break;
         }
 
@@ -300,20 +259,6 @@ private:
 
         // Licence
     }
-
-    void DrawContributorsInfo(rct_drawpixelinfo& dpi)
-    {
-        int32_t yPage = windowPos.y + widgets[WIDX_PAGE_BACKGROUND].top + 5;
-
-        auto screenCoords = ScreenCoordsXY{ windowPos.x + 15, yPage };
-
-        int32_t lineHeight = font_get_line_height(FontStyle::Medium);
-
-        auto text = GetContributorsText();
-
-        screenCoords.y += lineHeight;
-        gfx_draw_string(&dpi, screenCoords, text.c_str(), { colours[0] });
-    };
 };
 
 /**

--- a/src/openrct2/PlatformEnvironment.cpp
+++ b/src/openrct2/PlatformEnvironment.cpp
@@ -135,6 +135,7 @@ private:
             case PATHID::SCORES_RCT2:
                 return DIRBASE::RCT2;
             case PATHID::CHANGELOG:
+            case PATHID::CONTRIBUTORS:
                 return DIRBASE::DOCUMENTATION;
             case PATHID::NETWORK_GROUPS:
             case PATHID::NETWORK_SERVERS:
@@ -285,5 +286,6 @@ const u8string PlatformEnvironment::FileNames[] = {
     u8"scores.dat",                              // SCORES (LEGACY)
     u8"Saved Games" PATH_SEPARATOR "scores.dat", // SCORES (RCT2)
     u8"changelog.txt",                           // CHANGELOG
-    u8"plugin.store.json"                        // PLUGIN_STORE
+    u8"plugin.store.json",                       // PLUGIN_STORE
+    u8"contributors.md",                         // CONTRIBUTORS
 };

--- a/src/openrct2/PlatformEnvironment.h
+++ b/src/openrct2/PlatformEnvironment.h
@@ -70,6 +70,7 @@ namespace OpenRCT2
         SCORES_RCT2,             // Scenario scores, rct2 (\Saved Games\scores.dat).
         CHANGELOG,               // Notable changes to the game between versions, distributed with the game.
         PLUGIN_STORE,            // Shared storage for plugins.
+        CONTRIBUTORS,            // Who has provided work to the game (Contributors.md).
     };
 
     /**

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -382,6 +382,7 @@ enum
     WV_CHANGELOG,
     WV_NEW_VERSION_INFO,
     WV_FINANCE_MARKETING,
+    WV_CONTRIBUTORS,
 };
 
 enum WindowDetail

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3935,7 +3935,9 @@ enum : uint16_t
 
     STR_ABOUT_SPECIAL_THANKS_1 = 6540,
     STR_ABOUT_SPECIAL_THANKS_2 = 6541,
-    STR_TAB_CONTRIBUTORS = 6542,
+
+    STR_CONTRIBUTORS_WINDOW = 6542,
+    STR_CONTRIBUTORS_WINDOW_BUTTON = 6543,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3935,6 +3935,7 @@ enum : uint16_t
 
     STR_ABOUT_SPECIAL_THANKS_1 = 6540,
     STR_ABOUT_SPECIAL_THANKS_2 = 6541,
+    STR_TAB_CONTRIBUTORS = 6542,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings


### PR DESCRIPTION
This also includes 5 placeholders for other companies (parks, manufacturers, etc, if we get permission or help from them).

I think it's fair to give a shoutout to the companies we got a green light from in the about page. 

In the future I would also like to have another tab that reads out contributors.md (or rename that to a txt, similar to how the changelog works), but I'll leave that to a separate PR.