### PR TITLE
Fix #18787: Back of stall shown through vertical terrain

### DIFF
--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -66,7 +66,8 @@ static void PaintFacility(
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 
-    PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
+    if (direction == 1 || direction == 2)
+        PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 }
 
 /* 0x00762D44 */

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -53,7 +53,8 @@ static void PaintShop(
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 
-    PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
+    if (direction == 1 || direction == 2)
+        PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 }
 
 TRACK_PAINT_FUNCTION get_track_paint_function_shop(int32_t trackType)


### PR DESCRIPTION
Since Rik’s fix was merged after the v0.4.2 release, no need for a changelog entry.