### PR TITLE
Fix Ferris Wheel and Circus colored in ghost mode

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -49,6 +49,7 @@
 - Fix: [#18606] JSON objects do not take priority over the DAT files they supersede.
 - Fix: [#18620] [Plugin] Crash when reading widget properties from windows that have both static and tab widgets.
 - Fix: [#18653] Negative ratings multipliers do not appear in Vehicle tab
+- Fix: [#18755] Ferris Wheel and Circus ghosts not coloured correctly.
 
 0.4.2 (2022-10-05)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/gentle/Circus.cpp
+++ b/src/openrct2/ride/gentle/Circus.cpp
@@ -32,7 +32,7 @@ static void PaintCircusTent(PaintSession& session, const Ride& ride, uint8_t dir
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto imageFlags = session.TrackColours[SCHEME_MISC];
-    if (!imageFlags.HasPrimary())
+    if (imageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
         imageTemplate = imageFlags;
     }

--- a/src/openrct2/ride/gentle/FerrisWheel.cpp
+++ b/src/openrct2/ride/gentle/FerrisWheel.cpp
@@ -79,7 +79,7 @@ static void PaintFerrisWheelStructure(
     auto supportsImageTemplate = session.TrackColours[SCHEME_TRACK];
     auto wheelImageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);
     auto wheelImageFlags = session.TrackColours[SCHEME_MISC];
-    if (!wheelImageFlags.HasPrimary())
+    if (wheelImageFlags.ToUInt32() != IMAGE_TYPE_REMAP)
     {
         wheelImageTemplate = wheelImageFlags;
     }


### PR DESCRIPTION
Fixes #18755
This bug was introduced in 6f3790cf9838b522cdcb01d7fc5aa35fc5355415 for the Ferris Wheel, Circus and Merry-Go-Round.
Merry-Go-Round got fixed already in 26c080a0d7046e8f59ff66931df1ae209dd941cb.