### PR TITLE
Fix #17814: Prevent guests to "line up twice" and over-capacity a queue.

### DIFF
--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -121,15 +121,6 @@ GameActions::Result FootpathPlaceAction::Execute() const
     if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
         FootpathInterruptPeeps(_loc);
-
-        // This fixes a source of #17814, if a guest is queuing for a ride and the queue is removed, guests
-        // will still remain in the queue. This is a behaviour from the original game, but it also causes
-        // the fail of the logic to determine if the queue is full allowing all guests to join to the queue
-        // and reach the entrance of the ride.
-        //
-        // To prevent that, we need to interrupt all peeps that are queuing at this coordinate of the new
-        // footpath if the new footpath is no longer a queue.
-        FootpathInterruptQueuingPeeps(_loc);
     }
 
     gFootpathGroundFlags = 0;
@@ -270,6 +261,19 @@ GameActions::Result FootpathPlaceAction::ElementUpdateExecute(PathElement* pathE
     }
 
     RemoveIntersectingWalls(pathElement);
+
+    if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
+    {
+        // This fixes a source of #17814, if a guest is queuing for a ride and the queue is removed, guests
+        // will still remain in the queue. This is a behaviour from the original game, but it also causes
+        // the fail of the logic to determine if the queue is full allowing all guests to join to the queue
+        // and reach the entrance of the ride.
+        //
+        // To prevent that, we need to interrupt all peeps that are queuing at this coordinate of the new
+        // footpath if the new footpath is no longer a queue.
+        FootpathInterruptQueuingPeeps(_loc);
+    }
+
     return res;
 }
 
@@ -454,6 +458,18 @@ GameActions::Result FootpathPlaceAction::ElementInsertExecute(GameActions::Resul
     // Prevent the place sound from being spammed
     if (entranceIsSamePath)
         res.Cost = 0;
+
+    if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
+    {
+        // This fixes a source of #17814, if a guest is queuing for a ride and the queue is removed, guests
+        // will still remain in the queue. This is a behaviour from the original game, but it also causes
+        // the fail of the logic to determine if the queue is full allowing all guests to join to the queue
+        // and reach the entrance of the ride.
+        //
+        // To prevent that, we need to interrupt all peeps that are queuing at this coordinate of the new
+        // footpath if the new footpath is no longer a queue.
+        FootpathInterruptQueuingPeeps(_loc);
+    }
 
     return res;
 }

--- a/src/openrct2/actions/FootpathPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathPlaceAction.cpp
@@ -121,6 +121,15 @@ GameActions::Result FootpathPlaceAction::Execute() const
     if (!(GetFlags() & GAME_COMMAND_FLAG_GHOST))
     {
         FootpathInterruptPeeps(_loc);
+
+        // This fixes a source of #17814, if a guest is queuing for a ride and the queue is removed, guests
+        // will still remain in the queue. This is a behaviour from the original game, but it also causes
+        // the fail of the logic to determine if the queue is full allowing all guests to join to the queue
+        // and reach the entrance of the ride.
+        //
+        // To prevent that, we need to interrupt all peeps that are queuing at this coordinate of the new
+        // footpath if the new footpath is no longer a queue.
+        FootpathInterruptQueuingPeeps(_loc);
     }
 
     gFootpathGroundFlags = 0;

--- a/src/openrct2/entity/Guest.h
+++ b/src/openrct2/entity/Guest.h
@@ -337,7 +337,7 @@ public:
     void ChoseNotToGoOnRide(Ride* ride, bool peepAtRide, bool updateLastRide);
     void PickRideToGoOn();
     void ReadMap();
-    bool ShouldGoOnRide(Ride* ride, StationIndex entranceNum, bool atQueue, bool thinking);
+    bool ShouldGoOnRide(Ride* ride, StationIndex entranceNum, bool atQueue, bool thinking, TileElement* queueTileElement);
     bool ShouldGoToShop(Ride* ride, bool peepAtShop);
     bool ShouldFindBench();
     bool UpdateWalkingFindBench();
@@ -365,6 +365,7 @@ public:
     static Guest* Generate(const CoordsXYZ& coords);
     bool UpdateQueuePosition(PeepActionType previous_action);
     void RemoveFromQueue();
+    void RemoveFromQueueAndAllGuestsAfter();
 
     uint64_t GetItemFlags() const;
     void SetItemFlags(uint64_t itemFlags);

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -2267,7 +2267,9 @@ static void peep_interact_with_path(Peep* peep, const CoordsXYE& coords)
                     // Without this fix guests can overlap at the queue entrance, and the logic to determine if a queue is full
                     // can fail allowing more guests to join to the queue. Also the logic to update the queue position of the
                     // guest can fail allowing a guest to walk and reach the ride entrance ignoring the next guest in the queue.
-                    auto queueMiddle = CoordsXY{ CoordsXY{ guest->NextLoc.ToTileStart() } + CoordsDirectionDelta[guest->PeepDirection] }.ToTileCentre();
+                    auto queueMiddle = CoordsXY{ CoordsXY{ guest->NextLoc.ToTileStart() }
+                                                 + CoordsDirectionDelta[guest->PeepDirection] }
+                                           .ToTileCentre();
                     guest->SetDestination(queueMiddle);
 
                     peep_footpath_move_forward(guest, { coords, tile_element }, vandalism_present);

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -436,12 +436,15 @@ void FootpathInterruptQueuingPeeps(const CoordsXYZ& footpathPos)
     if (tileElement == nullptr)
         return;
 
-    auto isQueue = tileElement->AsPath()->IsQueue();
+    // Do not interrupt guests if the footpath is a queue.
+    if (tileElement->AsPath()->IsQueue())
+        return;
+
     auto quad = EntityTileList<Peep>(footpathPos);
 
     for (auto peep : quad)
     {
-        if (!isQueue && peep->State == PeepState::Queuing)
+        if (peep->State == PeepState::Queuing)
         {
             // Use the base Z coord to compare against the Z coord of the footpath.
             auto peepBaseZ = peep->GetLocation().z / COORDS_Z_STEP * COORDS_Z_STEP;

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -233,6 +233,7 @@ extern const CoordsXY BenchUseOffsets[NumOrthogonalDirections * 2];
 
 TileElement* MapGetFootpathElement(const CoordsXYZ& coords);
 void FootpathInterruptPeeps(const CoordsXYZ& footpathPos);
+void FootpathInterruptQueuingPeeps(const CoordsXYZ& footpathPos);
 money32 FootpathProvisionalSet(
     ObjectEntryIndex type, ObjectEntryIndex railingsType, const CoordsXYZ& footpathLoc, int32_t slope,
     PathConstructFlags constructFlags);


### PR DESCRIPTION
Fix #17814

First of all, this is my first contribution to the project (after a long time) and I'm not familiar with the current codebase of the project, so probably I have missed something or my solution could be improved, please help me by reviewing this PR and let me know if something is needed to be changed.

Also I do not have much experience with C++ (I'm a developer mainly in Java), so again, if something is needed to be changed please let me know.

Additional concern: I do not know if I need to update something related to multiplayer, please let me know if a change is required to address this.

Explanation of all situations that I've found related to #17814 , _remember that Im not very familiar with the codebase of the project, so I've wrote this explanation after analyzing the code and I may be wrong_.

----
1. If a queue is replaced by a normal footpath while guests are queuing, guests will remain queuing, that is a behaviour that can happens in the original game (as I can remember), but this behaviour causes the fail of the logic to determine if a queue is full because the last peep in queue will be outside of the queue entrance and the `maxD` variable will always be greater than the minimum required distance when a guest tries to enter to the queue, the relevant code of this logic is:
https://github.com/OpenRCT2/OpenRCT2/blob/73738bbdc8bc47122f62d0cfdad8a9d5d4d8cecd/src/openrct2/entity/Guest.cpp#L1964-L1969
To fix this issue, I've added the method `FootpathInterruptQueuingPeeps` to interrupt queuing guests and added this to the `FootpathPlaceAction`, when a queue is replaced by a normal footpath, queuing guests in the replaced footpath will stop queuing and the last guest in the queue will be recalculated. As I mentioned, this only applies if the queue is replaced by a normal footpath, if the queue is replaced by another type of queue (or by a normal footpath using the cheat to allow normal footpaths to be used as queue) then nothing will change and guests will still queuing.

    Here is the before and the after of this fix:
Before:
![image](https://user-images.githubusercontent.com/7508197/210198074-e4133ea6-3646-490a-8e57-6d330cd993e3.png)
After:
![image](https://user-images.githubusercontent.com/7508197/210197935-449593d4-1084-4895-aac2-3a087e2b0888.png)

----
2. Problem: Sometimes a guest may try to join to the queue from a edge of the path instead of from the centre, a easy way to reproduce this is to place a queue left of from a ride exit:
![image](https://user-images.githubusercontent.com/7508197/210195169-207abc69-c31c-483c-8d18-ca24c09b7d3c.png)
This can lead in an problem because a tile have a size of 32 in the X and Y coordinates (as I understood), if the last guest in the queue is in the another edge of the queue then the logic to check if a queue is full will allow the guest to join to the queue ignoring the fact that the queue is already full.
![image](https://user-images.githubusercontent.com/7508197/210195130-f705e0ef-9437-466b-b36c-4a1b90598bad.png)
To fix this issue I've rewrote a bit the logic to determine if there is space in the queue, instead of calculate the `maxD` value using X and Y axis, the new logic will use the relevant axis to calculate the distance between the last guest and the guest attemping to join to the queue. The relevant axis is determined using the direction of the queue banner.
![image](https://user-images.githubusercontent.com/7508197/210195356-f2ba9aaa-5c5c-47e9-9fdc-25eadefbf947.png)
Also this can lead in another problem, if the "purple" guest joins to the queue and is not quickly aligned to the center of the queue, the logic to update the queue position of the "purple" guest may allow the "purple" guest to bypass the "green" guest, then the "purple" guest will walk through the queue and reaches the entrance before the "green" guest. This is the logic for updating the queue position of the guest, as you can notice it uses the X and Y coordinate of the next guest in the queue to determine if guest will still moving through the queue:
https://github.com/OpenRCT2/OpenRCT2/blob/73738bbdc8bc47122f62d0cfdad8a9d5d4d8cecd/src/openrct2/entity/Guest.cpp#L7296-L7364
With the changes of this PR this problem should not happen unless due to player intervention, but I've made a fix in case that this happens, see the point four.

    Relevant code that I've made for this fix:
https://github.com/Wirlie/OpenRCT2/blob/a6013ea6c03827161a424af142f8da4dbf69322d/src/openrct2/entity/Guest.cpp#L1967-L1989

    Here is the before and the after of this fix:
Before:
![image](https://user-images.githubusercontent.com/7508197/210196271-de9dc5aa-514b-4c0e-b1d8-dca1d6174803.png)
After:
![image](https://user-images.githubusercontent.com/7508197/210267979-6055c9f7-7233-4f3b-9ab3-186af297d8a2.png)

----
3. When a guest joins to a queue, the destination of the guest is not set to the center of the queue, instead the guest will start traveling the queue with the same direction as the guest has entered to the queue, and, when the guest reaches the second queue tile, the pathfinding will fix the destination of the guest and finally the guest will be aligned to the center of the queue. I really do not know the reason why this is happening and I was unable to find the reason through the code, but I've fixed it by setting the destination of the guest to the center of the queue when it succesfully joins to the queue.

   Relevant code that I've made for this fix:
https://github.com/Wirlie/OpenRCT2/blob/a6013ea6c03827161a424af142f8da4dbf69322d/src/openrct2/entity/Peep.cpp#L2257-L2271

    Here is the before and the after of this fix:
Before:
![image](https://user-images.githubusercontent.com/7508197/210267979-6055c9f7-7233-4f3b-9ab3-186af297d8a2.png)
After:
![image](https://user-images.githubusercontent.com/7508197/210268238-fb88feb6-026b-4101-97dd-4275c498ec82.png)

----
4. Finally, the last change that I've made is to determinate if a guest that reaches the entrance of a ride has a valid queuing state. To determine that validation I've used the state of the next guest in the queue, if a guest reaches the entrance of a ride the expected state of the next guest in the queue is anything different to "queuing", if that is not the case we can assume that the guest has reached the entrance of the ride ignoring the next guest in the queue, so at this point we need to remove all invalid guests from the queue and recalculate the last guest in the queue.

    With this fix, guests will not be able to line up twice.

    Relevant code that I've made for this fix:
https://github.com/Wirlie/OpenRCT2/blob/a6013ea6c03827161a424af142f8da4dbf69322d/src/openrct2/entity/Peep.cpp#L1750-L1766

----

Thank you for reading all of my explanation, I hope that I have not missed something, I am open for suggestions and/or change requests.

I provide the two save games that I've used to test changes:
[save-games.zip](https://github.com/OpenRCT2/OpenRCT2/files/10330277/save-games.zip)

