### PR TITLE
Fix: A queuing guest can ignore the next guest in the queue in certain circumstances (RCT2 bug)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,9 @@ set(OPENMSX_VERSION "1.0.1")
 set(OPENMSX_URL  "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA1 "8ff94490180e2fbfdd13a4130eb300da726ca406")
 
-set(REPLAYS_VERSION "0.0.70")
+set(REPLAYS_VERSION "0.0.72")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "09B339E86AAE81580C5AC3E23AC4BC9E030DA076")
+set(REPLAYS_SHA1 "93744627E3F1FE5ED6317D5A292D15B63AA71765")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -21,6 +21,7 @@
 - Fix: [#18971] New Game does not prompt for save before quitting.
 - Fix: [#19025] Park loan behaves inconsistently with non-round and out-of-bounds values.
 - Fix: [#19026] Park loan is clamped to a 32-bit integer.
+- Fix: [#19068] Guests may not join queues correctly.
 - Fix: [#19091] [Plugin] Remote plugins in multiplayer servers do not unload properly.
 - Fix: [#19112] Clearing the last character in the Object Selection filter does not properly reset it.
 - Fix: [#19112] Text boxes not updated with empty strings in Track List, Server List, and Start Server windows.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -51,8 +51,8 @@
     <OpenSFXSha1>8f04aea33f8034131c3069f6accacce0d94f80c1</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.0.1/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha1>8ff94490180e2fbfdd13a4130eb300da726ca406</OpenMSXSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.70/replays.zip</ReplaysUrl>
-    <ReplaysSha1>09B339E86AAE81580C5AC3E23AC4BC9E030DA076</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.72/replays.zip</ReplaysUrl>
+    <ReplaysSha1>93744627E3F1FE5ED6317D5A292D15B63AA71765</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -7318,10 +7318,10 @@ bool Guest::UpdateQueuePosition(PeepActionType previous_action)
                 return false;
         }
 
-        if (sprite_direction != guestNext->sprite_direction)
+        if (PeepDirection != guestNext->PeepDirection)
             return false;
 
-        switch (guestNext->sprite_direction / 8)
+        switch (guestNext->PeepDirection)
         {
             case 0:
                 if (x >= guestNext->x)

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -2237,6 +2237,11 @@ static void PeepInteractWithPath(Peep* peep, const CoordsXYE& coords)
                         }
                     }
 
+                    // Force set centre of tile to prevent issues with guests accidentally skipping the queue
+                    auto queueTileCentre = CoordsXY{ CoordsXY{ guest->NextLoc } + CoordsDirectionDelta[guest->PeepDirection] }
+                                               .ToTileCentre();
+                    guest->SetDestination(queueTileCentre);
+
                     PeepFootpathMoveForward(guest, { coords, tile_element }, vandalism_present);
                 }
                 else

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "2"
+#define NETWORK_STREAM_VERSION "3"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
After some research I think that I have found the issue that I have seen in the original game (and also present in OpenRCT2) while testing my previous PR, this is related to the logic to update the queue position of a guest. 

----
**Explanation:**
The logic to update the queue position of a guest uses the direction of the next guest in the queue to determine if there is space available to walk and also to check if the current guest is still before the next guest in the queue, and according to what I understand, this logic uses the `sprite_direction` to determine if both guests have the same direction:
https://github.com/OpenRCT2/OpenRCT2/blob/8495dbf6a5d7441911f392010aebe3d308b2a8fc/src/openrct2/entity/Guest.cpp#L7328-L7331

If both guests have the same direction, then the next part of the code is used to ensure that the current guest is always before the next guest in the queue:
https://github.com/OpenRCT2/OpenRCT2/blob/8495dbf6a5d7441911f392010aebe3d308b2a8fc/src/openrct2/entity/Guest.cpp#L7332-L7350

The issue here is, when the next guest is looking at another direction different from the current guest, and the next guest is not too nearby to the current guest, the condition `sprite_direction != guestNext->sprite_direction` will be true and method will return with false, allowing the current guest to walk ignoring the next guest in the queue because the logic to ensure that a guest is always before to the next guest in the queue will not be reached.

<details>
  <summary>Circumstances needed  to reproduce this</summary>
<p>

![image](https://user-images.githubusercontent.com/7508197/211111147-f3b64887-a92c-4d20-82ab-4ce197d485e7.png)

Gif:
![openrct2_tFCKei0M5P](https://user-images.githubusercontent.com/7508197/211100061-6aa61f26-9278-43e3-a917-35b523c78827.gif)
</p>
</details>

----

**How I fixed it:**
I have used `PeepDirection` to compare directions between both guests instead of using `sprite_direction`

I do not know much about the game logic and I may be wrong, but after digging some methods used by the AI, I have found the method `CalculateNextDestination` in `GuestPathfinding.cpp` and as I understood, this calculates the next queue tile that guest should move in, and after that `peep_move_one_tile` is called with the direction that guest should move to the next tile.

The important thing here is inside the `peep_move_one_tile` method, this set the `PeepDirection` with the direction that guest is currently following.
https://github.com/OpenRCT2/OpenRCT2/blob/8495dbf6a5d7441911f392010aebe3d308b2a8fc/src/openrct2/peep/GuestPathfinding.cpp#L137-L138

~~I think that this variable should always have the real direction that guest is following, and it can be used to check the direction of a guest.~~
**Edit:** After more research, I am now  sure that `PeepDirection` always have the real direction that guest is currently following.

----

I have made some tests and confirmed that using `PeepDirection` fixes the issue.

![openrct2_K6VnJnQICn](https://user-images.githubusercontent.com/7508197/211114513-b82e2bd1-38db-4133-9e06-c38e74b14c5a.gif)

You can use this save game to reproduce this:
[bug-guest-ignore-next-guest.zip](https://github.com/OpenRCT2/OpenRCT2/files/10363720/bug-guest-ignore-next-guest.zip)

----

This partially fixes #17814 , but there is some remaining things that should be fixed and I will make another PR later to try to address remaining things.

If something is needed to be changed please let me know, thank you!
