### PR TITLE
Fix park loan behaviour with non-round and out-of-bounds values

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3646,6 +3646,7 @@ STR_6540    :{WINDOW_COLOUR_2}Special thanks to the following companies for allo
 STR_6541    :{WINDOW_COLOUR_2}Rocky Mountain Construction Group, Josef Wiegand GmbH & Co. KG
 STR_6542    :Contributors
 STR_6543    :Contributors…
+STR_6544    :Loan cannot be negative!
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -17,6 +17,7 @@
 - Fix: [#18905] Ride Construction window theme is not applied correctly.
 - Fix: [#18911] Mini Golf station does not draw correctly from all angles.
 - Fix: [#18971] New Game does not prompt for save before quitting.
+- Fix: [#19025] Park loan behaves inconsistently with non-round and out-of-bounds values.
 - Fix: [#19026] Park loan is clamped to a 32-bit integer.
 - Fix: [#19112] Clearing the last character in the Object Selection filter does not properly reset it.
 - Fix: [#19114] [Plugin] GameActionResult does not comply to API specification.

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -481,16 +481,29 @@ public:
         {
             case WIDX_LOAN_INCREASE:
             {
+                // If loan can be increased, do so.
+                // If not, action shows error message.
                 auto newLoan = gBankLoan + 1000.00_GBP;
+                if (gBankLoan < gMaxBankLoan)
+                {
+                    newLoan = std::min(gMaxBankLoan, newLoan);
+                }
                 auto gameAction = ParkSetLoanAction(newLoan);
                 GameActions::Execute(&gameAction);
                 break;
             }
             case WIDX_LOAN_DECREASE:
             {
-                if (gBankLoan > 0)
+                // If loan is positive, decrease it.
+                // If loan is negative, action shows error message.
+                // If loan is exactly 0, prevent error message.
+                if (gBankLoan != 0)
                 {
                     auto newLoan = gBankLoan - 1000.00_GBP;
+                    if (gBankLoan > 0)
+                    {
+                        newLoan = std::max(static_cast<money64>(0LL), newLoan);
+                    }
                     auto gameAction = ParkSetLoanAction(newLoan);
                     GameActions::Execute(&gameAction);
                 }

--- a/src/openrct2/actions/ParkSetLoanAction.cpp
+++ b/src/openrct2/actions/ParkSetLoanAction.cpp
@@ -42,21 +42,20 @@ GameActions::Result ParkSetLoanAction::Query() const
 {
     auto currentLoan = gBankLoan;
     auto loanDifference = currentLoan - _value;
-    if (_value > currentLoan)
+    if (_value > currentLoan && _value > gMaxBankLoan)
     {
-        if (_value > gMaxBankLoan)
-        {
-            return GameActions::Result(
-                GameActions::Status::Disallowed, STR_CANT_BORROW_ANY_MORE_MONEY, STR_BANK_REFUSES_TO_INCREASE_LOAN);
-        }
+        return GameActions::Result(
+            GameActions::Status::Disallowed, STR_CANT_BORROW_ANY_MORE_MONEY, STR_BANK_REFUSES_TO_INCREASE_LOAN);
     }
-    else
+    // FIXME: use money64 literal once it is implemented
+    if (_value < currentLoan && _value < 0)
     {
-        if (loanDifference > gCash)
-        {
-            return GameActions::Result(
-                GameActions::Status::InsufficientFunds, STR_CANT_PAY_BACK_LOAN, STR_NOT_ENOUGH_CASH_AVAILABLE);
-        }
+        return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_PAY_BACK_LOAN, STR_LOAN_CANT_BE_NEGATIVE);
+    }
+    if (loanDifference > gCash)
+    {
+        return GameActions::Result(
+            GameActions::Status::InsufficientFunds, STR_CANT_PAY_BACK_LOAN, STR_NOT_ENOUGH_CASH_AVAILABLE);
     }
     return GameActions::Result();
 }

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3939,6 +3939,8 @@ enum : uint16_t
     STR_CONTRIBUTORS_WINDOW = 6542,
     STR_CONTRIBUTORS_WINDOW_BUTTON = 6543,
 
+    STR_LOAN_CANT_BE_NEGATIVE = 6544,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };


### PR DESCRIPTION
1. When using `ParkSetLoanAction` in plugins, only the upper bound (`gMaxBankLoan`) is checked, but not the lower bound (zero). This PR adds a check of the lower bound to the action. For that, a new string `STR_6540 :Loan cannot be negative!` is introduced.

2. When plugins change the loan to an amount that is not a multiple of 1000€, then an increase or decrease in the finance window may fail even though the bounds are not reached yet.
Example: loan is 500€, cash is > 500€, decrease fails because the finance window attempts to set the loan to -500€. (Note: before (1), the loan dropped to -500€ but could not be decreased further.)
Example: loan is 19500€, max loan is 20000€, increase fails because the finance window attempts to set the loan to 20500€.
Example: loan is 20000€, max loan is 20500€, increase fails because the finance window attempts to set the loan to 21000€.
This PR adds checks to the finance window to clamp the value to the allowed range before attempting to set the loan.

3. If the loan is negative or higher than the maximum loan (which can be achieved by a plugin using direct access of `park.bankLoan`), the finance window should allow to change the loan into the direction of the allowed range.
Example: loan is -5000€, increase is possible, decrease yields error message.
Example: loan is 25000€, max loan is 20000€, decrease is possible, increase yields error message.

4. If the loan is exactly zero, then decreasing in the finance window should have no effect, especially it should not yield an error message. (This is the current behaviour).

Summary of the changes:
- `ParkSetLoanAction` now respects the lower bound of zero (when used in plugins).
- The finance window allows de/increases of less than 1000€ to exactly reach the lower/upper bounds.
- `ParkSetLoanAction` (used by the finance window or plugins) still allows to change the loan towards the allowed range in case that the current loan is outside of the current range.
- If no plugins are used, the behaviour does not change, i.e. the player sees no difference.