### PR TITLE
Fix upward helix being buildable on alpine coaster

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2119,6 +2119,12 @@ public:
                 && (bank != _previousTrackBankEnd))
                 continue;
 
+            if ((trackType == TrackElemType::LeftHalfBankedHelixUpSmall
+                 || trackType == TrackElemType::RightHalfBankedHelixUpSmall
+                 || trackType == TrackElemType::LeftHalfBankedHelixUpLarge
+                 || trackType == TrackElemType::RightHalfBankedHelixUpLarge))
+                continue;
+
             _currentPossibleRideConfigurations[currentPossibleRideConfigurationIndex] = trackType;
             _currentDisabledSpecialTrackPieces |= (1uLL << currentPossibleRideConfigurationIndex);
             if (_currentTrackPieceDirection < 4 && slope == _previousTrackSlopeEnd && bank == _previousTrackBankEnd

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2119,10 +2119,13 @@ public:
                 && (bank != _previousTrackBankEnd))
                 continue;
 
-            if ((trackType == TrackElemType::LeftHalfBankedHelixUpSmall
-                 || trackType == TrackElemType::RightHalfBankedHelixUpSmall
-                 || trackType == TrackElemType::LeftHalfBankedHelixUpLarge
-                 || trackType == TrackElemType::RightHalfBankedHelixUpLarge))
+            if (currentRide->GetRideTypeDescriptor().HasFlag(RIDE_TYPE_FLAG_UP_INCLINE_REQUIRES_LIFT)
+                && !gCheatsEnableAllDrawableTrackPieces
+                && ((
+                    trackType == TrackElemType::LeftHalfBankedHelixUpSmall
+                    || trackType == TrackElemType::RightHalfBankedHelixUpSmall
+                    || trackType == TrackElemType::LeftHalfBankedHelixUpLarge
+                    || trackType == TrackElemType::RightHalfBankedHelixUpLarge)))
                 continue;
 
             _currentPossibleRideConfigurations[currentPossibleRideConfigurationIndex] = trackType;


### PR DESCRIPTION
This PR fixes #18720, where an upward helix can still be built on the alpine coaster if selected from the special menu.