### PR TITLE
Split off SmallSceneryEntry into dedicated file

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -31,6 +31,7 @@
 #include <openrct2/entity/Staff.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
+#include <openrct2/object/SmallSceneryEntry.h>
 #include <openrct2/ride/Ride.h>
 #include <openrct2/ride/RideConstruction.h>
 #include <openrct2/ride/RideData.h>

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -21,6 +21,7 @@
 #include <openrct2/management/Research.h>
 #include <openrct2/network/network.h>
 #include <openrct2/object/ObjectList.h>
+#include <openrct2/object/SmallSceneryEntry.h>
 #include <openrct2/sprites.h>
 #include <openrct2/world/LargeScenery.h>
 #include <openrct2/world/Park.h>

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -23,6 +23,7 @@
 #include <openrct2/object/FootpathObject.h>
 #include <openrct2/object/FootpathRailingsObject.h>
 #include <openrct2/object/FootpathSurfaceObject.h>
+#include <openrct2/object/SmallSceneryEntry.h>
 #include <openrct2/object/TerrainEdgeObject.h>
 #include <openrct2/object/TerrainSurfaceObject.h>
 #include <openrct2/ride/RideData.h>

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -53,6 +53,7 @@
 #include <openrct2/interface/Screenshot.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/network/network.h>
+#include <openrct2/object/SmallSceneryEntry.h>
 #include <openrct2/paint/VirtualFloor.h>
 #include <openrct2/scenario/Scenario.h>
 #include <openrct2/ui/UiContext.h>

--- a/src/openrct2/actions/LandSetHeightAction.cpp
+++ b/src/openrct2/actions/LandSetHeightAction.cpp
@@ -15,6 +15,7 @@
 #include "../localisation/Localisation.h"
 #include "../localisation/StringIds.h"
 #include "../management/Finance.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../ride/RideData.h"
 #include "../windows/Intent.h"
 #include "../world/ConstructionClearance.h"

--- a/src/openrct2/actions/SmallSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/SmallSceneryPlaceAction.cpp
@@ -17,6 +17,7 @@
 #include "../localisation/Localisation.h"
 #include "../localisation/StringIds.h"
 #include "../management/Finance.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../ride/Ride.h"
 #include "../ride/TrackDesign.h"
 #include "../world/ConstructionClearance.h"

--- a/src/openrct2/actions/SmallSceneryRemoveAction.cpp
+++ b/src/openrct2/actions/SmallSceneryRemoveAction.cpp
@@ -17,6 +17,7 @@
 #include "../localisation/Localisation.h"
 #include "../localisation/StringIds.h"
 #include "../management/Finance.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../ride/Ride.h"
 #include "../world/Park.h"
 #include "../world/SmallScenery.h"

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -11,6 +11,7 @@
 
 #include "../OpenRCT2.h"
 #include "../management/Finance.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../ride/Track.h"
 #include "../ride/TrackDesign.h"
 #include "../world/Banner.h"

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -25,6 +25,7 @@
 #include "../network/network.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../object/TerrainSurfaceObject.h"
 #include "../paint/tile_element/Paint.TileElement.h"
 #include "../peep/GuestPathfinding.h"

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -22,6 +22,7 @@
 #include "../entity/Guest.h"
 #include "../entity/PatrolArea.h"
 #include "../entity/Staff.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../paint/Paint.h"
 #include "../profiling/Profiling.h"
 #include "../ride/Ride.h"

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -312,6 +312,7 @@
     <ClInclude Include="object\RideObject.h" />
     <ClInclude Include="object\SceneryGroupObject.h" />
     <ClInclude Include="object\SceneryObject.h" />
+    <ClInclude Include="object\SmallSceneryEntry.h" />
     <ClInclude Include="object\SmallSceneryObject.h" />
     <ClInclude Include="object\StationObject.h" />
     <ClInclude Include="object\StringTable.h" />

--- a/src/openrct2/object/SmallSceneryEntry.h
+++ b/src/openrct2/object/SmallSceneryEntry.h
@@ -1,0 +1,36 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#include "../common.h"
+#include "../interface/Cursors.h"
+
+using ObjectEntryIndex = uint16_t;
+
+struct SmallSceneryEntry
+{
+    StringId name;
+    uint32_t image;
+    uint32_t flags;
+    uint8_t height;
+    CursorID tool_id;
+    money32 price;
+    money32 removal_price;
+    uint8_t* frame_offsets;
+    uint16_t animation_delay;
+    uint16_t animation_mask;
+    uint16_t num_frames;
+    ObjectEntryIndex scenery_tab_id;
+
+    constexpr bool HasFlag(const uint32_t _flags) const
+    {
+        return (flags & _flags) != 0;
+    }
+};

--- a/src/openrct2/object/SmallSceneryEntry.h
+++ b/src/openrct2/object/SmallSceneryEntry.h
@@ -14,6 +14,43 @@
 
 using ObjectEntryIndex = uint16_t;
 
+enum SMALL_SCENERY_FLAGS : uint32_t
+{
+    SMALL_SCENERY_FLAG_FULL_TILE = (1 << 0),            // 0x1
+    SMALL_SCENERY_FLAG_VOFFSET_CENTRE = (1 << 1),       // 0x2
+    SMALL_SCENERY_FLAG_REQUIRE_FLAT_SURFACE = (1 << 2), // 0x4
+    SMALL_SCENERY_FLAG_ROTATABLE = (1 << 3),            // 0x8; when set, user can set rotation, otherwise rotation is automatic
+    SMALL_SCENERY_FLAG_ANIMATED = (1 << 4),             // 0x10
+    SMALL_SCENERY_FLAG_CAN_WITHER = (1 << 5),           // 0x20
+    SMALL_SCENERY_FLAG_CAN_BE_WATERED = (1 << 6),       // 0x40
+    SMALL_SCENERY_FLAG_ANIMATED_FG = (1 << 7),          // 0x80
+    SMALL_SCENERY_FLAG_DIAGONAL = (1 << 8),             // 0x100
+    SMALL_SCENERY_FLAG_HAS_GLASS = (1 << 9),            // 0x200
+    SMALL_SCENERY_FLAG_HAS_PRIMARY_COLOUR = (1 << 10),  // 0x400
+    SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1 = (1 << 11),    // 0x800
+    SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_4 = (1 << 12),    // 0x1000
+    SMALL_SCENERY_FLAG_IS_CLOCK = (1 << 13),            // 0x2000
+    SMALL_SCENERY_FLAG_SWAMP_GOO = (1 << 14),           // 0x4000
+    SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS = (1 << 15),   // 0x8000
+    SMALL_SCENERY_FLAG17 = (1 << 16),                   // 0x10000
+    SMALL_SCENERY_FLAG_STACKABLE = (1 << 17),           // 0x20000; means scenery item can be placed in the air and over water
+    SMALL_SCENERY_FLAG_NO_WALLS = (1 << 18),            // 0x40000
+    SMALL_SCENERY_FLAG_HAS_SECONDARY_COLOUR = (1 << 19), // 0x80000
+    SMALL_SCENERY_FLAG_NO_SUPPORTS = (1 << 20),          // 0x100000
+    SMALL_SCENERY_FLAG_VISIBLE_WHEN_ZOOMED = (1 << 21),  // 0x200000
+    SMALL_SCENERY_FLAG_COG = (1 << 22),                  // 0x400000
+    SMALL_SCENERY_FLAG_BUILD_DIRECTLY_ONTOP = (1 << 23), // 0x800000; means supports can be built on this object. Used for base
+                                                         // blocks.
+    SMALL_SCENERY_FLAG_HALF_SPACE = (1 << 24),           // 0x1000000
+    SMALL_SCENERY_FLAG_THREE_QUARTERS = (1 << 25),       // 0x2000000
+    SMALL_SCENERY_FLAG_PAINT_SUPPORTS = (1 << 26),       // 0x4000000; used for scenery items which are support structures
+    SMALL_SCENERY_FLAG27 = (1 << 27),                    // 0x8000000
+
+    // Added by OpenRCT2:
+    SMALL_SCENERY_FLAG_IS_TREE = (1 << 28),
+    SMALL_SCENERY_FLAG_HAS_TERTIARY_COLOUR = (1 << 29),
+};
+
 struct SmallSceneryEntry
 {
     StringId name;

--- a/src/openrct2/object/SmallSceneryObject.h
+++ b/src/openrct2/object/SmallSceneryObject.h
@@ -11,6 +11,7 @@
 
 #include "../world/Scenery.h"
 #include "SceneryObject.h"
+#include "SmallSceneryEntry.h"
 
 #include <vector>
 

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -13,6 +13,7 @@
 #include "../../config/Config.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Date.h"
+#include "../../object/SmallSceneryEntry.h"
 #include "../../profiling/Profiling.h"
 #include "../../ride/TrackDesign.h"
 #include "../../util/Util.h"

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -43,6 +43,7 @@
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
 #include "../object/ObjectRepository.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../object/StationObject.h"
 #include "../rct1/RCT1.h"
 #include "../rct1/Tables.h"

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -26,6 +26,7 @@
 #include "../localisation/Formatter.h"
 #include "../localisation/Localisation.h"
 #include "../management/NewsItem.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../platform/Platform.h"
 #include "../profiling/Profiling.h"
 #include "../rct12/RCT12.h"

--- a/src/openrct2/world/ConstructionClearance.cpp
+++ b/src/openrct2/world/ConstructionClearance.cpp
@@ -11,6 +11,7 @@
 
 #include "../Game.h"
 #include "../localisation/Formatter.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../openrct2/Cheats.h"
 #include "../ride/Ride.h"
 #include "../ride/RideData.h"

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -28,6 +28,7 @@
 #include "../management/Finance.h"
 #include "../network/network.h"
 #include "../object/ObjectManager.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../object/TerrainSurfaceObject.h"
 #include "../profiling/Profiling.h"
 #include "../ride/RideConstruction.h"

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -14,6 +14,7 @@
 #include "../entity/EntityList.h"
 #include "../entity/Peep.h"
 #include "../interface/Viewport.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../object/StationObject.h"
 #include "../profiling/Profiling.h"
 #include "../ride/Ride.h"

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -19,6 +19,7 @@
 #include "../localisation/StringIds.h"
 #include "../object/Object.h"
 #include "../object/ObjectManager.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../object/TerrainEdgeObject.h"
 #include "../object/TerrainSurfaceObject.h"
 #include "../platform/Platform.h"

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -25,6 +25,7 @@
 #include "../network/network.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../scenario/Scenario.h"
 #include "Climate.h"
 #include "Footpath.h"
@@ -394,22 +395,22 @@ static size_t GetMaxObjectsForSceneryType(const uint8_t sceneryType)
     }
 }
 
-static SceneryEntryBase* GetSceneryEntry(const ScenerySelection& item)
+static bool IsSceneryEntryValid(const ScenerySelection& item)
 {
     switch (item.SceneryType)
     {
         case SCENERY_TYPE_SMALL:
-            return GetSmallSceneryEntry(item.EntryIndex);
+            return GetSmallSceneryEntry(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_PATH_ITEM:
-            return GetFootpathItemEntry(item.EntryIndex);
+            return GetFootpathItemEntry(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_WALL:
-            return GetWallEntry(item.EntryIndex);
+            return GetWallEntry(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_LARGE:
-            return GetLargeSceneryEntry(item.EntryIndex);
+            return GetLargeSceneryEntry(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_BANNER:
-            return GetBannerEntry(item.EntryIndex);
+            return GetBannerEntry(item.EntryIndex) != nullptr;
         default:
-            return nullptr;
+            return false;
     }
 }
 
@@ -446,8 +447,7 @@ static std::vector<ScenerySelection> GetAllMiscScenery()
         for (ObjectEntryIndex i = 0; i < maxObjects; i++)
         {
             const ScenerySelection sceneryItem = { sceneryType, i };
-            const auto* sceneryEntry = GetSceneryEntry(sceneryItem);
-            if (sceneryEntry != nullptr)
+            if (IsSceneryEntryValid(sceneryItem))
             {
                 if (std::find(std::begin(nonMiscScenery), std::end(nonMiscScenery), sceneryItem) == std::end(nonMiscScenery))
                 {

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -118,25 +118,6 @@ enum WALL_SCENERY_2_FLAGS
     WALL_SCENERY_2_ANIMATED = (1 << 4),  // 0x10
 };
 
-struct SmallSceneryEntry : SceneryEntryBase
-{
-    uint32_t flags;
-    uint8_t height;
-    CursorID tool_id;
-    money32 price;
-    money32 removal_price;
-    uint8_t* frame_offsets;
-    uint16_t animation_delay;
-    uint16_t animation_mask;
-    uint16_t num_frames;
-    ObjectEntryIndex scenery_tab_id;
-
-    constexpr bool HasFlag(const uint32_t _flags) const
-    {
-        return (flags & _flags) != 0;
-    }
-};
-
 struct WallSceneryEntry : SceneryEntryBase
 {
     CursorID tool_id;

--- a/src/openrct2/world/SmallScenery.cpp
+++ b/src/openrct2/world/SmallScenery.cpp
@@ -16,6 +16,7 @@
 #include "../management/Finance.h"
 #include "../network/network.h"
 #include "../object/ObjectManager.h"
+#include "../object/SmallSceneryEntry.h"
 #include "../ride/TrackDesign.h"
 #include "Footpath.h"
 #include "Map.h"

--- a/src/openrct2/world/SmallScenery.h
+++ b/src/openrct2/world/SmallScenery.h
@@ -13,6 +13,8 @@
 #include "Map.h"
 #include "Scenery.h"
 
+struct SmallSceneryEntry;
+
 enum SMALL_SCENERY_FLAGS : uint32_t
 {
     SMALL_SCENERY_FLAG_FULL_TILE = (1 << 0),            // 0x1

--- a/src/openrct2/world/SmallScenery.h
+++ b/src/openrct2/world/SmallScenery.h
@@ -15,43 +15,6 @@
 
 struct SmallSceneryEntry;
 
-enum SMALL_SCENERY_FLAGS : uint32_t
-{
-    SMALL_SCENERY_FLAG_FULL_TILE = (1 << 0),            // 0x1
-    SMALL_SCENERY_FLAG_VOFFSET_CENTRE = (1 << 1),       // 0x2
-    SMALL_SCENERY_FLAG_REQUIRE_FLAT_SURFACE = (1 << 2), // 0x4
-    SMALL_SCENERY_FLAG_ROTATABLE = (1 << 3),            // 0x8; when set, user can set rotation, otherwise rotation is automatic
-    SMALL_SCENERY_FLAG_ANIMATED = (1 << 4),             // 0x10
-    SMALL_SCENERY_FLAG_CAN_WITHER = (1 << 5),           // 0x20
-    SMALL_SCENERY_FLAG_CAN_BE_WATERED = (1 << 6),       // 0x40
-    SMALL_SCENERY_FLAG_ANIMATED_FG = (1 << 7),          // 0x80
-    SMALL_SCENERY_FLAG_DIAGONAL = (1 << 8),             // 0x100
-    SMALL_SCENERY_FLAG_HAS_GLASS = (1 << 9),            // 0x200
-    SMALL_SCENERY_FLAG_HAS_PRIMARY_COLOUR = (1 << 10),  // 0x400
-    SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_1 = (1 << 11),    // 0x800
-    SMALL_SCENERY_FLAG_FOUNTAIN_SPRAY_4 = (1 << 12),    // 0x1000
-    SMALL_SCENERY_FLAG_IS_CLOCK = (1 << 13),            // 0x2000
-    SMALL_SCENERY_FLAG_SWAMP_GOO = (1 << 14),           // 0x4000
-    SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS = (1 << 15),   // 0x8000
-    SMALL_SCENERY_FLAG17 = (1 << 16),                   // 0x10000
-    SMALL_SCENERY_FLAG_STACKABLE = (1 << 17),           // 0x20000; means scenery item can be placed in the air and over water
-    SMALL_SCENERY_FLAG_NO_WALLS = (1 << 18),            // 0x40000
-    SMALL_SCENERY_FLAG_HAS_SECONDARY_COLOUR = (1 << 19), // 0x80000
-    SMALL_SCENERY_FLAG_NO_SUPPORTS = (1 << 20),          // 0x100000
-    SMALL_SCENERY_FLAG_VISIBLE_WHEN_ZOOMED = (1 << 21),  // 0x200000
-    SMALL_SCENERY_FLAG_COG = (1 << 22),                  // 0x400000
-    SMALL_SCENERY_FLAG_BUILD_DIRECTLY_ONTOP = (1 << 23), // 0x800000; means supports can be built on this object. Used for base
-                                                         // blocks.
-    SMALL_SCENERY_FLAG_HALF_SPACE = (1 << 24),           // 0x1000000
-    SMALL_SCENERY_FLAG_THREE_QUARTERS = (1 << 25),       // 0x2000000
-    SMALL_SCENERY_FLAG_PAINT_SUPPORTS = (1 << 26),       // 0x4000000; used for scenery items which are support structures
-    SMALL_SCENERY_FLAG27 = (1 << 27),                    // 0x8000000
-
-    // Added by OpenRCT2:
-    SMALL_SCENERY_FLAG_IS_TREE = (1 << 28),
-    SMALL_SCENERY_FLAG_HAS_TERTIARY_COLOUR = (1 << 29),
-};
-
 enum
 {
     MAP_ELEM_SMALL_SCENERY_COLOUR_FLAG_NEEDS_SUPPORTS = (1 << 5),


### PR DESCRIPTION
https://github.com/OpenRCT2/OpenRCT2/pull/18532 take 2

Trying to get the object files into a more logical layout. This is a follow on from #19113.
I'll make a PR for each of the entries splitting them off into standalone files.
Once that is done can remove all of the `GetSmallSceneryEntry` like functions and just have a `GetObjectEntry<TYPE>` function that returns the const meta data of the object. This will ensure const correctness, prevent huge include dependencies, make all objects handle the same.