### PR TITLE
fix mistake in #19018: change mapChangeSize to mapchangesize

### DIFF
--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1290,7 +1290,7 @@ const static EnumMap<GameCommand> ActionNameToType = {
     { "largesceneryremove", GameCommand::RemoveLargeScenery },
     { "largescenerysetcolour", GameCommand::SetLargeSceneryColour },
     { "loadorquit", GameCommand::LoadOrQuit },
-    { "mapChangeSize", GameCommand::ChangeMapSize },
+    { "mapchangesize", GameCommand::ChangeMapSize },
     { "mazeplacetrack", GameCommand::PlaceMazeDesign },
     { "mazesettrack", GameCommand::SetMazeTrack },
     { "networkmodifygroup", GameCommand::ModifyGroups },


### PR DESCRIPTION
The (very recent) #19018 mistakenly used camelCase instead of flatcase only for the MapChangeSizeAction in ScriptEngine.cpp.