### PR TITLE
fix listview type mistakes in .d.ts introduced by #18428

### DIFF
--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -3573,14 +3573,16 @@ declare global {
         column: number;
     }
 
+    type ListViewItem = ListViewItemSeperator | string[] | string;
+
     interface ListViewWidget extends WidgetBase {
         type: "listview";
         scrollbars: ScrollbarType;
         isStriped: boolean;
         showColumnHeaders: boolean;
         columns: ListViewColumn[];
-        items: string[];
-        selectedCell: RowColumn;
+        items: ListViewItem[];
+        selectedCell: RowColumn | null;
         readonly highlightedCell: RowColumn;
         canSelect: boolean;
     }
@@ -3702,8 +3704,6 @@ declare global {
         text?: string;
     }
 
-    type ListViewItem = ListViewItemSeperator | string[];
-
     interface RowColumn {
         row: number;
         column: number;
@@ -3715,7 +3715,7 @@ declare global {
         isStriped?: boolean;
         showColumnHeaders?: boolean;
         columns?: Partial<ListViewColumn>[];
-        items?: string[] | ListViewItem[];
+        items?: ListViewItem[];
         selectedCell?: RowColumn;
         canSelect?: boolean;
         onHighlight?: (item: number, column: number) => void;


### PR DESCRIPTION
- Although the type of `ListView.items` will always be reported as `string[][]`, it is still possible to write to it using `string` or `ListViewItemSeperator` per row.
- `ListView.selectedCell == null` indicates that no cell is selected.