### PR TITLE
Speedy Block Brakes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,9 @@ set(OPENMSX_VERSION "1.2.0")
 set(OPENMSX_URL  "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA1 "c1c9b030c83c12ff628e8ec72fcfe748291a5344")
 
-set(REPLAYS_VERSION "0.0.77")
+set(REPLAYS_VERSION "0.0.78")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "65CA6D830789C074F575F15E3F9E2C28691C24F8")
+set(REPLAYS_SHA1 "31C5D07EED8481D5C6D57F9E4FE9443AAEDE7739")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3679,6 +3679,9 @@ STR_6573    :Invisible
 STR_6574    :Void
 STR_6575    :Allow special colour schemes
 STR_6576    :Adds special colours to colour dropdown
+STR_6577    :Block brake speed
+STR_6578    :Set speed limit for block brakes. In block section mode, adjacent brakes with a slower speed are linked to the block brake.
+STR_6579    :Block brakes will be set to default speed when saved as track design
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.5 (in development)
 ------------------------------------------------------------------------
+- Feature: [#18713] Block brakes have speed control and brakes slower than adjacent block brakes copy block brake speed when block brake open.
 - Feature: [#19276] Add Powered Lifthill to Giga Coaster.
 - Feature: [#19446] Add new color options to color dropdown.
 - Feature: [#19547] Add large sloped turns to hybrid coaster and single rail coaster.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -51,8 +51,8 @@
     <OpenSFXSha1>64EF7E0B7785602C91AEC66F005C035B05A2133B</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.2.0/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha1>c1c9b030c83c12ff628e8ec72fcfe748291a5344</OpenMSXSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.77/replays.zip</ReplaysUrl>
-    <ReplaysSha1>65CA6D830789C074F575F15E3F9E2C28691C24F8</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.78/replays.zip</ReplaysUrl>
+    <ReplaysSha1>31C5D07EED8481D5C6D57F9E4FE9443AAEDE7739</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1405,6 +1405,8 @@ public:
                 _currentTrackBankEnd = TRACK_BANK_NONE;
                 _currentTrackLiftHill &= ~CONSTRUCTION_LIFT_HILL_SELECTED;
                 break;
+            case TrackElemType::BlockBrakes:
+                _currentBrakeSpeed2 = kRCT2DefaultBlockBrakeSpeed;
         }
         _currentTrackCurve = trackPiece | RideConstructionSpecialPieceSelected;
         WindowRideConstructionUpdateActiveElements();

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -455,6 +455,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Vehicle, target_seat_rotation);
         COMPARE_FIELD(Vehicle, BoatLocation.x);
         COMPARE_FIELD(Vehicle, BoatLocation.y);
+        COMPARE_FIELD(Vehicle, BlockBrakeSpeed);
     }
 
     void CompareSpriteDataLitter(const Litter& spriteBase, const Litter& spriteCmp, GameStateSpriteChange& changeData) const

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -573,12 +573,16 @@ GameActions::Result TrackPlaceAction::Execute() const
             case TrackElemType::SpinningTunnel:
                 MapAnimationCreate(MAP_ANIMATION_TYPE_TRACK_SPINNINGTUNNEL, CoordsXYZ{ mapLoc, trackElement->GetBaseZ() });
                 break;
+            case TrackElemType::Brakes:
+                trackElement->SetBrakeClosed(true);
+                break;
         }
         if (TrackTypeHasSpeedSetting(_trackType))
         {
             trackElement->SetBrakeBoosterSpeed(_brakeSpeed);
         }
-        else if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_LANDSCAPE_DOORS))
+
+        if (ride->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_HAS_LANDSCAPE_DOORS))
         {
             trackElement->SetDoorAState(LANDSCAPE_DOOR_CLOSED);
             trackElement->SetDoorBState(LANDSCAPE_DOOR_CLOSED);

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3977,6 +3977,10 @@ enum : uint16_t
     STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES = 6575,
     STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES_TIP = 6576,
 
+    STR_RIDE_CONSTRUCTION_BLOCK_BRAKE_SPEED = 6577,
+    STR_RIDE_CONSTRUCTION_BLOCK_BRAKE_SPEED_LIMIT_TIP = 6578,
+    STR_TRACK_DESIGN_BLOCK_BRAKE_SPEED_RESET = 6579,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "9"
+#define NETWORK_STREAM_VERSION "10"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -64,6 +64,8 @@
 #include <string_view>
 #include <vector>
 
+constexpr const uint32_t BlockBrakeImprovementsVersion = 27;
+
 using namespace OpenRCT2;
 
 namespace OpenRCT2
@@ -1092,11 +1094,18 @@ namespace OpenRCT2
                                 else if (it.element->GetType() == TileElementType::Track)
                                 {
                                     auto* trackElement = it.element->AsTrack();
+                                    auto trackType = trackElement->GetTrackType();
                                     if (TrackTypeMustBeMadeInvisible(
-                                            trackElement->GetRideType(), trackElement->GetTrackType(),
-                                            os.GetHeader().TargetVersion))
+                                            trackElement->GetRideType(), trackType, os.GetHeader().TargetVersion))
                                     {
                                         it.element->SetInvisible(true);
+                                    }
+                                    if (os.GetHeader().TargetVersion < BlockBrakeImprovementsVersion)
+                                    {
+                                        if (trackType == TrackElemType::Brakes)
+                                            trackElement->SetBrakeClosed(true);
+                                        if (trackType == TrackElemType::BlockBrakes)
+                                            trackElement->SetBrakeBoosterSpeed(kRCT2DefaultBlockBrakeSpeed);
                                     }
                                 }
                                 else if (
@@ -2088,7 +2097,18 @@ namespace OpenRCT2
         cs.ReadWrite(entity.scream_sound_id);
         cs.ReadWrite(entity.TrackSubposition);
         cs.ReadWrite(entity.NumLaps);
-        cs.ReadWrite(entity.brake_speed);
+        if (cs.GetMode() == OrcaStream::Mode::READING && os.GetHeader().TargetVersion < BlockBrakeImprovementsVersion)
+        {
+            uint8_t brakeSpeed;
+            cs.ReadWrite(brakeSpeed);
+            if (entity.GetTrackType() == TrackElemType::BlockBrakes)
+                brakeSpeed = kRCT2DefaultBlockBrakeSpeed;
+            entity.brake_speed = brakeSpeed;
+        }
+        else
+        {
+            cs.ReadWrite(entity.brake_speed);
+        }
         cs.ReadWrite(entity.lost_time_out);
         cs.ReadWrite(entity.vertical_drop_countdown);
         cs.ReadWrite(entity.var_D3);
@@ -2106,6 +2126,14 @@ namespace OpenRCT2
             {
                 entity.SetFlag(VehicleFlags::Crashed);
             }
+        }
+        if (cs.GetMode() == OrcaStream::Mode::READING && os.GetHeader().TargetVersion < BlockBrakeImprovementsVersion)
+        {
+            entity.BlockBrakeSpeed = kRCT2DefaultBlockBrakeSpeed;
+        }
+        else
+        {
+            cs.ReadWrite(entity.BlockBrakeSpeed);
         }
     }
 

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -9,10 +9,10 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 26;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 27;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t PARK_FILE_MIN_VERSION = 26;
+    constexpr uint32_t PARK_FILE_MIN_VERSION = 27;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1674,6 +1674,8 @@ namespace RCT1
                     // Skipping IsHighlighted()
 
                     auto trackType = dst2->GetTrackType();
+                    // Brakes import as closed to preserve legacy behaviour
+                    dst2->SetBrakeClosed(trackType == TrackElemType::Brakes);
                     if (TrackTypeHasSpeedSetting(trackType))
                     {
                         dst2->SetBrakeBoosterSpeed(src2->GetBrakeBoosterSpeed());
@@ -2817,6 +2819,7 @@ namespace RCT1
         {
             dst->SetFlag(VehicleFlags::Crashed);
         }
+        dst->BlockBrakeSpeed = kRCT2DefaultBlockBrakeSpeed;
     }
 
     template<> void S4Importer::ImportEntity<Guest>(const RCT12EntityBase& srcBase)

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1440,11 +1440,17 @@ namespace RCT2
                     dst2->SetInverted(src2->IsInverted());
                     dst2->SetStationIndex(StationIndex::FromUnderlying(src2->GetStationIndex()));
                     dst2->SetHasGreenLight(src2->HasGreenLight());
-                    dst2->SetBrakeClosed(src2->BlockBrakeClosed());
+                    // Brakes import as closed to preserve legacy behaviour
+                    dst2->SetBrakeClosed(src2->BlockBrakeClosed() || (trackType == TrackElemType::Brakes));
                     dst2->SetIsIndestructible(src2->IsIndestructible());
                     // Skipping IsHighlighted()
 
-                    if (TrackTypeHasSpeedSetting(trackType))
+                    // Import block brakes to keep legacy behaviour
+                    if (trackType == TrackElemType::BlockBrakes)
+                    {
+                        dst2->SetBrakeBoosterSpeed(kRCT2DefaultBlockBrakeSpeed);
+                    }
+                    else if (TrackTypeHasSpeedSetting(trackType))
                     {
                         dst2->SetBrakeBoosterSpeed(src2->GetBrakeBoosterSpeed());
                     }
@@ -2009,6 +2015,10 @@ namespace RCT2
                 if (tileElement2 != nullptr)
                     dst->SetTrackType(TrackElemType::RotationControlToggle);
             }
+            else if (src->GetTrackType() == TrackElemType::BlockBrakes)
+            {
+                dst->brake_speed = kRCT2DefaultBlockBrakeSpeed;
+            }
         }
         else
         {
@@ -2075,6 +2085,7 @@ namespace RCT2
         {
             dst->SetFlag(VehicleFlags::Crashed);
         }
+        dst->BlockBrakeSpeed = kRCT2DefaultBlockBrakeSpeed;
     }
 
     static uint32_t AdjustScenarioToCurrentTicks(const S6Data& s6, uint32_t tick)

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -304,7 +304,7 @@ private:
     void Update();
     void UpdateQueueLength(StationIndex stationIndex);
     ResultWithMessage CreateVehicles(const CoordsXYE& element, bool isApplying);
-    void MoveTrainsToBlockBrakes(TrackElement* firstBlock);
+    void MoveTrainsToBlockBrakes(const CoordsXYZ& firstBlockPosition, TrackElement& firstBlock);
     money64 CalculateIncomePerHour() const;
     void ChainQueues() const;
     void ConstructMissingEntranceOrExit() const;
@@ -1066,6 +1066,8 @@ money64 RideEntranceExitPlaceGhost(
 
 ResultWithMessage RideAreAllPossibleEntrancesAndExitsBuilt(const Ride& ride);
 void RideFixBreakdown(Ride& ride, int32_t reliabilityIncreaseFactor);
+
+void BlockBrakeSetLinkedBrakesClosed(const CoordsXYZ& vehicleTrackLocation, TrackElement& tileElement, bool isOpen);
 
 uint8_t RideEntryGetVehicleAtPosition(int32_t rideEntryIndex, int32_t numCarsPerTrain, int32_t position);
 void RideUpdateVehicleColours(const Ride& ride);

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -655,7 +655,7 @@ bool TrackElementIsCovered(track_type_t trackElementType)
 
 bool TrackTypeHasSpeedSetting(track_type_t trackType)
 {
-    return trackType == TrackElemType::Brakes || trackType == TrackElemType::Booster;
+    return trackType == TrackElemType::Brakes || trackType == TrackElemType::Booster || trackType == TrackElemType::BlockBrakes;
 }
 
 bool TrackTypeIsHelix(track_type_t trackType)

--- a/src/openrct2/ride/Track.h
+++ b/src/openrct2/ride/Track.h
@@ -18,7 +18,9 @@
 
 constexpr const uint32_t RideConstructionSpecialPieceSelected = 0x10000;
 
-constexpr const int32_t BLOCK_BRAKE_BASE_SPEED = 0x20364;
+constexpr const uint8_t kRCT2DefaultBlockBrakeSpeed = 2;
+constexpr const int32_t kBlockBrakeBaseSpeed = 0x20364;
+constexpr const int32_t kBlockBrakeSpeedOffset = kBlockBrakeBaseSpeed - (kRCT2DefaultBlockBrakeSpeed << 16);
 
 using track_type_t = uint16_t;
 using roll_type_t = uint8_t;

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -182,6 +182,8 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
         return { false, STR_TRACK_TOO_LARGE_OR_TOO_MUCH_SCENERY };
     }
 
+    StringId warningMessage = STR_NONE;
+
     RideGetStartOfTrack(&trackElement);
 
     int32_t z = trackElement.element->GetBaseZ();
@@ -222,13 +224,21 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
         track.type = trackElement.element->AsTrack()->GetTrackType();
 
         uint8_t trackFlags;
-        if (TrackTypeHasSpeedSetting(track.type))
+        // This if-else block only applies to td6. New track design format will always encode speed and seat rotation.
+        if (TrackTypeHasSpeedSetting(track.type) && track.type != TrackElemType::BlockBrakes)
         {
             trackFlags = trackElement.element->AsTrack()->GetBrakeBoosterSpeed() >> 1;
         }
         else
         {
             trackFlags = trackElement.element->AsTrack()->GetSeatRotation();
+        }
+
+        // This warning will not apply to new track design format
+        if (track.type == TrackElemType::BlockBrakes
+            && trackElement.element->AsTrack()->GetBrakeBoosterSpeed() != kRCT2DefaultBlockBrakeSpeed)
+        {
+            warningMessage = STR_TRACK_DESIGN_BLOCK_BRAKE_SPEED_RESET;
         }
 
         if (trackElement.element->AsTrack()->HasChain())
@@ -349,7 +359,7 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
 
     space_required_x = ((tds.PreviewMax.x - tds.PreviewMin.x) / 32) + 1;
     space_required_y = ((tds.PreviewMax.y - tds.PreviewMin.y) / 32) + 1;
-    return { true };
+    return { true, warningMessage };
 }
 
 ResultWithMessage TrackDesign::CreateTrackDesignMaze(TrackDesignState& tds, const Ride& ride)
@@ -1617,7 +1627,17 @@ static GameActions::Result TrackDesignPlaceRide(TrackDesignState& tds, TrackDesi
                 // di
                 int16_t tempZ = newCoords.z - trackCoordinates->z_begin;
                 uint32_t trackColour = (track.flags >> 4) & 0x3;
-                uint32_t brakeSpeed = (track.flags & 0x0F) * 2;
+                uint32_t brakeSpeed;
+                // RCT2-created track designs write brake speed to all tracks; block brake speed must be treated as
+                // garbage data.
+                if (trackType == TrackElemType::BlockBrakes)
+                {
+                    brakeSpeed = kRCT2DefaultBlockBrakeSpeed;
+                }
+                else
+                {
+                    brakeSpeed = (track.flags & 0x0F) * 2;
+                }
                 uint32_t seatRotation = track.flags & 0x0F;
 
                 int32_t liftHillAndAlternativeState = 0;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6193,6 +6193,7 @@ static void block_brakes_open_previous_section(
         else if (trackType == TrackElemType::BlockBrakes)
         {
             OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::BlockBrakeClose, location);
+            BlockBrakeSetLinkedBrakesClosed(location, *trackElement, false);
         }
     }
 }
@@ -7416,6 +7417,10 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(uint16_t trackType, const Rid
             }
             MapInvalidateElement(TrackLocation, tileElement);
             block_brakes_open_previous_section(curRide, TrackLocation, tileElement);
+            if (trackType == TrackElemType::BlockBrakes)
+            {
+                BlockBrakeSetLinkedBrakesClosed(TrackLocation, *tileElement->AsTrack(), true);
+            }
         }
     }
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6004,15 +6004,14 @@ void Vehicle::ApplyNonStopBlockBrake()
     if (velocity >= 0)
     {
         // If the vehicle is below the speed limit
-        if (velocity <= BLOCK_BRAKE_BASE_SPEED)
+        if (velocity <= kBlockBrakeBaseSpeed)
         {
             // Boost it to the fixed block brake speed
-            velocity = BLOCK_BRAKE_BASE_SPEED;
+            velocity = kBlockBrakeBaseSpeed;
             acceleration = 0;
         }
-        else
+        else if (velocity > (brake_speed << 16) + kBlockBrakeSpeedOffset)
         {
-            // Slow it down till the fixed block brake speed
             velocity -= velocity >> 4;
             acceleration = 0;
         }
@@ -6185,9 +6184,13 @@ static void block_brakes_open_previous_section(
     MapInvalidateElement(location, reinterpret_cast<TileElement*>(trackElement));
 
     auto trackType = trackElement->GetTrackType();
-    if (trackType == TrackElemType::BlockBrakes || trackType == TrackElemType::EndStation)
+    if (ride.IsBlockSectioned())
     {
-        if (ride.IsBlockSectioned())
+        if (trackType == TrackElemType::EndStation)
+        {
+            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::BlockBrakeClose, location);
+        }
+        else if (trackType == TrackElemType::BlockBrakes)
         {
             OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::BlockBrakeClose, location);
         }
@@ -6981,7 +6984,7 @@ void Vehicle::UpdateLandscapeDoorBackwards() const
 
 static void vehicle_update_play_water_splash_sound()
 {
-    if (_vehicleVelocityF64E08 <= BLOCK_BRAKE_BASE_SPEED)
+    if (_vehicleVelocityF64E08 <= kBlockBrakeBaseSpeed)
     {
         return;
     }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6184,17 +6184,14 @@ static void block_brakes_open_previous_section(
     MapInvalidateElement(location, reinterpret_cast<TileElement*>(trackElement));
 
     auto trackType = trackElement->GetTrackType();
-    if (ride.IsBlockSectioned())
+    if (trackType == TrackElemType::EndStation)
     {
-        if (trackType == TrackElemType::EndStation)
-        {
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::BlockBrakeClose, location);
-        }
-        else if (trackType == TrackElemType::BlockBrakes)
-        {
-            OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::BlockBrakeClose, location);
-            BlockBrakeSetLinkedBrakesClosed(location, *trackElement, false);
-        }
+        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::BlockBrakeClose, location);
+    }
+    else if (trackType == TrackElemType::BlockBrakes)
+    {
+        OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::BlockBrakeClose, location);
+        BlockBrakeSetLinkedBrakesClosed(location, *trackElement, false);
     }
 }
 

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -210,6 +210,7 @@ struct Vehicle : EntityBase
     uint8_t seat_rotation;
     uint8_t target_seat_rotation;
     CoordsXY BoatLocation;
+    uint8_t BlockBrakeSpeed;
 
     constexpr bool IsHead() const
     {
@@ -377,6 +378,8 @@ private:
     void UpdateLandscapeDoor() const;
     void UpdateLandscapeDoorBackwards() const;
     int32_t CalculateRiderBraking() const;
+    uint8_t ChooseBrakeSpeed() const;
+    void PopulateBrakeSpeed(const CoordsXYZ& vehicleTrackLocation, TrackElement& brake);
 
     void Loc6DCE02(const Ride& curRide);
 };


### PR DESCRIPTION
This is a continuation of #13838 since it was closed and unable to reopen.

This PR adds speedy block brakes, a long-requested feature. Block brakes now have a speed field which allows users to set the maximum speed a train may traverse the block brake. Vehicles stopped by the block brake will resume motion at the original speed when the block brake opens.

To compliment the speedy block brakes, regular brakes have new behavior. When an uninterrupted line of brakes precede a block brake, the brakes will disable themselves while these conditions are met:
- The block brake is open
- The brake's speed is lower than the block brake's speed

In addition to these two features, the following supporting modifications are made:
- Tile inspector changes checkbox text "block brake closed" to "brake closed" when selecting a non-block brake piece
- Track designs and older parks sets all block brake speed to default, which is identical to legacy behavior
- Special case added to track design export to overwrite speed field with rotation field when saving block brakes on multidim coasters
- Removed arbitrary limitation of TrackPlaceAction that prevents building track element with speed and seat rotation