### PR TITLE
Create framework for paint session unit tests with circus example

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -101,6 +101,7 @@ The following people are not part of the development team, but have been contrib
 * Andrew Pratt (andrewpratt64) - Added api hook for vehicle crashes, api function to get entities on a tile
 * Karst van Galen Last (AuraSpecs) - Ride paint (bounding boxes, extra track pieces), soundtrack, sound effects, misc.
 * (8street) - Misc.
+* Lucas Malo Belanger (frutiemax) - Various code refactoring, bug fixes and unit tests
 
 ## Bug fixes
 * (KirilAngelov)

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -324,6 +324,7 @@
     <ClInclude Include="paint\Paint.Entity.h" />
     <ClInclude Include="paint\Paint.h" />
     <ClInclude Include="paint\Painter.h" />
+    <ClInclude Include="paint\PaintHandler.h" />
     <ClInclude Include="paint\Supports.h" />
     <ClInclude Include="paint\tile_element\Paint.Surface.h" />
     <ClInclude Include="paint\tile_element\Paint.TileElement.h" />

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -22,6 +22,7 @@
 #include "../world/SmallScenery.h"
 #include "Boundbox.h"
 #include "Paint.Entity.h"
+#include "PaintHandler.h"
 #include "tile_element/Paint.TileElement.h"
 
 #include <algorithm>
@@ -54,6 +55,8 @@ static constexpr const uint8_t BoundBoxDebugColours[] = {
 bool gShowDirtyVisuals;
 bool gPaintBoundingBoxes;
 bool gPaintBlockedTiles;
+
+std::unique_ptr<PaintHandler> gPaintHandler = std::make_unique<PaintHandler>();
 
 static void PaintAttachedPS(rct_drawpixelinfo* dpi, PaintStruct* ps, uint32_t viewFlags);
 static void PaintPSImageWithBoundingBoxes(rct_drawpixelinfo* dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y);
@@ -718,6 +721,7 @@ PaintStruct* PaintAddImageAsParent(
 PaintStruct* PaintAddImageAsParent(
     PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
 {
+    gPaintHandler->OnPaintAddImageAsParent(session, image_id, offset, boundBox);
     session.LastPS = nullptr;
     session.LastAttachedPS = nullptr;
 
@@ -752,6 +756,7 @@ PaintStruct* PaintAddImageAsParent(
 [[nodiscard]] PaintStruct* PaintAddImageAsOrphan(
     PaintSession& session, const ImageId imageId, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
 {
+    gPaintHandler->OnPaintAddImageAsOrphan(session, imageId, offset, boundBox);
     session.LastPS = nullptr;
     session.LastAttachedPS = nullptr;
     return CreateNormalPaintStruct(session, imageId, offset, boundBox);
@@ -777,6 +782,7 @@ PaintStruct* PaintAddImageAsParent(
 PaintStruct* PaintAddImageAsChild(
     PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
 {
+    gPaintHandler->OnPaintAddImageAsChild(session, image_id, offset, boundBox);
     PaintStruct* parentPS = session.LastPS;
     if (parentPS == nullptr)
     {

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -17,6 +17,7 @@
 #include "../world/Map.h"
 #include "Boundbox.h"
 
+#include <memory>
 #include <mutex>
 #include <thread>
 
@@ -293,6 +294,9 @@ extern bool gShowDirtyVisuals;
 extern bool gPaintBoundingBoxes;
 extern bool gPaintBlockedTiles;
 extern bool gPaintWidePathsAsGhost;
+
+class PaintHandler;
+extern std::unique_ptr<PaintHandler> gPaintHandler;
 
 PaintStruct* PaintAddImageAsParent(
     PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const CoordsXYZ& boundBoxSize);

--- a/src/openrct2/paint/PaintHandler.h
+++ b/src/openrct2/paint/PaintHandler.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "../drawing/Image.h"
+
+struct PaintSession;
+struct CoordsXYZ;
+struct BoundBoxXYZ;
+
+class PaintHandler
+{
+public:
+    PaintHandler() = default;
+    virtual ~PaintHandler(){};
+
+    virtual void OnPaintAddImageAsParent(
+        PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox){};
+    virtual void OnPaintAddImageAsOrphan(
+        PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox){};
+    virtual void OnPaintAddImageAsChild(
+        PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox){};
+    virtual void OnPaintAddImageAsChildRotated(
+        PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
+        const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset){};
+    virtual void OnPaintAddImageAsParentRotated(
+        PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
+        const CoordsXYZ& boundBoxSize){};
+    virtual void OnPaintAddImageAsParentRotated(
+        PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,
+        const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset){};
+};

--- a/src/openrct2/paint/PaintHelpers.cpp
+++ b/src/openrct2/paint/PaintHelpers.cpp
@@ -10,11 +10,13 @@
 #include "../interface/Viewport.h"
 #include "../ride/TrackPaint.h"
 #include "Paint.h"
+#include "PaintHandler.h"
 
 PaintStruct* PaintAddImageAsParentRotated(
     PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
 {
+    gPaintHandler->OnPaintAddImageAsParentRotated(session, direction, imageId, offset, boundBoxSize, boundBoxOffset);
     if (direction & 1)
     {
         return PaintAddImageAsParent(
@@ -29,6 +31,7 @@ PaintStruct* PaintAddImageAsParentRotated(
     PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize)
 {
+    gPaintHandler->OnPaintAddImageAsParentRotated(session, direction, image_id, offset, boundBoxSize);
     if (direction & 1)
     {
         return PaintAddImageAsParent(
@@ -42,6 +45,7 @@ PaintStruct* PaintAddImageAsChildRotated(
     PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
     const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
 {
+    gPaintHandler->OnPaintAddImageAsChildRotated(session, direction, image_id, offset, boundBoxSize, boundBoxOffset);
     if (direction & 1)
     {
         return PaintAddImageAsChild(

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -196,3 +196,13 @@ SET_CHECK_CXX_FLAGS(test_enummap)
 target_link_libraries(test_enummap ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
 target_link_platform_libraries(test_enummap)
 add_test(NAME enummaptests COMMAND test_enummap)
+
+# PaintSession Tests
+set(PAINTSESSION_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/PaintSessionTest.cpp"
+								"${CMAKE_CURRENT_LIST_DIR}/TestData.cpp"
+								"${CMAKE_CURRENT_LIST_DIR}/CircusPaintSessionTest.cpp")
+add_executable(test_paintsession ${PAINTSESSION_TEST_SOURCES})
+SET_CHECK_CXX_FLAGS(test_paintsession)
+target_link_libraries(test_paintsession ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
+target_link_platform_libraries(test_paintsession)
+add_test(NAME paintsessiontests COMMAND test_paintsession)

--- a/test/tests/CircusPaintSessionTest.cpp
+++ b/test/tests/CircusPaintSessionTest.cpp
@@ -1,0 +1,23 @@
+
+#include "PaintSessionTest.h"
+
+#include <openrct2/ride/Track.h>
+#include <openrct2/ride/TrackPaint.h>
+TEST_F(PaintSessionTest, CircusPaintTestAll)
+{
+    auto trackElement = TrackElement();
+    auto paintFunction = GetTrackPaintFunctionCircus(TrackElemType::FlatTrack3x3);
+
+    // go through all the sequences and directions
+    std::vector<uint8_t> sequences = { 1, 3, 5, 6, 7, 8 };
+    for (uint8_t direction = 0; direction < 4; direction++)
+        for (auto sequence : sequences)
+            paintFunction(_paintSession, _ride, sequence, direction, 0, trackElement);
+
+    std::string filename = "CircusPaintTest";
+
+    // use this to regenerate the table, it will appear in the outputs
+    // you will need to manually copy the table to the testdata/paint_session folder
+    // DumpJson(filename);
+    CompareWith(filename);
+}

--- a/test/tests/PaintSessionTest.cpp
+++ b/test/tests/PaintSessionTest.cpp
@@ -1,0 +1,176 @@
+#include "PaintSessionTest.h"
+
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <openrct2/OpenRCT2.h>
+#include <openrct2/paint/Paint.SessionFlags.h>
+#include <openrct2/platform/Platform.h>
+#include <sstream>
+
+using namespace PaintSessionTestData;
+void PaintSessionTest::OnPaintAddImageAsParent(
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
+{
+    auto data = Data{ DataType::AddImageAsParent, image_id.ToUInt32(), offset, boundBox };
+    _data.push_back(data);
+}
+
+void PaintSessionTest::OnPaintAddImageAsOrphan(
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
+{
+    auto data = Data{ DataType::AddImageAsOrphan, image_id.ToUInt32(), offset, boundBox };
+    _data.push_back(data);
+}
+
+void PaintSessionTest::OnPaintAddImageAsChild(
+    PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox)
+{
+    auto data = Data{ DataType::AddImageAsChild, image_id.ToUInt32(), offset, boundBox };
+    _data.push_back(data);
+}
+
+void PaintSessionTest::OnPaintAddImageAsChildRotated(
+    PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
+{
+    auto boundBox = BoundBoxXYZ{ boundBoxOffset, boundBoxSize };
+    auto data = Data{ DataType::AddImageAsChildRotated, image_id.ToUInt32(), offset, boundBox };
+    _data.push_back(data);
+}
+
+void PaintSessionTest::OnPaintAddImageAsParentRotated(
+    PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize)
+{
+    auto boundBox = BoundBoxXYZ{ offset, boundBoxSize };
+    auto data = Data{ DataType::AddImageAsParentRotated, image_id.ToUInt32(), offset, boundBox, direction };
+    _data.push_back(data);
+}
+
+void PaintSessionTest::OnPaintAddImageAsParentRotated(
+    PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,
+    const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
+{
+    auto boundBox = BoundBoxXYZ{ offset, boundBoxSize };
+    auto data = Data{ DataType::AddImageAsParentRotated, imageId.ToUInt32(), boundBoxOffset, boundBox, direction };
+    _data.push_back(data);
+}
+
+void PaintSessionTest::DumpJson(const std::string& filepath) const
+{
+    json_t root;
+    for (auto& elem : _data)
+    {
+        json_t json_elem;
+        json_elem["type"] = elem.Type;
+        json_elem["id"] = elem.Id;
+
+        json_t json_offset;
+        json_offset["x"] = elem.Offset.x;
+        json_offset["y"] = elem.Offset.y;
+        json_offset["z"] = elem.Offset.z;
+
+        json_elem["offset"] = json_offset;
+
+        json_t json_boundBox;
+        json_boundBox["offset_x"] = elem.BoundBox.offset.x;
+        json_boundBox["offset_y"] = elem.BoundBox.offset.y;
+        json_boundBox["offset_z"] = elem.BoundBox.offset.z;
+        json_boundBox["length_x"] = elem.BoundBox.length.x;
+        json_boundBox["length_y"] = elem.BoundBox.length.y;
+        json_boundBox["length_z"] = elem.BoundBox.length.z;
+
+        json_elem["bound_box"] = json_boundBox;
+        json_elem["direction"] = elem.Direction;
+        root.push_back(json_elem);
+    }
+    auto stringContent = root.dump(4, ' ', true, nlohmann::detail::error_handler_t::strict);
+
+    // write to the file
+    auto path = Path::Combine(PaintSessionTest::PaintSessionTestDataPath(), filepath);
+    std::ofstream file(path, std::ofstream::out);
+
+    file << stringContent;
+    file.close();
+}
+
+std::vector<PaintSessionTestData::Data> PaintSessionTest::LoadFromJson(const std::string& filename) const
+{
+    std::vector<PaintSessionTestData::Data> result;
+
+    // load the file
+    auto path = Path::Combine(PaintSessionTest::PaintSessionTestDataPath(), filename);
+    std::ifstream file(path);
+
+    // read all the lines and dump it into a string
+    std::string jsonString;
+    std::stringstream stringData;
+    stringData << file.rdbuf();
+
+    // parse the json
+    auto jsonData = nlohmann::json::parse(stringData.str());
+
+    // we expect an array of data
+    for (auto& jsonElement : jsonData)
+    {
+        PaintSessionTestData::Data element;
+        element.Type = static_cast<DataType>(jsonElement["type"]);
+        element.Id = static_cast<uint32_t>(jsonElement["id"]);
+        element.Direction = static_cast<uint8_t>(jsonElement["direction"]);
+
+        auto offsetJson = jsonElement["offset"];
+        element.Offset = CoordsXYZ{ static_cast<int32_t>(offsetJson["x"]), static_cast<int32_t>(offsetJson["y"]),
+                                    static_cast<int32_t>(offsetJson["z"]) };
+
+        auto boundBoxJson = jsonElement["bound_box"];
+        element.BoundBox = BoundBoxXYZ{
+            { static_cast<int32_t>(boundBoxJson["offset_x"]), static_cast<int32_t>(boundBoxJson["offset_y"]),
+              static_cast<int32_t>(boundBoxJson["offset_z"]) },
+            { static_cast<int32_t>(boundBoxJson["length_x"]), static_cast<int32_t>(boundBoxJson["length_y"]),
+              static_cast<int32_t>(boundBoxJson["length_z"]) }
+        };
+        result.push_back(element);
+    }
+    return result;
+}
+
+void PaintSessionTest::CompareWith(const std::string& filename) const
+{
+    // assert that the length of the internal array is the same as the one we compare to
+    auto dataToCompare = LoadFromJson(filename);
+    ASSERT_EQ(_data.size(), dataToCompare.size());
+
+    for (size_t i = 0; i < _data.size(); i++)
+    {
+        const auto& elem0 = _data[i];
+        const auto& elem1 = dataToCompare[i];
+
+        EXPECT_EQ(elem0.Id, elem1.Id);
+        EXPECT_EQ(elem0.Direction, elem1.Direction);
+        EXPECT_EQ(elem0.Type, elem1.Type);
+
+        EXPECT_EQ(elem0.BoundBox.length.x, elem1.BoundBox.length.x);
+        EXPECT_EQ(elem0.BoundBox.length.y, elem1.BoundBox.length.y);
+        EXPECT_EQ(elem0.BoundBox.length.z, elem1.BoundBox.length.z);
+
+        EXPECT_EQ(elem0.BoundBox.offset.x, elem1.BoundBox.offset.x);
+        EXPECT_EQ(elem0.BoundBox.offset.y, elem1.BoundBox.offset.y);
+        EXPECT_EQ(elem0.BoundBox.offset.z, elem1.BoundBox.offset.z);
+
+        EXPECT_EQ(elem0.Offset.x, elem1.Offset.x);
+        EXPECT_EQ(elem0.Offset.y, elem1.Offset.y);
+        EXPECT_EQ(elem0.Offset.z, elem1.Offset.z);
+    }
+}
+
+void PaintSessionTest::SetUp()
+{
+    // override the global paint handler pointer so that the paint functions call our functions
+    gPaintHandler.reset(this);
+    gOpenRCT2Headless = true;
+    Platform::CoreInit();
+
+    _context = OpenRCT2::CreateContext();
+    _context->Initialise();
+    _paintSession.Flags |= PaintSessionFlags::PassedSurface;
+}

--- a/test/tests/PaintSessionTest.h
+++ b/test/tests/PaintSessionTest.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "TestData.h"
+
+#include <gtest/gtest.h>
+#include <openrct2/Context.h>
+#include <openrct2/core/Path.hpp>
+#include <openrct2/paint/Paint.h>
+#include <openrct2/paint/PaintHandler.h>
+#include <openrct2/ride/Ride.h>
+
+namespace PaintSessionTestData
+{
+    enum class DataType
+    {
+        AddImageAsParent,
+        AddImageAsOrphan,
+        AddImageAsChild,
+        AddImageAsChildRotated,
+        AddImageAsParentRotated
+    };
+
+    struct Data
+    {
+        DataType Type;
+        uint32_t Id;
+        CoordsXYZ Offset;
+        BoundBoxXYZ BoundBox;
+        uint8_t Direction;
+
+        Data() = default;
+        Data(
+            const DataType& type, const uint32_t id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox,
+            uint8_t direction = 0)
+            : Type(type)
+            , Id(id)
+            , Offset(offset)
+            , BoundBox(boundBox)
+            , Direction(direction)
+        {
+        }
+    };
+} // namespace PaintSessionTestData
+
+class PaintSessionTest : public testing::Test, public PaintHandler
+{
+public:
+    PaintSessionTest() = default;
+    virtual ~PaintSessionTest(){};
+    void OnPaintAddImageAsParent(
+        PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox) override;
+    void OnPaintAddImageAsOrphan(
+        PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox) override;
+    void OnPaintAddImageAsChild(
+        PaintSession& session, const ImageId image_id, const CoordsXYZ& offset, const BoundBoxXYZ& boundBox) override;
+    void OnPaintAddImageAsChildRotated(
+        PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
+        const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset) override;
+    void OnPaintAddImageAsParentRotated(
+        PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
+        const CoordsXYZ& boundBoxSize) override;
+    void OnPaintAddImageAsParentRotated(
+        PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,
+        const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset) override;
+
+    // json writing and reading functions
+    void DumpJson(const std::string& filepath) const;
+    std::vector<PaintSessionTestData::Data> LoadFromJson(const std::string& filename) const;
+
+    // test data comparison function
+    void CompareWith(const std::string& filename) const;
+
+    static std::string PaintSessionTestDataPath()
+    {
+        return Path::Combine(TestData::GetBasePath(), u8"paint_session");
+    }
+
+protected:
+    void SetUp() override;
+    PaintSession _paintSession;
+    Ride _ride;
+    std::unique_ptr<OpenRCT2::IContext> _context;
+
+private:
+    std::vector<PaintSessionTestData::Data> _data;
+};

--- a/test/tests/testdata/paint_session/CircusPaintTest
+++ b/test/tests/testdata/paint_session/CircusPaintTest
@@ -1,0 +1,1514 @@
+[
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22137,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22136,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 30,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22139,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22136,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 30,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22139,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22135,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 30,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22140,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22134,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 30,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22139,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 30,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22140,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22135,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 30,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22140,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22136,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 30,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22139,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22134,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 30,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22139,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 30,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22140,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22135,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 30,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22140,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22137,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22135,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 30,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22140,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22137,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22134,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 30,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22139,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 30,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22140,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22135,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 30,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22140,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22137,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22136,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 30,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22139,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22137,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22137,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22135,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 30,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22140,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22137,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 2,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22141,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22137,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22134,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 30,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22139,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 30,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22140,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22136,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 2
+    },
+    {
+        "bound_box": {
+            "length_x": 1,
+            "length_y": 32,
+            "length_z": 7,
+            "offset_x": 2,
+            "offset_y": 0,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22138,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 30,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22139,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 32,
+            "length_z": 1,
+            "offset_x": 0,
+            "offset_y": 0,
+            "offset_z": 0
+        },
+        "direction": 0,
+        "id": 22136,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    },
+    {
+        "bound_box": {
+            "length_x": 32,
+            "length_y": 1,
+            "length_z": 7,
+            "offset_x": 0,
+            "offset_y": 30,
+            "offset_z": 2
+        },
+        "direction": 0,
+        "id": 22139,
+        "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+        },
+        "type": 0
+    }
+]

--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -63,11 +63,13 @@
   <ItemGroup>
     <ClInclude Include="AssertHelpers.hpp" />
     <ClInclude Include="helpers\StringHelpers.hpp" />
+    <ClInclude Include="PaintSessionTest.h" />
     <ClInclude Include="TestData.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="BitSetTests.cpp" />
     <ClCompile Include="CircularBuffer.cpp" />
+	<ClCompile Include="CircusPaintSessionTest.cpp" />
     <ClCompile Include="CLITests.cpp" />
     <ClCompile Include="CryptTests.cpp" />
     <ClCompile Include="Endianness.cpp" />
@@ -79,6 +81,7 @@
     <ClCompile Include="IniWriterTest.cpp" />
     <ClCompile Include="Localisation.cpp" />
     <ClCompile Include="MultiLaunch.cpp" />
+    <ClCompile Include="PaintSessionTest.cpp" />
     <ClCompile Include="ReplayTests.cpp" />
     <ClCompile Include="PlayTests.cpp" />
     <ClCompile Include="Pathfinding.cpp" />


### PR DESCRIPTION
This PR creates a framework for testing the paint calls i.e. validate those parameters:

- Paint call type
- Image ID
- Offset
- Boundbox
- Direction

These parameters are saved in a Json file and compared to i.e. the number of lines in this PR is largely caused by the size of the generated json file.

It also includes an example with the circus ride painting.