### PR TITLE
[Plugin] Wrap callback arguments for custom game actions in event arguments object, fix issue with unloading multiplayer plugins

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,11 +11,13 @@
 - Improved: [#18970] Trying to load a non-park save will now display a context error.
 - Improved: [#19044] Added special thanks to RMC and Wiegand to the About page.
 - Change: [#19018] Renamed actions to fit the naming scheme.
+- Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
 - Fix: [#18467] “Selected only” Object Selection filter is active in Track Designs Manager, and cannot be toggled.
 - Fix: [#18905] Ride Construction window theme is not applied correctly.
 - Fix: [#18911] Mini Golf station does not draw correctly from all angles.
 - Fix: [#18971] New Game does not prompt for save before quitting.
 - Fix: [#19026] Park loan is clamped to a 32-bit integer.
+- Fix: [#19091] [Plugin] Remote plugins in multiplayer servers do not unload properly.
 - Fix: [#19112] Clearing the last character in the Object Selection filter does not properly reset it.
 - Fix: [#19114] [Plugin] GameActionResult does not comply to API specification.
 

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -265,10 +265,10 @@ declare global {
          * @param execute Logic for validating and executing the action.
          * @throws An error if the action has already been registered by this or another plugin.
          */
-        registerAction(
+        registerAction<T = object>(
             action: string,
-            query: (args: object) => GameActionResult,
-            execute: (args: object) => GameActionResult): void;
+            query: (args: GameActionEventArgs<T>) => GameActionResult,
+            execute: (args: GameActionEventArgs<T>) => GameActionResult): void;
 
         /**
          * Query the result of running a game action. This allows you to check the outcome and validity of
@@ -1278,12 +1278,12 @@ declare global {
         height: number;
     }
 
-    interface GameActionEventArgs {
+    interface GameActionEventArgs<T = object> {
         readonly player: number;
         readonly type: number;
         readonly action: string;
         readonly isClientOnly: boolean;
-        readonly args: object;
+        readonly args: T;
         result: GameActionResult;
     }
 

--- a/distribution/scripting.md
+++ b/distribution/scripting.md
@@ -56,8 +56,9 @@ The hot reload feature can be enabled by editing your `config.ini` file and sett
 ## Breaking changes
 As of version 34 there are breaking Api changes.
 
-> Version 34
-```Entity.type will now return "guest" or "staff" instead of "peep"```
+- **Version 34:** `Entity.type` will now return `"guest"` or `"staff"` instead of `"peep"`.
+- **Version 63:** Accessing G2 sprites by id directly is now deprecated in favor of a future-proof implementation using `IconName` and/or `context.getIcon()`.
+- **Version 68:** Custom game actions registered through `context.registerAction()` now wrap the callback arguments in a `GameActionEventArgs`, similar to `context.subscribe()` callbacks.
 
 ## Frequently Asked Questions
 

--- a/src/openrct2/actions/CustomAction.cpp
+++ b/src/openrct2/actions/CustomAction.cpp
@@ -43,13 +43,13 @@ void CustomAction::Serialise(DataSerialiser& stream)
 GameActions::Result CustomAction::Query() const
 {
     auto& scriptingEngine = OpenRCT2::GetContext()->GetScriptEngine();
-    return scriptingEngine.QueryOrExecuteCustomGameAction(this, false);
+    return scriptingEngine.QueryOrExecuteCustomGameAction(*this, false);
 }
 
 GameActions::Result CustomAction::Execute() const
 {
     auto& scriptingEngine = OpenRCT2::GetContext()->GetScriptEngine();
-    return scriptingEngine.QueryOrExecuteCustomGameAction(this, true);
+    return scriptingEngine.QueryOrExecuteCustomGameAction(*this, true);
 }
 
 #endif

--- a/src/openrct2/actions/CustomAction.cpp
+++ b/src/openrct2/actions/CustomAction.cpp
@@ -43,13 +43,13 @@ void CustomAction::Serialise(DataSerialiser& stream)
 GameActions::Result CustomAction::Query() const
 {
     auto& scriptingEngine = OpenRCT2::GetContext()->GetScriptEngine();
-    return scriptingEngine.QueryOrExecuteCustomGameAction(_id, _json, false);
+    return scriptingEngine.QueryOrExecuteCustomGameAction(this, false);
 }
 
 GameActions::Result CustomAction::Execute() const
 {
     auto& scriptingEngine = OpenRCT2::GetContext()->GetScriptEngine();
-    return scriptingEngine.QueryOrExecuteCustomGameAction(_id, _json, true);
+    return scriptingEngine.QueryOrExecuteCustomGameAction(this, true);
 }
 
 #endif

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -1019,8 +1019,13 @@ void ScriptEngine::RemoveNetworkPlugins()
     auto it = _plugins.begin();
     while (it != _plugins.end())
     {
-        if (!(*it)->HasPath())
+        auto plugin = (*it);
+        if (!plugin->HasPath())
         {
+            StopPlugin(plugin);
+            UnloadPlugin(plugin);
+            LogPluginInfo(plugin, "Unregistered network plugin");
+
             it = _plugins.erase(it);
         }
         else
@@ -1030,16 +1035,16 @@ void ScriptEngine::RemoveNetworkPlugins()
     }
 }
 
-GameActions::Result ScriptEngine::QueryOrExecuteCustomGameAction(std::string_view id, std::string_view args, bool isExecute)
+GameActions::Result ScriptEngine::QueryOrExecuteCustomGameAction(const CustomAction* customAction, bool isExecute)
 {
-    std::string actionz = std::string(id);
+    std::string actionz = customAction->GetId();
     auto kvp = _customActions.find(actionz);
     if (kvp != _customActions.end())
     {
-        const auto& customAction = kvp->second;
+        const auto& customActionInfo = kvp->second;
 
         // Deserialise the JSON args
-        std::string argsz(args);
+        std::string argsz = customAction->GetJson();
 
         auto dukArgs = DuktapeTryParseJson(_context, argsz);
         if (!dukArgs)
@@ -1050,15 +1055,36 @@ GameActions::Result ScriptEngine::QueryOrExecuteCustomGameAction(std::string_vie
             return action;
         }
 
+        std::vector<DukValue> pluginCallArgs;
+        if (GetTargetAPIVersion() <= API_VERSION_68_CUSTOM_ACTION_ARGS)
+        {
+            pluginCallArgs = { *dukArgs };
+        }
+        else
+        {
+            log_info(
+                "Current player id = %i, action player id = %i", network_get_current_player_id(), customAction->GetPlayer());
+
+            DukObject obj(_context);
+            obj.Set("action", actionz);
+            obj.Set("args", *dukArgs);
+            obj.Set("player", customAction->GetPlayer());
+            obj.Set("type", EnumValue(customAction->GetType()));
+
+            auto flags = customAction->GetActionFlags();
+            obj.Set("isClientOnly", (flags & GameActions::Flags::ClientOnly) != 0);
+            pluginCallArgs = { obj.Take() };
+        }
+
         // Ready to call plugin handler
         DukValue dukResult;
         if (!isExecute)
         {
-            dukResult = ExecutePluginCall(customAction.Owner, customAction.Query, { *dukArgs }, false);
+            dukResult = ExecutePluginCall(customActionInfo.Owner, customActionInfo.Query, pluginCallArgs, false);
         }
         else
         {
-            dukResult = ExecutePluginCall(customAction.Owner, customAction.Execute, { *dukArgs }, true);
+            dukResult = ExecutePluginCall(customActionInfo.Owner, customActionInfo.Execute, pluginCallArgs, true);
         }
         return DukToGameActionResult(dukResult);
     }
@@ -1469,7 +1495,14 @@ std::unique_ptr<GameAction> ScriptEngine::CreateGameAction(const std::string& ac
     auto jsonz = duk_json_encode(ctx, -1);
     auto json = std::string(jsonz);
     duk_pop(ctx);
-    return std::make_unique<CustomAction>(actionid, json);
+    log_info("Create custom game action %s for player %i", actionid.c_str(), network_get_current_player_id());
+    auto customAction = std::make_unique<CustomAction>(actionid, json);
+
+    if (customAction->GetPlayer() == -1 && network_get_mode() != NETWORK_MODE_NONE)
+    {
+        customAction->SetPlayer(network_get_current_player_id());
+    }
+    return customAction;
 }
 
 void ScriptEngine::InitSharedStorage()

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -11,6 +11,7 @@
 
 #ifdef ENABLE_SCRIPTING
 
+#    include "../actions/CustomAction.h"
 #    include "../common.h"
 #    include "../core/FileWatcher.h"
 #    include "../management/Finance.h"
@@ -46,11 +47,12 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 68;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 69;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;
     static constexpr int32_t API_VERSION_63_G2_REORDER = 63;
+    static constexpr int32_t API_VERSION_68_CUSTOM_ACTION_ARGS = 68;
 
 #    ifndef DISABLE_NETWORK
     class ScSocketBase;
@@ -236,8 +238,7 @@ namespace OpenRCT2::Scripting
         void AddNetworkPlugin(std::string_view code);
         void RemoveNetworkPlugins();
 
-        [[nodiscard]] GameActions::Result QueryOrExecuteCustomGameAction(
-            std::string_view id, std::string_view args, bool isExecute);
+        [[nodiscard]] GameActions::Result QueryOrExecuteCustomGameAction(const CustomAction* action, bool isExecute);
         bool RegisterCustomAction(
             const std::shared_ptr<Plugin>& plugin, std::string_view action, const DukValue& query, const DukValue& execute);
         void RunGameActionHooks(const GameAction& action, GameActions::Result& result, bool isExecute);

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -238,7 +238,7 @@ namespace OpenRCT2::Scripting
         void AddNetworkPlugin(std::string_view code);
         void RemoveNetworkPlugins();
 
-        [[nodiscard]] GameActions::Result QueryOrExecuteCustomGameAction(const CustomAction* action, bool isExecute);
+        [[nodiscard]] GameActions::Result QueryOrExecuteCustomGameAction(const CustomAction& action, bool isExecute);
         bool RegisterCustomAction(
             const std::shared_ptr<Plugin>& plugin, std::string_view action, const DukValue& query, const DukValue& execute);
         void RunGameActionHooks(const GameAction& action, GameActions::Result& result, bool isExecute);


### PR DESCRIPTION
Hey all,

Hereby a PR that fixes some issues with custom actions in plugins in multiplayer.

- Implemented the breaking change regarding the callback arguments, as discussed in the #plugin channel in Discord.
- Fixed an issue where if a user descyncs from a multiplayer server, any remote plugins from that server would not unload properly.
   - This would break plugins with custom actions when the game tries to load the plugin in a new park, because the custom actions from the previous plugin load were still registered even though the plugin itself was not active anymore.
 - Updated documentation regarding this breaking change and the previous G2 breaking change from #18675.
 - Incremented plugin version to 69 (hehe nice) and network version to 2.

Some further issues I noticed but did not resolve here (may need to make issues for them):

- After a desync, remote plugins that are installed locally do not load into the current map.
- [GameActionResult.error](https://github.com/OpenRCT2/OpenRCT2/blob/0fa0e168725bb2848c68445346141d9396a139a4/distribution/openrct2.d.ts#L1291) has the same issues as the G2 sprite enum had, in that it is referring to an [unnumbered enum class that may be reordered at any time](https://github.com/OpenRCT2/OpenRCT2/blob/0fa0e168725bb2848c68445346141d9396a139a4/src/openrct2/actions/GameActionResult.h#L29). This could break any plugin using this the next time this enum is updated.
   - Also if you do not specify an enum number (but you do specify a `errorTitle` and/or `errorMessage`), it will fallback to `Ok` and your error will be ignored.

Thank you for your time.