### PR TITLE
improve behaviour of awards

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -3,6 +3,7 @@
 - Feature: [#18537] Add shift/control modifiers to window close buttons, closing all but the given window or all windows of the same type, respectively.
 - Feature: [#18732] [Plugin] API to get the guests thoughts.
 - Feature: [#18744] Cheat to allow using a regular path as a queue path.
+- Improved: [#18749] Ability to have 4 active awards for more than one month in a row. 
 - Improved: [#18826] [Plugin] Added all actions and their documentation to plugin API.
 - Fix: [#18467] “Selected only” Object Selection filter is active in Track Designs Manager, and cannot be toggled.
 - Fix: [#18905] Ride Construction window theme is not applied correctly.

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -605,7 +605,19 @@ void award_reset()
 void award_update_all()
 {
     PROFILED_FUNCTION();
-
+    // Decrease award times
+    for (auto& award : _currentAwards)
+    {
+        --award.Time;
+    }
+    // Remove any 0 time awards
+    auto res = std::remove_if(
+        std::begin(_currentAwards), std::end(_currentAwards), [](const Award& award) { return award.Time == 0; });
+    if (res != std::end(_currentAwards))
+    {
+        _currentAwards.erase(res, std::end(_currentAwards));
+        window_invalidate_by_class(WindowClass::ParkInformation);
+    }
     // Only add new awards if park is open
     if (gParkFlags & PARK_FLAGS_PARK_OPEN)
     {
@@ -638,20 +650,5 @@ void award_update_all()
                 window_invalidate_by_class(WindowClass::ParkInformation);
             }
         }
-    }
-
-    // Decrease award times
-    for (auto& award : _currentAwards)
-    {
-        --award.Time;
-    }
-
-    // Remove any 0 time awards
-    auto res = std::remove_if(
-        std::begin(_currentAwards), std::end(_currentAwards), [](const Award& award) { return award.Time == 0; });
-    if (res != std::end(_currentAwards))
-    {
-        _currentAwards.erase(res, std::end(_currentAwards));
-        window_invalidate_by_class(WindowClass::ParkInformation);
     }
 }

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -605,6 +605,7 @@ void award_reset()
 void award_update_all()
 {
     PROFILED_FUNCTION();
+
     // Decrease award times
     for (auto& award : _currentAwards)
     {
@@ -618,6 +619,7 @@ void award_update_all()
         _currentAwards.erase(res, std::end(_currentAwards));
         window_invalidate_by_class(WindowClass::ParkInformation);
     }
+
     // Only add new awards if park is open
     if (gParkFlags & PARK_FLAGS_PARK_OPEN)
     {


### PR DESCRIPTION
this will change awards so that it will remove an expiring award before it checks to see if you qualify for another award, thus allowing you to qualify for a 4th award when a 4th award expires (may require replay update) Currently in the game, it arbitrarily denies an earned award.