### PR TITLE
Fix #18024: Confusing error message on loading incompatible .park files

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3593,9 +3593,9 @@ STR_6487    :Hide staff toggle
 STR_6488    :{RED}Guests are complaining about the length of the queues in your park.{NEWLINE}Consider shortening problematic queues, or increasing the rides’ throughput.
 STR_6489    :Error: Incompatible Park Version
 STR_6490    :Warning: Semi-compatible Park Version
-STR_6491    :This park was saved in a later version of OpenRCT2. Park is v{INT32} and requires at least v{INT32}.
+STR_6491    :This park was saved in a later version of OpenRCT2. The park was saved in v{INT32} and requires at least v{INT32}. You are currently on v{INT32}.
 STR_6492    :This park was saved in an old version of OpenRCT2, and can not be opened with this version of OpenRCT2. Park is v{INT32}.
-STR_6493    :This park was saved in a later version of OpenRCT2, some data may be lost. Park is v{INT32} and requires at least v{INT32}.
+STR_6493    :This park was saved in a later version of OpenRCT2, some data may be lost. The park was saved in v{INT32}. You are currently on v{INT32}.
 STR_6494    :Group by ride type
 STR_6495    :Group rides by ride types instead of showing each vehicle separately.
 STR_6496    :{WINDOW_COLOUR_2}{STRINGID}
@@ -3638,6 +3638,7 @@ STR_6532    :Katy’s Dreamworld
 STR_6533    :{WINDOW_COLOUR_2}Excitement Factor: {BLACK}-{COMMA16}%
 STR_6534    :{WINDOW_COLOUR_2}Intensity Factor: {BLACK}-{COMMA16}%
 STR_6535    :{WINDOW_COLOUR_2}Nausea Factor: {BLACK}-{COMMA16}%
+STR_6536    :This park was saved in a later version of OpenRCT2. The park was saved in v{INT32}, you are currently on v{INT32}.
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Feature: [objects#225] Add log cabin roofs.
 - Feature: [OpenMusic#14, OpenMusic#15, OpenMusic#18] Added Galaxy, Acid and Dodgems ride music styles.
 - Improved: [#18013, #18016, #18018, #18019, #18514, objects#224] Added colour presets to Spiral Slide, Dodgems, Boat Hire, Flying Saucers, and Car Ride.
+- Improved: [#18024] Clearer error messages when loading incompatible .park files.
 - Improved: [#18192] Tycoon Park has been added to the Extras tab.
 - Improved: [#18214] Competition scenarios have received their own section.
 - Improved: [#18250] Added modern style file and folder pickers on Windows.

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -708,8 +708,8 @@ namespace OpenRCT2
                 {
                     auto windowManager = _uiContext->GetWindowManager();
                     auto ft = Formatter();
-                    ft.Add<uint32_t>(result.MinVersion);
                     ft.Add<uint32_t>(result.TargetVersion);
+                    ft.Add<uint32_t>(OpenRCT2::PARK_FILE_CURRENT_VERSION);
                     windowManager->ShowError(STR_WARNING_PARK_VERSION_TITLE, STR_WARNING_PARK_VERSION_MESSAGE, ft);
                 }
                 else if (HasObjectsThatUseFallbackImages())
@@ -769,9 +769,19 @@ namespace OpenRCT2
                 }
                 else*/
                 {
-                    ft.Add<uint32_t>(e.MinVersion);
-                    ft.Add<uint32_t>(e.TargetVersion);
-                    windowManager->ShowError(STR_ERROR_PARK_VERSION_TITLE, STR_ERROR_PARK_VERSION_TOO_NEW_MESSAGE, ft);
+                    if (e.MinVersion == e.TargetVersion)
+                    {
+                        ft.Add<uint32_t>(e.TargetVersion);
+                        ft.Add<uint32_t>(OpenRCT2::PARK_FILE_CURRENT_VERSION);
+                        windowManager->ShowError(STR_ERROR_PARK_VERSION_TITLE, STR_ERROR_PARK_VERSION_TOO_NEW_MESSAGE_2, ft);
+                    }
+                    else
+                    {
+                        ft.Add<uint32_t>(e.TargetVersion);
+                        ft.Add<uint32_t>(e.MinVersion);
+                        ft.Add<uint32_t>(OpenRCT2::PARK_FILE_CURRENT_VERSION);
+                        windowManager->ShowError(STR_ERROR_PARK_VERSION_TITLE, STR_ERROR_PARK_VERSION_TOO_NEW_MESSAGE, ft);
+                    }
                 }
             }
             catch (const std::exception& e)

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3926,6 +3926,8 @@ enum : uint16_t
     STR_INTENSITY_FACTOR_NEGATIVE = 6534,
     STR_NAUSEA_FACTOR_NEGATIVE = 6535,
 
+    STR_ERROR_PARK_VERSION_TOO_NEW_MESSAGE_2 = 6536,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
- The "incompatible" warning now shows the version the current build supports, and doesn’t mention the minimum version if it’s equal to the target version. Also fixes the order if the minimum and target versions.
- The "semi-compatible" warning now also shows the version the current build supports, and leaves out the minimum version altogether - the fact that it loads means that it’s already at least at that version.