### PR TITLE
fix: park loan is clamped to a 32-bit integer

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Fix: [#18467] “Selected only” Object Selection filter is active in Track Designs Manager, and cannot be toggled.
 - Fix: [#18905] Ride Construction window theme is not applied correctly.
 - Fix: [#18911] Mini Golf station does not draw correctly from all angles.
+- Fix: [#19026] Park loan is clamped to a 32-bit integer.
 
 0.4.3 (2022-12-14)
 ------------------------------------------------------------------------
@@ -35,7 +36,7 @@
 - Change: [#17998] Show cursor when using inverted mouse dragging.
 - Change: [#18230] Make the large flat to steep pieces available on the corkscrew roller coaster without cheats.
 - Change: [#18381] Convert custom invisible paths to the built-in ones.
-- Change: [OpenSFX#11, OpenMusic#19] First implementation of official replacement asset packs for sound effects & music. 
+- Change: [OpenSFX#11, OpenMusic#19] First implementation of official replacement asset packs for sound effects & music.
 - Fix: [#1491] Clearance of the Cash Machine is too low (original bug).
 - Fix: [#1519] “See-through rides” doesn't affect all rides (original bug).
 - Fix: [#6341] “Unlock vehicle limits” does not allow setting fewer vehicles than the vehicle type requires.

--- a/src/openrct2/actions/ParkSetLoanAction.h
+++ b/src/openrct2/actions/ParkSetLoanAction.h
@@ -14,7 +14,7 @@
 class ParkSetLoanAction final : public GameActionBase<GameCommand::SetCurrentLoan>
 {
 private:
-    money32 _value{ MONEY32_UNDEFINED };
+    money64 _value{ MONEY64_UNDEFINED };
 
 public:
     ParkSetLoanAction() = default;


### PR DESCRIPTION
Follow-up of #18120 to fix #18087.