### PR TITLE
Remove snake_case methods from localisation folder

### DIFF
--- a/src/openrct2-ui/TextComposition.cpp
+++ b/src/openrct2-ui/TextComposition.cpp
@@ -204,7 +204,7 @@ void TextComposition::CursorEnd()
 {
     size_t selectionOffset = _session.Size;
     const utf8* ch = _session.Buffer + _session.SelectionStart;
-    while (!utf8_is_codepoint_start(ch) && selectionOffset > 0)
+    while (!UTF8IsCodepointStart(ch) && selectionOffset > 0)
     {
         ch--;
         selectionOffset--;
@@ -223,7 +223,7 @@ void TextComposition::CursorLeft()
         {
             ch--;
             selectionOffset--;
-        } while (!utf8_is_codepoint_start(ch) && selectionOffset > 0);
+        } while (!UTF8IsCodepointStart(ch) && selectionOffset > 0);
 
         _session.SelectionStart = selectionOffset;
     }
@@ -240,7 +240,7 @@ void TextComposition::CursorRight()
         {
             ch++;
             selectionOffset++;
-        } while (!utf8_is_codepoint_start(ch) && selectionOffset < selectionMaxOffset);
+        } while (!UTF8IsCodepointStart(ch) && selectionOffset < selectionMaxOffset);
 
         _session.SelectionSize = std::max<size_t>(0, _session.SelectionSize - (selectionOffset - _session.SelectionStart));
         _session.SelectionStart = selectionOffset;
@@ -251,7 +251,7 @@ void TextComposition::Insert(const utf8* text)
 {
     const utf8* ch = text;
     uint32_t codepoint;
-    while ((codepoint = utf8_get_next(ch, &ch)) != 0)
+    while ((codepoint = UTF8GetNext(ch, &ch)) != 0)
     {
         InsertCodepoint(codepoint);
     }
@@ -259,7 +259,7 @@ void TextComposition::Insert(const utf8* text)
 
 void TextComposition::InsertCodepoint(codepoint_t codepoint)
 {
-    size_t codepointLength = utf8_get_codepoint_length(codepoint);
+    size_t codepointLength = UTF8GetCodepointLength(codepoint);
     size_t remainingSize = _session.BufferSize - _session.Size;
     if (codepointLength <= remainingSize)
     {
@@ -278,7 +278,7 @@ void TextComposition::InsertCodepoint(codepoint_t codepoint)
             buffer[_session.Size + codepointLength] = 0;
         }
 
-        utf8_write_codepoint(insertPtr, codepoint);
+        UTF8WriteCodepoint(insertPtr, codepoint);
         _session.SelectionStart += codepointLength;
         _session.Size += codepointLength;
         _session.Length++;
@@ -306,7 +306,7 @@ void TextComposition::Delete()
     {
         ch++;
         selectionOffset++;
-    } while (!utf8_is_codepoint_start(ch) && selectionOffset < selectionMaxOffset);
+    } while (!UTF8IsCodepointStart(ch) && selectionOffset < selectionMaxOffset);
 
     utf8* buffer = _session.Buffer;
     utf8* targetShiftPtr = buffer + _session.SelectionStart;

--- a/src/openrct2-ui/UiContext.Linux.cpp
+++ b/src/openrct2-ui/UiContext.Linux.cpp
@@ -402,7 +402,7 @@ namespace OpenRCT2::Ui
         static void ThrowMissingDialogApp()
         {
             auto uiContext = GetContext()->GetUiContext();
-            std::string dialogMissingWarning = language_get_string(STR_MISSING_DIALOG_APPLICATION_ERROR);
+            std::string dialogMissingWarning = LanguageGetString(STR_MISSING_DIALOG_APPLICATION_ERROR);
             uiContext->ShowMessageBox(dialogMissingWarning);
             throw std::runtime_error(dialogMissingWarning);
         }

--- a/src/openrct2-ui/input/ShortcutInput.cpp
+++ b/src/openrct2-ui/input/ShortcutInput.cpp
@@ -203,7 +203,7 @@ std::string_view ShortcutInput::GetModifierName(uint32_t key, bool localised)
     {
         if (localised && r->second.second != STR_NONE)
         {
-            return language_get_string(r->second.second);
+            return LanguageGetString(r->second.second);
         }
 
         return r->second.first;
@@ -250,7 +250,7 @@ std::string_view ShortcutInput::GetLocalisedKeyName(uint32_t key)
     auto r = _keys.find(key);
     if (r != _keys.end())
     {
-        return language_get_string(r->second);
+        return LanguageGetString(r->second);
     }
 
     return {};
@@ -319,13 +319,13 @@ std::string ShortcutInput::ToString(bool localised) const
     else if (Kind == InputDeviceKind::JoyHat)
     {
         if (Button & SDL_HAT_LEFT)
-            result += localised ? language_get_string(STR_SHORTCUT_JOY_LEFT) : "JOY LEFT";
+            result += localised ? LanguageGetString(STR_SHORTCUT_JOY_LEFT) : "JOY LEFT";
         else if (Button & SDL_HAT_RIGHT)
-            result += localised ? language_get_string(STR_SHORTCUT_JOY_RIGHT) : "JOY RIGHT";
+            result += localised ? LanguageGetString(STR_SHORTCUT_JOY_RIGHT) : "JOY RIGHT";
         else if (Button & SDL_HAT_UP)
-            result += localised ? language_get_string(STR_SHORTCUT_JOY_UP) : "JOY UP";
+            result += localised ? LanguageGetString(STR_SHORTCUT_JOY_UP) : "JOY UP";
         else if (Button & SDL_HAT_DOWN)
-            result += localised ? language_get_string(STR_SHORTCUT_JOY_DOWN) : "JOY DOWN";
+            result += localised ? LanguageGetString(STR_SHORTCUT_JOY_DOWN) : "JOY DOWN";
         else
             result += "JOY ?";
     }

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -17,7 +17,7 @@ namespace Graph
 {
     static void DrawMonths(rct_drawpixelinfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
-        int32_t currentMonth = date_get_month(gDateMonthsElapsed);
+        int32_t currentMonth = DateGetMonth(gDateMonthsElapsed);
         int32_t currentDay = gDateMonthTicks;
         int32_t yearOver32 = (currentMonth * 4) + (currentDay >> 14) - 31;
         auto screenCoords = origCoords;
@@ -27,7 +27,7 @@ namespace Graph
             {
                 // Draw month text
                 auto ft = Formatter();
-                ft.Add<uint32_t>(DateGameShortMonthNames[date_get_month((yearOver32 / 4) + MONTH_COUNT)]);
+                ft.Add<uint32_t>(DateGameShortMonthNames[DateGetMonth((yearOver32 / 4) + MONTH_COUNT)]);
                 DrawTextBasic(
                     dpi, screenCoords - ScreenCoordsXY{ 0, 10 }, STR_GRAPH_LABEL, ft,
                     { FontStyle::Small, TextAlignment::CENTRE });
@@ -154,7 +154,7 @@ namespace Graph
     {
         int32_t i, yearOver32, currentMonth, currentDay;
 
-        currentMonth = date_get_month(gDateMonthsElapsed);
+        currentMonth = DateGetMonth(gDateMonthsElapsed);
         currentDay = gDateMonthTicks;
         yearOver32 = (currentMonth * 4) + (currentDay >> 14) - 31;
         auto screenCoords = origCoords;
@@ -164,7 +164,7 @@ namespace Graph
             {
                 // Draw month text
                 auto ft = Formatter();
-                ft.Add<StringId>(DateGameShortMonthNames[date_get_month((yearOver32 / 4) + MONTH_COUNT)]);
+                ft.Add<StringId>(DateGameShortMonthNames[DateGetMonth((yearOver32 / 4) + MONTH_COUNT)]);
                 DrawTextBasic(
                     dpi, screenCoords - ScreenCoordsXY{ 0, 10 }, STR_GRAPH_LABEL, ft,
                     { FontStyle::Small, TextAlignment::CENTRE });

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -79,7 +79,7 @@ void InGameConsole::Input(ConsoleInput input)
                 std::memcpy(_consoleCurrentLine, _consoleHistory[_consoleHistoryIndex], CONSOLE_INPUT_SIZE);
             }
             _consoleTextInputSession->Size = strlen(_consoleTextInputSession->Buffer);
-            _consoleTextInputSession->Length = utf8_length(_consoleTextInputSession->Buffer);
+            _consoleTextInputSession->Length = UTF8Length(_consoleTextInputSession->Buffer);
             _consoleTextInputSession->SelectionStart = strlen(_consoleCurrentLine);
             break;
         case ConsoleInput::HistoryNext:
@@ -88,7 +88,7 @@ void InGameConsole::Input(ConsoleInput input)
                 _consoleHistoryIndex++;
                 std::memcpy(_consoleCurrentLine, _consoleHistory[_consoleHistoryIndex], CONSOLE_INPUT_SIZE);
                 _consoleTextInputSession->Size = strlen(_consoleTextInputSession->Buffer);
-                _consoleTextInputSession->Length = utf8_length(_consoleTextInputSession->Buffer);
+                _consoleTextInputSession->Length = UTF8Length(_consoleTextInputSession->Buffer);
                 _consoleTextInputSession->SelectionStart = strlen(_consoleCurrentLine);
             }
             else

--- a/src/openrct2-ui/interface/Theme.cpp
+++ b/src/openrct2-ui/interface/Theme.cpp
@@ -682,7 +682,7 @@ const utf8* ThemeManagerGetAvailableThemeConfigName(size_t index)
 const utf8* ThemeManagerGetAvailableThemeName(size_t index)
 {
     if (index < ThemeManager::NumPredefinedThemes)
-        return language_get_string(PredefinedThemes[index].Name);
+        return LanguageGetString(PredefinedThemes[index].Name);
     return ThemeManager::AvailableThemes[index].Name.c_str();
 }
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -1163,7 +1163,7 @@ static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex
 
     GfxDrawStringNoFormatting(dpi, { topLeft.x + 2, topLeft.y }, wrapped_string, { w.colours[1], FontStyle::Medium });
 
-    size_t string_length = get_string_size(wrapped_string) - 1;
+    size_t string_length = GetStringSize(wrapped_string) - 1;
 
     // Make a copy of the string for measuring the width.
     char temp_string[TEXT_INPUT_SIZE] = { 0 };

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -588,7 +588,7 @@ public:
     {
         if (page == WINDOW_CHEATS_PAGE_MONEY && widgetIndex == WIDX_MONEY_SPINNER)
         {
-            auto val = string_to_money(std::string(text).c_str());
+            auto val = StringToMoney(std::string(text).c_str());
             if (val != MONEY64_UNDEFINED)
             {
                 _moneySpinnerValue = val;
@@ -774,7 +774,7 @@ private:
                 CheatsSet(CheatType::NoMoney, gParkFlags & PARK_FLAGS_NO_MONEY ? 0 : 1);
                 break;
             case WIDX_MONEY_SPINNER:
-                money_to_string(_moneySpinnerValue, _moneySpinnerText, MONEY_STRING_MAXLENGTH, false);
+                MoneyToString(_moneySpinnerValue, _moneySpinnerText, MONEY_STRING_MAXLENGTH, false);
                 WindowTextInputRawOpen(
                     this, WIDX_MONEY_SPINNER, STR_ENTER_NEW_VALUE, STR_ENTER_NEW_VALUE, {}, _moneySpinnerText,
                     MONEY_STRING_MAXLENGTH);

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -750,7 +750,7 @@ public:
                     width_limit /= 2;
                     // Draw ride type
                     StringId rideTypeStringId = GetRideTypeStringId(listItem.repositoryItem);
-                    safe_strcpy(buffer, language_get_string(rideTypeStringId), 256 - (buffer - bufferWithColour));
+                    safe_strcpy(buffer, LanguageGetString(rideTypeStringId), 256 - (buffer - bufferWithColour));
                     auto ft = Formatter();
                     ft.Add<const char*>(gCommonStringFormatBuffer);
                     DrawTextEllipsised(
@@ -1212,7 +1212,7 @@ private:
                     if (!sells.empty())
                         sells += ", ";
 
-                    sells += language_get_string(GetShopItemDescriptor(rideEntry->shop_item[i]).Naming.Plural);
+                    sells += LanguageGetString(GetShopItemDescriptor(rideEntry->shop_item[i]).Naming.Plural);
                 }
                 auto ft = Formatter();
                 ft.Add<const char*>(sells.c_str());
@@ -1336,7 +1336,7 @@ private:
     {
         if (item.Type == ObjectType::Ride)
         {
-            auto rideTypeName = language_get_string(GetRideTypeStringId(&item));
+            auto rideTypeName = LanguageGetString(GetRideTypeStringId(&item));
             if (String::Contains(rideTypeName, filter, true))
                 return true;
         }
@@ -1534,8 +1534,8 @@ static bool VisibleListSortRideName(const ObjectListItem& a, const ObjectListIte
 
 static bool VisibleListSortRideType(const ObjectListItem& a, const ObjectListItem& b)
 {
-    auto rideTypeA = language_get_string(GetRideTypeStringId(a.repositoryItem));
-    auto rideTypeB = language_get_string(GetRideTypeStringId(b.repositoryItem));
+    auto rideTypeA = LanguageGetString(GetRideTypeStringId(a.repositoryItem));
+    auto rideTypeB = LanguageGetString(GetRideTypeStringId(b.repositoryItem));
     int32_t result = String::Compare(rideTypeA, rideTypeB);
     return result != 0 ? result < 0 : VisibleListSortRideName(a, b);
 }

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -203,7 +203,7 @@ static OpenRCT2String WindowGameBottomToolbarTooltip(rct_window* w, const Widget
             ft.Add<int16_t>(gParkRating);
             break;
         case WIDX_DATE:
-            month = date_get_month(gDateMonthsElapsed);
+            month = DateGetMonth(gDateMonthsElapsed);
             day = ((gDateMonthTicks * days_in_month[month]) >> 16) & 0xFF;
 
             ft.Add<StringId>(DateDayNames[day]);
@@ -496,8 +496,8 @@ static void WindowGameBottomToolbarDrawRightPanel(rct_drawpixelinfo* dpi, rct_wi
                                         window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].top + w->windowPos.y + 2 };
 
     // Date
-    int32_t year = date_get_year(gDateMonthsElapsed) + 1;
-    int32_t month = date_get_month(gDateMonthsElapsed);
+    int32_t year = DateGetYear(gDateMonthsElapsed) + 1;
+    int32_t month = DateGetMonth(gDateMonthsElapsed);
     int32_t day = ((gDateMonthTicks * days_in_month[month]) >> 16) & 0xFF;
 
     colour_t colour

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -417,34 +417,33 @@ static u8string OpenSystemFileBrowser(bool isSave)
             extension = u8".park";
             fileType = FileExtension::PARK;
             title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_GAME : STR_FILE_DIALOG_TITLE_LOAD_GAME;
-            desc.Filters.emplace_back(language_get_string(STR_OPENRCT2_SAVED_GAME), GetFilterPatternByType(_type, isSave));
+            desc.Filters.emplace_back(LanguageGetString(STR_OPENRCT2_SAVED_GAME), GetFilterPatternByType(_type, isSave));
             break;
 
         case LOADSAVETYPE_LANDSCAPE:
             extension = u8".park";
             fileType = FileExtension::PARK;
             title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_LANDSCAPE : STR_FILE_DIALOG_TITLE_LOAD_LANDSCAPE;
-            desc.Filters.emplace_back(language_get_string(STR_OPENRCT2_LANDSCAPE_FILE), GetFilterPatternByType(_type, isSave));
+            desc.Filters.emplace_back(LanguageGetString(STR_OPENRCT2_LANDSCAPE_FILE), GetFilterPatternByType(_type, isSave));
             break;
 
         case LOADSAVETYPE_SCENARIO:
             extension = u8".park";
             fileType = FileExtension::PARK;
             title = STR_FILE_DIALOG_TITLE_SAVE_SCENARIO;
-            desc.Filters.emplace_back(language_get_string(STR_OPENRCT2_SCENARIO_FILE), GetFilterPatternByType(_type, isSave));
+            desc.Filters.emplace_back(LanguageGetString(STR_OPENRCT2_SCENARIO_FILE), GetFilterPatternByType(_type, isSave));
             break;
 
         case LOADSAVETYPE_TRACK:
             extension = u8".td6";
             fileType = FileExtension::TD6;
             title = isSave ? STR_FILE_DIALOG_TITLE_SAVE_TRACK : STR_FILE_DIALOG_TITLE_INSTALL_NEW_TRACK_DESIGN;
-            desc.Filters.emplace_back(
-                language_get_string(STR_OPENRCT2_TRACK_DESIGN_FILE), GetFilterPatternByType(_type, isSave));
+            desc.Filters.emplace_back(LanguageGetString(STR_OPENRCT2_TRACK_DESIGN_FILE), GetFilterPatternByType(_type, isSave));
             break;
 
         case LOADSAVETYPE_HEIGHTMAP:
             title = STR_FILE_DIALOG_TITLE_LOAD_HEIGHTMAP;
-            desc.Filters.emplace_back(language_get_string(STR_OPENRCT2_HEIGHTMAP_FILE), GetFilterPatternByType(_type, isSave));
+            desc.Filters.emplace_back(LanguageGetString(STR_OPENRCT2_HEIGHTMAP_FILE), GetFilterPatternByType(_type, isSave));
             break;
     }
 
@@ -474,9 +473,9 @@ static u8string OpenSystemFileBrowser(bool isSave)
     desc.DefaultFilename = isSave ? path : u8string();
 
     // Add 'all files' filter. If the number of filters is increased, this code will need to be adjusted.
-    desc.Filters.emplace_back(language_get_string(STR_ALL_FILES), "*");
+    desc.Filters.emplace_back(LanguageGetString(STR_ALL_FILES), "*");
 
-    desc.Title = language_get_string(title);
+    desc.Title = LanguageGetString(title);
 
     u8string outPath = ContextOpenCommonFileDialog(desc);
     if (!outPath.empty())

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -589,7 +589,7 @@ private:
             }
 
             // Append vehicle name
-            auto vehicleName = language_get_string(currentRideEntry->naming.Name);
+            auto vehicleName = LanguageGetString(currentRideEntry->naming.Name);
             _vehicleAvailability += vehicleName;
 
             isFirst = false;

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -198,7 +198,7 @@ public:
             {
                 auto ft = Formatter();
                 ft.Add<StringId>(DateDayNames[newsItem.Day - 1]);
-                ft.Add<StringId>(DateGameMonthNames[date_get_month(newsItem.MonthYear)]);
+                ft.Add<StringId>(DateGameMonthNames[DateGetMonth(newsItem.MonthYear)]);
                 DrawTextBasic(&dpi, { 2, y }, STR_NEWS_DATE_FORMAT, ft, { COLOUR_WHITE, FontStyle::Small });
             }
             // Item text

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -1215,11 +1215,11 @@ private:
                 auto fallbackLanguage = LocalisationService_GetCurrentLanguage();
                 if (dropdownIndex != LocalisationService_GetCurrentLanguage() - 1)
                 {
-                    if (!language_open(dropdownIndex + 1))
+                    if (!LanguageOpen(dropdownIndex + 1))
                     {
                         // Failed to open language file, try to recover by falling
                         // back to previously used language
-                        if (language_open(fallbackLanguage))
+                        if (LanguageOpen(fallbackLanguage))
                         {
                             // It worked, so we can say it with error message in-game
                             ContextShowError(STR_LANGUAGE_LOAD_FAILED, STR_NONE, {});
@@ -1891,7 +1891,7 @@ private:
             case WIDX_PATH_TO_RCT1_BUTTON:
             {
                 auto rct1path = OpenRCT2::GetContext()->GetUiContext()->ShowDirectoryDialog(
-                    language_get_string(STR_PATH_TO_RCT1_BROWSER));
+                    LanguageGetString(STR_PATH_TO_RCT1_BROWSER));
                 if (!rct1path.empty())
                 {
                     // Check if this directory actually contains RCT1

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -1094,7 +1094,7 @@ private:
         else
         {
             ft.Add<uint16_t>(gScenarioObjective.NumGuests);
-            ft.Add<int16_t>(date_get_total_months(MONTH_OCTOBER, gScenarioObjective.Year));
+            ft.Add<int16_t>(DateGetTotalMonths(MONTH_OCTOBER, gScenarioObjective.Year));
             if (gScenarioObjective.Type == OBJECTIVE_FINISH_5_ROLLERCOASTERS)
                 ft.Add<uint16_t>(gScenarioObjective.MinimumExcitement);
             else

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -6508,7 +6508,7 @@ static void WindowRideIncomeMouseup(rct_window* w, WidgetIndex widgetIndex)
             auto ride = get_ride(w->rideId);
             if (ride != nullptr)
             {
-                money_to_string(static_cast<money64>(ride->price[0]), _moneyInputText, MONEY_STRING_MAXLENGTH, true);
+                MoneyToString(static_cast<money64>(ride->price[0]), _moneyInputText, MONEY_STRING_MAXLENGTH, true);
                 WindowTextInputRawOpen(
                     w, WIDX_PRIMARY_PRICE, STR_ENTER_NEW_VALUE, STR_ENTER_NEW_VALUE, {}, _moneyInputText,
                     MONEY_STRING_MAXLENGTH);
@@ -6522,7 +6522,7 @@ static void WindowRideIncomeMouseup(rct_window* w, WidgetIndex widgetIndex)
         {
             auto price64 = WindowRideIncomeGetSecondaryPrice(w);
 
-            money_to_string(price64, _moneyInputText, MONEY_STRING_MAXLENGTH, true);
+            MoneyToString(price64, _moneyInputText, MONEY_STRING_MAXLENGTH, true);
             WindowTextInputRawOpen(
                 w, WIDX_SECONDARY_PRICE, STR_ENTER_NEW_VALUE, STR_ENTER_NEW_VALUE, {}, _moneyInputText, MONEY_STRING_MAXLENGTH);
         }
@@ -6588,7 +6588,7 @@ static void WindowRideIncomeTextinput(rct_window* w, WidgetIndex widgetIndex, ch
     if ((widgetIndex != WIDX_PRIMARY_PRICE && widgetIndex != WIDX_SECONDARY_PRICE) || text == nullptr)
         return;
 
-    money64 price = string_to_money(text);
+    money64 price = StringToMoney(text);
     if (price == MONEY64_UNDEFINED)
     {
         return;
@@ -7069,7 +7069,7 @@ static void WindowRideCustomerPaint(rct_window* w, rct_drawpixelinfo* dpi)
 
     // Age
     // If the ride has a build date that is in the future, show it as built this year.
-    int16_t age = std::max(date_get_year(ride->GetAge()), 0);
+    int16_t age = std::max(DateGetYear(ride->GetAge()), 0);
     stringId = age == 0 ? STR_BUILT_THIS_YEAR : age == 1 ? STR_BUILT_LAST_YEAR : STR_BUILT_YEARS_AGO;
     ft = Formatter();
     ft.Add<int16_t>(age);

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -610,7 +610,7 @@ public:
                     break;
                 case INFORMATION_TYPE_AGE:
                 {
-                    const auto age = date_get_year(ridePtr->GetAge());
+                    const auto age = DateGetYear(ridePtr->GetAge());
                     switch (age)
                     {
                         case 0:

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -527,7 +527,7 @@ static void WindowScenarioselectPaint(rct_window* w, rct_drawpixelinfo* dpi)
     else
     {
         ft.Add<int16_t>(scenario->objective_arg_3);
-        ft.Add<int16_t>(date_get_total_months(MONTH_OCTOBER, scenario->objective_arg_1));
+        ft.Add<int16_t>(DateGetTotalMonths(MONTH_OCTOBER, scenario->objective_arg_1));
         if (scenario->objective_type == OBJECTIVE_FINISH_5_ROLLERCOASTERS)
             ft.Add<uint16_t>(scenario->objective_arg_2);
         else

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -242,7 +242,7 @@ public:
             screenCoords.x = windowPos.x + 12;
             GfxDrawStringNoFormatting(&dpi, screenCoords, wrap_pointer, { colours[1], FontStyle::Medium });
 
-            size_t string_length = get_string_size(wrap_pointer) - 1;
+            size_t string_length = GetStringSize(wrap_pointer) - 1;
 
             if (!cur_drawn && (gTextInput->SelectionStart <= char_count + string_length))
             {
@@ -258,8 +258,8 @@ public:
                     // Make a 1 utf8-character wide string for measuring the width
                     // of the currently selected character.
                     utf8 tmp[5] = { 0 }; // This is easier than setting temp_string[0..5]
-                    uint32_t codepoint = utf8_get_next(_buffer.data() + gTextInput->SelectionStart, nullptr);
-                    utf8_write_codepoint(tmp, codepoint);
+                    uint32_t codepoint = UTF8GetNext(_buffer.data() + gTextInput->SelectionStart, nullptr);
+                    UTF8WriteCodepoint(tmp, codepoint);
                     textWidth = std::max(GfxGetStringWidthNoFormatting(tmp, FontStyle::Medium) - 2, 4);
                 }
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1591,55 +1591,55 @@ public:
             switch (type)
             {
                 case TileElementType::Surface:
-                    typeName = language_get_string(STR_TILE_INSPECTOR_SURFACE);
+                    typeName = LanguageGetString(STR_TILE_INSPECTOR_SURFACE);
                     break;
 
                 case TileElementType::Path:
-                    typeName = tileElement->AsPath()->IsQueue() ? language_get_string(STR_QUEUE_LINE_MAP_TIP)
-                                                                : language_get_string(STR_FOOTPATH_MAP_TIP);
+                    typeName = tileElement->AsPath()->IsQueue() ? LanguageGetString(STR_QUEUE_LINE_MAP_TIP)
+                                                                : LanguageGetString(STR_FOOTPATH_MAP_TIP);
                     break;
 
                 case TileElementType::Track:
-                    typeName = language_get_string(STR_RIDE_COMPONENT_TRACK_CAPITALISED);
+                    typeName = LanguageGetString(STR_RIDE_COMPONENT_TRACK_CAPITALISED);
                     break;
 
                 case TileElementType::SmallScenery:
                 {
                     const auto* sceneryEntry = tileElement->AsSmallScenery()->GetEntry();
                     snprintf(
-                        buffer, sizeof(buffer), "%s (%s)", language_get_string(STR_OBJECT_SELECTION_SMALL_SCENERY),
-                        sceneryEntry != nullptr ? language_get_string(sceneryEntry->name) : "");
+                        buffer, sizeof(buffer), "%s (%s)", LanguageGetString(STR_OBJECT_SELECTION_SMALL_SCENERY),
+                        sceneryEntry != nullptr ? LanguageGetString(sceneryEntry->name) : "");
                     typeName = buffer;
                     break;
                 }
 
                 case TileElementType::Entrance:
-                    typeName = language_get_string(STR_RIDE_CONSTRUCTION_ENTRANCE);
+                    typeName = LanguageGetString(STR_RIDE_CONSTRUCTION_ENTRANCE);
                     break;
 
                 case TileElementType::Wall:
                 {
                     const auto* entry = tileElement->AsWall()->GetEntry();
                     snprintf(
-                        buffer, sizeof(buffer), "%s (%s)", language_get_string(STR_TILE_INSPECTOR_WALL),
-                        entry != nullptr ? language_get_string(entry->name) : "");
+                        buffer, sizeof(buffer), "%s (%s)", LanguageGetString(STR_TILE_INSPECTOR_WALL),
+                        entry != nullptr ? LanguageGetString(entry->name) : "");
                     typeName = buffer;
                     break;
                 }
 
                 case TileElementType::LargeScenery:
-                    typeName = language_get_string(STR_OBJECT_SELECTION_LARGE_SCENERY);
+                    typeName = LanguageGetString(STR_OBJECT_SELECTION_LARGE_SCENERY);
                     break;
 
                 case TileElementType::Banner:
                     snprintf(
-                        buffer, sizeof(buffer), "%s (%u)", language_get_string(STR_BANNER_WINDOW_TITLE),
+                        buffer, sizeof(buffer), "%s (%u)", LanguageGetString(STR_BANNER_WINDOW_TITLE),
                         tileElement->AsBanner()->GetIndex().ToUnderlying());
                     typeName = buffer;
                     break;
 
                 default:
-                    snprintf(buffer, sizeof(buffer), "%s (%d)", language_get_string(STR_UNKNOWN_OBJECT_TYPE), EnumValue(type));
+                    snprintf(buffer, sizeof(buffer), "%s (%d)", LanguageGetString(STR_UNKNOWN_OBJECT_TYPE), EnumValue(type));
                     typeName = buffer;
             }
 

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -235,99 +235,99 @@ const char* CheatsGetName(CheatType cheatType)
     switch (cheatType)
     {
         case CheatType::SandboxMode:
-            return language_get_string(STR_CHEAT_SANDBOX_MODE);
+            return LanguageGetString(STR_CHEAT_SANDBOX_MODE);
         case CheatType::DisableClearanceChecks:
-            return language_get_string(STR_DISABLE_CLEARANCE_CHECKS);
+            return LanguageGetString(STR_DISABLE_CLEARANCE_CHECKS);
         case CheatType::DisableSupportLimits:
-            return language_get_string(STR_DISABLE_SUPPORT_LIMITS);
+            return LanguageGetString(STR_DISABLE_SUPPORT_LIMITS);
         case CheatType::ShowAllOperatingModes:
-            return language_get_string(STR_CHEAT_SHOW_ALL_OPERATING_MODES);
+            return LanguageGetString(STR_CHEAT_SHOW_ALL_OPERATING_MODES);
         case CheatType::ShowVehiclesFromOtherTrackTypes:
-            return language_get_string(STR_CHEAT_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES);
+            return LanguageGetString(STR_CHEAT_SHOW_VEHICLES_FROM_OTHER_TRACK_TYPES);
         case CheatType::FastLiftHill:
-            return language_get_string(STR_CHEAT_UNLOCK_OPERATING_LIMITS);
+            return LanguageGetString(STR_CHEAT_UNLOCK_OPERATING_LIMITS);
         case CheatType::DisableBrakesFailure:
-            return language_get_string(STR_CHEAT_DISABLE_BRAKES_FAILURE);
+            return LanguageGetString(STR_CHEAT_DISABLE_BRAKES_FAILURE);
         case CheatType::DisableAllBreakdowns:
-            return language_get_string(STR_CHEAT_DISABLE_BREAKDOWNS);
+            return LanguageGetString(STR_CHEAT_DISABLE_BREAKDOWNS);
         case CheatType::DisableTrainLengthLimit:
-            return language_get_string(STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT);
+            return LanguageGetString(STR_CHEAT_DISABLE_TRAIN_LENGTH_LIMIT);
         case CheatType::EnableChainLiftOnAllTrack:
-            return language_get_string(STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK);
+            return LanguageGetString(STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK);
         case CheatType::BuildInPauseMode:
-            return language_get_string(STR_CHEAT_BUILD_IN_PAUSE_MODE);
+            return LanguageGetString(STR_CHEAT_BUILD_IN_PAUSE_MODE);
         case CheatType::IgnoreRideIntensity:
-            return language_get_string(STR_CHEAT_IGNORE_INTENSITY);
+            return LanguageGetString(STR_CHEAT_IGNORE_INTENSITY);
         case CheatType::DisableVandalism:
-            return language_get_string(STR_CHEAT_DISABLE_VANDALISM);
+            return LanguageGetString(STR_CHEAT_DISABLE_VANDALISM);
         case CheatType::DisableLittering:
-            return language_get_string(STR_CHEAT_DISABLE_LITTERING);
+            return LanguageGetString(STR_CHEAT_DISABLE_LITTERING);
         case CheatType::NoMoney:
-            return language_get_string(STR_MAKE_PARK_NO_MONEY);
+            return LanguageGetString(STR_MAKE_PARK_NO_MONEY);
         case CheatType::AddMoney:
-            return language_get_string(STR_LOG_CHEAT_ADD_MONEY);
+            return LanguageGetString(STR_LOG_CHEAT_ADD_MONEY);
         case CheatType::ClearLoan:
-            return language_get_string(STR_CHEAT_CLEAR_LOAN);
+            return LanguageGetString(STR_CHEAT_CLEAR_LOAN);
         case CheatType::SetGuestParameter:
-            return language_get_string(STR_CHEAT_SET_GUESTS_PARAMETERS);
+            return LanguageGetString(STR_CHEAT_SET_GUESTS_PARAMETERS);
         case CheatType::GenerateGuests:
-            return language_get_string(STR_CHEAT_LARGE_TRAM_GUESTS);
+            return LanguageGetString(STR_CHEAT_LARGE_TRAM_GUESTS);
         case CheatType::RemoveAllGuests:
-            return language_get_string(STR_CHEAT_REMOVE_ALL_GUESTS);
+            return LanguageGetString(STR_CHEAT_REMOVE_ALL_GUESTS);
         case CheatType::GiveAllGuests:
-            return language_get_string(STR_CHEAT_GIVE_ALL_GUESTS);
+            return LanguageGetString(STR_CHEAT_GIVE_ALL_GUESTS);
         case CheatType::SetGrassLength:
-            return language_get_string(STR_CHEAT_CLEAR_GRASS);
+            return LanguageGetString(STR_CHEAT_CLEAR_GRASS);
         case CheatType::WaterPlants:
-            return language_get_string(STR_CHEAT_WATER_PLANTS);
+            return LanguageGetString(STR_CHEAT_WATER_PLANTS);
         case CheatType::FixVandalism:
-            return language_get_string(STR_CHEAT_FIX_VANDALISM);
+            return LanguageGetString(STR_CHEAT_FIX_VANDALISM);
         case CheatType::RemoveLitter:
-            return language_get_string(STR_CHEAT_REMOVE_LITTER);
+            return LanguageGetString(STR_CHEAT_REMOVE_LITTER);
         case CheatType::DisablePlantAging:
-            return language_get_string(STR_CHEAT_DISABLE_PLANT_AGING);
+            return LanguageGetString(STR_CHEAT_DISABLE_PLANT_AGING);
         case CheatType::SetStaffSpeed:
-            return language_get_string(STR_CHEAT_STAFF_SPEED);
+            return LanguageGetString(STR_CHEAT_STAFF_SPEED);
         case CheatType::RenewRides:
-            return language_get_string(STR_CHEAT_RENEW_RIDES);
+            return LanguageGetString(STR_CHEAT_RENEW_RIDES);
         case CheatType::MakeDestructible:
-            return language_get_string(STR_CHEAT_MAKE_DESTRUCTABLE);
+            return LanguageGetString(STR_CHEAT_MAKE_DESTRUCTABLE);
         case CheatType::FixRides:
-            return language_get_string(STR_CHEAT_FIX_ALL_RIDES);
+            return LanguageGetString(STR_CHEAT_FIX_ALL_RIDES);
         case CheatType::ResetCrashStatus:
-            return language_get_string(STR_CHEAT_RESET_CRASH_STATUS);
+            return LanguageGetString(STR_CHEAT_RESET_CRASH_STATUS);
         case CheatType::TenMinuteInspections:
-            return language_get_string(STR_CHEAT_10_MINUTE_INSPECTIONS);
+            return LanguageGetString(STR_CHEAT_10_MINUTE_INSPECTIONS);
         case CheatType::WinScenario:
-            return language_get_string(STR_CHEAT_WIN_SCENARIO);
+            return LanguageGetString(STR_CHEAT_WIN_SCENARIO);
         case CheatType::ForceWeather:
-            return language_get_string(STR_CHANGE_WEATHER);
+            return LanguageGetString(STR_CHANGE_WEATHER);
         case CheatType::FreezeWeather:
-            return language_get_string(STR_CHEAT_FREEZE_WEATHER);
+            return LanguageGetString(STR_CHEAT_FREEZE_WEATHER);
         case CheatType::NeverEndingMarketing:
-            return language_get_string(STR_CHEAT_NEVERENDING_MARKETING);
+            return LanguageGetString(STR_CHEAT_NEVERENDING_MARKETING);
         case CheatType::OpenClosePark:
-            return language_get_string(STR_CHEAT_OPEN_PARK);
+            return LanguageGetString(STR_CHEAT_OPEN_PARK);
         case CheatType::HaveFun:
-            return language_get_string(STR_CHEAT_HAVE_FUN);
+            return LanguageGetString(STR_CHEAT_HAVE_FUN);
         case CheatType::SetForcedParkRating:
-            return language_get_string(STR_FORCE_PARK_RATING);
+            return LanguageGetString(STR_FORCE_PARK_RATING);
         case CheatType::AllowArbitraryRideTypeChanges:
-            return language_get_string(STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES);
+            return LanguageGetString(STR_CHEAT_ALLOW_ARBITRARY_RIDE_TYPE_CHANGES);
         case CheatType::SetMoney:
-            return language_get_string(STR_SET_MONEY);
+            return LanguageGetString(STR_SET_MONEY);
         case CheatType::OwnAllLand:
-            return language_get_string(STR_CHEAT_OWN_ALL_LAND);
+            return LanguageGetString(STR_CHEAT_OWN_ALL_LAND);
         case CheatType::DisableRideValueAging:
-            return language_get_string(STR_CHEAT_DISABLE_RIDE_VALUE_AGING);
+            return LanguageGetString(STR_CHEAT_DISABLE_RIDE_VALUE_AGING);
         case CheatType::IgnoreResearchStatus:
-            return language_get_string(STR_CHEAT_IGNORE_RESEARCH_STATUS);
+            return LanguageGetString(STR_CHEAT_IGNORE_RESEARCH_STATUS);
         case CheatType::EnableAllDrawableTrackPieces:
-            return language_get_string(STR_CHEAT_ENABLE_ALL_DRAWABLE_TRACK_PIECES);
+            return LanguageGetString(STR_CHEAT_ENABLE_ALL_DRAWABLE_TRACK_PIECES);
         case CheatType::AllowTrackPlaceInvalidHeights:
-            return language_get_string(STR_CHEAT_ALLOW_TRACK_PLACE_INVALID_HEIGHTS);
+            return LanguageGetString(STR_CHEAT_ALLOW_TRACK_PLACE_INVALID_HEIGHTS);
         case CheatType::AllowRegularPathAsQueue:
-            return language_get_string(STR_CHEAT_ALLOW_PATH_AS_QUEUE);
+            return LanguageGetString(STR_CHEAT_ALLOW_PATH_AS_QUEUE);
         default:
             return "Unknown Cheat";
     }

--- a/src/openrct2/Context.cpp
+++ b/src/openrct2/Context.cpp
@@ -1183,7 +1183,7 @@ namespace OpenRCT2
                 gPaletteEffectFrame += gCurrentDeltaTime;
             }
 
-            date_update_real_time_of_day();
+            DateUpdateRealTimeOfDay();
 
             if (gIntroState != IntroState::None)
             {

--- a/src/openrct2/Editor.cpp
+++ b/src/openrct2/Editor.cpp
@@ -115,7 +115,7 @@ namespace Editor
         mainWindow->SetLocation(TileCoordsXYZ{ 75, 75, 14 }.ToCoordsXYZ());
         LoadPalette();
         gScreenAge = 0;
-        gScenarioName = language_get_string(STR_MY_NEW_SCENARIO);
+        gScenarioName = LanguageGetString(STR_MY_NEW_SCENARIO);
     }
 
     /**

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -330,11 +330,11 @@ static void load_landscape()
     ContextOpenIntent(&intent);
 }
 
-void rct2_to_utf8_self(char* buffer, size_t length)
+void RCT2StringToUTF8Self(char* buffer, size_t length)
 {
     if (length > 0)
     {
-        auto temp = rct2_to_utf8(buffer, RCT2LanguageId::EnglishUK);
+        auto temp = RCT2StringToUTF8(buffer, RCT2LanguageId::EnglishUK);
         safe_strcpy(buffer, temp.data(), length);
     }
 }

--- a/src/openrct2/Game.h
+++ b/src/openrct2/Game.h
@@ -172,7 +172,7 @@ void save_game_as();
 void save_game_cmd(u8string_view name = {});
 void save_game_with_name(u8string_view name);
 void game_autosave();
-void rct2_to_utf8_self(char* buffer, size_t length);
+void RCT2StringToUTF8Self(char* buffer, size_t length);
 void game_fix_save_vars();
 void start_silent_record();
 bool stop_silent_record();

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -70,7 +70,7 @@ void GameState::InitAll(const TileCoordsXY& mapSize)
     ride_init_all();
     ResetAllEntities();
     UpdateConsolidatedPatrolAreas();
-    date_reset();
+    DateReset();
     ClimateReset(ClimateType::CoolAndWet);
     News::InitQueue();
 
@@ -313,7 +313,7 @@ void GameState::UpdateLogic(LogicTimings* timings)
     auto day = _date.GetDay();
 #endif
 
-    date_update();
+    DateUpdate();
     _date = Date(static_cast<uint32_t>(gDateMonthsElapsed), gDateMonthTicks);
     report_time(LogicTimePart::Date);
 

--- a/src/openrct2/actions/ParkSetDateAction.cpp
+++ b/src/openrct2/actions/ParkSetDateAction.cpp
@@ -54,6 +54,6 @@ GameActions::Result ParkSetDateAction::Query() const
 
 GameActions::Result ParkSetDateAction::Execute() const
 {
-    date_set(_year, _month, _day);
+    DateSet(_year, _month, _day);
     return GameActions::Result();
 }

--- a/src/openrct2/audio/Audio.cpp
+++ b/src/openrct2/audio/Audio.cpp
@@ -140,13 +140,13 @@ namespace OpenRCT2::Audio
         {
             if (device.empty())
             {
-                device = language_get_string(STR_OPTIONS_SOUND_VALUE_DEFAULT);
+                device = LanguageGetString(STR_OPTIONS_SOUND_VALUE_DEFAULT);
             }
         }
 
 #ifndef __linux__
         // The first device is always system default on Windows and macOS
-        std::string defaultDevice = language_get_string(STR_OPTIONS_SOUND_VALUE_DEFAULT);
+        std::string defaultDevice = LanguageGetString(STR_OPTIONS_SOUND_VALUE_DEFAULT);
         devices.insert(devices.begin(), defaultDevice);
 #endif
 

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -736,9 +736,9 @@ namespace Config
     {
         FileDialogDesc desc{};
         desc.Type = FileDialogType::Open;
-        desc.Title = language_get_string(STR_SELECT_GOG_INSTALLER);
-        desc.Filters.emplace_back(language_get_string(STR_GOG_INSTALLER), "*.exe");
-        desc.Filters.emplace_back(language_get_string(STR_ALL_FILES), "*");
+        desc.Title = LanguageGetString(STR_SELECT_GOG_INSTALLER);
+        desc.Filters.emplace_back(LanguageGetString(STR_GOG_INSTALLER), "*.exe");
+        desc.Filters.emplace_back(LanguageGetString(STR_ALL_FILES), "*");
 
         const auto userHomePath = Platform::GetFolderPath(SPECIAL_FOLDER::USER_HOME);
         desc.InitialDirectory = userHomePath;
@@ -788,7 +788,7 @@ bool ConfigOpen(u8string_view path)
     auto result = Config::ReadFile(path);
     if (result)
     {
-        currency_load_custom_currency_config();
+        CurrencyLoadCustomCurrencyConfig();
     }
     return result;
 }
@@ -837,8 +837,8 @@ bool ConfigFindOrBrowseInstallDirectory()
             while (true)
             {
                 uiContext->ShowMessageBox(format_string(STR_NEEDS_RCT2_FILES, nullptr));
-                std::string gog = language_get_string(STR_OWN_ON_GOG);
-                std::string hdd = language_get_string(STR_INSTALLED_ON_HDD);
+                std::string gog = LanguageGetString(STR_OWN_ON_GOG);
+                std::string hdd = LanguageGetString(STR_INSTALLED_ON_HDD);
 
                 std::vector<std::string> options;
                 std::string chosenOption;
@@ -848,7 +848,7 @@ bool ConfigFindOrBrowseInstallDirectory()
                     options.push_back(hdd);
                     options.push_back(gog);
                     int optionIndex = uiContext->ShowMenuDialog(
-                        options, language_get_string(STR_OPENRCT2_SETUP), language_get_string(STR_WHICH_APPLIES_BEST));
+                        options, LanguageGetString(STR_OPENRCT2_SETUP), LanguageGetString(STR_WHICH_APPLIES_BEST));
                     if (optionIndex < 0 || static_cast<uint32_t>(optionIndex) >= options.size())
                     {
                         // graceful fallback if app errors or user exits out of window
@@ -867,7 +867,7 @@ bool ConfigFindOrBrowseInstallDirectory()
                 std::string installPath;
                 if (chosenOption == hdd)
                 {
-                    installPath = uiContext->ShowDirectoryDialog(language_get_string(STR_PICK_RCT2_DIR));
+                    installPath = uiContext->ShowDirectoryDialog(LanguageGetString(STR_PICK_RCT2_DIR));
                 }
                 else if (chosenOption == gog)
                 {
@@ -884,7 +884,7 @@ bool ConfigFindOrBrowseInstallDirectory()
 
                     while (true)
                     {
-                        uiContext->ShowMessageBox(language_get_string(STR_PLEASE_SELECT_GOG_INSTALLER));
+                        uiContext->ShowMessageBox(LanguageGetString(STR_PLEASE_SELECT_GOG_INSTALLER));
                         utf8 gogPath[4096];
                         if (!Config::SelectGogInstaller(gogPath))
                         {
@@ -892,12 +892,12 @@ bool ConfigFindOrBrowseInstallDirectory()
                             return false;
                         }
 
-                        uiContext->ShowMessageBox(language_get_string(STR_THIS_WILL_TAKE_A_FEW_MINUTES));
+                        uiContext->ShowMessageBox(LanguageGetString(STR_THIS_WILL_TAKE_A_FEW_MINUTES));
 
                         if (Config::ExtractGogInstaller(gogPath, dest))
                             break;
 
-                        uiContext->ShowMessageBox(language_get_string(STR_NOT_THE_GOG_INSTALLER));
+                        uiContext->ShowMessageBox(LanguageGetString(STR_NOT_THE_GOG_INSTALLER));
                     }
 
                     installPath = Path::Combine(dest, u8"app");

--- a/src/openrct2/core/String.cpp
+++ b/src/openrct2/core/String.cpp
@@ -297,7 +297,7 @@ namespace String
 
     size_t LengthOf(const utf8* str)
     {
-        return utf8_length(str);
+        return UTF8Length(str);
     }
 
     size_t SizeOf(const utf8* str)
@@ -478,7 +478,7 @@ namespace String
 
     size_t GetCodepointLength(codepoint_t codepoint)
     {
-        return utf8_get_codepoint_length(codepoint);
+        return UTF8GetCodepointLength(codepoint);
     }
 
     codepoint_t GetNextCodepoint(utf8* ptr, utf8** nextPtr)
@@ -488,18 +488,18 @@ namespace String
 
     codepoint_t GetNextCodepoint(const utf8* ptr, const utf8** nextPtr)
     {
-        return utf8_get_next(ptr, nextPtr);
+        return UTF8GetNext(ptr, nextPtr);
     }
 
     utf8* WriteCodepoint(utf8* dst, codepoint_t codepoint)
     {
-        return utf8_write_codepoint(dst, codepoint);
+        return UTF8WriteCodepoint(dst, codepoint);
     }
 
     void AppendCodepoint(std::string& str, codepoint_t codepoint)
     {
         char buffer[8]{};
-        utf8_write_codepoint(buffer, codepoint);
+        UTF8WriteCodepoint(buffer, codepoint);
         str.append(buffer);
     }
 
@@ -755,5 +755,5 @@ namespace String
 
 char32_t CodepointView::iterator::GetNextCodepoint(const char* ch, const char** next)
 {
-    return utf8_get_next(ch, next);
+    return UTF8GetNext(ch, next);
 }

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -154,7 +154,7 @@ int32_t GfxClipString(utf8* text, int32_t width, FontStyle fontStyle)
             }
 
             char cb[8]{};
-            utf8_write_codepoint(cb, codepoint);
+            UTF8WriteCodepoint(cb, codepoint);
             buffer.append(cb);
         }
     }
@@ -195,7 +195,7 @@ int32_t GfxWrapString(utf8* text, int32_t width, FontStyle fontStyle, int32_t* o
             for (auto codepoint : codepoints)
             {
                 char cb[8]{};
-                utf8_write_codepoint(cb, codepoint);
+                UTF8WriteCodepoint(cb, codepoint);
                 buffer.append(cb);
 
                 auto lineWidth = GfxGetStringWidth(&buffer[currentLineIndex], fontStyle);
@@ -349,7 +349,7 @@ void DrawStringCentredRaw(
         const utf8* ch = text;
         const utf8* nextCh = nullptr;
 
-        while ((utf8_get_next(ch, &nextCh)) != 0)
+        while ((UTF8GetNext(ch, &nextCh)) != 0)
         {
             ch = nextCh;
         }
@@ -482,7 +482,7 @@ void DrawNewsTicker(
             break;
         }
 
-        buffer = get_string_end(buffer) + 1;
+        buffer = GetStringEnd(buffer) + 1;
         lineY += lineHeight;
     }
 }
@@ -878,7 +878,7 @@ static void TTFProcessStringLiteral(rct_drawpixelinfo* dpi, std::string_view tex
 static void TTFProcessStringCodepoint(rct_drawpixelinfo* dpi, codepoint_t codepoint, text_draw_info* info)
 {
     char buffer[8]{};
-    utf8_write_codepoint(buffer, codepoint);
+    UTF8WriteCodepoint(buffer, codepoint);
     TTFProcessStringLiteral(dpi, buffer, info);
 }
 

--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -355,7 +355,7 @@ bool FontSupportsStringSprite(const utf8* text)
     const utf8* src = text;
 
     uint32_t codepoint;
-    while ((codepoint = utf8_get_next(src, &src)) != 0)
+    while ((codepoint = UTF8GetNext(src, &src)) != 0)
     {
         bool supported = false;
 
@@ -388,7 +388,7 @@ bool FontSupportsStringTTF(const utf8* text, FontStyle fontStyle)
     }
 
     uint32_t codepoint;
-    while ((codepoint = utf8_get_next(src, &src)) != 0)
+    while ((codepoint = UTF8GetNext(src, &src)) != 0)
     {
         bool supported = TTFProvidesGlyph(font, codepoint);
         if (!supported)

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -150,7 +150,7 @@ static void ScrollingTextFormat(utf8* dst, size_t size, rct_draw_scroll_text* sc
 {
     if (gConfigGeneral.UpperCaseBanners)
     {
-        format_string_to_upper(dst, size, scrollText->string_id, scrollText->string_args);
+        FormatStringToUpper(dst, size, scrollText->string_id, scrollText->string_args);
     }
     else
     {

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -60,7 +60,7 @@ public:
         {
             DrawText(dpi, lineCoords, tempPaint, buffer);
             tempPaint.Colour = TEXT_COLOUR_254;
-            buffer = get_string_end(buffer) + 1;
+            buffer = GetStringEnd(buffer) + 1;
             lineCoords.y += LineHeight;
         }
     }

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -171,7 +171,7 @@ void Duck::UpdateSwim()
     }
     else
     {
-        int32_t currentMonth = date_get_month(gDateMonthsElapsed);
+        int32_t currentMonth = DateGetMonth(gDateMonthsElapsed);
         if (currentMonth >= MONTH_SEPTEMBER && (randomNumber >> 16) < 218)
         {
             state = DuckState::FlyAway;

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -292,7 +292,7 @@ static int32_t ChatHistoryDrawString(
     for (int32_t line = 0; line <= numLines; ++line)
     {
         GfxDrawString(dpi, { screenCoords.x, lineY - (numLines * lineHeight) }, bufferPtr, { TEXT_COLOUR_254 });
-        bufferPtr = get_string_end(bufferPtr) + 1;
+        bufferPtr = GetStringEnd(bufferPtr) + 1;
         lineY += lineHeight;
     }
     return lineY - screenCoords.y;
@@ -313,7 +313,7 @@ int32_t ChatStringWrappedGetHeight(void* args, int32_t width)
     int32_t lineY = 0;
     for (int32_t line = 0; line <= numLines; ++line)
     {
-        bufferPtr = get_string_end(bufferPtr) + 1;
+        bufferPtr = GetStringEnd(bufferPtr) + 1;
         lineY += lineHeight;
     }
 

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1029,7 +1029,7 @@ static int32_t ConsoleCommandSet(InteractiveConsole& console, const arguments_t&
 
             if (invalidArgs)
             {
-                console.WriteLine(language_get_string(STR_INVALID_CLIMATE_ID));
+                console.WriteLine(LanguageGetString(STR_INVALID_CLIMATE_ID));
             }
             else
             {
@@ -1484,7 +1484,7 @@ static int32_t ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& cons
         }
     }
 
-    date_set(year, month, day);
+    DateSet(year, month, day);
     WindowInvalidateByClass(WindowClass::BottomToolbar);
 
     return 1;

--- a/src/openrct2/localisation/ConversionTables.cpp
+++ b/src/openrct2/localisation/ConversionTables.cpp
@@ -105,7 +105,7 @@ const encoding_convert_entry RCT2ToUnicodeTable[] = {
     { CSChar::z_acute, UnicodeChar::z_acute },
 };
 
-static int32_t encoding_search_compare(const void* pKey, const void* pEntry)
+static int32_t EncodingSearchCompare(const void* pKey, const void* pEntry)
 {
     const uint16_t key = *reinterpret_cast<const uint16_t*>(pKey);
     const encoding_convert_entry* entry = static_cast<const encoding_convert_entry*>(pEntry);
@@ -116,10 +116,10 @@ static int32_t encoding_search_compare(const void* pKey, const void* pEntry)
     return 0;
 }
 
-wchar_t encoding_convert_rct2_to_unicode(wchar_t rct2str)
+wchar_t EncodingConvertRCT2ToUnicode(wchar_t rct2str)
 {
     encoding_convert_entry* entry = static_cast<encoding_convert_entry*>(std::bsearch(
-        &rct2str, RCT2ToUnicodeTable, std::size(RCT2ToUnicodeTable), sizeof(encoding_convert_entry), encoding_search_compare));
+        &rct2str, RCT2ToUnicodeTable, std::size(RCT2ToUnicodeTable), sizeof(encoding_convert_entry), EncodingSearchCompare));
     if (entry == nullptr)
         return rct2str;
     return entry->unicode;

--- a/src/openrct2/localisation/ConversionTables.h
+++ b/src/openrct2/localisation/ConversionTables.h
@@ -11,4 +11,4 @@
 
 #include "../common.h"
 
-wchar_t encoding_convert_rct2_to_unicode(wchar_t rct2str);
+wchar_t EncodingConvertRCT2ToUnicode(wchar_t rct2str);

--- a/src/openrct2/localisation/Convert.cpp
+++ b/src/openrct2/localisation/Convert.cpp
@@ -111,13 +111,13 @@ template<typename TConvertFunc> static std::string DecodeConvertWithTable(std::s
     return String::ToUtf8(u16);
 }
 
-std::string rct2_to_utf8(std::string_view src, RCT2LanguageId languageId)
+std::string RCT2StringToUTF8(std::string_view src, RCT2LanguageId languageId)
 {
     auto codePage = GetCodePageForRCT2Language(languageId);
     if (codePage == OpenRCT2::CodePage::CP_1252)
     {
         // The code page used by RCT2 was not quite 1252 as some codes were used for Polish characters.
-        return DecodeConvertWithTable(src, encoding_convert_rct2_to_unicode);
+        return DecodeConvertWithTable(src, EncodingConvertRCT2ToUnicode);
     }
 
     auto decoded = DecodeToMultiByte(src);

--- a/src/openrct2/localisation/Currency.cpp
+++ b/src/openrct2/localisation/Currency.cpp
@@ -36,7 +36,7 @@ currency_descriptor CurrencyDescriptors[EnumValue(CurrencyType::Count)] = {
 };
 // clang-format on
 
-void currency_load_custom_currency_config()
+void CurrencyLoadCustomCurrencyConfig()
 {
     CurrencyDescriptors[EnumValue(CurrencyType::Custom)].rate = gConfigGeneral.CustomCurrencyRate;
     CurrencyDescriptors[EnumValue(CurrencyType::Custom)].affix_unicode = gConfigGeneral.CustomCurrencyAffix;

--- a/src/openrct2/localisation/Currency.h
+++ b/src/openrct2/localisation/Currency.h
@@ -67,4 +67,4 @@ extern currency_descriptor CurrencyDescriptors[static_cast<uint8_t>(CurrencyType
  * Loads custom currency saved parameters into {@link CurrencyDescriptors}'
  * custom currency entry
  */
-void currency_load_custom_currency_config();
+void CurrencyLoadCustomCurrencyConfig();

--- a/src/openrct2/localisation/Date.h
+++ b/src/openrct2/localisation/Date.h
@@ -52,14 +52,14 @@ extern int32_t gDateMonthsElapsed;
 
 extern openrct2_timeofday gRealTimeOfDay;
 
-int32_t date_get_month(int32_t months);
-int32_t date_get_year(int32_t months);
-int32_t date_get_total_months(int32_t month, int32_t year);
-void date_reset();
-void date_update();
-void date_set(int32_t year, int32_t month, int32_t day);
-void date_update_real_time_of_day();
-bool date_is_day_start(int32_t monthTicks);
-bool date_is_week_start(int32_t monthTicks);
-bool date_is_fortnight_start(int32_t monthTicks);
-bool date_is_month_start(int32_t monthTicks);
+int32_t DateGetMonth(int32_t months);
+int32_t DateGetYear(int32_t months);
+int32_t DateGetTotalMonths(int32_t month, int32_t year);
+void DateReset();
+void DateUpdate();
+void DateSet(int32_t year, int32_t month, int32_t day);
+void DateUpdateRealTimeOfDay();
+bool DateIsDayStart(int32_t monthTicks);
+bool DateIsWeekStart(int32_t monthTicks);
+bool DateIsFortnightStart(int32_t monthTicks);
+bool DateIsMonthStart(int32_t monthTicks);

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -270,13 +270,13 @@ namespace OpenRCT2
 
     static std::string_view GetDigitSeparator()
     {
-        auto sz = language_get_string(STR_LOCALE_THOUSANDS_SEPARATOR);
+        auto sz = LanguageGetString(STR_LOCALE_THOUSANDS_SEPARATOR);
         return sz != nullptr ? sz : std::string_view();
     }
 
     static std::string_view GetDecimalSeparator()
     {
-        auto sz = language_get_string(STR_LOCALE_DECIMAL_POINT);
+        auto sz = LanguageGetString(STR_LOCALE_DECIMAL_POINT);
         return sz != nullptr ? sz : std::string_view();
     }
 
@@ -579,15 +579,15 @@ namespace OpenRCT2
             case FormatToken::MonthYear:
                 if constexpr (std::is_integral<T>())
                 {
-                    auto month = date_get_month(arg);
-                    auto year = date_get_year(arg) + 1;
+                    auto month = DateGetMonth(arg);
+                    auto year = DateGetYear(arg) + 1;
                     FormatMonthYear(ss, month, year);
                 }
                 break;
             case FormatToken::Month:
                 if constexpr (std::is_integral<T>())
                 {
-                    auto szMonth = language_get_string(DateGameMonthNames[date_get_month(arg)]);
+                    auto szMonth = LanguageGetString(DateGameMonthNames[DateGetMonth(arg)]);
                     if (szMonth != nullptr)
                     {
                         ss << szMonth;
@@ -629,7 +629,7 @@ namespace OpenRCT2
 
     FmtString GetFmtStringById(StringId id)
     {
-        auto fmtc = language_get_string(id);
+        auto fmtc = LanguageGetString(id);
         return FmtString(fmtc);
     }
 

--- a/src/openrct2/localisation/Language.cpp
+++ b/src/openrct2/localisation/Language.cpp
@@ -53,7 +53,7 @@ const language_descriptor LanguagesDescriptors[LANGUAGE_COUNT] =
 };
 // clang-format on
 
-uint8_t language_get_id_from_locale(const char* locale)
+uint8_t LanguageGetIDFromLocale(const char* locale)
 {
     uint8_t i = 0;
     for (const auto& langDesc : LanguagesDescriptors)
@@ -67,13 +67,13 @@ uint8_t language_get_id_from_locale(const char* locale)
     return LANGUAGE_UNDEFINED;
 }
 
-const char* language_get_string(StringId id)
+const char* LanguageGetString(StringId id)
 {
     const auto& localisationService = OpenRCT2::GetContext()->GetLocalisationService();
     return localisationService.GetString(id);
 }
 
-bool language_open(int32_t id)
+bool LanguageOpen(int32_t id)
 {
     auto context = OpenRCT2::GetContext();
     auto& localisationService = context->GetLocalisationService();
@@ -91,7 +91,7 @@ bool language_open(int32_t id)
     }
 }
 
-bool language_get_localised_scenario_strings(const utf8* scenarioFilename, StringId* outStringIds)
+bool LanguageGetLocalisedScenarioStrings(const utf8* scenarioFilename, StringId* outStringIds)
 {
     const auto& localisationService = OpenRCT2::GetContext()->GetLocalisationService();
     auto result = localisationService.GetLocalisedScenarioStrings(scenarioFilename);
@@ -101,13 +101,13 @@ bool language_get_localised_scenario_strings(const utf8* scenarioFilename, Strin
     return outStringIds[0] != STR_NONE || outStringIds[1] != STR_NONE || outStringIds[2] != STR_NONE;
 }
 
-void language_free_object_string(StringId stringId)
+void LanguageFreeObjectString(StringId stringId)
 {
     auto& localisationService = OpenRCT2::GetContext()->GetLocalisationService();
     localisationService.FreeObjectString(stringId);
 }
 
-StringId language_allocate_object_string(const std::string& target)
+StringId LanguageAllocateObjectString(const std::string& target)
 {
     auto& localisationService = OpenRCT2::GetContext()->GetLocalisationService();
     return localisationService.AllocateObjectString(target);

--- a/src/openrct2/localisation/Language.h
+++ b/src/openrct2/localisation/Language.h
@@ -94,22 +94,22 @@ constexpr const char* BlackRightArrowString = u8"{BLACK}▶";
 constexpr const char* CheckBoxMarkString = u8"✓";
 constexpr const char* EyeString = u8"👁";
 
-uint8_t language_get_id_from_locale(const char* locale);
-const char* language_get_string(StringId id);
-bool language_open(int32_t id);
+uint8_t LanguageGetIDFromLocale(const char* locale);
+const char* LanguageGetString(StringId id);
+bool LanguageOpen(int32_t id);
 
-uint32_t utf8_get_next(const utf8* char_ptr, const utf8** nextchar_ptr);
-int32_t utf8_insert_codepoint(utf8* dst, uint32_t codepoint);
-bool utf8_is_codepoint_start(const utf8* text);
-int32_t utf8_get_codepoint_length(char32_t codepoint);
-int32_t utf8_length(const utf8* text);
+uint32_t UTF8GetNext(const utf8* char_ptr, const utf8** nextchar_ptr);
+int32_t UTF8InsertCodepoint(utf8* dst, uint32_t codepoint);
+bool UTF8IsCodepointStart(const utf8* text);
+int32_t UTF8GetCodepointLength(char32_t codepoint);
+int32_t UTF8Length(const utf8* text);
 
-std::string rct2_to_utf8(std::string_view src, RCT2LanguageId languageId);
-bool language_get_localised_scenario_strings(const utf8* scenarioFilename, StringId* outStringIds);
-void language_free_object_string(StringId stringId);
-StringId language_allocate_object_string(const std::string& target);
+std::string RCT2StringToUTF8(std::string_view src, RCT2LanguageId languageId);
+bool LanguageGetLocalisedScenarioStrings(const utf8* scenarioFilename, StringId* outStringIds);
+void LanguageFreeObjectString(StringId stringId);
+StringId LanguageAllocateObjectString(const std::string& target);
 
-constexpr utf8* utf8_write_codepoint(utf8* dst, uint32_t codepoint)
+constexpr utf8* UTF8WriteCodepoint(utf8* dst, uint32_t codepoint)
 {
     if (codepoint <= 0x7F)
     {

--- a/src/openrct2/localisation/Localisation.Date.cpp
+++ b/src/openrct2/localisation/Localisation.Date.cpp
@@ -40,17 +40,17 @@ const StringId DateFormatStringFormatIds[] = {
 
 openrct2_timeofday gRealTimeOfDay;
 
-int32_t date_get_month(int32_t months)
+int32_t DateGetMonth(int32_t months)
 {
     return months % MONTH_COUNT;
 }
 
-int32_t date_get_year(int32_t months)
+int32_t DateGetYear(int32_t months)
 {
     return months / MONTH_COUNT;
 }
 
-int32_t date_get_total_months(int32_t month, int32_t year)
+int32_t DateGetTotalMonths(int32_t month, int32_t year)
 {
     return (year - 1) * MONTH_COUNT + month;
 }
@@ -59,14 +59,14 @@ int32_t date_get_total_months(int32_t month, int32_t year)
  *
  *  rct2: 0x006C4494
  */
-void date_reset()
+void DateReset()
 {
     gDateMonthsElapsed = 0;
     gDateMonthTicks = 0;
     gCurrentRealTimeTicks = 0;
 }
 
-void date_set(int32_t year, int32_t month, int32_t day)
+void DateSet(int32_t year, int32_t month, int32_t day)
 {
     year = std::clamp(year, 1, MAX_YEAR);
     month = std::clamp(month, 1, static_cast<int>(MONTH_COUNT));
@@ -75,7 +75,7 @@ void date_set(int32_t year, int32_t month, int32_t day)
     gDateMonthTicks = TICKS_PER_MONTH / days_in_month[month - 1] * (day - 1) + 4;
 }
 
-void date_update()
+void DateUpdate()
 {
     PROFILED_FUNCTION();
 
@@ -91,7 +91,7 @@ void date_update()
     }
 }
 
-void date_update_real_time_of_day()
+void DateUpdateRealTimeOfDay()
 {
     time_t timestamp = time(nullptr);
     struct tm* now = localtime(&timestamp);
@@ -101,29 +101,29 @@ void date_update_real_time_of_day()
     gRealTimeOfDay.hour = now->tm_hour;
 }
 
-bool date_is_day_start(int32_t monthTicks)
+bool DateIsDayStart(int32_t monthTicks)
 {
     if (monthTicks < 4)
     {
         return false;
     }
     int32_t prevMonthTick = monthTicks - 4;
-    int32_t currentMonth = date_get_month(gDateMonthsElapsed);
+    int32_t currentMonth = DateGetMonth(gDateMonthsElapsed);
     int32_t currentDaysInMonth = days_in_month[currentMonth];
     return ((currentDaysInMonth * monthTicks) >> 16 != (currentDaysInMonth * prevMonthTick) >> 16);
 }
 
-bool date_is_week_start(int32_t monthTicks)
+bool DateIsWeekStart(int32_t monthTicks)
 {
     return (monthTicks & 0x3FFF) == 0;
 }
 
-bool date_is_fortnight_start(int32_t monthTicks)
+bool DateIsFortnightStart(int32_t monthTicks)
 {
     return (monthTicks & 0x7FFF) == 0;
 }
 
-bool date_is_month_start(int32_t monthTicks)
+bool DateIsMonthStart(int32_t monthTicks)
 {
     return (monthTicks == 0);
 }

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -361,12 +361,12 @@ std::string format_string(StringId format, const void* args)
  * format (ax)
  * args (ecx)
  */
-void format_string_to_upper(utf8* dest, size_t size, StringId format, const void* args)
+void FormatStringToUpper(utf8* dest, size_t size, StringId format, const void* args)
 {
 #ifdef DEBUG
     if (gDebugStringFormatting)
     {
-        printf("format_string_to_upper(%hu)\n", format);
+        printf("FormatStringToUpper(%hu)\n", format);
     }
 #endif
 
@@ -390,7 +390,7 @@ void format_string_to_upper(utf8* dest, size_t size, StringId format, const void
     dest[upperString.size()] = '\0';
 }
 
-void format_readable_size(char* buf, size_t bufSize, uint64_t sizeBytes)
+void FormatReadableSize(char* buf, size_t bufSize, uint64_t sizeBytes)
 {
     constexpr uint32_t SizeTable[] = {
         STR_SIZE_BYTE, STR_SIZE_KILOBYTE, STR_SIZE_MEGABYTE, STR_SIZE_GIGABYTE, STR_SIZE_TERABYTE,
@@ -410,10 +410,10 @@ void format_readable_size(char* buf, size_t bufSize, uint64_t sizeBytes)
     snprintf(buf, bufSize, "%.03f %s", size, sizeType);
 }
 
-void format_readable_speed(char* buf, size_t bufSize, uint64_t sizeBytes)
+void FormatReadableSpeed(char* buf, size_t bufSize, uint64_t sizeBytes)
 {
     char sizeText[128] = {};
-    format_readable_size(sizeText, sizeof(sizeText), sizeBytes);
+    FormatReadableSize(sizeText, sizeof(sizeText), sizeBytes);
 
     const char* args[1] = {
         sizeText,
@@ -421,9 +421,9 @@ void format_readable_speed(char* buf, size_t bufSize, uint64_t sizeBytes)
     format_string(buf, bufSize, STR_NETWORK_SPEED_SEC, args);
 }
 
-money64 string_to_money(const char* string_to_monetise)
+money64 StringToMoney(const char* string_to_monetise)
 {
-    const char* decimal_char = language_get_string(STR_LOCALE_DECIMAL_POINT);
+    const char* decimal_char = LanguageGetString(STR_LOCALE_DECIMAL_POINT);
     const currency_descriptor* currencyDesc = &CurrencyDescriptors[EnumValue(gConfigGeneral.CurrencyFormat)];
     char processedString[128] = {};
 
@@ -510,7 +510,7 @@ money64 string_to_money(const char* string_to_monetise)
  * @param forceDecimals Show decimals, even if the amount does not have them. Will be ignored if the current exchange
  *                          rate is too big to have decimals.
  */
-void money_to_string(money64 amount, char* buffer_to_put_value_to, size_t buffer_len, bool forceDecimals)
+void MoneyToString(money64 amount, char* buffer_to_put_value_to, size_t buffer_len, bool forceDecimals)
 {
     if (amount == MONEY64_UNDEFINED)
     {
@@ -530,7 +530,7 @@ void money_to_string(money64 amount, char* buffer_to_put_value_to, size_t buffer
     // If whole and decimal exist
     if ((whole > 0 && decimal > 0) || (amountIsInteger && forceDecimals && currencyDesc.rate < 100))
     {
-        const char* decimalChar = language_get_string(STR_LOCALE_DECIMAL_POINT);
+        const char* decimalChar = LanguageGetString(STR_LOCALE_DECIMAL_POINT);
         auto precedingZero = (decimal < 10) ? "0" : "";
         snprintf(buffer_to_put_value_to, buffer_len, "%s%llu%s%s%llu", sign, whole, decimalChar, precedingZero, decimal);
     }
@@ -542,7 +542,7 @@ void money_to_string(money64 amount, char* buffer_to_put_value_to, size_t buffer
     // If decimal exists, but not whole
     else if (whole == 0 && decimal > 0)
     {
-        const char* decimalChar = language_get_string(STR_LOCALE_DECIMAL_POINT);
+        const char* decimalChar = LanguageGetString(STR_LOCALE_DECIMAL_POINT);
         snprintf(buffer_to_put_value_to, buffer_len, "%s0%s%llu", sign, decimalChar, decimal);
     }
     else

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -20,26 +20,26 @@
 
 std::string format_string(StringId format, const void* args);
 void format_string(char* dest, size_t size, StringId format, const void* args);
-void format_string_to_upper(char* dest, size_t size, StringId format, const void* args);
+void FormatStringToUpper(char* dest, size_t size, StringId format, const void* args);
 void generate_string_file();
 
 /**
  * Formats sizeBytes into buf as a human readable text, e.x.: "1024 MB"
  */
-void format_readable_size(char* buf, size_t bufSize, uint64_t sizeBytes);
+void FormatReadableSize(char* buf, size_t bufSize, uint64_t sizeBytes);
 
 /**
  * Formats sizeBytesPerSec into buf as a human readable text, e.x.: "1024 MB/sec"
  */
-void format_readable_speed(char* buf, size_t bufSize, uint64_t sizeBytesPerSec);
+void FormatReadableSpeed(char* buf, size_t bufSize, uint64_t sizeBytesPerSec);
 
-utf8* get_string_end(const utf8* text);
-size_t get_string_size(const utf8* text);
+utf8* GetStringEnd(const utf8* text);
+size_t GetStringSize(const utf8* text);
 
 // The maximum number of characters allowed for string/money conversions (anything above will risk integer overflow issues)
 #define MONEY_STRING_MAXLENGTH 14
-money64 string_to_money(const char* string_to_monetise);
-void money_to_string(money64 amount, char* buffer_to_put_value_to, size_t buffer_len, bool forceDecimals);
+money64 StringToMoney(const char* string_to_monetise);
+void MoneyToString(money64 amount, char* buffer_to_put_value_to, size_t buffer_len, bool forceDecimals);
 
 bool is_user_string_id(StringId stringId);
 

--- a/src/openrct2/localisation/UTF8.cpp
+++ b/src/openrct2/localisation/UTF8.cpp
@@ -12,7 +12,7 @@
 #include <cstring>
 #include <wchar.h>
 
-uint32_t utf8_get_next(const utf8* char_ptr, const utf8** nextchar_ptr)
+uint32_t UTF8GetNext(const utf8* char_ptr, const utf8** nextchar_ptr)
 {
     int32_t result;
     int32_t numBytes;
@@ -54,16 +54,16 @@ uint32_t utf8_get_next(const utf8* char_ptr, const utf8** nextchar_ptr)
  * Inserts the given codepoint at the given address, shifting all characters after along.
  * @returns the size of the inserted codepoint.
  */
-int32_t utf8_insert_codepoint(utf8* dst, uint32_t codepoint)
+int32_t UTF8InsertCodepoint(utf8* dst, uint32_t codepoint)
 {
-    int32_t shift = utf8_get_codepoint_length(codepoint);
-    utf8* endPoint = get_string_end(dst);
+    int32_t shift = UTF8GetCodepointLength(codepoint);
+    utf8* endPoint = GetStringEnd(dst);
     memmove(dst + shift, dst, endPoint - dst + 1);
-    utf8_write_codepoint(dst, codepoint);
+    UTF8WriteCodepoint(dst, codepoint);
     return shift;
 }
 
-bool utf8_is_codepoint_start(const utf8* text)
+bool UTF8IsCodepointStart(const utf8* text)
 {
     if ((text[0] & 0x80) == 0)
         return true;
@@ -72,7 +72,7 @@ bool utf8_is_codepoint_start(const utf8* text)
     return false;
 }
 
-int32_t utf8_get_codepoint_length(char32_t codepoint)
+int32_t UTF8GetCodepointLength(char32_t codepoint)
 {
     if (codepoint <= 0x7F)
     {
@@ -93,12 +93,12 @@ int32_t utf8_get_codepoint_length(char32_t codepoint)
  * Gets the number of characters / codepoints in a UTF-8 string (not necessarily 1:1 with bytes and not including null
  * terminator).
  */
-int32_t utf8_length(const utf8* text)
+int32_t UTF8Length(const utf8* text)
 {
     const utf8* ch = text;
 
     int32_t count = 0;
-    while (utf8_get_next(ch, &ch) != 0)
+    while (UTF8GetNext(ch, &ch) != 0)
     {
         count++;
     }
@@ -108,7 +108,7 @@ int32_t utf8_length(const utf8* text)
 /**
  * Returns a pointer to the null terminator of the given UTF-8 string.
  */
-utf8* get_string_end(const utf8* text)
+utf8* GetStringEnd(const utf8* text)
 {
     return const_cast<char*>(std::strchr(text, 0));
 }
@@ -116,7 +116,7 @@ utf8* get_string_end(const utf8* text)
 /**
  * Return the number of bytes (including the null terminator) in the given UTF-8 string.
  */
-size_t get_string_size(const utf8* text)
+size_t GetStringSize(const utf8* text)
 {
-    return get_string_end(text) - text + 1;
+    return GetStringEnd(text) - text + 1;
 }

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -328,7 +328,7 @@ News::Item* News::AddItemToQueue(News::ItemType type, const utf8* text, uint32_t
     newsItem->Assoc = assoc; // Make optional for Award, Money, Graph and Null
     newsItem->Ticks = 0;
     newsItem->MonthYear = static_cast<uint16_t>(gDateMonthsElapsed);
-    newsItem->Day = ((days_in_month[date_get_month(newsItem->MonthYear)] * gDateMonthTicks) >> 16) + 1;
+    newsItem->Day = ((days_in_month[DateGetMonth(newsItem->MonthYear)] * gDateMonthTicks) >> 16) + 1;
     newsItem->Text = text;
 
     return newsItem;

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -114,7 +114,7 @@ static void research_calculate_expected_date()
         int32_t dayQuotient = expectedDay / 0x10000;
         int32_t dayRemainder = expectedDay % 0x10000;
 
-        int32_t expectedMonth = date_get_month(gDateMonthsElapsed + dayQuotient + (daysRemaining >> 16));
+        int32_t expectedMonth = DateGetMonth(gDateMonthsElapsed + dayQuotient + (daysRemaining >> 16));
         expectedDay = (dayRemainder * days_in_month[expectedMonth]) >> 16;
 
         gResearchExpectedDay = expectedDay;

--- a/src/openrct2/network/DiscordService.cpp
+++ b/src/openrct2/network/DiscordService.cpp
@@ -111,7 +111,7 @@ void DiscordService::RefreshPresence() const
                     {
                         auto codepoint = token.GetCodepoint();
                         char buffer[8]{};
-                        utf8_write_codepoint(buffer, codepoint);
+                        UTF8WriteCodepoint(buffer, codepoint);
                         serverName += buffer;
                     }
                 }

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -61,13 +61,13 @@ void BannerObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* st
 void BannerObject::Load()
 {
     GetStringTable().Sort();
-    _legacyType.name = language_allocate_object_string(GetName());
+    _legacyType.name = LanguageAllocateObjectString(GetName());
     _legacyType.image = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
 }
 
 void BannerObject::Unload()
 {
-    language_free_object_string(_legacyType.name);
+    LanguageFreeObjectString(_legacyType.name);
     GfxObjectFreeImages(_legacyType.image, GetImageTable().GetCount());
 
     _legacyType.name = 0;

--- a/src/openrct2/object/EntranceObject.cpp
+++ b/src/openrct2/object/EntranceObject.cpp
@@ -29,13 +29,13 @@ void EntranceObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* 
 void EntranceObject::Load()
 {
     GetStringTable().Sort();
-    _legacyType.string_idx = language_allocate_object_string(GetName());
+    _legacyType.string_idx = LanguageAllocateObjectString(GetName());
     _legacyType.image_id = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
 }
 
 void EntranceObject::Unload()
 {
-    language_free_object_string(_legacyType.string_idx);
+    LanguageFreeObjectString(_legacyType.string_idx);
     GfxObjectFreeImages(_legacyType.image_id, GetImageTable().GetCount());
 
     _legacyType.string_idx = 0;

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -65,7 +65,7 @@ void FootpathItemObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
 void FootpathItemObject::Load()
 {
     GetStringTable().Sort();
-    _legacyType.name = language_allocate_object_string(GetName());
+    _legacyType.name = LanguageAllocateObjectString(GetName());
     _legacyType.image = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
 
     _legacyType.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
@@ -73,7 +73,7 @@ void FootpathItemObject::Load()
 
 void FootpathItemObject::Unload()
 {
-    language_free_object_string(_legacyType.name);
+    LanguageFreeObjectString(_legacyType.name);
     GfxObjectFreeImages(_legacyType.image, GetImageTable().GetCount());
 
     _legacyType.name = 0;

--- a/src/openrct2/object/FootpathObject.cpp
+++ b/src/openrct2/object/FootpathObject.cpp
@@ -37,7 +37,7 @@ void FootpathObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* 
 void FootpathObject::Load()
 {
     GetStringTable().Sort();
-    _legacyType.string_idx = language_allocate_object_string(GetName());
+    _legacyType.string_idx = LanguageAllocateObjectString(GetName());
     _legacyType.image = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
     _legacyType.bridge_image = _legacyType.image + 109;
 
@@ -62,7 +62,7 @@ void FootpathObject::Load()
 
 void FootpathObject::Unload()
 {
-    language_free_object_string(_legacyType.string_idx);
+    LanguageFreeObjectString(_legacyType.string_idx);
     GfxObjectFreeImages(_legacyType.image, GetImageTable().GetCount());
 
     _legacyType.string_idx = 0;

--- a/src/openrct2/object/FootpathRailingsObject.cpp
+++ b/src/openrct2/object/FootpathRailingsObject.cpp
@@ -16,7 +16,7 @@
 void FootpathRailingsObject::Load()
 {
     GetStringTable().Sort();
-    NameStringId = language_allocate_object_string(GetName());
+    NameStringId = LanguageAllocateObjectString(GetName());
 
     auto numImages = GetImageTable().GetCount();
     if (numImages != 0)
@@ -38,7 +38,7 @@ void FootpathRailingsObject::Load()
 
 void FootpathRailingsObject::Unload()
 {
-    language_free_object_string(NameStringId);
+    LanguageFreeObjectString(NameStringId);
     GfxObjectFreeImages(PreviewImageId, GetImageTable().GetCount());
 
     NameStringId = 0;

--- a/src/openrct2/object/FootpathSurfaceObject.cpp
+++ b/src/openrct2/object/FootpathSurfaceObject.cpp
@@ -17,7 +17,7 @@
 void FootpathSurfaceObject::Load()
 {
     GetStringTable().Sort();
-    NameStringId = language_allocate_object_string(GetName());
+    NameStringId = LanguageAllocateObjectString(GetName());
 
     auto numImages = GetImageTable().GetCount();
     if (numImages != 0)
@@ -34,7 +34,7 @@ void FootpathSurfaceObject::Load()
 
 void FootpathSurfaceObject::Unload()
 {
-    language_free_object_string(NameStringId);
+    LanguageFreeObjectString(NameStringId);
     GfxObjectFreeImages(PreviewImageId, GetImageTable().GetCount());
 
     NameStringId = 0;

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -108,7 +108,7 @@ void LargeSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
 void LargeSceneryObject::Load()
 {
     GetStringTable().Sort();
-    _legacyType.name = language_allocate_object_string(GetName());
+    _legacyType.name = LanguageAllocateObjectString(GetName());
     _baseImageId = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
     _legacyType.image = _baseImageId;
 
@@ -131,7 +131,7 @@ void LargeSceneryObject::Load()
 
 void LargeSceneryObject::Unload()
 {
-    language_free_object_string(_legacyType.name);
+    LanguageFreeObjectString(_legacyType.name);
     GfxObjectFreeImages(_baseImageId, GetImageTable().GetCount());
 
     _legacyType.name = 0;

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -33,7 +33,7 @@ constexpr size_t DEFAULT_BYTES_PER_TICK = 1378;
 void MusicObject::Load()
 {
     GetStringTable().Sort();
-    NameStringId = language_allocate_object_string(GetName());
+    NameStringId = LanguageAllocateObjectString(GetName());
 
     // Start with base images
     _loadedSampleTable.LoadFrom(_sampleTable, 0, _sampleTable.GetCount());
@@ -79,7 +79,7 @@ void MusicObject::Load()
 
 void MusicObject::Unload()
 {
-    language_free_object_string(NameStringId);
+    LanguageFreeObjectString(NameStringId);
     NameStringId = 0;
 }
 

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -123,7 +123,7 @@ std::string Object::GetOverrideString(uint8_t index) const
     const utf8* result = nullptr;
     if (stringId != STR_NONE)
     {
-        result = language_get_string(stringId);
+        result = LanguageGetString(stringId);
     }
     return String::ToStd(result);
 }

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -690,15 +690,15 @@ std::unique_ptr<Object> object_repository_load_object(const rct_object_entry* ob
 void scenario_translate(scenario_index_entry* scenarioEntry)
 {
     StringId localisedStringIds[3];
-    if (language_get_localised_scenario_strings(scenarioEntry->name, localisedStringIds))
+    if (LanguageGetLocalisedScenarioStrings(scenarioEntry->name, localisedStringIds))
     {
         if (localisedStringIds[0] != STR_NONE)
         {
-            String::Set(scenarioEntry->name, sizeof(scenarioEntry->name), language_get_string(localisedStringIds[0]));
+            String::Set(scenarioEntry->name, sizeof(scenarioEntry->name), LanguageGetString(localisedStringIds[0]));
         }
         if (localisedStringIds[2] != STR_NONE)
         {
-            String::Set(scenarioEntry->details, sizeof(scenarioEntry->details), language_get_string(localisedStringIds[2]));
+            String::Set(scenarioEntry->details, sizeof(scenarioEntry->details), LanguageGetString(localisedStringIds[2]));
         }
     }
 }

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -203,9 +203,9 @@ void RideObject::Load()
     _legacyType.obj = this;
 
     GetStringTable().Sort();
-    _legacyType.naming.Name = language_allocate_object_string(GetName());
-    _legacyType.naming.Description = language_allocate_object_string(GetDescription());
-    _legacyType.capacity = language_allocate_object_string(GetCapacity());
+    _legacyType.naming.Name = LanguageAllocateObjectString(GetName());
+    _legacyType.naming.Description = LanguageAllocateObjectString(GetDescription());
+    _legacyType.capacity = LanguageAllocateObjectString(GetCapacity());
     _legacyType.images_offset = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
     _legacyType.vehicle_preset_list = &_presetColours;
 
@@ -272,9 +272,9 @@ void RideObject::Load()
 
 void RideObject::Unload()
 {
-    language_free_object_string(_legacyType.naming.Name);
-    language_free_object_string(_legacyType.naming.Description);
-    language_free_object_string(_legacyType.capacity);
+    LanguageFreeObjectString(_legacyType.naming.Name);
+    LanguageFreeObjectString(_legacyType.naming.Description);
+    LanguageFreeObjectString(_legacyType.capacity);
     GfxObjectFreeImages(_legacyType.images_offset, GetImageTable().GetCount());
 
     _legacyType.naming.Name = 0;

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -56,14 +56,14 @@ void SceneryGroupObject::ReadLegacy(IReadObjectContext* context, IStream* stream
 void SceneryGroupObject::Load()
 {
     GetStringTable().Sort();
-    _legacyType.name = language_allocate_object_string(GetName());
+    _legacyType.name = LanguageAllocateObjectString(GetName());
     _legacyType.image = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
     _legacyType.SceneryEntries.clear();
 }
 
 void SceneryGroupObject::Unload()
 {
-    language_free_object_string(_legacyType.name);
+    LanguageFreeObjectString(_legacyType.name);
     GfxObjectFreeImages(_legacyType.image, GetImageTable().GetCount());
 
     _legacyType.name = 0;

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -74,7 +74,7 @@ void SmallSceneryObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStre
 void SmallSceneryObject::Load()
 {
     GetStringTable().Sort();
-    _legacyType.name = language_allocate_object_string(GetName());
+    _legacyType.name = LanguageAllocateObjectString(GetName());
     _legacyType.image = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
 
     _legacyType.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
@@ -89,7 +89,7 @@ void SmallSceneryObject::Load()
 
 void SmallSceneryObject::Unload()
 {
-    language_free_object_string(_legacyType.name);
+    LanguageFreeObjectString(_legacyType.name);
     GfxObjectFreeImages(_legacyType.image, GetImageTable().GetCount());
 
     _legacyType.name = 0;

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -20,7 +20,7 @@
 void StationObject::Load()
 {
     GetStringTable().Sort();
-    NameStringId = language_allocate_object_string(GetName());
+    NameStringId = LanguageAllocateObjectString(GetName());
 
     auto numImages = GetImageTable().GetCount();
     if (numImages != 0)
@@ -37,7 +37,7 @@ void StationObject::Load()
 
 void StationObject::Unload()
 {
-    language_free_object_string(NameStringId);
+    LanguageFreeObjectString(NameStringId);
     GfxObjectFreeImages(BaseImageId, GetImageTable().GetCount());
 
     NameStringId = 0;

--- a/src/openrct2/object/StringTable.cpp
+++ b/src/openrct2/object/StringTable.cpp
@@ -60,7 +60,7 @@ void StringTable::Read(IReadObjectContext* context, OpenRCT2::IStream* stream, O
                 ? RCT2ToOpenRCT2LanguageId[EnumValue(rct2LanguageId)]
                 : static_cast<uint8_t>(LANGUAGE_UNDEFINED);
             std::string stringAsWin1252 = stream->ReadStdString();
-            auto stringAsUtf8 = rct2_to_utf8(stringAsWin1252, rct2LanguageId);
+            auto stringAsUtf8 = RCT2StringToUTF8(stringAsWin1252, rct2LanguageId);
 
             if (!StringIsBlank(stringAsUtf8.data()))
             {
@@ -108,7 +108,7 @@ void StringTable::ReadJson(json_t& root)
         {
             for (auto& [locale, jsonString] : jsonLanguages.items())
             {
-                auto langId = language_get_id_from_locale(locale.c_str());
+                auto langId = LanguageGetIDFromLocale(locale.c_str());
                 if (langId != LANGUAGE_UNDEFINED)
                 {
                     auto string = Json::GetString(jsonString);

--- a/src/openrct2/object/TerrainEdgeObject.cpp
+++ b/src/openrct2/object/TerrainEdgeObject.cpp
@@ -21,7 +21,7 @@
 void TerrainEdgeObject::Load()
 {
     GetStringTable().Sort();
-    NameStringId = language_allocate_object_string(GetName());
+    NameStringId = LanguageAllocateObjectString(GetName());
     IconImageId = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
 
     // First image is icon followed by edge images
@@ -30,7 +30,7 @@ void TerrainEdgeObject::Load()
 
 void TerrainEdgeObject::Unload()
 {
-    language_free_object_string(NameStringId);
+    LanguageFreeObjectString(NameStringId);
     GfxObjectFreeImages(IconImageId, GetImageTable().GetCount());
 
     NameStringId = 0;

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -24,7 +24,7 @@
 void TerrainSurfaceObject::Load()
 {
     GetStringTable().Sort();
-    NameStringId = language_allocate_object_string(GetName());
+    NameStringId = LanguageAllocateObjectString(GetName());
     IconImageId = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
     if ((Flags & SMOOTH_WITH_SELF) || (Flags & SMOOTH_WITH_OTHER))
     {
@@ -40,7 +40,7 @@ void TerrainSurfaceObject::Load()
 
 void TerrainSurfaceObject::Unload()
 {
-    language_free_object_string(NameStringId);
+    LanguageFreeObjectString(NameStringId);
     GfxObjectFreeImages(IconImageId, GetImageTable().GetCount());
 
     NameStringId = 0;

--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -55,13 +55,13 @@ void WallObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* stre
 void WallObject::Load()
 {
     GetStringTable().Sort();
-    _legacyType.name = language_allocate_object_string(GetName());
+    _legacyType.name = LanguageAllocateObjectString(GetName());
     _legacyType.image = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
 }
 
 void WallObject::Unload()
 {
-    language_free_object_string(_legacyType.name);
+    LanguageFreeObjectString(_legacyType.name);
     GfxObjectFreeImages(_legacyType.image, GetImageTable().GetCount());
 
     _legacyType.name = 0;

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -37,7 +37,7 @@ void WaterObject::ReadLegacy(IReadObjectContext* context, OpenRCT2::IStream* str
 void WaterObject::Load()
 {
     GetStringTable().Sort();
-    _legacyType.string_idx = language_allocate_object_string(GetName());
+    _legacyType.string_idx = LanguageAllocateObjectString(GetName());
     _legacyType.image_id = GfxObjectAllocateImages(GetImageTable().GetImages(), GetImageTable().GetCount());
     _legacyType.palette_index_1 = _legacyType.image_id + 1;
     _legacyType.palette_index_2 = _legacyType.image_id + 4;
@@ -48,7 +48,7 @@ void WaterObject::Load()
 void WaterObject::Unload()
 {
     GfxObjectFreeImages(_legacyType.image_id, GetImageTable().GetCount());
-    language_free_object_string(_legacyType.string_idx);
+    LanguageFreeObjectString(_legacyType.string_idx);
 
     _legacyType.string_idx = 0;
     _legacyType.image_id = 0;

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -54,7 +54,7 @@ static void PaintBannerScrollingText(
     char text[256];
     if (gConfigGeneral.UpperCaseBanners)
     {
-        format_string_to_upper(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
+        FormatStringToUpper(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
     }
     else
     {

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -63,7 +63,7 @@ static void PaintRideEntranceExitScrollingText(
     char text[256];
     if (gConfigGeneral.UpperCaseBanners)
     {
-        format_string_to_upper(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
+        FormatStringToUpper(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
     }
     else
     {
@@ -234,7 +234,7 @@ static void PaintParkEntranceScrollingText(
     char text[256];
     if (gConfigGeneral.UpperCaseBanners)
     {
-        format_string_to_upper(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
+        FormatStringToUpper(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
     }
     else
     {

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -224,7 +224,7 @@ static void PaintLargeScenery3DText(
         for (auto codepoint : CodepointView(displayText))
         {
             char line[8]{};
-            utf8_write_codepoint(line, codepoint);
+            UTF8WriteCodepoint(line, codepoint);
             PaintLargeScenery3DTextLine(
                 session, sceneryEntry, *text, line, imageTemplate, direction, offsetY - displayTextHeight);
 
@@ -313,7 +313,7 @@ static void PaintLargeSceneryScrollingText(
     char text[256];
     if (gConfigGeneral.UpperCaseBanners)
     {
-        format_string_to_upper(text, sizeof(text), STR_SCROLLING_SIGN_TEXT, ft.Data());
+        FormatStringToUpper(text, sizeof(text), STR_SCROLLING_SIGN_TEXT, ft.Data());
     }
     else
     {

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -458,7 +458,7 @@ static void PathPaintFencesAndQueueBanners(
             }
             if (gConfigGeneral.UpperCaseBanners)
             {
-                format_string_to_upper(
+                FormatStringToUpper(
                     gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, ft.Data());
             }
             else

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -174,7 +174,7 @@ static void PaintWallScrollingText(
     char signString[256];
     if (gConfigGeneral.UpperCaseBanners)
     {
-        format_string_to_upper(signString, sizeof(signString), STR_SCROLLING_SIGN_TEXT, ft.Data());
+        FormatStringToUpper(signString, sizeof(signString), STR_SCROLLING_SIGN_TEXT, ft.Data());
     }
     else
     {

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -230,7 +230,7 @@ namespace RCT1
                 dst->objective_arg_3 = GetBuildTheBestRideId();
             }
 
-            auto name = rct2_to_utf8(_s4.scenario_name, RCT2LanguageId::EnglishUK);
+            auto name = RCT2StringToUTF8(_s4.scenario_name, RCT2LanguageId::EnglishUK);
             std::string details;
 
             // TryGetById won't set this property if the scenario is not recognised,
@@ -243,15 +243,15 @@ namespace RCT1
             String::Set(dst->internal_name, sizeof(dst->internal_name), desc.title);
 
             StringId localisedStringIds[3];
-            if (language_get_localised_scenario_strings(desc.title, localisedStringIds))
+            if (LanguageGetLocalisedScenarioStrings(desc.title, localisedStringIds))
             {
                 if (localisedStringIds[0] != STR_NONE)
                 {
-                    name = String::ToStd(language_get_string(localisedStringIds[0]));
+                    name = String::ToStd(LanguageGetString(localisedStringIds[0]));
                 }
                 if (localisedStringIds[2] != STR_NONE)
                 {
-                    details = String::ToStd(language_get_string(localisedStringIds[2]));
+                    details = String::ToStd(LanguageGetString(localisedStringIds[2]));
                 }
             }
 
@@ -2305,15 +2305,15 @@ namespace RCT1
                 if (ScenarioSources::TryGetById(scNumber, &sourceDesc))
                 {
                     StringId localisedStringIds[3];
-                    if (language_get_localised_scenario_strings(sourceDesc.title, localisedStringIds))
+                    if (LanguageGetLocalisedScenarioStrings(sourceDesc.title, localisedStringIds))
                     {
                         if (localisedStringIds[0] != STR_NONE)
                         {
-                            name = String::ToStd(language_get_string(localisedStringIds[0]));
+                            name = String::ToStd(LanguageGetString(localisedStringIds[0]));
                         }
                         if (localisedStringIds[2] != STR_NONE)
                         {
-                            details = String::ToStd(language_get_string(localisedStringIds[2]));
+                            details = String::ToStd(LanguageGetString(localisedStringIds[2]));
                         }
                     }
                 }
@@ -2475,7 +2475,7 @@ namespace RCT1
             const auto originalString = _s4.string_table[(stringId - USER_STRING_START) % 1024];
             auto originalStringView = std::string_view(
                 originalString, RCT2::GetRCT2StringBufferLen(originalString, USER_STRING_MAX_LENGTH));
-            auto asUtf8 = rct2_to_utf8(originalStringView, RCT2LanguageId::EnglishUK);
+            auto asUtf8 = RCT2StringToUTF8(originalStringView, RCT2LanguageId::EnglishUK);
             auto justText = RCT12RemoveFormattingUTF8(asUtf8);
             return justText.data();
         }

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -632,7 +632,7 @@ std::string ConvertFormattedStringToOpenRCT2(std::string_view buffer)
     {
         buffer = buffer.substr(0, nullTerminator);
     }
-    auto asUtf8 = rct2_to_utf8(buffer, RCT2LanguageId::EnglishUK);
+    auto asUtf8 = RCT2StringToUTF8(buffer, RCT2LanguageId::EnglishUK);
 
     std::string result;
     CodepointView codepoints(asUtf8);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -232,7 +232,7 @@ namespace RCT2
 
             // Some scenarios have their scenario details in UTF-8, due to earlier bugs in OpenRCT2.
             auto loadMaybeUTF8 = [](std::string_view str) -> std::string {
-                return !IsLikelyUTF8(str) ? rct2_to_utf8(str, RCT2LanguageId::EnglishUK) : std::string(str);
+                return !IsLikelyUTF8(str) ? RCT2StringToUTF8(str, RCT2LanguageId::EnglishUK) : std::string(str);
             };
 
             if (_s6.header.type == S6_TYPE_SCENARIO)
@@ -527,9 +527,9 @@ namespace RCT2
         void ConvertScenarioStringsToUTF8()
         {
             // Scenario details
-            gScenarioCompletedBy = rct2_to_utf8(gScenarioCompletedBy, RCT2LanguageId::EnglishUK);
-            gScenarioName = rct2_to_utf8(gScenarioName, RCT2LanguageId::EnglishUK);
-            gScenarioDetails = rct2_to_utf8(gScenarioDetails, RCT2LanguageId::EnglishUK);
+            gScenarioCompletedBy = RCT2StringToUTF8(gScenarioCompletedBy, RCT2LanguageId::EnglishUK);
+            gScenarioName = RCT2StringToUTF8(gScenarioName, RCT2LanguageId::EnglishUK);
+            gScenarioDetails = RCT2StringToUTF8(gScenarioDetails, RCT2LanguageId::EnglishUK);
         }
 
         void FixLandOwnership() const
@@ -1831,7 +1831,7 @@ namespace RCT2
             const auto originalString = _s6.custom_strings[(stringId - USER_STRING_START) % 1024];
             auto originalStringView = std::string_view(
                 originalString, GetRCT2StringBufferLen(originalString, USER_STRING_MAX_LENGTH));
-            auto asUtf8 = rct2_to_utf8(originalStringView, RCT2LanguageId::EnglishUK);
+            auto asUtf8 = RCT2StringToUTF8(originalStringView, RCT2LanguageId::EnglishUK);
             auto justText = RCT12RemoveFormattingUTF8(asUtf8);
             return justText.data();
         }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -1299,7 +1299,7 @@ static void ride_inspection_update(Ride& ride)
 
 static int32_t get_age_penalty(const Ride& ride)
 {
-    auto years = date_get_year(ride.GetAge());
+    auto years = DateGetYear(ride.GetAge());
     switch (years)
     {
         case 0:

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -120,19 +120,19 @@ void scenario_reset()
         ScenarioSources::NormaliseName(normalisedName, sizeof(normalisedName), gScenarioName.c_str());
 
         StringId localisedStringIds[3];
-        if (language_get_localised_scenario_strings(normalisedName, localisedStringIds))
+        if (LanguageGetLocalisedScenarioStrings(normalisedName, localisedStringIds))
         {
             if (localisedStringIds[0] != STR_NONE)
             {
-                gScenarioName = language_get_string(localisedStringIds[0]);
+                gScenarioName = LanguageGetString(localisedStringIds[0]);
             }
             if (localisedStringIds[1] != STR_NONE)
             {
-                park.Name = language_get_string(localisedStringIds[1]);
+                park.Name = LanguageGetString(localisedStringIds[1]);
             }
             if (localisedStringIds[2] != STR_NONE)
             {
-                gScenarioDetails = language_get_string(localisedStringIds[2]);
+                gScenarioDetails = LanguageGetString(localisedStringIds[2]);
             }
         }
     }
@@ -157,7 +157,7 @@ void scenario_reset()
     finance_reset_history();
     award_reset();
     reset_all_ride_build_dates();
-    date_reset();
+    DateReset();
     Duck::RemoveAll();
     ParkCalculateSize();
     MapCountRemainingLandRights();
@@ -325,7 +325,7 @@ static void scenario_day_update()
 
 static void scenario_week_update()
 {
-    int32_t month = date_get_month(gDateMonthsElapsed);
+    int32_t month = DateGetMonth(gDateMonthsElapsed);
 
     finance_pay_wages();
     finance_pay_research();
@@ -408,19 +408,19 @@ void scenario_update()
 
     if (gScreenFlags == SCREEN_FLAGS_PLAYING)
     {
-        if (date_is_day_start(gDateMonthTicks))
+        if (DateIsDayStart(gDateMonthTicks))
         {
             scenario_day_update();
         }
-        if (date_is_week_start(gDateMonthTicks))
+        if (DateIsWeekStart(gDateMonthTicks))
         {
             scenario_week_update();
         }
-        if (date_is_fortnight_start(gDateMonthTicks))
+        if (DateIsFortnightStart(gDateMonthTicks))
         {
             scenario_fortnight_update();
         }
-        if (date_is_month_start(gDateMonthTicks))
+        if (DateIsMonthStart(gDateMonthTicks))
         {
             scenario_month_update();
         }

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -253,8 +253,8 @@ private:
                 // This is caused by a bug that was in OpenRCT2 for 3 years.
                 if (!IsLikelyUTF8(info.name) && !IsLikelyUTF8(info.details))
                 {
-                    rct2_to_utf8_self(info.name, sizeof(info.name));
-                    rct2_to_utf8_self(info.details, sizeof(info.details));
+                    RCT2StringToUTF8Self(info.name, sizeof(info.name));
+                    RCT2StringToUTF8Self(info.details, sizeof(info.details));
                 }
 
                 *entry = CreateNewScenarioEntry(path, timestamp, &info);
@@ -680,7 +680,7 @@ private:
                             if (scBasic.CompanyValue > highscore->company_value)
                             {
                                 SafeFree(highscore->name);
-                                std::string name = rct2_to_utf8(scBasic.CompletedBy, RCT2LanguageId::EnglishUK);
+                                std::string name = RCT2StringToUTF8(scBasic.CompletedBy, RCT2LanguageId::EnglishUK);
                                 highscore->name = String::Duplicate(name.c_str());
                                 highscore->company_value = scBasic.CompanyValue;
                                 highscore->timestamp = DATETIME64_MIN;
@@ -692,7 +692,7 @@ private:
                     {
                         scenario_highscore_entry* highscore = InsertHighscore();
                         highscore->fileName = String::Duplicate(scBasic.Path);
-                        std::string name = rct2_to_utf8(scBasic.CompletedBy, RCT2LanguageId::EnglishUK);
+                        std::string name = RCT2StringToUTF8(scBasic.CompletedBy, RCT2LanguageId::EnglishUK);
                         highscore->name = String::Duplicate(name.c_str());
                         highscore->company_value = scBasic.CompanyValue;
                         highscore->timestamp = DATETIME64_MIN;

--- a/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
+++ b/src/openrct2/scripting/bindings/ride/ScTrackSegment.cpp
@@ -48,7 +48,7 @@ int32_t ScTrackSegment::type_get() const
 std::string ScTrackSegment::description_get() const
 {
     const auto& ted = GetTrackElementDescriptor(_type);
-    return language_get_string(ted.Description);
+    return LanguageGetString(ted.Description);
 }
 
 int32_t ScTrackSegment::beginZ_get() const

--- a/src/openrct2/title/TitleSequenceManager.cpp
+++ b/src/openrct2/title/TitleSequenceManager.cpp
@@ -236,7 +236,7 @@ namespace TitleSequenceManager
         if (item.PredefinedIndex != PREDEFINED_INDEX_CUSTOM)
         {
             StringId stringId = PredefinedSequences[item.PredefinedIndex].StringId;
-            item.Name = language_get_string(stringId);
+            item.Name = LanguageGetString(stringId);
         }
         else if (IsNameReserved(item.Name))
         {

--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -269,11 +269,11 @@ char* safe_strcpy(char* destination, const char* source, size_t size)
     const char* sourceLimit = source + size - 1;
     const char* ch = source;
     uint32_t codepoint;
-    while ((codepoint = utf8_get_next(ch, &ch)) != 0)
+    while ((codepoint = UTF8GetNext(ch, &ch)) != 0)
     {
         if (ch <= sourceLimit)
         {
-            destination = utf8_write_codepoint(destination, codepoint);
+            destination = UTF8WriteCodepoint(destination, codepoint);
         }
         else
         {

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -91,7 +91,7 @@ int32_t ClimateCelsiusToFahrenheit(int32_t celsius)
 void ClimateReset(ClimateType climate)
 {
     auto weather = WeatherType::PartiallyCloudy;
-    int32_t month = date_get_month(gDateMonthsElapsed);
+    int32_t month = DateGetMonth(gDateMonthsElapsed);
     const WeatherTransition* transition = &ClimateTransitions[static_cast<uint8_t>(climate)][month];
     const WeatherState* weatherState = &ClimateWeatherData[EnumValue(weather)];
 
@@ -197,7 +197,7 @@ void ClimateUpdate()
 
 void ClimateForceWeather(WeatherType weather)
 {
-    int32_t month = date_get_month(gDateMonthsElapsed);
+    int32_t month = DateGetMonth(gDateMonthsElapsed);
     const WeatherTransition* transition = &ClimateTransitions[static_cast<uint8_t>(gClimate)][month];
     const auto weatherState = &ClimateWeatherData[EnumValue(weather)];
 
@@ -295,7 +295,7 @@ static int8_t ClimateStepWeatherLevel(int8_t currentWeatherLevel, int8_t nextWea
  */
 static void ClimateDetermineFutureWeather(int32_t randomDistribution)
 {
-    int32_t month = date_get_month(gDateMonthsElapsed);
+    int32_t month = DateGetMonth(gDateMonthsElapsed);
 
     // Generate a random variable with values 0 up to DistributionSize-1 and chose weather from the distribution table
     // accordingly

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -300,7 +300,7 @@ void Park::Initialise()
     award_reset();
 
     gScenarioName.clear();
-    gScenarioDetails = String::ToStd(language_get_string(STR_NO_DETAILS_YET));
+    gScenarioDetails = String::ToStd(LanguageGetString(STR_NO_DETAILS_YET));
 }
 
 void Park::Update(const Date& date)

--- a/test/tests/FormattingTests.cpp
+++ b/test/tests/FormattingTests.cpp
@@ -78,7 +78,7 @@ protected:
         _context = CreateContext();
         ASSERT_TRUE(_context->Initialise());
 
-        language_open(LANGUAGE_ENGLISH_UK);
+        LanguageOpen(LANGUAGE_ENGLISH_UK);
     }
 
     static void TearDownTestCase()

--- a/test/tests/Localisation.cpp
+++ b/test/tests/Localisation.cpp
@@ -18,14 +18,14 @@ class Localisation : public testing::Test
 };
 
 ///////////////////////////////////////////////////////////////////////////////
-// Tests for rct2_to_utf8
+// Tests for RCT2StringToUTF8
 ///////////////////////////////////////////////////////////////////////////////
 
 TEST_F(Localisation, RCT2_to_UTF8_UK)
 {
     auto input = "The quick brown fox";
     auto expected = u8"The quick brown fox";
-    auto actual = rct2_to_utf8(input, RCT2LanguageId::EnglishUK);
+    auto actual = RCT2StringToUTF8(input, RCT2LanguageId::EnglishUK);
     ASSERT_EQ(expected, actual);
 }
 
@@ -33,7 +33,7 @@ TEST_F(Localisation, RCT2_to_UTF8_JP)
 {
     auto input = StringFromHex("ff8374ff8340ff8358ff8367ff8375ff8389ff8345ff8393ff8374ff8348ff8362ff834eff8358");
     auto expected = u8"ファストブラウンフォックス";
-    auto actual = rct2_to_utf8(input, RCT2LanguageId::Japanese);
+    auto actual = RCT2StringToUTF8(input, RCT2LanguageId::Japanese);
     ASSERT_EQ(expected, actual);
 }
 
@@ -41,7 +41,7 @@ TEST_F(Localisation, RCT2_to_UTF8_ZH_TW)
 {
     auto input = StringFromHex("ffa7d6ffb374ffaabaffb4c4ffa6e2ffaab0ffaf57");
     auto expected = u8"快速的棕色狐狸";
-    auto actual = rct2_to_utf8(input, RCT2LanguageId::ChineseTraditional);
+    auto actual = RCT2StringToUTF8(input, RCT2LanguageId::ChineseTraditional);
     ASSERT_EQ(expected, actual);
 }
 
@@ -49,7 +49,7 @@ TEST_F(Localisation, RCT2_to_UTF8_PL)
 {
     auto input = StringFromHex("47F372736b6120446ff76b692054e6637a6f7779");
     auto expected = u8"Górska Dołki Tęczowy";
-    auto actual = rct2_to_utf8(input, RCT2LanguageId::EnglishUK);
+    auto actual = RCT2StringToUTF8(input, RCT2LanguageId::EnglishUK);
     ASSERT_EQ(expected, actual);
 }
 
@@ -58,6 +58,6 @@ TEST_F(Localisation, RCT2_to_UTF8_ZH_TW_PREMATURE_END)
     // This string can be found in BATFL.DAT, the last double byte character is missing its second byte.
     auto input = StringFromHex("ffa470ffabacffa8aeffbdf8ffa662ffc54bffb944ffa457ffaeb6ffb0caffb76effc2");
     auto expected = u8"小型車輛在鐵道上振動搖";
-    auto actual = rct2_to_utf8(input, RCT2LanguageId::ChineseTraditional);
+    auto actual = RCT2StringToUTF8(input, RCT2LanguageId::ChineseTraditional);
     ASSERT_EQ(expected, actual);
 }


### PR DESCRIPTION
This leaves out `format_string`, which needs a bit of custom work to convert as FormatString already exists, with a different signature.