### PR TITLE
Rename FootpathPlaceFromTrack to FootpathLayoutPlace

### DIFF
--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -38,7 +38,7 @@ enum class GameCommand : int32_t
     PlaceScenery,             // GA
     SetWaterHeight,           // GA
     PlacePath,                // GA
-    PlacePathFromTrack,       // GA
+    PlacePathLayout,          // GA
     RemovePath,               // GA
     ChangeSurfaceStyle,       // GA
     SetRidePrice,             // GA

--- a/src/openrct2/actions/FootpathLayoutPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathLayoutPlaceAction.cpp
@@ -7,7 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
-#include "FootpathPlaceFromTrackAction.h"
+#include "FootpathLayoutPlaceAction.h"
 
 #include "../Cheats.h"
 #include "../OpenRCT2.h"
@@ -23,7 +23,7 @@
 #include "../world/Surface.h"
 #include "../world/Wall.h"
 
-FootpathPlaceFromTrackAction::FootpathPlaceFromTrackAction(
+FootpathLayoutPlaceAction::FootpathLayoutPlaceAction(
     const CoordsXYZ& loc, uint8_t slope, ObjectEntryIndex type, ObjectEntryIndex railingsType, uint8_t edges,
     PathConstructFlags constructFlags)
     : _loc(loc)
@@ -35,7 +35,7 @@ FootpathPlaceFromTrackAction::FootpathPlaceFromTrackAction(
 {
 }
 
-void FootpathPlaceFromTrackAction::Serialise(DataSerialiser& stream)
+void FootpathLayoutPlaceAction::Serialise(DataSerialiser& stream)
 {
     GameAction::Serialise(stream);
 
@@ -43,7 +43,7 @@ void FootpathPlaceFromTrackAction::Serialise(DataSerialiser& stream)
            << DS_TAG(_constructFlags);
 }
 
-void FootpathPlaceFromTrackAction::AcceptParameters(GameActionParameterVisitor& visitor)
+void FootpathLayoutPlaceAction::AcceptParameters(GameActionParameterVisitor& visitor)
 {
     visitor.Visit(_loc);
     visitor.Visit("slope", _slope);
@@ -53,12 +53,12 @@ void FootpathPlaceFromTrackAction::AcceptParameters(GameActionParameterVisitor& 
     visitor.Visit("constructFlags", _constructFlags);
 }
 
-uint16_t FootpathPlaceFromTrackAction::GetActionFlags() const
+uint16_t FootpathLayoutPlaceAction::GetActionFlags() const
 {
     return GameAction::GetActionFlags();
 }
 
-GameActions::Result FootpathPlaceFromTrackAction::Query() const
+GameActions::Result FootpathLayoutPlaceAction::Query() const
 {
     auto res = GameActions::Result();
     res.Cost = 0;
@@ -94,7 +94,7 @@ GameActions::Result FootpathPlaceFromTrackAction::Query() const
     return ElementInsertQuery(std::move(res));
 }
 
-GameActions::Result FootpathPlaceFromTrackAction::Execute() const
+GameActions::Result FootpathLayoutPlaceAction::Execute() const
 {
     auto res = GameActions::Result();
     res.Cost = 0;
@@ -114,7 +114,7 @@ GameActions::Result FootpathPlaceFromTrackAction::Execute() const
     return ElementInsertExecute(std::move(res));
 }
 
-GameActions::Result FootpathPlaceFromTrackAction::ElementInsertQuery(GameActions::Result res) const
+GameActions::Result FootpathLayoutPlaceAction::ElementInsertQuery(GameActions::Result res) const
 {
     bool entrancePath = false, entranceIsSamePath = false;
 
@@ -186,7 +186,7 @@ GameActions::Result FootpathPlaceFromTrackAction::ElementInsertQuery(GameActions
     return res;
 }
 
-GameActions::Result FootpathPlaceFromTrackAction::ElementInsertExecute(GameActions::Result res) const
+GameActions::Result FootpathLayoutPlaceAction::ElementInsertExecute(GameActions::Result res) const
 {
     bool entrancePath = false, entranceIsSamePath = false;
 
@@ -294,7 +294,7 @@ GameActions::Result FootpathPlaceFromTrackAction::ElementInsertExecute(GameActio
     return res;
 }
 
-bool FootpathPlaceFromTrackAction::IsSameAsEntranceElement(const EntranceElement& entranceElement) const
+bool FootpathLayoutPlaceAction::IsSameAsEntranceElement(const EntranceElement& entranceElement) const
 {
     if (entranceElement.HasLegacyPathEntry())
     {

--- a/src/openrct2/actions/FootpathLayoutPlaceAction.h
+++ b/src/openrct2/actions/FootpathLayoutPlaceAction.h
@@ -11,7 +11,7 @@
 
 #include "GameAction.h"
 
-class FootpathPlaceFromTrackAction final : public GameActionBase<GameCommand::PlacePathFromTrack>
+class FootpathLayoutPlaceAction final : public GameActionBase<GameCommand::PlacePathLayout>
 {
 private:
     CoordsXYZ _loc;
@@ -22,8 +22,8 @@ private:
     PathConstructFlags _constructFlags{};
 
 public:
-    FootpathPlaceFromTrackAction() = default;
-    FootpathPlaceFromTrackAction(
+    FootpathLayoutPlaceAction() = default;
+    FootpathLayoutPlaceAction(
         const CoordsXYZ& loc, uint8_t slope, ObjectEntryIndex type, ObjectEntryIndex railingsType, uint8_t edges,
         PathConstructFlags constructFlags = 0);
 

--- a/src/openrct2/actions/GameActionRegistry.cpp
+++ b/src/openrct2/actions/GameActionRegistry.cpp
@@ -19,8 +19,8 @@
 #include "CustomAction.h"
 #include "FootpathAdditionPlaceAction.h"
 #include "FootpathAdditionRemoveAction.h"
+#include "FootpathLayoutPlaceAction.h"
 #include "FootpathPlaceAction.h"
-#include "FootpathPlaceFromTrackAction.h"
 #include "FootpathRemoveAction.h"
 #include "GameAction.h"
 #include "GuestSetFlagsAction.h"
@@ -133,7 +133,7 @@ namespace GameActions
         REGISTER_ACTION(BannerSetStyleAction);
         REGISTER_ACTION(ClimateSetAction);
         REGISTER_ACTION(FootpathPlaceAction);
-        REGISTER_ACTION(FootpathPlaceFromTrackAction);
+        REGISTER_ACTION(FootpathLayoutPlaceAction);
         REGISTER_ACTION(FootpathRemoveAction);
         REGISTER_ACTION(FootpathAdditionPlaceAction);
         REGISTER_ACTION(FootpathAdditionRemoveAction);

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -71,8 +71,8 @@
     <ClInclude Include="actions\ClearAction.h" />
     <ClInclude Include="actions\ClimateSetAction.h" />
     <ClInclude Include="actions\CustomAction.h" />
+    <ClInclude Include="actions\FootpathLayoutPlaceAction.h" />
     <ClInclude Include="actions\FootpathPlaceAction.h" />
-    <ClInclude Include="actions\FootpathPlaceFromTrackAction.h" />
     <ClInclude Include="actions\FootpathRemoveAction.h" />
     <ClInclude Include="actions\FootpathAdditionPlaceAction.h" />
     <ClInclude Include="actions\FootpathAdditionRemoveAction.h" />
@@ -573,8 +573,8 @@
     <ClCompile Include="actions\CustomAction.cpp" />
     <ClCompile Include="actions\FootpathAdditionPlaceAction.cpp" />
     <ClCompile Include="actions\FootpathAdditionRemoveAction.cpp" />
+    <ClCompile Include="actions\FootpathLayoutPlaceAction.cpp" />
     <ClCompile Include="actions\FootpathPlaceAction.cpp" />
-    <ClCompile Include="actions\FootpathPlaceFromTrackAction.cpp" />
     <ClCompile Include="actions\FootpathRemoveAction.cpp" />
     <ClCompile Include="actions\GameAction.cpp" />
     <ClCompile Include="actions\GameActionRegistry.cpp" />

--- a/src/openrct2/network/NetworkAction.cpp
+++ b/src/openrct2/network/NetworkAction.cpp
@@ -149,7 +149,7 @@ const std::array<NetworkAction, static_cast<size_t>(NetworkPermission::Count)> N
         "PERMISSION_PATH",
         {
             GameCommand::PlacePath,
-            GameCommand::PlacePathFromTrack,
+            GameCommand::PlacePathLayout,
             GameCommand::RemovePath,
             GameCommand::PlaceFootpathAddition,
             GameCommand::RemoveFootpathAddition,

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -14,7 +14,7 @@
 #include "../Game.h"
 #include "../OpenRCT2.h"
 #include "../TrackImporter.h"
-#include "../actions/FootpathPlaceFromTrackAction.h"
+#include "../actions/FootpathLayoutPlaceAction.h"
 #include "../actions/FootpathRemoveAction.h"
 #include "../actions/LargeSceneryPlaceAction.h"
 #include "../actions/LargeSceneryRemoveAction.h"
@@ -1237,7 +1237,7 @@ static GameActions::Result TrackDesignPlaceSceneryElement(
                     constructFlags |= PathConstructFlag::IsQueue;
                 if (entryInfo->Type == ObjectType::Paths)
                     constructFlags |= PathConstructFlag::IsLegacyPathObject;
-                auto footpathPlaceAction = FootpathPlaceFromTrackAction(
+                auto footpathPlaceAction = FootpathLayoutPlaceAction(
                     { mapCoord.x, mapCoord.y, z }, slope, entryInfo->Index, entryInfo->SecondaryIndex, edges, constructFlags);
                 footpathPlaceAction.SetFlags(flags);
                 auto res = flags & GAME_COMMAND_FLAG_APPLY ? GameActions::ExecuteNested(&footpathPlaceAction)

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1275,7 +1275,7 @@ const static EnumMap<GameCommand> ActionNameToType = {
     { "clearscenery", GameCommand::ClearScenery },
     { "climateset", GameCommand::SetClimate },
     { "footpathplace", GameCommand::PlacePath },
-    { "footpathlayoutplace", GameCommand::PlacePathFromTrack },
+    { "footpathlayoutplace", GameCommand::PlacePathLayout },
     { "footpathremove", GameCommand::RemovePath },
     { "footpathadditionplace", GameCommand::PlaceFootpathAddition },
     { "footpathadditionremove", GameCommand::RemoveFootpathAddition },


### PR DESCRIPTION
Suggested by Duncan in #18826

`FootpathPlaceFromTrackAction` describes how the action is used, and not what the action does, which is placing path with a certain layout, i.e. with predefined edges & corners.

In the plugin API, it is already called `FootpathLayoutPlace`.