### PR TITLE
Change openrct2/ride methods to UpperCamelCase, part 2

### DIFF
--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -105,7 +105,8 @@ static void DrawResearchItem(
     if (researchItem.type == Research::EntryType::Ride
         && !GetRideTypeDescriptor(researchItem.baseRideType).HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
     {
-        const StringId rideTypeName = GetRideNaming(researchItem.baseRideType, *GetRideEntryByIndex(researchItem.entryIndex)).Name;
+        const StringId rideTypeName = GetRideNaming(researchItem.baseRideType, *GetRideEntryByIndex(researchItem.entryIndex))
+                                          .Name;
 
         // Draw group name
         auto ft = Formatter();
@@ -413,7 +414,8 @@ public:
             && !GetRideTypeDescriptor(researchItem->baseRideType).HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
         {
             drawString = STR_WINDOW_COLOUR_2_STRINGID_STRINGID;
-            StringId rideTypeName = GetRideNaming(researchItem->baseRideType, *GetRideEntryByIndex(researchItem->entryIndex)).Name;
+            StringId rideTypeName = GetRideNaming(researchItem->baseRideType, *GetRideEntryByIndex(researchItem->entryIndex))
+                                        .Name;
             ft.Add<StringId>(rideTypeName);
             ft.Add<StringId>(stringId);
         }

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -105,7 +105,7 @@ static void DrawResearchItem(
     if (researchItem.type == Research::EntryType::Ride
         && !GetRideTypeDescriptor(researchItem.baseRideType).HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
     {
-        const StringId rideTypeName = GetRideNaming(researchItem.baseRideType, *get_ride_entry(researchItem.entryIndex)).Name;
+        const StringId rideTypeName = GetRideNaming(researchItem.baseRideType, *GetRideEntryByIndex(researchItem.entryIndex)).Name;
 
         // Draw group name
         auto ft = Formatter();
@@ -413,7 +413,7 @@ public:
             && !GetRideTypeDescriptor(researchItem->baseRideType).HasFlag(RIDE_TYPE_FLAG_LIST_VEHICLES_SEPARATELY))
         {
             drawString = STR_WINDOW_COLOUR_2_STRINGID_STRINGID;
-            StringId rideTypeName = GetRideNaming(researchItem->baseRideType, *get_ride_entry(researchItem->entryIndex)).Name;
+            StringId rideTypeName = GetRideNaming(researchItem->baseRideType, *GetRideEntryByIndex(researchItem->entryIndex)).Name;
             ft.Add<StringId>(rideTypeName);
             ft.Add<StringId>(stringId);
         }

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1505,7 +1505,7 @@ private:
         for (; object_entry_get_chunk(ObjectType::Ride, entry_index) == nullptr; entry_index++)
             ;
 
-        rct_ride_entry* ride_entry = get_ride_entry(entry_index);
+        rct_ride_entry* ride_entry = GetRideEntryByIndex(entry_index);
         auto rideType = ride_entry->GetFirstNonNullRideType();
 
         auto intent = Intent(WindowClass::TrackDesignList);
@@ -1586,7 +1586,7 @@ void EditorLoadSelectedObjects()
                     auto entryIndex = object_manager_get_loaded_object_entry_index(loadedObject);
                     if (objectType == ObjectType::Ride)
                     {
-                        rct_ride_entry* rideEntry = get_ride_entry(entryIndex);
+                        rct_ride_entry* rideEntry = GetRideEntryByIndex(entryIndex);
                         auto rideType = rideEntry->GetFirstNonNullRideType();
                         ResearchCategory category = static_cast<ResearchCategory>(GetRideTypeDescriptor(rideType).Category);
                         research_insert_ride_entry(rideType, entryIndex, category, true);

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -201,7 +201,7 @@ public:
             if (objectEntry != nullptr)
             {
                 auto groupIndex = object_manager_get_loaded_object_entry_index(objectEntry);
-                auto rideName = GetRideNaming(td6->type, *get_ride_entry(groupIndex));
+                auto rideName = GetRideNaming(td6->type, *GetRideEntryByIndex(groupIndex));
                 ft.Add<StringId>(rideName.Name);
             }
             else

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -574,7 +574,7 @@ private:
         auto isFirst = true;
         for (auto rideEntryIndex : rideEntries)
         {
-            auto currentRideEntry = get_ride_entry(rideEntryIndex);
+            auto currentRideEntry = GetRideEntryByIndex(rideEntryIndex);
 
             // Skip if vehicle type is not invented yet
             if (!ride_entry_is_invented(rideEntryIndex) && !gCheatsIgnoreResearchStatus)
@@ -643,7 +643,7 @@ private:
                 continue;
 
             // Ride entries
-            rct_ride_entry* rideEntry = get_ride_entry(rideEntryIndex);
+            rct_ride_entry* rideEntry = GetRideEntryByIndex(rideEntryIndex);
 
             // Skip if the vehicle isn't the preferred vehicle for this generic track type
             if (!gConfigInterface.ListRideVehiclesSeparately
@@ -824,7 +824,7 @@ private:
 
     void DrawRideInformation(rct_drawpixelinfo& dpi, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
     {
-        rct_ride_entry* rideEntry = get_ride_entry(item.EntryIndex);
+        rct_ride_entry* rideEntry = GetRideEntryByIndex(item.EntryIndex);
         RideNaming rideNaming = GetRideNaming(item.Type, *rideEntry);
         auto ft = Formatter();
 
@@ -982,7 +982,7 @@ void WindowNewRideFocus(RideSelection rideItem)
         return;
     }
 
-    rct_ride_entry* rideEntry = get_ride_entry(rideItem.EntryIndex);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(rideItem.EntryIndex);
     if (rideEntry == nullptr)
         return;
 

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -1073,7 +1073,7 @@ static void WindowRideDisableTabs(rct_window* w)
     if ((gScreenFlags & SCREEN_FLAGS_TRACK_DESIGNER) != 0)
         disabled_tabs |= (1uLL << WIDX_TAB_4 | 1uLL << WIDX_TAB_6 | 1uLL << WIDX_TAB_9 | 1uLL << WIDX_TAB_10); // 0x3280
 
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride->subtype);
 
     if (rideEntry == nullptr)
     {
@@ -2029,7 +2029,7 @@ static void PopulateVehicleTypeDropdown(const Ride& ride, bool forceRefresh)
         auto& rideEntries = objManager.GetAllRideEntries(rideTypeIterator);
         for (auto rideEntryIndex : rideEntries)
         {
-            const auto* currentRideEntry = get_ride_entry(rideEntryIndex);
+            const auto* currentRideEntry = GetRideEntryByIndex(rideEntryIndex);
             if (currentRideEntry == nullptr)
                 continue;
 
@@ -6331,7 +6331,7 @@ static void WindowRideIncomeTogglePrimaryPrice(rct_window* w)
     }
     else
     {
-        auto rideEntry = get_ride_entry(ride->subtype);
+        auto rideEntry = GetRideEntryByIndex(ride->subtype);
         if (rideEntry != nullptr)
         {
             shop_item = rideEntry->shop_item[0];
@@ -6361,7 +6361,7 @@ static void WindowRideIncomeToggleSecondaryPrice(rct_window* w)
     if (ride == nullptr)
         return;
 
-    auto rideEntry = get_ride_entry(ride->subtype);
+    auto rideEntry = GetRideEntryByIndex(ride->subtype);
     if (rideEntry == nullptr)
         return;
 

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2737,7 +2737,7 @@ static void WindowRideConstructionUpdateDisabledPieces(ObjectEntryIndex rideType
 
         for (auto rideEntryIndex : rideEntries)
         {
-            const auto* currentRideEntry = get_ride_entry(rideEntryIndex);
+            const auto* currentRideEntry = GetRideEntryByIndex(rideEntryIndex);
             if (currentRideEntry == nullptr)
                 continue;
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -362,7 +362,7 @@ public:
     void OnPrepareDraw() override
     {
         StringId stringId = STR_NONE;
-        rct_ride_entry* entry = get_ride_entry(_window_track_list_item.EntryIndex);
+        rct_ride_entry* entry = GetRideEntryByIndex(_window_track_list_item.EntryIndex);
 
         if (entry != nullptr)
         {

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -346,7 +346,7 @@ static void RemoveSelectedObjectsFromResearch(const ObjectEntryDescriptor& descr
         {
             case ObjectType::Ride:
             {
-                auto rideEntry = get_ride_entry(entryIndex);
+                auto rideEntry = GetRideEntryByIndex(entryIndex);
                 for (auto rideType : rideEntry->ride_type)
                 {
                     ResearchItem tmp = {};

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -97,7 +97,7 @@ GameActions::Result RideCreateAction::Query() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_CREATE_NEW_RIDE_ATTRACTION, STR_NONE);
     }
 
-    rct_ride_entry* rideEntry = get_ride_entry(rideEntryIndex);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(rideEntryIndex);
     if (rideEntry == nullptr)
     {
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_CREATE_NEW_RIDE_ATTRACTION, STR_NONE);
@@ -124,7 +124,7 @@ GameActions::Result RideCreateAction::Execute() const
     auto rideIndex = GetNextFreeRideId();
 
     auto ride = GetOrAllocateRide(rideIndex);
-    rideEntry = get_ride_entry(rideEntryIndex);
+    rideEntry = GetRideEntryByIndex(rideEntryIndex);
     if (rideEntry == nullptr)
     {
         LOG_WARNING("Invalid request for ride %u", rideIndex);

--- a/src/openrct2/actions/RideSetPriceAction.cpp
+++ b/src/openrct2/actions/RideSetPriceAction.cpp
@@ -58,7 +58,7 @@ GameActions::Result RideSetPriceAction::Query() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_NONE, STR_NONE);
     }
 
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride->subtype);
     if (rideEntry == nullptr)
     {
         LOG_WARNING("Invalid game command for ride %u", _rideIndex.ToUnderlying());
@@ -80,7 +80,7 @@ GameActions::Result RideSetPriceAction::Execute() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_NONE, STR_NONE);
     }
 
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride->subtype);
     if (rideEntry == nullptr)
     {
         LOG_WARNING("Invalid game command for ride %u", _rideIndex.ToUnderlying());
@@ -150,7 +150,7 @@ void RideSetPriceAction::RideSetCommonPrice(ShopItem shopItem) const
     for (auto& ride : GetRideManager())
     {
         auto invalidate = false;
-        auto rideEntry = get_ride_entry(ride.subtype);
+        auto rideEntry = GetRideEntryByIndex(ride.subtype);
         const auto& rtd = ride.GetRideTypeDescriptor();
         if (rtd.HasFlag(RIDE_TYPE_FLAG_IS_TOILET) && shopItem == ShopItem::Admission)
         {

--- a/src/openrct2/actions/RideSetVehicleAction.cpp
+++ b/src/openrct2/actions/RideSetVehicleAction.cpp
@@ -95,7 +95,7 @@ GameActions::Result RideSetVehicleAction::Query() const
                 LOG_ERROR("Invalid vehicle type. type = %d", _value);
                 return GameActions::Result(GameActions::Status::InvalidParameters, errTitle, STR_NONE);
             }
-            auto rideEntry = get_ride_entry(_value);
+            auto rideEntry = GetRideEntryByIndex(_value);
             if (rideEntry == nullptr)
             {
                 LOG_WARNING("Invalid ride entry, ride->subtype = %d", ride->subtype);
@@ -146,7 +146,7 @@ GameActions::Result RideSetVehicleAction::Execute() const
             ride->vehicle_change_timeout = 100;
 
             InvalidateTestResults(*ride);
-            auto rideEntry = get_ride_entry(ride->subtype);
+            auto rideEntry = GetRideEntryByIndex(ride->subtype);
             if (rideEntry == nullptr)
             {
                 LOG_WARNING("Invalid ride entry, ride->subtype = %d", ride->subtype);
@@ -169,7 +169,7 @@ GameActions::Result RideSetVehicleAction::Execute() const
 
             InvalidateTestResults(*ride);
             ride->subtype = _value;
-            auto rideEntry = get_ride_entry(ride->subtype);
+            auto rideEntry = GetRideEntryByIndex(ride->subtype);
             if (rideEntry == nullptr)
             {
                 LOG_WARNING("Invalid ride entry, ride->subtype = %d", ride->subtype);

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -74,7 +74,7 @@ GameActions::Result TrackPlaceAction::Query() const
         return GameActions::Result(
             GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_NONE);
     }
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride->subtype);
     if (rideEntry == nullptr)
     {
         LOG_WARNING("Invalid ride subtype for track placement, rideIndex = %d", _rideIndex.ToUnderlying());
@@ -417,7 +417,7 @@ GameActions::Result TrackPlaceAction::Execute() const
             GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_CONSTRUCT_THIS_HERE, STR_NONE);
     }
 
-    rct_ride_entry* rideEntry = get_ride_entry(ride->subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride->subtype);
     if (rideEntry == nullptr)
     {
         LOG_WARNING("Invalid ride subtype for track placement, rideIndex = %d", _rideIndex.ToUnderlying());

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2499,7 +2499,7 @@ void Guest::GoToRideEntrance(const Ride& ride)
     int16_t y_shift = DirectionOffsets[location.direction].y;
 
     uint8_t shift_multiplier = 21;
-    rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride.subtype);
     if (rideEntry != nullptr)
     {
         if (rideEntry->Cars[rideEntry->DefaultCar].flags & CAR_ENTRY_FLAG_MINI_GOLF
@@ -3382,7 +3382,7 @@ void Guest::UpdateBuying()
         }
         else
         {
-            rct_ride_entry* ride_type = get_ride_entry(ride->subtype);
+            rct_ride_entry* ride_type = GetRideEntryByIndex(ride->subtype);
             if (ride_type == nullptr)
             {
                 return;
@@ -3785,7 +3785,7 @@ static void peep_go_to_ride_exit(Peep* peep, const Ride& ride, int16_t x, int16_
 
     int16_t shift_multiplier = 20;
 
-    rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride.subtype);
     if (rideEntry != nullptr)
     {
         CarEntry* carEntry = &rideEntry->Cars[rideEntry->DefaultCar];
@@ -4170,7 +4170,7 @@ void Guest::UpdateRideLeaveVehicle()
             uint8_t shiftMultiplier = 12;
             uint8_t specialDirection = platformLocation.direction;
 
-            rideEntry = get_ride_entry(ride->subtype);
+            rideEntry = GetRideEntryByIndex(ride->subtype);
 
             if (rideEntry != nullptr)
             {
@@ -4537,7 +4537,7 @@ void Guest::UpdateRideApproachExitWaypoints()
 
     int16_t shift_multiplier = 20;
 
-    auto rideEntry = get_ride_entry(ride->subtype);
+    auto rideEntry = GetRideEntryByIndex(ride->subtype);
     if (rideEntry != nullptr)
     {
         auto carEntry = &rideEntry->Cars[rideEntry->DefaultCar];

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -1234,7 +1234,7 @@ static int32_t ConsoleCommandLoadObject(InteractiveConsole& console, const argum
             // Automatically research the ride so it's supported by the game.
             rct_ride_entry* rideEntry;
 
-            rideEntry = get_ride_entry(groupIndex);
+            rideEntry = GetRideEntryByIndex(groupIndex);
 
             for (int32_t j = 0; j < RCT2::ObjectLimits::MaxRideTypesPerRideEntry; j++)
             {

--- a/src/openrct2/management/Award.cpp
+++ b/src/openrct2/management/Award.cpp
@@ -297,7 +297,7 @@ static bool award_is_deserved_best_food(int32_t activeAwardTypes)
             continue;
 
         shops++;
-        auto rideEntry = get_ride_entry(ride.subtype);
+        auto rideEntry = GetRideEntryByIndex(ride.subtype);
         if (rideEntry != nullptr)
         {
             if (!(shopTypes & EnumToFlag(rideEntry->shop_item[0])))

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -201,7 +201,7 @@ void research_finish_item(ResearchItem* researchItem)
         // Ride
         auto base_ride_type = researchItem->baseRideType;
         ObjectEntryIndex rideEntryIndex = researchItem->entryIndex;
-        rct_ride_entry* rideEntry = get_ride_entry(rideEntryIndex);
+        rct_ride_entry* rideEntry = GetRideEntryByIndex(rideEntryIndex);
 
         if (rideEntry != nullptr && base_ride_type != RIDE_TYPE_NULL)
         {
@@ -233,7 +233,7 @@ void research_finish_item(ResearchItem* researchItem)
             {
                 if (!seenRideEntry[i])
                 {
-                    rct_ride_entry* rideEntry2 = get_ride_entry(i);
+                    rct_ride_entry* rideEntry2 = GetRideEntryByIndex(i);
                     if (rideEntry2 != nullptr)
                     {
                         for (uint8_t j = 0; j < RCT2::ObjectLimits::MaxRideTypesPerRideEntry; j++)
@@ -474,7 +474,7 @@ void research_populate_list_random()
     // Rides
     for (int32_t i = 0; i < MAX_RIDE_OBJECTS; i++)
     {
-        rct_ride_entry* rideEntry = get_ride_entry(i);
+        rct_ride_entry* rideEntry = GetRideEntryByIndex(i);
         if (rideEntry == nullptr)
         {
             continue;
@@ -519,7 +519,7 @@ bool research_insert_ride_entry(ride_type_t rideType, ObjectEntryIndex entryInde
 
 void research_insert_ride_entry(ObjectEntryIndex entryIndex, bool researched)
 {
-    rct_ride_entry* rideEntry = get_ride_entry(entryIndex);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(entryIndex);
     if (rideEntry == nullptr)
         return;
 
@@ -706,7 +706,7 @@ StringId ResearchItem::GetName() const
 {
     if (type == Research::EntryType::Ride)
     {
-        rct_ride_entry* rideEntry = get_ride_entry(entryIndex);
+        rct_ride_entry* rideEntry = GetRideEntryByIndex(entryIndex);
         if (rideEntry == nullptr)
         {
             return STR_EMPTY;
@@ -747,7 +747,7 @@ static void ResearchRemoveNullItems(std::vector<ResearchItem>& items)
     const auto it = std::remove_if(std::begin(items), std::end(items), [](const ResearchItem& researchItem) {
         if (researchItem.type == Research::EntryType::Ride)
         {
-            return get_ride_entry(researchItem.entryIndex) == nullptr;
+            return GetRideEntryByIndex(researchItem.entryIndex) == nullptr;
         }
         else
         {
@@ -761,7 +761,7 @@ static void research_mark_item_as_researched(const ResearchItem& item)
 {
     if (item.type == Research::EntryType::Ride)
     {
-        const auto* rideEntry = get_ride_entry(item.entryIndex);
+        const auto* rideEntry = GetRideEntryByIndex(item.entryIndex);
         if (rideEntry != nullptr)
         {
             ride_entry_set_invented(item.entryIndex);
@@ -813,7 +813,7 @@ static void ResearchAddAllMissingItems(bool isResearched)
 {
     for (ObjectEntryIndex i = 0; i < MAX_RIDE_OBJECTS; i++)
     {
-        const auto* rideEntry = get_ride_entry(i);
+        const auto* rideEntry = GetRideEntryByIndex(i);
         if (rideEntry != nullptr)
         {
             research_insert_ride_entry(i, isResearched);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -806,7 +806,7 @@ namespace RCT1
                 dst->subtype = _rideTypeToRideEntryMap[EnumValue(src->type)];
             }
 
-            rct_ride_entry* rideEntry = get_ride_entry(dst->subtype);
+            rct_ride_entry* rideEntry = GetRideEntryByIndex(dst->subtype);
             // This can happen with hacked parks
             if (rideEntry == nullptr)
             {
@@ -2230,7 +2230,7 @@ namespace RCT1
 
                 if (entryIndex != OBJECT_ENTRY_INDEX_NULL)
                 {
-                    rct_ride_entry* rideEntry = get_ride_entry(entryIndex);
+                    rct_ride_entry* rideEntry = GetRideEntryByIndex(entryIndex);
 
                     if (rideEntry != nullptr)
                     {
@@ -2249,7 +2249,7 @@ namespace RCT1
 
                 if (entryIndex != OBJECT_ENTRY_INDEX_NULL)
                 {
-                    rct_ride_entry* rideEntry = get_ride_entry(entryIndex);
+                    rct_ride_entry* rideEntry = GetRideEntryByIndex(entryIndex);
 
                     if (rideEntry != nullptr)
                     {

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -847,7 +847,7 @@ ResearchItem RCT12ResearchItem::ToResearchItem() const
         newResearchItem.category = static_cast<ResearchCategory>(category);
         if (newResearchItem.type == Research::EntryType::Ride)
         {
-            auto* rideEntry = get_ride_entry(newResearchItem.entryIndex);
+            auto* rideEntry = GetRideEntryByIndex(newResearchItem.entryIndex);
             newResearchItem.baseRideType = rideEntry != nullptr ? RCT2::RCT2RideTypeToOpenRCT2RideType(baseRideType, *rideEntry)
                                                                 : baseRideType;
         }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -730,7 +730,7 @@ namespace RCT2
                     continue;
 
                 auto subtype = RCTEntryIndexToOpenRCT2EntryIndex(src->subtype);
-                auto* rideEntry = get_ride_entry(subtype);
+                auto* rideEntry = GetRideEntryByIndex(subtype);
                 // If the ride is tracked, we don’t need to check the vehicle any more.
                 if (!GetRideTypeDescriptor(src->type).HasFlag(RIDE_TYPE_FLAG_FLAT_RIDE))
                 {
@@ -766,7 +766,7 @@ namespace RCT2
             auto subtype = RCTEntryIndexToOpenRCT2EntryIndex(src->subtype);
             if (RCT2RideTypeNeedsConversion(src->type))
             {
-                auto* rideEntry = get_ride_entry(subtype);
+                auto* rideEntry = GetRideEntryByIndex(subtype);
                 if (rideEntry != nullptr)
                 {
                     rideType = RCT2RideTypeToOpenRCT2RideType(src->type, *rideEntry);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -196,7 +196,7 @@ Ride* GetRide(RideId index)
     return nullptr;
 }
 
-rct_ride_entry* get_ride_entry(ObjectEntryIndex index)
+rct_ride_entry* GetRideEntryByIndex(ObjectEntryIndex index)
 {
     rct_ride_entry* result = nullptr;
     auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
@@ -228,7 +228,7 @@ std::string_view GetRideEntryName(ObjectEntryIndex index)
 
 rct_ride_entry* Ride::GetRideEntry() const
 {
-    return get_ride_entry(subtype);
+    return GetRideEntryByIndex(subtype);
 }
 
 int32_t RideGetCount()
@@ -2148,7 +2148,7 @@ static bool RideTypeVehicleColourExists(ObjectEntryIndex subType, const VehicleC
 
 int32_t RideGetUnusedPresetVehicleColour(ObjectEntryIndex subType)
 {
-    const auto* rideEntry = get_ride_entry(subType);
+    const auto* rideEntry = GetRideEntryByIndex(subType);
     if (rideEntry == nullptr)
         return 0;
 
@@ -2185,7 +2185,7 @@ int32_t RideGetUnusedPresetVehicleColour(ObjectEntryIndex subType)
  */
 void RideSetVehicleColoursToRandomPreset(Ride& ride, uint8_t preset_index)
 {
-    rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride.subtype);
     vehicle_colour_preset_list* presetList = rideEntry->vehicle_preset_list;
 
     if (presetList->count != 0 && presetList->count != 255)
@@ -4162,7 +4162,7 @@ void Ride::SetColourPreset(uint8_t index)
     // Stalls save their default colour in the vehicle settings (since they share a common ride type)
     if (!IsRide())
     {
-        auto rideEntry = get_ride_entry(subtype);
+        auto rideEntry = GetRideEntryByIndex(subtype);
         if (rideEntry != nullptr && rideEntry->vehicle_preset_list->count > 0)
         {
             auto list = rideEntry->vehicle_preset_list->list[0];
@@ -4582,7 +4582,7 @@ void RideUpdateVehicleColours(const Ride& ride)
 
 uint8_t RideEntryGetVehicleAtPosition(int32_t rideEntryIndex, int32_t numCarsPerTrain, int32_t position)
 {
-    rct_ride_entry* rideEntry = get_ride_entry(rideEntryIndex);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(rideEntryIndex);
     if (position == 0 && rideEntry->FrontCar != 255)
     {
         return rideEntry->FrontCar;
@@ -4877,7 +4877,7 @@ void Ride::UpdateMaxVehicles()
     if (subtype == OBJECT_ENTRY_INDEX_NULL)
         return;
 
-    rct_ride_entry* rideEntry = get_ride_entry(subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(subtype);
     if (rideEntry == nullptr)
     {
         return;
@@ -5344,7 +5344,7 @@ int32_t RideGetEntryIndex(int32_t rideType, int32_t rideSubType)
             subType = rideEntries[0];
             for (auto rideEntryIndex : rideEntries)
             {
-                auto rideEntry = get_ride_entry(rideEntryIndex);
+                auto rideEntry = GetRideEntryByIndex(rideEntryIndex);
                 if (rideEntry == nullptr)
                 {
                     return OBJECT_ENTRY_INDEX_NULL;
@@ -5760,7 +5760,7 @@ ResultWithMessage Ride::ChangeStatusCheckTrackValidity(const CoordsXYE& trackEle
 
     if (subtype != OBJECT_ENTRY_INDEX_NULL && !gCheatsEnableAllDrawableTrackPieces)
     {
-        rct_ride_entry* rideEntry = get_ride_entry(subtype);
+        rct_ride_entry* rideEntry = GetRideEntryByIndex(subtype);
         if (rideEntry->flags & RIDE_ENTRY_FLAG_NO_INVERSIONS)
         {
             if (ride_check_track_contains_inversions(trackElement, &problematicTrackElement))

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -1002,7 +1002,7 @@ struct RideManager
 RideManager GetRideManager();
 RideId GetNextFreeRideId();
 Ride* GetOrAllocateRide(RideId index);
-rct_ride_entry* get_ride_entry(ObjectEntryIndex index);
+rct_ride_entry* GetRideEntryByIndex(ObjectEntryIndex index);
 std::string_view GetRideEntryName(ObjectEntryIndex index);
 
 extern money16 gTotalRideValueForMoney;

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -976,7 +976,7 @@ static uint16_t ride_compute_upkeep(RideRatingUpdateState& state, const Ride& ri
  */
 static void ride_ratings_apply_adjustments(const Ride& ride, RatingTuple* ratings)
 {
-    rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride.subtype);
 
     if (rideEntry == nullptr)
     {
@@ -1135,7 +1135,7 @@ static ShelteredEights get_num_of_sheltered_eighths(const Ride& ride)
     }
 
     uint8_t trackShelteredEighths = numShelteredEighths;
-    rct_ride_entry* rideType = get_ride_entry(ride.subtype);
+    rct_ride_entry* rideType = GetRideEntryByIndex(ride.subtype);
     if (rideType == nullptr)
     {
         return { 0, 0 };

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -9121,7 +9121,7 @@ int32_t Vehicle::UpdateTrackMotion(int32_t* outStation)
 
 rct_ride_entry* Vehicle::GetRideEntry() const
 {
-    return get_ride_entry(ride_subtype);
+    return GetRideEntryByIndex(ride_subtype);
 }
 
 CarEntry* Vehicle::Entry() const

--- a/src/openrct2/ride/coaster/ClassicWoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ClassicWoodenRollerCoaster.cpp
@@ -250,8 +250,8 @@ static void classic_wooden_rc_track_flat_to_left_bank(
             { SPR_CLASSIC_WOODEN_RC_FLAT_TO_LEFT_BANK_FRONT_SE_NW, 0, { 0, 0, 0 }, { 26, 0, 5 }, { 1, 32, 9 } },
         } }
     };
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -283,8 +283,8 @@ static void classic_wooden_rc_track_flat_to_right_bank(
             },
         }
     };
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -330,7 +330,7 @@ static void classic_wooden_rc_track_left_bank(
             },
         }
     };
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -369,8 +369,8 @@ static void classic_wooden_rc_track_left_bank_to_25_deg_up(
             },
         }
     };
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     WoodenASupportsPaintSetup(session, direction & 1, 1 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
     if (direction == 0 || direction == 3)
     {
@@ -410,8 +410,8 @@ static void classic_wooden_rc_track_right_bank_to_25_deg_up(
         }
     };
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     WoodenASupportsPaintSetup(session, direction & 1, 1 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
     if (direction == 0 || direction == 3)
     {
@@ -451,8 +451,8 @@ static void classic_wooden_rc_track_25_deg_up_to_left_bank(
         }
     };
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     WoodenASupportsPaintSetup(session, direction & 1, 5 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
     if (direction == 0 || direction == 3)
     {
@@ -492,8 +492,8 @@ static void classic_wooden_rc_track_25_deg_up_to_right_bank(
         }
     };
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     WoodenASupportsPaintSetup(session, direction & 1, 5 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
     if (direction == 0 || direction == 3)
     {
@@ -690,8 +690,8 @@ static void classic_wooden_rc_track_banked_right_quarter_turn_5(
         SEGMENT_B4 | SEGMENT_B8 | SEGMENT_BC | SEGMENT_C0 | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4,
     };
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     track_paint_util_right_quarter_turn_5_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_SQUARE_FLAT);
 
     if (supportType[direction][trackSequence] != -1)
@@ -809,8 +809,8 @@ static void classic_wooden_rc_track_right_quarter_turn_3_bank(
         SEGMENT_B4 | SEGMENT_B8 | SEGMENT_BC | SEGMENT_C4 | SEGMENT_C8 | SEGMENT_CC | SEGMENT_D0 | SEGMENT_D4,
     };
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     track_paint_util_right_quarter_turn_3_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_SQUARE_FLAT);
 
     if (supportType[direction][trackSequence] != -1)
@@ -955,8 +955,8 @@ static void classic_wooden_rc_track_left_eighth_bank_to_diag(
         WoodenASupportsPaintSetup(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
 
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments[trackSequence], direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -1094,8 +1094,8 @@ static void classic_wooden_rc_track_right_eighth_bank_to_diag(
         WoodenASupportsPaintSetup(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
 
     PaintUtilSetSegmentSupportHeight(session, PaintUtilRotateSegments(blockedSegments[trackSequence], direction), 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -1209,8 +1209,8 @@ static void classic_wooden_rc_track_diag_flat_to_left_bank(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -1307,8 +1307,8 @@ static void classic_wooden_rc_track_diag_flat_to_right_bank(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -1420,8 +1420,8 @@ static void classic_wooden_rc_track_diag_left_bank(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
@@ -1525,8 +1525,8 @@ static void classic_wooden_rc_track_diag_left_bank_to_25_deg_up(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -1623,8 +1623,8 @@ static void classic_wooden_rc_track_diag_right_bank_to_25_deg_up(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -1721,8 +1721,8 @@ static void classic_wooden_rc_track_diag_25_deg_up_to_left_bank(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -1819,8 +1819,8 @@ static void classic_wooden_rc_track_diag_25_deg_up_to_right_bank(
             session, supportType[direction][trackSequence], 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     }
 
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][0], height);
-    wooden_rc_track_paint_bb<true>(session, &imageIds[direction][trackSequence][1], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][0], height);
+    WoodenRcTrackPaintBb<true>(session, &imageIds[direction][trackSequence][1], height);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
@@ -1864,7 +1864,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_classic_wooden_rc(int32_t trackTyp
 {
     if (!IsCsgLoaded())
     {
-        return get_track_paint_function_classic_wooden_rc_fallback(trackType);
+        return GetTrackPaintFunctionClassicWoodenRcFallback(trackType);
     }
 
     switch (trackType)
@@ -1943,5 +1943,5 @@ TRACK_PAINT_FUNCTION get_track_paint_function_classic_wooden_rc(int32_t trackTyp
             return classic_wooden_rc_track_diag_right_bank;
     }
 
-    return get_track_paint_function_classic_wooden_rc_fallback(trackType);
+    return GetTrackPaintFunctionClassicWoodenRcFallback(trackType);
 }

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.cpp
@@ -1812,7 +1812,7 @@ static constexpr const uint32_t junior_rc_track_pieces_diag_60_deg_down_to_25_de
     },
 };
 
-void junior_rc_paint_track_flat(
+void JuniorRcPaintTrackFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -1832,7 +1832,7 @@ void junior_rc_paint_track_flat(
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
 
-void junior_rc_paint_station(
+void JuniorRcPaintStation(
     PaintSession& session, const Ride& ride, [[maybe_unused]] uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, bool drawBlockBrake)
 {
@@ -1890,7 +1890,7 @@ void junior_rc_paint_station(
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
 
-void junior_rc_paint_track_25_deg_up(
+void JuniorRcPaintTrack25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -1913,7 +1913,7 @@ void junior_rc_paint_track_25_deg_up(
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
 
-void junior_rc_paint_track_flat_to_25_deg_up(
+void JuniorRcPaintTrackFlatTo25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -1942,7 +1942,7 @@ void junior_rc_paint_track_flat_to_25_deg_up(
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
 
-void junior_rc_paint_track_25_deg_up_to_flat(
+void JuniorRcPaintTrack25DegUpToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -2692,7 +2692,7 @@ static void junior_rc_right_bank_paint_setup(
     junior_rc_left_bank_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
-void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
+void JuniorRcPaintTrackLeftQuarterTurn5Tiles25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -2770,7 +2770,7 @@ void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
     }
 }
 
-void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
+void JuniorRcPaintTrackRightQuarterTurn5Tiles25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -2854,7 +2854,7 @@ static void junior_rc_left_quarter_turn_5_tiles_25_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
+    JuniorRcPaintTrackLeftQuarterTurn5Tiles25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -2865,7 +2865,7 @@ static void junior_rc_right_quarter_turn_5_tiles_25_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
+    JuniorRcPaintTrackRightQuarterTurn5Tiles25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -3245,7 +3245,7 @@ static void junior_rc_right_quarter_turn_3_tiles_bank_paint_setup(
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
 
-void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
+void juniorRcPaintTrackRightQuarterTurn3Tiles25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -3326,7 +3326,7 @@ void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
         PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
 
-void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
+void JuniorRcPaintTrackRightQuarterTurn3Tiles25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -3423,7 +3423,7 @@ static void junior_rc_right_quarter_turn_3_tiles_25_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
+    juniorRcPaintTrackRightQuarterTurn3Tiles25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -3434,7 +3434,7 @@ static void junior_rc_right_quarter_turn_3_tiles_25_deg_down_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
+    JuniorRcPaintTrackRightQuarterTurn3Tiles25DegDown(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4368,7 +4368,7 @@ static constexpr const uint8_t junior_rc_diag_support_segment[] = {
     3,
 };
 
-void junior_rc_paint_track_diag_flat(
+void JuniorRcPaintTrackDiagFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4388,7 +4388,7 @@ void junior_rc_paint_track_diag_flat(
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
 }
 
-void junior_rc_paint_track_diag_25_deg_up(
+void JuniorRcPaintTrackDiag25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4408,7 +4408,7 @@ void junior_rc_paint_track_diag_25_deg_up(
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
 
-void junior_rc_paint_track_diag_flat_to_25_deg_up(
+void JuniorRcPaintTrackDiagFlatTo25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4429,7 +4429,7 @@ void junior_rc_paint_track_diag_flat_to_25_deg_up(
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
 
-void junior_rc_paint_track_diag_flat_to_60_deg_up(
+void JuniorRcPaintTrackDiagFlatTo60DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4453,7 +4453,7 @@ void junior_rc_paint_track_diag_flat_to_60_deg_up(
     PaintUtilSetGeneralSupportHeight(session, height + 64, 0x20);
 }
 
-void junior_rc_paint_track_diag_25_deg_up_to_flat(
+void JuniorRcPaintTrackDiag25DegUpToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4474,7 +4474,7 @@ void junior_rc_paint_track_diag_25_deg_up_to_flat(
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
 
-void junior_rc_paint_track_diag_60_deg_up_to_flat(
+void JuniorRcPaintTrackDiag60DegUpToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4498,7 +4498,7 @@ void junior_rc_paint_track_diag_60_deg_up_to_flat(
     PaintUtilSetGeneralSupportHeight(session, height + 64, 0x20);
 }
 
-void junior_rc_paint_track_diag_25_deg_down(
+void JuniorRcPaintTrackDiag25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4519,7 +4519,7 @@ void junior_rc_paint_track_diag_25_deg_down(
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
 
-void junior_rc_paint_track_diag_flat_to_25_deg_down(
+void JuniorRcPaintTrackDiagFlatTo25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4540,7 +4540,7 @@ void junior_rc_paint_track_diag_flat_to_25_deg_down(
     PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
 }
 
-void junior_rc_paint_track_diag_flat_to_60_deg_down(
+void JuniorRcPaintTrackDiagFlatTo60DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4564,7 +4564,7 @@ void junior_rc_paint_track_diag_flat_to_60_deg_down(
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
 
-void junior_rc_paint_track_diag_25_deg_down_to_flat(
+void JuniorRcPaintTrackDiag25DegDownToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4585,7 +4585,7 @@ void junior_rc_paint_track_diag_25_deg_down_to_flat(
     PaintUtilSetGeneralSupportHeight(session, height + 48, 0x20);
 }
 
-void junior_rc_paint_track_diag_60_deg_down_to_flat(
+void JuniorRcPaintTrackDiag60DegDownToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -4615,7 +4615,7 @@ static void junior_rc_diag_flat_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_flat(
+    JuniorRcPaintTrackDiagFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4626,7 +4626,7 @@ static void junior_rc_diag_25_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_25_deg_up(
+    JuniorRcPaintTrackDiag25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4637,7 +4637,7 @@ static void junior_rc_diag_flat_to_25_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_flat_to_25_deg_up(
+    JuniorRcPaintTrackDiagFlatTo25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4647,7 +4647,7 @@ static void junior_rc_diag_flat_to_60_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_flat_to_60_deg_up(
+    JuniorRcPaintTrackDiagFlatTo60DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4658,7 +4658,7 @@ static void junior_rc_diag_25_deg_up_to_flat_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_25_deg_up_to_flat(
+    JuniorRcPaintTrackDiag25DegUpToFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4668,7 +4668,7 @@ static void junior_rc_diag_60_deg_up_to_flat_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_60_deg_up_to_flat(
+    JuniorRcPaintTrackDiag60DegUpToFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4679,7 +4679,7 @@ static void junior_rc_diag_25_deg_down_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_25_deg_down(
+    JuniorRcPaintTrackDiag25DegDown(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4690,7 +4690,7 @@ static void junior_rc_diag_flat_to_25_deg_down_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_flat_to_25_deg_down(
+    JuniorRcPaintTrackDiagFlatTo25DegDown(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4700,7 +4700,7 @@ static void junior_rc_diag_flat_to_60_deg_down_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_flat_to_60_deg_down(
+    JuniorRcPaintTrackDiagFlatTo60DegDown(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4711,7 +4711,7 @@ static void junior_rc_diag_25_deg_down_to_flat_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_25_deg_down_to_flat(
+    JuniorRcPaintTrackDiag25DegDownToFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -4721,7 +4721,7 @@ static void junior_rc_diag_60_deg_down_to_flat_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_60_deg_down_to_flat(
+    JuniorRcPaintTrackDiag60DegDownToFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5138,7 +5138,7 @@ static constexpr const CoordsXY junior_rc_60_deg_up_bound_lengths[4] = {
     { 20, 32 },
 };
 
-void junior_rc_paint_track_60_deg_up(
+void JuniorRcPaintTrack60DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -5184,7 +5184,7 @@ static void junior_rc_60_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_60_deg_up(
+    JuniorRcPaintTrack60DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5217,7 +5217,7 @@ static constexpr const CoordsXY junior_rc_25_deg_up_to_60_deg_up_bound_offsets[4
     { { 6, 0 }, { 0, 0 } },
 };
 
-void junior_rc_paint_track_25_deg_up_to_60_deg_up(
+void JuniorRcPaintTrack25DegUpTo60DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -5276,7 +5276,7 @@ static void junior_rc_25_deg_up_to_60_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_25_deg_up_to_60_deg_up(
+    JuniorRcPaintTrack25DegUpTo60DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5288,7 +5288,7 @@ static void junior_rc_60_deg_down_to_25_deg_down_paint_setup(
     junior_rc_25_deg_up_to_60_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
-void junior_rc_paint_track_60_deg_up_to_25_deg_up(
+void JuniorRcPaintTrack60DegUpTo25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -5346,7 +5346,7 @@ static void junior_rc_60_deg_up_to_25_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_60_deg_up_to_25_deg_up(
+    JuniorRcPaintTrack60DegUpTo25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5358,7 +5358,7 @@ static void junior_rc_25_deg_down_to_60_deg_down_paint_setup(
     junior_rc_60_deg_up_to_25_deg_up_paint_setup(session, ride, trackSequence, (direction + 2) % 4, height, trackElement);
 }
 
-void junior_rc_paint_track_diag_60_deg_up(
+void JuniorRcPaintTrackDiag60DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -5378,7 +5378,7 @@ void junior_rc_paint_track_diag_60_deg_up(
     PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
 }
 
-void junior_rc_paint_track_diag_60_deg_down(
+void JuniorRcPaintTrackDiag60DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -5399,7 +5399,7 @@ void junior_rc_paint_track_diag_60_deg_down(
     PaintUtilSetGeneralSupportHeight(session, height + 104, 0x20);
 }
 
-void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
+void JuniorRcPaintTrackDiag25DegUpTo60DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -5420,7 +5420,7 @@ void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
     PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
 }
 
-void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
+void JuniorRcPaintTrackDiag60DegUpTo25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -5452,7 +5452,7 @@ void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
     PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
 }
 
-void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
+void JuniorRcPaintTrackDiag25DegDownTo60DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -5484,7 +5484,7 @@ void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
     PaintUtilSetGeneralSupportHeight(session, height + 72, 0x20);
 }
 
-void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
+void JuniorRcPaintTrackDiag60DegDownTo25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType)
 {
@@ -5510,7 +5510,7 @@ static void junior_rc_diag_60_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_60_deg_up(
+    JuniorRcPaintTrackDiag60DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5520,7 +5520,7 @@ static void junior_rc_diag_60_deg_down_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_60_deg_down(
+    JuniorRcPaintTrackDiag60DegDown(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5530,7 +5530,7 @@ static void junior_rc_diag_25_deg_up_to_60_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
+    JuniorRcPaintTrackDiag25DegUpTo60DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5540,7 +5540,7 @@ static void junior_rc_diag_60_deg_up_to_25_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
+    JuniorRcPaintTrackDiag60DegUpTo25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5550,7 +5550,7 @@ static void junior_rc_diag_25_deg_down_to_60_deg_down_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
+    JuniorRcPaintTrackDiag25DegDownTo60DegDown(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5560,7 +5560,7 @@ static void junior_rc_diag_60_deg_down_to_25_deg_down_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
+    JuniorRcPaintTrackDiag60DegDownTo25DegDown(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5729,7 +5729,7 @@ static void junior_rc_flat_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_flat(
+    JuniorRcPaintTrackFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5739,7 +5739,7 @@ static void paint_junior_rc_station_track(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_station(session, ride, trackSequence, direction, height, trackElement, true);
+    JuniorRcPaintStation(session, ride, trackSequence, direction, height, trackElement, true);
 }
 
 /* rct2: 0x0051881E */
@@ -5748,7 +5748,7 @@ static void junior_rc_25_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_25_deg_up(
+    JuniorRcPaintTrack25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5759,7 +5759,7 @@ static void junior_rc_flat_to_25_deg_up_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_flat_to_25_deg_up(
+    JuniorRcPaintTrackFlatTo25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }
@@ -5770,7 +5770,7 @@ static void junior_rc_25_deg_up_to_flat_paint_setup(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_25_deg_up_to_flat(
+    JuniorRcPaintTrack25DegUpToFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::FrictionWheels : JuniorRcChainType::None);
 }

--- a/src/openrct2/ride/coaster/JuniorRollerCoaster.h
+++ b/src/openrct2/ride/coaster/JuniorRollerCoaster.h
@@ -22,94 +22,94 @@ struct Ride;
 struct PaintSession;
 struct TrackElement;
 
-void junior_rc_paint_station(
+void JuniorRcPaintStation(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, bool drawBlockBrake);
 
-void junior_rc_paint_track_flat(
+void JuniorRcPaintTrackFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_25_deg_up(
+void JuniorRcPaintTrack25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_60_deg_up(
+void JuniorRcPaintTrack60DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_flat_to_25_deg_up(
+void JuniorRcPaintTrackFlatTo25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_25_deg_up_to_60_deg_up(
+void JuniorRcPaintTrack25DegUpTo60DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_60_deg_up_to_25_deg_up(
+void JuniorRcPaintTrack60DegUpTo25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_25_deg_up_to_flat(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
-    const TrackElement& trackElement, JuniorRcChainType chainType);
-
-void junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
-    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
-    const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
+void JuniorRcPaintTrack25DegUpToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 
-void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
+void JuniorRcPaintTrackLeftQuarterTurn5Tiles25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
+void JuniorRcPaintTrackRightQuarterTurn5Tiles25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
 
-void junior_rc_paint_track_diag_flat(
+void juniorRcPaintTrackRightQuarterTurn3Tiles25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_25_deg_up(
+void JuniorRcPaintTrackRightQuarterTurn3Tiles25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_60_deg_up(
+
+void JuniorRcPaintTrackDiagFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_flat_to_25_deg_up(
+void JuniorRcPaintTrackDiag25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_flat_to_60_deg_up(
+void JuniorRcPaintTrackDiag60DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
+void JuniorRcPaintTrackDiagFlatTo25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
+void JuniorRcPaintTrackDiagFlatTo60DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_25_deg_up_to_flat(
+void JuniorRcPaintTrackDiag25DegUpTo60DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_60_deg_up_to_flat(
+void JuniorRcPaintTrackDiag60DegUpTo25DegUp(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_25_deg_down(
+void JuniorRcPaintTrackDiag25DegUpToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_60_deg_down(
+void JuniorRcPaintTrackDiag60DegUpToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_flat_to_25_deg_down(
+void JuniorRcPaintTrackDiag25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_flat_to_60_deg_down(
+void JuniorRcPaintTrackDiag60DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
+void JuniorRcPaintTrackDiagFlatTo25DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
+void JuniorRcPaintTrackDiagFlatTo60DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_25_deg_down_to_flat(
+void JuniorRcPaintTrackDiag25DegDownTo60DegDown(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);
-void junior_rc_paint_track_diag_60_deg_down_to_flat(
+void JuniorRcPaintTrackDiag60DegDownTo25DegDown(
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    const TrackElement& trackElement, JuniorRcChainType chainType);
+void JuniorRcPaintTrackDiag25DegDownToFlat(
+    PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
+    const TrackElement& trackElement, JuniorRcChainType chainType);
+void JuniorRcPaintTrackDiag60DegDownToFlat(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, uint16_t height,
     const TrackElement& trackElement, JuniorRcChainType chainType);

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -2298,8 +2298,8 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23781), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24647), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24647), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2307,14 +2307,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23786), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24652), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24652), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23812), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24678), { 0, 0, height },
-                        { 32, 27, 0 }, { 0, 2, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24678), { 0, 0, height }, { 32, 27, 0 },
+                        { 0, 2, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2322,8 +2322,8 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23791), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24657), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24657), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2331,8 +2331,8 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23796), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24662), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24662), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2356,8 +2356,8 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23782), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24648), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24648), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2365,14 +2365,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23787), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24653), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24653), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23813), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24679), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24679), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2380,8 +2380,8 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23792), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24658), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24658), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2389,14 +2389,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23797), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24663), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24663), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23819), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24685), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24685), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2414,8 +2414,8 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23783), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24649), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24649), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2423,14 +2423,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23788), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24654), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24654), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23814), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24680), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 59 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24680), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 59 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2438,8 +2438,8 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23793), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24659), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24659), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2447,14 +2447,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23798), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24664), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24664), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23820), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24686), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 59 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24686), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 59 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2479,8 +2479,8 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23784), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24650), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24650), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2488,14 +2488,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23789), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24655), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24655), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23815), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24681), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24681), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2503,14 +2503,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23794), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24660), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24660), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23817), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24683), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24683), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2518,14 +2518,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23799), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24665), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24665), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23821), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24687), { 0, 0, height },
-                        { 16, 32, 0 }, { 16, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24687), { 0, 0, height }, { 16, 32, 0 },
+                        { 16, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2543,8 +2543,8 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23785), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24651), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24651), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2552,14 +2552,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23790), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24656), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24656), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23816), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24682), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24682), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2567,14 +2567,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23795), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24661), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24661), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23818), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24684), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24684), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2582,14 +2582,14 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23800), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24666), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24666), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23822), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24688), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24688), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2624,8 +2624,8 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23761), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24627), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24627), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2633,8 +2633,8 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23766), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24632), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24632), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2642,14 +2642,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23771), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24637), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24637), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23807), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24673), { 0, 0, height },
-                        { 32, 27, 0 }, { 0, 2, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24673), { 0, 0, height }, { 32, 27, 0 },
+                        { 0, 2, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2657,8 +2657,8 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23776), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24642), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24642), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2682,14 +2682,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23762), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24628), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24628), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23801), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24667), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24667), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2697,8 +2697,8 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23767), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24633), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24633), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2706,14 +2706,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23772), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24638), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24638), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23808), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24674), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24674), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2721,8 +2721,8 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23777), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24643), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24643), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2740,14 +2740,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23763), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24629), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24629), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23802), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24668), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 59 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24668), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 59 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2755,8 +2755,8 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23768), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24634), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24634), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2764,14 +2764,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23773), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24639), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24639), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23809), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24675), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 59 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24675), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 59 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2779,8 +2779,8 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23778), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24644), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24644), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2805,14 +2805,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23764), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24630), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24630), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23803), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24669), { 0, 0, height },
-                        { 16, 32, 0 }, { 16, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24669), { 0, 0, height }, { 16, 32, 0 },
+                        { 16, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2820,14 +2820,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23769), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24635), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24635), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23805), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24671), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24671), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2835,14 +2835,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23774), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24640), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24640), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23810), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24676), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24676), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2850,8 +2850,8 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23779), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24645), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24645), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2869,14 +2869,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23765), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24631), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24631), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23804), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24670), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24670), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2884,14 +2884,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23770), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24636), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24636), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23806), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24672), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24672), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2899,14 +2899,14 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23775), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24641), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24641), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23811), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24677), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24677), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2914,8 +2914,8 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23780), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24646), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24646), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2972,8 +2972,8 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23725), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24591), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24591), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2981,14 +2981,14 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23729), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24595), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24595), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23741), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24607), { 0, 0, height },
-                        { 32, 25, 0 }, { 0, 3, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24607), { 0, 0, height }, { 32, 25, 0 },
+                        { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2996,8 +2996,8 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23728), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24594), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24594), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3005,14 +3005,14 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23732), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24598), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24598), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23744), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24610), { 0, 0, height },
-                        { 32, 27, 0 }, { 0, 2, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24610), { 0, 0, height }, { 32, 27, 0 },
+                        { 0, 2, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3031,8 +3031,8 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23726), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24592), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24592), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3040,14 +3040,14 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23730), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24596), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24596), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23742), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24608), { 0, 0, height },
-                        { 32, 26, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24608), { 0, 0, height }, { 32, 26, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3055,8 +3055,8 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23727), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24593), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24593), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3064,14 +3064,14 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23731), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24597), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24597), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23743), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24609), { 0, 0, height },
-                        { 32, 26, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24609), { 0, 0, height }, { 32, 26, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3089,8 +3089,8 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23727), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24593), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24593), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3098,14 +3098,14 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23731), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24597), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24597), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23743), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24609), { 0, 0, height },
-                        { 32, 26, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24609), { 0, 0, height }, { 32, 26, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3113,8 +3113,8 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23726), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24592), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24592), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3122,14 +3122,14 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23730), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24596), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24596), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23742), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24608), { 0, 0, height },
-                        { 32, 26, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24608), { 0, 0, height }, { 32, 26, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3147,8 +3147,8 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23728), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24594), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24594), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3156,14 +3156,14 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23732), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24598), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24598), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23744), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24610), { 0, 0, height },
-                        { 32, 27, 0 }, { 0, 2, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24610), { 0, 0, height }, { 32, 27, 0 },
+                        { 0, 2, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3171,8 +3171,8 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23725), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24591), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24591), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3180,14 +3180,14 @@ static void wooden_rc_track_s_bend_left(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23729), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24595), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24595), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23741), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24607), { 0, 0, height },
-                        { 32, 25, 0 }, { 0, 3, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24607), { 0, 0, height }, { 32, 25, 0 },
+                        { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3222,14 +3222,14 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23733), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24599), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24599), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23745), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24611), { 0, 0, height },
-                        { 32, 25, 0 }, { 0, 3, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24611), { 0, 0, height }, { 32, 25, 0 },
+                        { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3237,8 +3237,8 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23737), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24603), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24603), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3246,14 +3246,14 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23736), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24602), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24602), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23748), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24614), { 0, 0, height },
-                        { 32, 25, 0 }, { 0, 3, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24614), { 0, 0, height }, { 32, 25, 0 },
+                        { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3261,8 +3261,8 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23740), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24606), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24606), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3281,14 +3281,14 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23734), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24600), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24600), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23746), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24612), { 0, 0, height },
-                        { 32, 26, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24612), { 0, 0, height }, { 32, 26, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3296,8 +3296,8 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23738), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24604), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24604), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3305,14 +3305,14 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23735), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24601), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24601), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23747), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24613), { 0, 0, height },
-                        { 32, 26, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24613), { 0, 0, height }, { 32, 26, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3320,8 +3320,8 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23739), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24605), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24605), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3339,14 +3339,14 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23735), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24601), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24601), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23747), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24613), { 0, 0, height },
-                        { 32, 26, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24613), { 0, 0, height }, { 32, 26, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3354,8 +3354,8 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23739), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24605), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24605), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3363,14 +3363,14 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23734), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24600), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24600), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23746), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24612), { 0, 0, height },
-                        { 32, 26, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24612), { 0, 0, height }, { 32, 26, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3378,8 +3378,8 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23738), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24604), { 0, 0, height },
-                        { 32, 26, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24604), { 0, 0, height }, { 32, 26, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3397,14 +3397,14 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23736), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24602), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24602), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23748), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24614), { 0, 0, height },
-                        { 32, 25, 0 }, { 0, 3, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24614), { 0, 0, height }, { 32, 25, 0 },
+                        { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3412,8 +3412,8 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23740), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24606), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24606), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3421,14 +3421,14 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23733), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24599), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24599), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23745), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24611), { 0, 0, height },
-                        { 32, 25, 0 }, { 0, 3, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24611), { 0, 0, height }, { 32, 25, 0 },
+                        { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3436,8 +3436,8 @@ static void wooden_rc_track_s_bend_right(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23737), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24603), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24603), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3469,23 +3469,19 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23453), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23453), { 0, 6, height }, { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23461), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23461), { 0, 6, height }, { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23460), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23460), { 0, 6, height }, { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23468), { 0, 6, height },
-                        { 32, 20, 7 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23468), { 0, 6, height }, { 32, 20, 7 });
                     break;
             }
             MetalASupportsPaintSetup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3504,29 +3500,25 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23454), { 0, 0, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23454), { 0, 0, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23462), { 0, 14, height },
-                        { 32, 2, 63 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23462), { 0, 14, height }, { 32, 2, 63 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23459), { 0, 6, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23459), { 0, 6, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23467), { 0, 6, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23467), { 0, 6, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3542,23 +3534,19 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23455), { 16, 0, height },
-                        { 5, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23455), { 16, 0, height }, { 5, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23463), { 12, 0, height },
-                        { 3, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23463), { 12, 0, height }, { 3, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23458), { 10, 16, height },
-                        { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23458), { 10, 16, height }, { 4, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23466), { 16, 16, height },
-                        { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23466), { 16, 16, height }, { 4, 16, 119 });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3636,23 +3624,19 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23458), { 10, 16, height },
-                        { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23458), { 10, 16, height }, { 4, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23466), { 16, 16, height },
-                        { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23466), { 16, 16, height }, { 4, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23455), { 16, 0, height },
-                        { 5, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23455), { 16, 0, height }, { 5, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23463), { 12, 0, height },
-                        { 3, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23463), { 12, 0, height }, { 3, 16, 119 });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3664,29 +3648,25 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23459), { 0, 6, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23459), { 0, 6, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23467), { 0, 6, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23467), { 0, 6, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23454), { 0, 0, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23454), { 0, 0, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23462), { 0, 14, height },
-                        { 32, 2, 63 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23462), { 0, 14, height }, { 32, 2, 63 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3702,23 +3682,19 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23460), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23460), { 0, 6, height }, { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23468), { 0, 6, height },
-                        { 32, 20, 7 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23468), { 0, 6, height }, { 32, 20, 7 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23453), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23453), { 0, 6, height }, { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23461), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23461), { 0, 6, height }, { 32, 20, 3 });
                     break;
             }
             MetalASupportsPaintSetup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3753,23 +3729,19 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23484), { 0, 6, height },
-                        { 32, 20, 7 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23484), { 0, 6, height }, { 32, 20, 7 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23476), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23476), { 0, 6, height }, { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23477), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23477), { 0, 6, height }, { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23469), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23469), { 0, 6, height }, { 32, 20, 3 });
                     break;
             }
             MetalASupportsPaintSetup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3784,29 +3756,25 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23483), { 0, 6, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23483), { 0, 6, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23475), { 0, 6, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23475), { 0, 6, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23478), { 0, 14, height },
-                        { 32, 2, 63 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23478), { 0, 14, height }, { 32, 2, 63 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23470), { 0, 0, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23470), { 0, 0, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3818,23 +3786,19 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23482), { 16, 16, height },
-                        { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23482), { 16, 16, height }, { 4, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23474), { 10, 16, height },
-                        { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23474), { 10, 16, height }, { 4, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23479), { 12, 0, height },
-                        { 3, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23479), { 12, 0, height }, { 3, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23471), { 16, 0, height },
-                        { 5, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23471), { 16, 0, height }, { 5, 16, 119 });
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 168, 0x20);
@@ -3902,23 +3866,19 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23479), { 12, 0, height },
-                        { 3, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23479), { 12, 0, height }, { 3, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23471), { 16, 0, height },
-                        { 5, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23471), { 16, 0, height }, { 5, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23482), { 16, 16, height },
-                        { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23482), { 16, 16, height }, { 4, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23474), { 10, 16, height },
-                        { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23474), { 10, 16, height }, { 4, 16, 119 });
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 168, 0x20);
@@ -3928,29 +3888,25 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23478), { 0, 14, height },
-                        { 32, 2, 63 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23478), { 0, 14, height }, { 32, 2, 63 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23470), { 0, 0, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23470), { 0, 0, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23483), { 0, 6, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23483), { 0, 6, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23475), { 0, 6, height },
-                        { 32, 26, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23475), { 0, 6, height }, { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3962,23 +3918,19 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23477), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23477), { 0, 6, height }, { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23469), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23469), { 0, 6, height }, { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23484), { 0, 6, height },
-                        { 32, 20, 7 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23484), { 0, 6, height }, { 32, 20, 7 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23476), { 0, 6, height },
-                        { 32, 20, 3 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23476), { 0, 6, height }, { 32, 20, 3 });
                     break;
             }
             MetalASupportsPaintSetup(session, METAL_SUPPORTS_BOXED, 4, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -4014,8 +3966,8 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23828), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24694), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24694), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4023,14 +3975,14 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23831), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24697), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24697), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23840), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24706), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24706), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4038,8 +3990,8 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23834), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24700), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24700), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4047,14 +3999,14 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23825), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24691), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24691), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23837), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24703), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24703), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4076,44 +4028,44 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23827), { 16, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24693), { 16, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24693), { 16, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23830), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24696), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24696), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23839), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24705), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24705), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23833), { 0, 16, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24699), { 0, 16, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24699), { 0, 16, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23824), { 16, 16, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24690), { 16, 16, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24690), { 16, 16, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23836), { 16, 16, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24702), { 16, 16, height },
-                        { 16, 16, 0 }, { 16, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24702), { 16, 16, height }, { 16, 16, 0 },
+                        { 16, 16, height + 27 });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -4128,8 +4080,8 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23826), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24692), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24692), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4137,14 +4089,14 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23829), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24695), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24695), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23838), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24704), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24704), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4152,8 +4104,8 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23832), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24698), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24698), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4161,14 +4113,14 @@ static void wooden_rc_track_left_quarter_turn_3(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23823), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24689), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24689), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23835), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24701), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24701), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4214,8 +4166,8 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_5),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24712), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24712), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4224,15 +4176,15 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_8),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24715), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24715), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_17),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24724), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24724), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4241,8 +4193,8 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_11),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24718), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24718), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4251,15 +4203,15 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_2),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24709), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24709), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_14),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24721), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24721), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4282,8 +4234,8 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_4),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24711), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24711), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4291,15 +4243,15 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_7),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24714), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24714), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_16),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24723), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24723), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4307,8 +4259,8 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_10),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24717), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24717), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4316,15 +4268,15 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_1),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24708), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24708), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_13),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24720), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24720), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 27 });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -4340,8 +4292,8 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_3),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24710), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24710), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4350,15 +4302,15 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_6),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24713), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24713), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_15),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24722), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24722), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4367,8 +4319,8 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_9),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24716), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24716), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4377,15 +4329,15 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_0),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24707), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24707), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_12),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24719), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24719), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4431,8 +4383,8 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23906), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24772), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24772), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4440,14 +4392,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23908), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24774), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24774), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23919), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24785), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24785), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4455,8 +4407,8 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23910), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24776), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24776), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4464,14 +4416,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23904), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24770), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24770), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23917), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24783), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24783), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4498,8 +4450,8 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23905), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24771), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24771), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4507,14 +4459,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23907), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24773), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24773), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23918), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24784), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24784), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4522,14 +4474,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23909), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24775), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24775), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23920), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24786), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24786), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4537,14 +4489,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23903), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24769), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24769), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23916), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24782), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24782), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4579,14 +4531,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23895), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24761), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24761), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23911), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24777), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24777), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4594,8 +4546,8 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23897), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24763), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24763), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4603,14 +4555,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23899), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24765), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24765), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23914), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24780), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24780), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4618,8 +4570,8 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23901), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24767), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24767), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4646,14 +4598,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23896), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24762), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24762), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23912), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24778), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24778), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4661,14 +4613,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23898), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24764), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24764), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23913), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24779), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24779), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4676,14 +4628,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23900), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24766), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24766), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23915), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24781), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24781), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4691,8 +4643,8 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23902), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24768), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24768), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4750,8 +4702,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24748), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24748), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4760,15 +4712,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24751), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24751), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24760), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24760), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4777,8 +4729,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24754), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24754), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4787,15 +4739,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24745), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24745), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24757), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24757), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4837,8 +4789,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24747), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24747), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4846,15 +4798,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24750), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24750), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24759), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24759), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4862,8 +4814,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24753), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24753), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4871,15 +4823,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24744), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24744), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24756), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24756), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 27 });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -4895,8 +4847,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24746), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24746), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4905,15 +4857,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24749), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24749), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24758), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24758), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4922,8 +4874,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24752), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24752), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4932,15 +4884,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24743), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height + 8 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24743), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24755), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24755), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4969,15 +4921,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24745), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24745), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24757), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24757), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4986,8 +4938,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24748), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24748), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4996,15 +4948,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24751), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24751), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24760), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24760), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5013,8 +4965,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24754), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24754), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5061,15 +5013,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24744), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24744), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24756), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24756), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5077,8 +5029,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24747), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24747), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5086,15 +5038,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24750), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24750), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24759), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24759), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5102,8 +5054,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24753), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24753), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -5119,15 +5071,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24743), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height + 8 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24743), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24755), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24755), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5136,8 +5088,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24746), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24746), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5146,15 +5098,15 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24749), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24749), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24758), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24758), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5163,8 +5115,8 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24752), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24752), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5199,15 +5151,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24725), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24725), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24737), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24737), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5216,8 +5168,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24728), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24728), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5226,15 +5178,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24731), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24731), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24740), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24740), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5243,8 +5195,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24734), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24734), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5286,15 +5238,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_19),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24726), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24726), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24738), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24738), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5302,8 +5254,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24729), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24729), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5311,15 +5263,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24732), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24732), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24741), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24741), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5327,8 +5279,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24735), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24735), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -5344,15 +5296,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24727), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height + 8 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24727), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24739), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24739), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5361,8 +5313,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24730), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24730), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5371,15 +5323,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24733), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24733), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24742), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24742), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5388,8 +5340,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24736), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24736), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5418,8 +5370,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24728), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24728), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5428,15 +5380,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24731), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24731), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24740), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24740), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5445,8 +5397,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24734), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24734), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5455,15 +5407,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24725), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24725), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24737), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24737), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5510,8 +5462,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24729), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24729), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5519,15 +5471,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24732), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24732), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24741), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24741), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5535,23 +5487,23 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24735), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24735), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23860), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24726), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24726), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24738), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24738), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 27 });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -5567,8 +5519,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24730), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24730), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5577,15 +5529,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24733), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24733), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24742), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24742), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5594,8 +5546,8 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24736), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24736), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5604,15 +5556,15 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24727), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height + 8 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24727), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24739), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24739), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5678,8 +5630,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23704), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24570), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24570), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5687,14 +5639,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23709), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24575), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24575), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23724), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24590), { 0, 0, height },
-                        { 32, 27, 0 }, { 0, 2, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24590), { 0, 0, height }, { 32, 27, 0 },
+                        { 0, 2, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5702,8 +5654,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23714), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24580), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24580), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5711,14 +5663,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23699), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24565), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24565), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23719), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24585), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24585), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5746,8 +5698,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23703), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24569), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24569), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5755,14 +5707,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23708), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24574), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24574), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23723), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24589), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24589), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5770,8 +5722,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23713), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24579), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24579), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5779,14 +5731,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23698), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24564), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24564), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23718), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24584), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24584), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5804,8 +5756,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23702), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24568), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24568), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5813,14 +5765,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23707), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24573), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24573), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23722), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24588), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 29 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24588), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 29 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5828,8 +5780,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23712), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24578), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24578), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5837,14 +5789,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23697), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24563), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24563), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23717), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24583), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24583), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5867,8 +5819,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23701), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24567), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24567), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5876,14 +5828,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23706), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24572), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24572), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23721), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24587), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 33 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24587), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5891,8 +5843,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23711), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24577), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24577), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5900,14 +5852,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23696), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24562), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24562), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23716), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24582), { 0, 0, height },
-                        { 16, 32, 0 }, { 16, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24582), { 0, 0, height }, { 16, 32, 0 },
+                        { 16, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5925,8 +5877,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23700), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24566), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24566), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5934,14 +5886,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23705), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24571), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24571), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23720), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24586), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 33 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24586), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5949,8 +5901,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23710), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24576), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24576), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5958,14 +5910,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23695), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24561), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height + 8 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24561), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23715), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24581), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24581), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5993,14 +5945,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23699), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24565), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24565), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23719), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24585), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24585), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6008,8 +5960,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23704), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24570), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24570), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6017,14 +5969,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23709), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24575), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24575), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23724), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24590), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24590), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6032,8 +5984,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23714), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24580), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24580), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6066,14 +6018,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23698), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24564), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24564), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23718), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24584), { 0, 0, height },
-                        { 16, 32, 0 }, { 16, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24584), { 0, 0, height }, { 16, 32, 0 },
+                        { 16, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6081,8 +6033,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23703), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24569), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24569), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6090,14 +6042,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23708), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24574), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24574), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23723), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24589), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24589), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6105,8 +6057,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23713), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24579), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24579), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6124,14 +6076,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23697), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24563), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24563), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23717), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24583), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24583), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6139,8 +6091,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23702), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24568), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24568), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6148,14 +6100,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23707), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24573), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24573), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23722), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24588), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 29 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24588), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 29 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6163,8 +6115,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23712), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24578), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24578), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6187,14 +6139,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23696), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24562), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24562), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23716), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24582), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24582), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6202,8 +6154,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23701), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24567), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24567), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6211,14 +6163,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23706), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24572), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24572), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23721), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24587), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 33 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24587), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6226,8 +6178,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23711), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24577), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24577), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6245,14 +6197,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23695), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24561), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height + 8 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24561), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23715), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24581), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24581), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6260,8 +6212,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23700), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24566), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24566), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6269,14 +6221,14 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23705), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24571), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24571), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23720), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24586), { 0, 0, height },
-                        { 32, 27, 0 }, { 0, 2, height + 33 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24586), { 0, 0, height }, { 32, 27, 0 },
+                        { 0, 2, height + 33 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6284,8 +6236,8 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23710), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24576), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24576), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6319,14 +6271,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23665), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24531), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24531), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23685), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24551), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24551), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6334,8 +6286,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23670), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24536), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24536), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6343,14 +6295,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23675), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24541), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24541), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23690), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24556), { 0, 0, height },
-                        { 32, 27, 0 }, { 0, 2, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24556), { 0, 0, height }, { 32, 27, 0 },
+                        { 0, 2, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6358,8 +6310,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23680), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24546), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24546), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6387,14 +6339,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23666), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24532), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24532), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23686), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24552), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24552), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6402,8 +6354,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23671), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24537), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24537), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6411,14 +6363,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23676), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24542), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24542), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23691), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24557), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24557), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6426,8 +6378,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23681), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24547), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24547), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6445,14 +6397,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23667), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24533), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24533), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23687), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24553), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24553), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6460,8 +6412,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23672), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24538), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24538), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6469,14 +6421,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23677), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24543), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24543), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23692), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24558), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 29 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24558), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 29 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6484,8 +6436,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23682), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24548), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24548), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6508,14 +6460,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23668), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24534), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24534), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23688), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24554), { 0, 0, height },
-                        { 16, 32, 0 }, { 16, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24554), { 0, 0, height }, { 16, 32, 0 },
+                        { 16, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6523,8 +6475,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23673), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24539), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24539), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6532,14 +6484,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23678), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24544), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24544), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23693), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24559), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 33 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24559), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6547,8 +6499,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23683), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24549), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24549), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6566,14 +6518,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23669), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24535), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height + 8 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24535), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23689), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24555), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24555), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6581,8 +6533,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23674), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24540), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24540), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6590,14 +6542,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23679), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24545), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24545), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23694), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24560), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 33 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24560), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6605,8 +6557,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23684), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24550), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24550), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6634,8 +6586,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23670), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24536), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24536), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6643,14 +6595,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23675), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24541), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24541), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23690), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24556), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24556), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6658,8 +6610,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23680), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24546), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24546), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6667,14 +6619,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23665), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24531), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24531), { 0, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23685), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24551), { 0, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24551), { 0, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6707,8 +6659,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23671), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24537), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24537), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6716,14 +6668,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23676), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24542), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24542), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23691), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24557), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24557), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6731,8 +6683,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23681), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24547), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24547), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6740,14 +6692,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23666), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24532), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24532), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23686), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24552), { 0, 0, height },
-                        { 16, 32, 0 }, { 16, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24552), { 0, 0, height }, { 16, 32, 0 },
+                        { 16, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6765,8 +6717,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23672), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24538), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24538), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6774,14 +6726,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23677), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24543), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24543), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23692), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24558), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 29 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24558), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 29 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6789,8 +6741,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23682), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24548), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24548), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6798,14 +6750,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23667), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24533), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24533), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23687), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24553), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24553), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6828,8 +6780,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23673), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24539), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24539), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6837,14 +6789,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23678), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24544), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24544), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23693), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24559), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 33 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24559), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6852,8 +6804,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23683), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24549), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24549), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6861,14 +6813,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23668), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24534), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24534), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23688), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24554), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24554), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6886,8 +6838,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23674), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24540), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24540), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6895,14 +6847,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23679), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24545), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24545), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23694), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24560), { 0, 0, height },
-                        { 32, 27, 0 }, { 0, 2, height + 33 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24560), { 0, 0, height }, { 32, 27, 0 },
+                        { 0, 2, height + 33 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6910,8 +6862,8 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23684), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24550), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24550), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6919,14 +6871,14 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23669), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24535), { 0, 0, height },
-                        { 32, 20, 2 }, { 0, 6, height + 8 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24535), { 0, 0, height }, { 32, 20, 2 },
+                        { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23689), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24555), { 0, 0, height },
-                        { 32, 20, 0 }, { 0, 6, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24555), { 0, 0, height }, { 32, 20, 0 },
+                        { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -7381,8 +7333,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23989), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24855), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24855), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7397,16 +7349,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23993), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24859), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24859), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23990), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24856), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24856), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7421,16 +7373,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23994), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24860), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24860), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23987), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24853), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24853), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7445,16 +7397,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23991), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24857), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24857), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23988), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24854), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24854), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7469,8 +7421,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23992), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24858), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24858), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7486,8 +7438,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23977), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24843), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24843), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7502,16 +7454,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23981), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24847), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24847), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23978), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24844), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24844), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7526,16 +7478,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23982), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24848), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24848), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23975), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24841), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24841), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7550,16 +7502,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23979), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24845), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24845), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23976), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24842), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24842), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7574,8 +7526,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23980), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24846), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24846), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7591,8 +7543,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23999), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24865), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24865), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7607,8 +7559,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24001), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24867), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24867), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 1:
                 case 3:
@@ -7616,8 +7568,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24000), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24866), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24866), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7632,8 +7584,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24002), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24868), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24868), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7648,8 +7600,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23975), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24841), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24841), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7664,16 +7616,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23979), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24845), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24845), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23976), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24842), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24842), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7688,16 +7640,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23980), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24846), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24846), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23977), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24843), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24843), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7712,16 +7664,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23981), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24847), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24847), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23978), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24844), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24844), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7736,8 +7688,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23982), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24848), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24848), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7752,8 +7704,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23987), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24853), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24853), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7768,16 +7720,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23991), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24857), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24857), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23988), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24854), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24854), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7792,16 +7744,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23992), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24858), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24858), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23989), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24855), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24855), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7816,16 +7768,16 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23993), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24859), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24859), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23990), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24856), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24856), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
                     PaintAddImageAsChildRotated(
@@ -7840,8 +7792,8 @@ static void wooden_rc_track_water_splash(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23994), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24860), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24860), { 0, 0, height }, { 32, 25, 2 },
+                        { 0, 3, height });
                     break;
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7868,8 +7820,8 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24137), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25003), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25003), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7877,14 +7829,14 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24141), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25007), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25007), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24153), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25019), { 0, 0, height },
-                        { 32, 32, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25019), { 0, 0, height }, { 32, 32, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -7892,8 +7844,8 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24145), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25011), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25011), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7901,14 +7853,14 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24149), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25015), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25015), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24157), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25023), { 0, 0, height },
-                        { 32, 32, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25023), { 0, 0, height }, { 32, 32, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -7927,8 +7879,8 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24138), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25004), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25004), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7936,14 +7888,14 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24142), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25008), { 0, 0, height },
-                        { 34, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25008), { 0, 0, height }, { 34, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24154), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25020), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25020), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -7951,8 +7903,8 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24146), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25012), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25012), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7960,14 +7912,14 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24150), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25016), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25016), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24158), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25024), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25024), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -7982,8 +7934,8 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24139), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25005), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25005), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7991,14 +7943,14 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24143), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25009), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25009), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24155), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25021), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25021), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8006,8 +7958,8 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24147), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25013), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25013), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8015,14 +7967,14 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24151), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25017), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25017), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24159), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25025), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25025), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8056,44 +8008,44 @@ static void wooden_rc_track_left_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24140), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25006), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25006), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24144), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25010), { 0, 0, height },
-                        { 16, 18, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25010), { 0, 0, height }, { 16, 18, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24156), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25022), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25022), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24148), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25014), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25014), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24152), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25018), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25018), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24160), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25026), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25026), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 0, height + 27 });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8118,14 +8070,14 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24113), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24979), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24979), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24129), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24995), { 0, 0, height },
-                        { 32, 32, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24995), { 0, 0, height }, { 32, 32, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8133,8 +8085,8 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24117), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24983), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24983), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8142,14 +8094,14 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24121), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24987), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24987), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24133), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24999), { 0, 0, height },
-                        { 32, 32, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24999), { 0, 0, height }, { 32, 32, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8157,8 +8109,8 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24125), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24991), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24991), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8177,14 +8129,14 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24114), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24980), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24980), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24130), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24996), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24996), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8192,8 +8144,8 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24118), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24984), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24984), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8201,14 +8153,14 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24122), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24988), { 0, 0, height },
-                        { 34, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24988), { 0, 0, height }, { 34, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24134), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25000), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25000), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8216,8 +8168,8 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24126), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24992), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24992), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8232,14 +8184,14 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24115), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24981), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24981), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24131), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24997), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24997), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8247,8 +8199,8 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24119), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24985), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24985), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8256,14 +8208,14 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24123), { 0, 0, height },
                         { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24989), { 0, 0, height },
-                        { 28, 28, 2 }, { 4, 4, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24989), { 0, 0, height }, { 28, 28, 2 },
+                        { 4, 4, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24135), { 0, 0, height },
                         { 28, 28, 0 }, { 4, 4, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25001), { 0, 0, height },
-                        { 28, 28, 0 }, { 4, 4, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25001), { 0, 0, height }, { 28, 28, 0 },
+                        { 4, 4, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8271,8 +8223,8 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24127), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24993), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24993), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8306,44 +8258,44 @@ static void wooden_rc_track_right_eighth_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24116), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24982), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24982), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24132), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24998), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24998), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24120), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24986), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24986), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24124), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24990), { 0, 0, height },
-                        { 16, 18, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24990), { 0, 0, height }, { 16, 18, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24136), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25002), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25002), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24128), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24994), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24994), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8388,8 +8340,8 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24185), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25051), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25051), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8397,14 +8349,14 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24189), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25055), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25055), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24201), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25067), { 0, 0, height },
-                        { 32, 32, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25067), { 0, 0, height }, { 32, 32, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8412,8 +8364,8 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24193), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25059), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25059), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8421,14 +8373,14 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24197), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25063), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25063), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24205), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25071), { 0, 0, height },
-                        { 32, 32, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25071), { 0, 0, height }, { 32, 32, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8447,8 +8399,8 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24186), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25052), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25052), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8456,14 +8408,14 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24190), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25056), { 0, 0, height },
-                        { 34, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25056), { 0, 0, height }, { 34, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24202), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25068), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25068), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8471,8 +8423,8 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24194), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25060), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25060), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8480,14 +8432,14 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24198), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25064), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25064), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24206), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25072), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25072), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8502,8 +8454,8 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24187), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25053), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25053), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8511,14 +8463,14 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24191), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25057), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25057), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24203), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25069), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25069), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8526,8 +8478,8 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24195), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25061), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25061), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8535,14 +8487,14 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24199), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25065), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25065), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24207), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25073), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25073), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8576,44 +8528,44 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24188), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25054), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25054), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24192), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25058), { 0, 0, height },
-                        { 16, 18, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25058), { 0, 0, height }, { 16, 18, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24204), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25070), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25070), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24196), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25062), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25062), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24200), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25066), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25066), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24208), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25074), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25074), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 0, height + 27 });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8638,14 +8590,14 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24161), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25027), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25027), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24177), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25043), { 0, 0, height },
-                        { 32, 32, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25043), { 0, 0, height }, { 32, 32, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8653,8 +8605,8 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24165), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25031), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25031), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8662,14 +8614,14 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24169), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25035), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25035), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24181), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25047), { 0, 0, height },
-                        { 32, 32, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25047), { 0, 0, height }, { 32, 32, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8677,8 +8629,8 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24173), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25039), { 0, 0, height },
-                        { 32, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25039), { 0, 0, height }, { 32, 32, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8697,14 +8649,14 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24162), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25028), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25028), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24178), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25044), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25044), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8712,8 +8664,8 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24166), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25032), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25032), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8721,14 +8673,14 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24170), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25036), { 0, 0, height },
-                        { 34, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25036), { 0, 0, height }, { 34, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24182), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25048), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25048), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8736,8 +8688,8 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24174), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25040), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25040), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8752,14 +8704,14 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24163), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25029), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25029), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24179), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25045), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25045), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8767,8 +8719,8 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24167), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25033), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25033), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8776,14 +8728,14 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24171), { 0, 0, height },
                         { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25037), { 0, 0, height },
-                        { 28, 28, 2 }, { 4, 4, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25037), { 0, 0, height }, { 28, 28, 2 },
+                        { 4, 4, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24183), { 0, 0, height },
                         { 28, 28, 0 }, { 4, 4, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25049), { 0, 0, height },
-                        { 28, 28, 0 }, { 4, 4, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25049), { 0, 0, height }, { 28, 28, 0 },
+                        { 4, 4, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8791,8 +8743,8 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24175), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25041), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25041), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8826,44 +8778,44 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24164), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25030), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25030), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24180), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25046), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 0, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25046), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24168), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25034), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25034), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24172), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25038), { 0, 0, height },
-                        { 16, 18, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25038), { 0, 0, height }, { 16, 18, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24184), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25050), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 16, height + 27 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25050), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24176), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25042), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25042), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12376,8 +12328,8 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23958), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24824), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24824), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12385,14 +12337,14 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23960), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24826), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24826), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23971), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24837), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24837), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12400,8 +12352,8 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23962), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24828), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24828), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12409,14 +12361,14 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23956), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24822), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24822), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23969), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24835), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24835), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12443,8 +12395,8 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23957), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24823), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24823), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12452,14 +12404,14 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23959), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24825), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24825), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23970), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24836), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24836), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12467,14 +12419,14 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23961), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24827), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24827), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23972), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24838), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24838), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12482,14 +12434,14 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23955), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24821), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24821), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23968), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24834), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24834), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12524,14 +12476,14 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23947), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24813), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24813), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23963), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24829), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24829), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12539,8 +12491,8 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23949), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24815), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24815), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12548,14 +12500,14 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23951), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24817), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24817), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23966), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24832), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24832), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12563,8 +12515,8 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23953), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24819), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24819), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12591,14 +12543,14 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23948), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24814), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24814), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23964), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24830), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24830), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12606,14 +12558,14 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23950), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24816), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24816), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23965), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24831), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24831), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12621,14 +12573,14 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23952), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24818), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24818), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23967), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24833), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24833), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12636,8 +12588,8 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23954), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24820), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24820), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12672,14 +12624,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23950), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24816), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24816), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23965), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24831), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24831), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12687,14 +12639,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23952), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24818), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24818), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23967), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24833), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24833), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12702,8 +12654,8 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23954), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24820), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24820), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12711,14 +12663,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23948), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24814), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24814), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23964), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24830), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24830), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12745,8 +12697,8 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23949), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24815), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24815), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12754,14 +12706,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23951), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24817), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24817), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23966), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24832), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24832), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12769,8 +12721,8 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23953), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24819), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24819), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12778,14 +12730,14 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23947), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24813), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24813), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23963), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24829), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24829), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12820,14 +12772,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23955), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24821), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24821), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23968), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24834), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24834), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12835,8 +12787,8 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23957), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24823), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24823), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12844,14 +12796,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23959), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24825), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24825), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23970), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24836), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24836), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12859,14 +12811,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23961), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24827), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24827), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23972), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24838), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24838), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12893,14 +12845,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23956), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24822), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24822), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23969), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24835), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24835), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12908,8 +12860,8 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23958), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24824), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24824), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12917,14 +12869,14 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23960), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24826), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24826), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23971), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24837), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24837), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12932,8 +12884,8 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23962), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24828), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24828), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12984,8 +12936,8 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23932), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24798), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24798), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12993,14 +12945,14 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23934), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24800), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24800), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23945), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24811), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24811), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13008,8 +12960,8 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23936), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24802), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24802), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13017,14 +12969,14 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23930), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24796), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24796), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23943), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24809), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24809), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13051,8 +13003,8 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23931), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24797), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24797), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13060,14 +13012,14 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23933), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24799), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24799), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23944), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24810), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24810), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13075,14 +13027,14 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23935), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24801), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24801), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23946), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24812), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24812), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13090,14 +13042,14 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23929), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24795), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24795), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23942), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24808), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24808), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13132,14 +13084,14 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23921), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24787), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24787), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23937), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24803), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24803), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13147,8 +13099,8 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23923), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24789), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24789), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13156,14 +13108,14 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23925), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24791), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24791), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23940), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24806), { 0, 6, height },
-                        { 32, 20, 0 }, { 0, 6, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24806), { 0, 6, height }, { 32, 20, 0 },
+                        { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13171,8 +13123,8 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23927), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24793), { 0, 6, height },
-                        { 32, 20, 2 }, { 0, 6, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24793), { 0, 6, height }, { 32, 20, 2 },
+                        { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13199,14 +13151,14 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23922), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24788), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24788), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23938), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24804), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24804), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13214,14 +13166,14 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23924), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24790), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24790), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23939), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24805), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24805), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13229,14 +13181,14 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23926), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24792), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24792), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23941), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24807), { 6, 0, height },
-                        { 20, 32, 0 }, { 6, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24807), { 6, 0, height }, { 20, 32, 0 },
+                        { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13244,8 +13196,8 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23928), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24794), { 6, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24794), { 6, 0, height }, { 20, 32, 2 },
+                        { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13302,8 +13254,8 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24321), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25187), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25187), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13311,14 +13263,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24326), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25192), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25192), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24352), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25218), { 0, 0, height },
-                        { 32, 27, 0 }, { 0, 2, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25218), { 0, 0, height }, { 32, 27, 0 },
+                        { 0, 2, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13326,8 +13278,8 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24331), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25197), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25197), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13335,8 +13287,8 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24336), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25202), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25202), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13360,8 +13312,8 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24322), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25188), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25188), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13369,14 +13321,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24327), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25193), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25193), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24353), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25219), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25219), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13384,8 +13336,8 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24332), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25198), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25198), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13393,14 +13345,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24337), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25203), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25203), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24359), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25225), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25225), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13418,8 +13370,8 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24323), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25189), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25189), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13427,14 +13379,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24328), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25194), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25194), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24354), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25220), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 59 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25220), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 59 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13442,8 +13394,8 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24333), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25199), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25199), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13451,14 +13403,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24338), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25204), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25204), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24360), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25226), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 59 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25226), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 59 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13483,8 +13435,8 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24324), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25190), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25190), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13492,14 +13444,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24329), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25195), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25195), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24355), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25221), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25221), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13507,14 +13459,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24334), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25200), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25200), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24357), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25223), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25223), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13522,14 +13474,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24339), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25205), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25205), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24361), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25227), { 0, 0, height },
-                        { 16, 32, 0 }, { 16, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25227), { 0, 0, height }, { 16, 32, 0 },
+                        { 16, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13547,8 +13499,8 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24325), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25191), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25191), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13556,14 +13508,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24330), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25196), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25196), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24356), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25222), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25222), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13571,14 +13523,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24335), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25201), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25201), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24358), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25224), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25224), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13586,14 +13538,14 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24340), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25206), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25206), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24362), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25228), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25228), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13628,8 +13580,8 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24301), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25167), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25167), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13637,8 +13589,8 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24306), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25172), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25172), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13646,14 +13598,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24311), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25177), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25177), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24347), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25213), { 0, 0, height },
-                        { 32, 27, 0 }, { 0, 2, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25213), { 0, 0, height }, { 32, 27, 0 },
+                        { 0, 2, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13661,8 +13613,8 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24316), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25182), { 0, 0, height },
-                        { 32, 27, 2 }, { 0, 2, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25182), { 0, 0, height }, { 32, 27, 2 },
+                        { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13686,14 +13638,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24302), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25168), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25168), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24341), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25207), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 16, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25207), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 16, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13701,8 +13653,8 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24307), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25173), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25173), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13710,14 +13662,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24312), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25178), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25178), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24348), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25214), { 0, 0, height },
-                        { 32, 16, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25214), { 0, 0, height }, { 32, 16, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13725,8 +13677,8 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24317), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25183), { 0, 0, height },
-                        { 32, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25183), { 0, 0, height }, { 32, 16, 2 },
+                        { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13744,14 +13696,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24303), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25169), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25169), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24342), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25208), { 0, 0, height },
-                        { 16, 16, 0 }, { 0, 0, height + 59 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25208), { 0, 0, height }, { 16, 16, 0 },
+                        { 0, 0, height + 59 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13759,8 +13711,8 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24308), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25174), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25174), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13768,14 +13720,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24313), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25179), { 0, 0, height },
-                        { 16, 16, 2 }, { 16, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25179), { 0, 0, height }, { 16, 16, 2 },
+                        { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24349), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25215), { 0, 0, height },
-                        { 16, 16, 0 }, { 16, 16, height + 59 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25215), { 0, 0, height }, { 16, 16, 0 },
+                        { 16, 16, height + 59 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13783,8 +13735,8 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24318), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25184), { 0, 0, height },
-                        { 16, 16, 2 }, { 0, 16, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25184), { 0, 0, height }, { 16, 16, 2 },
+                        { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13809,14 +13761,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24304), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25170), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25170), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24343), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25209), { 0, 0, height },
-                        { 16, 32, 0 }, { 16, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25209), { 0, 0, height }, { 16, 32, 0 },
+                        { 16, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13824,14 +13776,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24309), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25175), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25175), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24345), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25211), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25211), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13839,14 +13791,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24314), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25180), { 0, 0, height },
-                        { 16, 32, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25180), { 0, 0, height }, { 16, 32, 2 },
+                        { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24350), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25216), { 0, 0, height },
-                        { 16, 32, 0 }, { 0, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25216), { 0, 0, height }, { 16, 32, 0 },
+                        { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13854,8 +13806,8 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24319), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25185), { 0, 0, height },
-                        { 16, 32, 2 }, { 16, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25185), { 0, 0, height }, { 16, 32, 2 },
+                        { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13873,14 +13825,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24305), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25171), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25171), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24344), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25210), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25210), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13888,14 +13840,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24310), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25176), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25176), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24346), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25212), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25212), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13903,14 +13855,14 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24315), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25181), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25181), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24351), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25217), { 0, 0, height },
-                        { 27, 32, 0 }, { 2, 0, height + 67 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25217), { 0, 0, height }, { 27, 32, 0 },
+                        { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13918,8 +13870,8 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
                         session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24320), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25186), { 0, 0, height },
-                        { 27, 32, 2 }, { 2, 0, height });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25186), { 0, 0, height }, { 27, 32, 2 },
+                        { 2, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -3534,19 +3534,23 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23455), { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23455), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23463), { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23463), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23458), { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23458), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23466), { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23466), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3624,19 +3628,23 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23458), { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23458), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23466), { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23466), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23455), { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23455), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23463), { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23463), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3786,19 +3794,23 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23482), { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23482), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23474), { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23474), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23479), { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23479), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23471), { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23471), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 168, 0x20);
@@ -3866,19 +3878,23 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23479), { 12, 0, height }, { 3, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23479), { 12, 0, height },
+                        { 3, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23471), { 16, 0, height }, { 5, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23471), { 16, 0, height },
+                        { 5, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23482), { 16, 16, height }, { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23482), { 16, 16, height },
+                        { 4, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23474), { 10, 16, height }, { 4, 16, 119 });
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23474), { 10, 16, height },
+                        { 4, 16, 119 });
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 168, 0x20);
@@ -7134,8 +7150,8 @@ static void wooden_rc_track_25_deg_up_left_banked(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25116), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24257), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24257), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25123), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -7149,8 +7165,8 @@ static void wooden_rc_track_25_deg_up_left_banked(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25117), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24258), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24258), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25124), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -7203,8 +7219,8 @@ static void wooden_rc_track_25_deg_up_right_banked(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25120), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24259), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24259), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25125), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -7218,8 +7234,8 @@ static void wooden_rc_track_25_deg_up_right_banked(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25121), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24260), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24260), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25126), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -9265,8 +9281,8 @@ static void wooden_rc_track_diag_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24044),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24044), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24910), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -9280,14 +9296,14 @@ static void wooden_rc_track_diag_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24041),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24041), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24907), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24045),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24045), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24911), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 91 });
@@ -9317,14 +9333,14 @@ static void wooden_rc_track_diag_60_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24043),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24043), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24909), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24046),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24046), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24912), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 91 });
@@ -9342,8 +9358,8 @@ static void wooden_rc_track_diag_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24042),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24042), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24908), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -9571,8 +9587,8 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24032),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24032), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24898), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -9586,14 +9602,14 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24029),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24029), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24895), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24033),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24033), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24899), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
@@ -9623,14 +9639,14 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24031),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24031), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24897), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24034),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24034), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24900), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
@@ -9648,8 +9664,8 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24030),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24030), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24896), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -9674,8 +9690,8 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24038),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24038), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24904), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -9689,14 +9705,14 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24035),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24035), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24901), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24039),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24039), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24905), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
@@ -9726,14 +9742,14 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24037),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24037), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24903), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24040),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24040), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24906), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
@@ -9751,8 +9767,8 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24036),
-                        { -16, -16, height }, { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24036), { -16, -16, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24902), { -16, -16, height },
                         { 16, 16, 2 }, { 0, 0, height });
@@ -10183,8 +10199,8 @@ static void wooden_rc_track_diag_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24042),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24042), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24908), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -10198,14 +10214,14 @@ static void wooden_rc_track_diag_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24043),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24043), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24909), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24046),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24046), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24912), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 91 });
@@ -10235,14 +10251,14 @@ static void wooden_rc_track_diag_60_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24041),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24041), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24907), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24045),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24045), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24911), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 91 });
@@ -10260,8 +10276,8 @@ static void wooden_rc_track_diag_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24044),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24044), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24910), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -10484,8 +10500,8 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24036),
-                        { -16, -16, height }, { 16, 16, 2 }, { 0, 0, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24036), { -16, -16, height },
+                        { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24902), { -16, -16, height },
                         { 16, 16, 2 }, { 0, 0, height });
@@ -10499,14 +10515,14 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24037),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24037), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24903), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24040),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24040), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24906), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
@@ -10536,14 +10552,14 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24035),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24035), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24901), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24039),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24039), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24905), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
@@ -10561,8 +10577,8 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24038),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24038), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24904), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -10587,8 +10603,8 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24030),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24030), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24896), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -10602,14 +10618,14 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24031),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24031), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24897), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24034),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24034), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24900), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
@@ -10639,14 +10655,14 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24029),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24029), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24895), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24033),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24033), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24899), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
@@ -10664,8 +10680,8 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24032),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24032), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24898), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -10893,8 +10909,8 @@ static void wooden_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24080),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24080), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24946), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -10908,14 +10924,14 @@ static void wooden_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24077),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24077), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24943), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24081),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24081), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24947), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -10945,14 +10961,14 @@ static void wooden_rc_track_diag_flat_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24079),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24079), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24945), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24082),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24082), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24948), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -10970,8 +10986,8 @@ static void wooden_rc_track_diag_flat_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24078),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24078), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24944), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -10996,8 +11012,8 @@ static void wooden_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24086),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24086), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24952), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11011,14 +11027,14 @@ static void wooden_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24083),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24083), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24949), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24087),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24087), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24953), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -11048,14 +11064,14 @@ static void wooden_rc_track_diag_flat_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24085),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24085), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24951), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24088),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24088), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24954), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -11073,8 +11089,8 @@ static void wooden_rc_track_diag_flat_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24084),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24084), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24950), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11099,8 +11115,8 @@ static void wooden_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24084),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24084), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24950), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11114,14 +11130,14 @@ static void wooden_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24085),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24085), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24951), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24088),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24088), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24954), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -11151,14 +11167,14 @@ static void wooden_rc_track_diag_left_bank_to_flat(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24083),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24083), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24949), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24087),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24087), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24953), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -11176,8 +11192,8 @@ static void wooden_rc_track_diag_left_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24086),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24086), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24952), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11202,8 +11218,8 @@ static void wooden_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24078),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24078), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24944), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11217,14 +11233,14 @@ static void wooden_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24079),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24079), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24945), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24082),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24082), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24948), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -11254,14 +11270,14 @@ static void wooden_rc_track_diag_right_bank_to_flat(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24077),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24077), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24943), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24081),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24081), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24947), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -11279,8 +11295,8 @@ static void wooden_rc_track_diag_right_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24080),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24080), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24946), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11305,8 +11321,8 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24104),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24104), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24970), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11320,14 +11336,14 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24101),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24101), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24967), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24105),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24105), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24971), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11357,14 +11373,14 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24103),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24103), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24969), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24106),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24106), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24972), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11382,8 +11398,8 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24102),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24102), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24968), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11408,8 +11424,8 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24110),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24110), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24976), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11423,14 +11439,14 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24107),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24107), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24973), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24111),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24111), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24977), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11460,14 +11476,14 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24109),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24109), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24975), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24112),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24112), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24978), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11485,8 +11501,8 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24108),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24108), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24974), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11511,8 +11527,8 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24092),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24092), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24958), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11526,14 +11542,14 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24089),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24089), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24955), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24093),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24093), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24959), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11563,14 +11579,14 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24091),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24091), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24957), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24094),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24094), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24960), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11588,8 +11604,8 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24090),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24090), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24956), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11614,8 +11630,8 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24098),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24098), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24964), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11629,14 +11645,14 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24095),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24095), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24961), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24099),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24099), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24965), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11666,14 +11682,14 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24097),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24097), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24963), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24100),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24100), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24966), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11691,8 +11707,8 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24096),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24096), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24962), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11717,8 +11733,8 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24096),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24096), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24962), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11730,14 +11746,14 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24097),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24097), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24963), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24100),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24100), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24966), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11765,14 +11781,14 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24095),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24095), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24961), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24099),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24099), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24965), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11788,8 +11804,8 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24098),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24098), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24964), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11815,8 +11831,8 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24090),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24090), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24956), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11828,14 +11844,14 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24091),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24091), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24957), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24094),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24094), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24960), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11863,14 +11879,14 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24089),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24089), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24955), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24093),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24093), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24959), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11886,8 +11902,8 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24092),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24092), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24958), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11913,8 +11929,8 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24108),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24108), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24974), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -11928,14 +11944,14 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24109),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24109), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24975), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24112),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24112), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24978), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11965,14 +11981,14 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24107),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24107), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24973), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24111),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24111), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24977), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -11990,8 +12006,8 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24110),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24110), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24976), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -12016,8 +12032,8 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24102),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24102), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24968), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -12031,14 +12047,14 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24103),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24103), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24969), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24106),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24106), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24972), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -12068,14 +12084,14 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24101),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24101), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24967), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24105),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24105), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24971), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
@@ -12093,8 +12109,8 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24104),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24104), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24970), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -12119,8 +12135,8 @@ static void wooden_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24074),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24074), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24940), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -12134,14 +12150,14 @@ static void wooden_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24071),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24071), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24937), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24075),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24075), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24941), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -12171,14 +12187,14 @@ static void wooden_rc_track_diag_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24073),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24073), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24939), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24076),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24076), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24942), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -12196,8 +12212,8 @@ static void wooden_rc_track_diag_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24072),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24072), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24938), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -12222,8 +12238,8 @@ static void wooden_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24072),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24072), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24938), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -12237,14 +12253,14 @@ static void wooden_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24073),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24073), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24939), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24076),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24076), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24942), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -12274,14 +12290,14 @@ static void wooden_rc_track_diag_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24071),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24071), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24937), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24075),
-                        { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24075), { -16, -16, height },
+                        { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24941), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
@@ -12299,8 +12315,8 @@ static void wooden_rc_track_diag_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24074),
-                        { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24074), { -16, -16, height },
+                        { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRcGetRailsColour(session).WithIndex(24940), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
@@ -14205,8 +14221,8 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25144), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24293), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24293), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25159), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14220,8 +14236,8 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25145), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24294), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24294), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25160), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14274,8 +14290,8 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25148), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24295), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24295), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25161), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14289,8 +14305,8 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25149), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24296), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24296), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25162), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14343,8 +14359,8 @@ static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25152), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24297), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24297), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25163), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14358,8 +14374,8 @@ static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25153), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24298), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24298), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25164), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14412,8 +14428,8 @@ static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25156), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24299), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24299), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25165), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14427,8 +14443,8 @@ static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25157), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24300), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24300), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25166), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14521,8 +14537,8 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_up(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25092), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24241), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24241), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25107), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14536,8 +14552,8 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_up(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25093), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24242), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24242), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25108), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14590,8 +14606,8 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_up(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25096), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24243), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24243), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25109), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14605,8 +14621,8 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_up(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25097), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24244), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24244), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25110), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14659,8 +14675,8 @@ static void wooden_rc_track_left_banked_25_deg_up_to_flat(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25100), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24245), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24245), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25111), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14674,8 +14690,8 @@ static void wooden_rc_track_left_banked_25_deg_up_to_flat(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25101), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24246), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24246), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25112), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14728,8 +14744,8 @@ static void wooden_rc_track_right_banked_25_deg_up_to_flat(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25104), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24247), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24247), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25113), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
@@ -14743,8 +14759,8 @@ static void wooden_rc_track_right_banked_25_deg_up_to_flat(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25105), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24248), { 0, 0, height },
-                { 32, 1, 9 }, { 0, 26, height + 5 });
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24248), { 0, 0, height }, { 32, 1, 9 },
+                { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
                 session, direction, WoodenRcGetRailsColour(session).WithIndex(25114), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -448,7 +448,7 @@ static constexpr const uint32_t _wooden_rc_station_block_brakes_image_ids[4][2] 
     { SPR_G2_WOODEN_RC_STATION_BLOCK_BRAKE_OPEN_NW_SE, SPR_G2_WOODEN_RC_STATION_BLOCK_BRAKE_CLOSED_NW_SE },
 };
 
-ImageId wooden_rc_get_rails_colour(PaintSession& session)
+ImageId WoodenRcGetRailsColour(PaintSession& session)
 {
     return session.TrackColours[SCHEME_TRACK];
 }
@@ -473,7 +473,7 @@ static void wooden_rc_track_flat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[direction][isChained], railsImageIds[direction][isChained], direction, 0, 2, 32, 25, 2, height, 0, 3,
         height);
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -499,11 +499,11 @@ static void wooden_rc_track_station(
     {
         const auto brakeImg = trackElement.IsBrakeClosed() ? _wooden_rc_station_block_brakes_image_ids[direction][1]
                                                            : _wooden_rc_station_block_brakes_image_ids[direction][0];
-        wooden_rc_track_paint<isClassic>(session, brakeImg, SPR_G2_EMPTY, direction, 0, 2, 32, 27, 2, height, 0, 2, height);
+        WoodenRcTrackPaint<isClassic>(session, brakeImg, SPR_G2_EMPTY, direction, 0, 2, 32, 27, 2, height, 0, 2, height);
     }
     else
     {
-        wooden_rc_track_paint<isClassic>(
+        WoodenRcTrackPaint<isClassic>(
             session, stationImageIds[direction][0], stationImageIds[direction][1], direction, 0, 2, 32, 27, 2, height, 0, 2,
             height);
     }
@@ -576,12 +576,12 @@ static void wooden_rc_track_25_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[isChained][direction][0], imageIds[isChained][direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3,
         height);
     if (direction == 1 || direction == 2)
     {
-        wooden_rc_track_paint<isClassic>(
+        WoodenRcTrackPaint<isClassic>(
             session, imageIds[isChained][direction][2], imageIds[isChained][direction][3], direction, 0, 0, 32, 1, 9, height, 0,
             26, height + 5);
     }
@@ -624,13 +624,13 @@ static void wooden_rc_track_60_deg_up(
     {
         if (direction == 0 || direction == 3)
         {
-            wooden_rc_track_paint<isClassic>(
+            WoodenRcTrackPaint<isClassic>(
                 session, imageIdsChained[direction][0], imageIdsChained[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3,
                 height);
         }
         else
         {
-            session.WoodenSupportsPrependTo = wooden_rc_track_paint<isClassic>(
+            session.WoodenSupportsPrependTo = WoodenRcTrackPaint<isClassic>(
                 session, imageIdsChained[direction][0], imageIdsChained[direction][1], direction, 0, 0, 2, 24, 93, height, 28,
                 4, height - 16);
         }
@@ -639,12 +639,12 @@ static void wooden_rc_track_60_deg_up(
     {
         if (direction == 0 || direction == 3)
         {
-            wooden_rc_track_paint<isClassic>(
+            WoodenRcTrackPaint<isClassic>(
                 session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
         }
         else
         {
-            session.WoodenSupportsPrependTo = wooden_rc_track_paint<isClassic>(
+            session.WoodenSupportsPrependTo = WoodenRcTrackPaint<isClassic>(
                 session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 2, 24, 93, height, 28, 4,
                 height - 16);
         }
@@ -727,12 +727,12 @@ static void wooden_rc_track_flat_to_25_deg_up(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[isChained][direction][0], imageIds[isChained][direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3,
         height);
     if (direction == 1 || direction == 2)
     {
-        wooden_rc_track_paint<isClassic>(
+        WoodenRcTrackPaint<isClassic>(
             session, imageIds[isChained][direction][2], imageIds[isChained][direction][3], direction, 0, 0, 32, 1, 9, height, 0,
             26, height + 5);
     }
@@ -814,16 +814,16 @@ static void wooden_rc_track_25_deg_up_to_60_deg_up(
     {
         if (direction == 0 || direction == 3)
         {
-            wooden_rc_track_paint<isClassic>(
+            WoodenRcTrackPaint<isClassic>(
                 session, imageIdsChained[direction][0], imageIdsChained[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3,
                 height);
         }
         else
         {
-            session.WoodenSupportsPrependTo = wooden_rc_track_paint<isClassic>(
+            session.WoodenSupportsPrependTo = WoodenRcTrackPaint<isClassic>(
                 session, imageIdsChained[direction][0], imageIdsChained[direction][1], direction, 0, 0, 2, 24, 43, height, 28,
                 4, height + 2);
-            wooden_rc_track_paint<isClassic>(
+            WoodenRcTrackPaint<isClassic>(
                 session, imageIdsChained[direction][2], imageIdsChained[direction][3], direction, 0, 0, 32, 2, 43, height, 0, 4,
                 height);
         }
@@ -832,14 +832,14 @@ static void wooden_rc_track_25_deg_up_to_60_deg_up(
     {
         if (direction == 0 || direction == 3)
         {
-            wooden_rc_track_paint<isClassic>(
+            WoodenRcTrackPaint<isClassic>(
                 session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
         }
         else
         {
-            session.WoodenSupportsPrependTo = wooden_rc_track_paint<isClassic>(
+            session.WoodenSupportsPrependTo = WoodenRcTrackPaint<isClassic>(
                 session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 2, 24, 43, height, 28, 4, height + 2);
-            wooden_rc_track_paint<isClassic>(
+            WoodenRcTrackPaint<isClassic>(
                 session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 2, 43, height, 0, 4, height);
         }
     }
@@ -923,16 +923,16 @@ static void wooden_rc_track_60_deg_up_to_25_deg_up(
     {
         if (direction == 0 || direction == 3)
         {
-            wooden_rc_track_paint<isClassic>(
+            WoodenRcTrackPaint<isClassic>(
                 session, imageIdsChained[direction][0], imageIdsChained[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3,
                 height);
         }
         else
         {
-            session.WoodenSupportsPrependTo = wooden_rc_track_paint<isClassic>(
+            session.WoodenSupportsPrependTo = WoodenRcTrackPaint<isClassic>(
                 session, imageIdsChained[direction][0], imageIdsChained[direction][1], direction, 0, 0, 24, 1, 61, height, 4,
                 28, height - 16);
-            wooden_rc_track_paint<isClassic>(
+            WoodenRcTrackPaint<isClassic>(
                 session, imageIdsChained[direction][2], imageIdsChained[direction][3], direction, 0, 0, 32, 2, 43, height, 0, 4,
                 height);
         }
@@ -941,15 +941,15 @@ static void wooden_rc_track_60_deg_up_to_25_deg_up(
     {
         if (direction == 0 || direction == 3)
         {
-            wooden_rc_track_paint<isClassic>(
+            WoodenRcTrackPaint<isClassic>(
                 session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
         }
         else
         {
-            session.WoodenSupportsPrependTo = wooden_rc_track_paint<isClassic>(
+            session.WoodenSupportsPrependTo = WoodenRcTrackPaint<isClassic>(
                 session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 24, 1, 61, height, 4, 28,
                 height - 16);
-            wooden_rc_track_paint<isClassic>(
+            WoodenRcTrackPaint<isClassic>(
                 session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 2, 43, height, 0, 4, height);
         }
     }
@@ -1031,12 +1031,12 @@ static void wooden_rc_track_25_deg_up_to_flat(
     };
 
     uint8_t isChained = trackElement.HasChain() ? 1 : 0;
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[isChained][direction][0], imageIds[isChained][direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3,
         height);
     if (direction == 1 || direction == 2)
     {
-        wooden_rc_track_paint<isClassic>(
+        WoodenRcTrackPaint<isClassic>(
             session, imageIds[isChained][direction][2], imageIds[isChained][direction][3], direction, 0, 0, 32, 1, 9, height, 0,
             26, height + 5);
     }
@@ -1451,8 +1451,8 @@ static void wooden_rc_track_right_quarter_turn_5(
         { 1, -1, 3, 5, -1, 3, 0 },
     };
 
-    wooden_rc_track_paint_bb<isClassic>(session, &imageIds[0][direction][trackSequence], height);
-    wooden_rc_track_paint_bb<isClassic>(session, &imageIds[1][direction][trackSequence], height);
+    WoodenRcTrackPaintBb<isClassic>(session, &imageIds[0][direction][trackSequence], height);
+    WoodenRcTrackPaintBb<isClassic>(session, &imageIds[1][direction][trackSequence], height);
     track_paint_util_right_quarter_turn_5_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_SQUARE_FLAT);
 
     if (supportType[direction][trackSequence] != -1)
@@ -1534,11 +1534,11 @@ static void wooden_rc_track_flat_to_left_bank(
         },
     };
 
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
     if (direction == 1 || direction == 3)
     {
-        wooden_rc_track_paint<isClassic>(
+        WoodenRcTrackPaint<isClassic>(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1580,11 +1580,11 @@ static void wooden_rc_track_flat_to_right_bank(
         },
     };
 
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
     if (direction == 0 || direction == 2)
     {
-        wooden_rc_track_paint<isClassic>(
+        WoodenRcTrackPaint<isClassic>(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -1953,8 +1953,8 @@ static void wooden_rc_track_banked_right_quarter_turn_5(
         { 1, -1, 3, 5, -1, 3, 0 },
     };
 
-    wooden_rc_track_paint_bb<isClassic>(session, &imageIds[0][direction][trackSequence], height);
-    wooden_rc_track_paint_bb<isClassic>(session, &imageIds[1][direction][trackSequence], height);
+    WoodenRcTrackPaintBb<isClassic>(session, &imageIds[0][direction][trackSequence], height);
+    WoodenRcTrackPaintBb<isClassic>(session, &imageIds[1][direction][trackSequence], height);
     track_paint_util_right_quarter_turn_5_tiles_tunnel(session, height, direction, trackSequence, TUNNEL_SQUARE_FLAT);
 
     if (supportType[direction][trackSequence] != -1)
@@ -2037,11 +2037,11 @@ static void wooden_rc_track_left_bank_to_25_deg_up(
         },
     };
 
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
     if (direction == 1 || direction == 2)
     {
-        wooden_rc_track_paint<isClassic>(
+        WoodenRcTrackPaint<isClassic>(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
     WoodenASupportsPaintSetup(session, direction & 1, 1 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2090,11 +2090,11 @@ static void wooden_rc_track_right_bank_to_25_deg_up(
         },
     };
 
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
     if (direction == 1 || direction == 2)
     {
-        wooden_rc_track_paint<isClassic>(
+        WoodenRcTrackPaint<isClassic>(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
     WoodenASupportsPaintSetup(session, direction & 1, 1 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2143,11 +2143,11 @@ static void wooden_rc_track_25_deg_up_to_left_bank(
         },
     };
 
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
     if (direction == 1 || direction == 2)
     {
-        wooden_rc_track_paint<isClassic>(
+        WoodenRcTrackPaint<isClassic>(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
     WoodenASupportsPaintSetup(session, direction & 1, 5 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2196,11 +2196,11 @@ static void wooden_rc_track_25_deg_up_to_right_bank(
         },
     };
 
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
     if (direction == 1 || direction == 2)
     {
-        wooden_rc_track_paint<isClassic>(
+        WoodenRcTrackPaint<isClassic>(
             session, imageIds[direction][2], imageIds[direction][3], direction, 0, 0, 32, 1, 9, height, 0, 26, height + 5);
     }
     WoodenASupportsPaintSetup(session, direction & 1, 5 + direction, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -2265,7 +2265,7 @@ static void wooden_rc_track_left_bank(
         { SPR_WOODEN_RC_LEFT_BANK_SE_NW, SPR_WOODEN_RC_LEFT_BANK_RAILS_SE_NW },
     };
 
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[direction][0], imageIds[direction][1], direction, 0, 0, 32, 25, 2, height, 0, 3, height);
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -2295,43 +2295,43 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23781), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23781), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24647), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24647), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23786), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23786), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24652), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24652), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23812), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23812), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24678), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24678), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23791), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23791), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24657), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24657), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23796), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23796), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24662), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24662), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2353,49 +2353,49 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23782), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23782), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24648), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24648), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23787), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23787), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24653), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24653), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23813), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23813), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24679), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24679), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23792), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23792), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24658), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24658), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23797), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23797), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24663), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24663), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23819), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23819), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24685), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24685), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2411,49 +2411,49 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23783), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23783), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24649), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24649), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23788), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23788), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24654), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24654), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23814), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23814), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24680), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24680), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23793), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23793), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24659), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24659), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23798), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23798), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24664), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24664), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23820), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23820), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24686), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24686), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2476,55 +2476,55 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23784), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23784), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24650), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24650), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23789), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23789), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24655), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24655), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23815), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23815), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24681), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24681), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23794), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23794), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24660), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24660), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23817), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23817), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24683), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24683), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23799), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23799), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24665), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24665), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23821), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23821), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24687), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24687), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2540,55 +2540,55 @@ static void wooden_rc_track_left_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23785), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23785), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24651), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24651), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23790), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23790), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24656), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24656), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23816), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23816), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24682), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24682), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23795), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23795), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24661), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24661), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23818), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23818), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24684), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24684), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23800), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23800), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24666), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24666), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23822), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23822), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24688), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24688), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2621,43 +2621,43 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23761), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23761), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24627), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24627), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23766), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23766), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24632), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24632), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23771), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23771), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24637), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24637), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23807), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23807), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24673), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24673), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23776), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23776), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24642), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24642), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2679,49 +2679,49 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23762), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23762), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24628), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24628), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23801), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23801), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24667), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24667), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23767), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23767), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24633), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24633), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23772), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23772), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24638), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24638), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23808), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23808), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24674), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24674), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23777), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23777), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24643), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24643), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2737,49 +2737,49 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23763), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23763), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24629), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24629), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23802), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23802), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24668), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24668), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23768), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23768), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24634), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24634), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23773), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23773), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24639), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24639), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23809), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23809), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24675), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24675), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23778), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23778), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24644), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24644), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2802,55 +2802,55 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23764), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23764), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24630), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24630), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23803), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23803), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24669), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24669), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23769), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23769), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24635), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24635), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23805), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23805), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24671), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24671), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23774), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23774), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24640), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24640), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23810), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23810), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24676), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24676), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23779), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23779), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24645), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24645), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2866,55 +2866,55 @@ static void wooden_rc_track_right_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23765), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23765), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24631), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24631), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23804), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23804), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24670), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24670), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23770), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23770), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24636), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24636), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23806), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23806), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24672), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24672), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23775), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23775), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24641), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24641), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23811), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23811), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24677), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24677), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23780), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23780), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24646), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24646), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -2969,49 +2969,49 @@ static void wooden_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23725), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23725), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24591), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24591), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23729), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23729), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24595), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24595), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23741), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23741), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24607), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24607), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23728), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23728), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24594), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24594), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23732), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23732), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24598), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24598), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23744), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23744), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24610), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24610), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3028,49 +3028,49 @@ static void wooden_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23726), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23726), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24592), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24592), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23730), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23730), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24596), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24596), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23742), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23742), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24608), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24608), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23727), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23727), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24593), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24593), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23731), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23731), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24597), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24597), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23743), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23743), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24609), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24609), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3086,49 +3086,49 @@ static void wooden_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23727), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23727), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24593), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24593), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23731), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23731), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24597), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24597), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23743), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23743), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24609), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24609), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23726), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23726), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24592), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24592), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23730), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23730), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24596), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24596), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23742), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23742), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24608), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24608), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3144,49 +3144,49 @@ static void wooden_rc_track_s_bend_left(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23728), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23728), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24594), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24594), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23732), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23732), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24598), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24598), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23744), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23744), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24610), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24610), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23725), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23725), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24591), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24591), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23729), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23729), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24595), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24595), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23741), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23741), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24607), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24607), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3219,49 +3219,49 @@ static void wooden_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23733), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23733), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24599), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24599), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23745), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23745), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24611), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24611), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23737), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23737), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24603), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24603), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23736), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23736), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24602), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24602), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23748), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23748), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24614), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24614), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23740), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23740), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24606), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24606), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3278,49 +3278,49 @@ static void wooden_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23734), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23734), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24600), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24600), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23746), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23746), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24612), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24612), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23738), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23738), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24604), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24604), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23735), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23735), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24601), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24601), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23747), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23747), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24613), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24613), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23739), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23739), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24605), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24605), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3336,49 +3336,49 @@ static void wooden_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23735), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23735), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24601), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24601), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23747), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23747), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24613), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24613), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23739), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23739), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24605), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24605), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23734), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23734), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24600), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24600), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23746), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23746), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24612), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24612), { 0, 0, height },
                         { 32, 26, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23738), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23738), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24604), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24604), { 0, 0, height },
                         { 32, 26, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3394,49 +3394,49 @@ static void wooden_rc_track_s_bend_right(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23736), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23736), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24602), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24602), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23748), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23748), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24614), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24614), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23740), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23740), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24606), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24606), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23733), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23733), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24599), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24599), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23745), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23745), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24611), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24611), { 0, 0, height },
                         { 32, 25, 0 }, { 0, 3, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23737), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23737), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24603), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24603), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -3469,22 +3469,22 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23453), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23453), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23461), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23461), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23460), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23460), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23468), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23468), { 0, 6, height },
                         { 32, 20, 7 });
                     break;
             }
@@ -3504,28 +3504,28 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23454), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23454), { 0, 0, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23462), { 0, 14, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23462), { 0, 14, height },
                         { 32, 2, 63 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23459), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23459), { 0, 6, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23467), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23467), { 0, 6, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3542,22 +3542,22 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23455), { 16, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23455), { 16, 0, height },
                         { 5, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23463), { 12, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23463), { 12, 0, height },
                         { 3, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23458), { 10, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23458), { 10, 16, height },
                         { 4, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23466), { 16, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23466), { 16, 16, height },
                         { 4, 16, 119 });
                     break;
             }
@@ -3570,22 +3570,22 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23456), { 0, 0, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23456), { 0, 0, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23464), { 0, 0, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23464), { 0, 0, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23457), { 0, 16, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23457), { 0, 16, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23465), { 0, 16, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23465), { 0, 16, height + 32 },
                         { 32, 16, 3 });
                     break;
             }
@@ -3606,22 +3606,22 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23457), { 0, 16, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23457), { 0, 16, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23465), { 0, 16, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23465), { 0, 16, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23456), { 0, 0, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23456), { 0, 0, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23464), { 0, 0, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23464), { 0, 0, height + 32 },
                         { 32, 16, 3 });
                     break;
             }
@@ -3636,22 +3636,22 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23458), { 10, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23458), { 10, 16, height },
                         { 4, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23466), { 16, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23466), { 16, 16, height },
                         { 4, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23455), { 16, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23455), { 16, 0, height },
                         { 5, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23463), { 12, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23463), { 12, 0, height },
                         { 3, 16, 119 });
                     break;
             }
@@ -3664,28 +3664,28 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23459), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23459), { 0, 6, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23467), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23467), { 0, 6, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23454), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23454), { 0, 0, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23462), { 0, 14, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23462), { 0, 14, height },
                         { 32, 2, 63 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3702,22 +3702,22 @@ static void wooden_rc_track_left_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23460), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23460), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23468), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23468), { 0, 6, height },
                         { 32, 20, 7 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23453), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23453), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23461), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23461), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
             }
@@ -3753,22 +3753,22 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23484), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23484), { 0, 6, height },
                         { 32, 20, 7 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23476), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23476), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23477), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23477), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23469), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23469), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
             }
@@ -3784,28 +3784,28 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23483), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23483), { 0, 6, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23475), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23475), { 0, 6, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23478), { 0, 14, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23478), { 0, 14, height },
                         { 32, 2, 63 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23470), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23470), { 0, 0, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3818,22 +3818,22 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23482), { 16, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23482), { 16, 16, height },
                         { 4, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23474), { 10, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23474), { 10, 16, height },
                         { 4, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23479), { 12, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23479), { 12, 0, height },
                         { 3, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23471), { 16, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23471), { 16, 0, height },
                         { 5, 16, 119 });
                     break;
             }
@@ -3844,22 +3844,22 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23481), { 0, 16, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23481), { 0, 16, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23473), { 0, 16, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23473), { 0, 16, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23480), { 0, 0, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23480), { 0, 0, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23472), { 0, 0, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23472), { 0, 0, height + 32 },
                         { 32, 16, 3 });
                     break;
             }
@@ -3876,22 +3876,22 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23480), { 0, 0, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23480), { 0, 0, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23472), { 0, 0, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23472), { 0, 0, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23481), { 0, 16, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23481), { 0, 16, height + 32 },
                         { 32, 16, 3 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23473), { 0, 16, height + 32 },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23473), { 0, 16, height + 32 },
                         { 32, 16, 3 });
                     break;
             }
@@ -3902,22 +3902,22 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23479), { 12, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23479), { 12, 0, height },
                         { 3, 16, 119 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23471), { 16, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23471), { 16, 0, height },
                         { 5, 16, 119 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23482), { 16, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23482), { 16, 16, height },
                         { 4, 16, 119 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23474), { 10, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23474), { 10, 16, height },
                         { 4, 16, 119 });
                     break;
             }
@@ -3928,28 +3928,28 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23478), { 0, 14, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23478), { 0, 14, height },
                         { 32, 2, 63 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23470), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23470), { 0, 0, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23483), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23483), { 0, 6, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23475), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23475), { 0, 6, height },
                         { 32, 26, 3 });
                     MetalASupportsPaintSetup(
                         session, METAL_SUPPORTS_BOXED, 4, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -3962,22 +3962,22 @@ static void wooden_rc_track_right_vertical_loop(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23477), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23477), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23469), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23469), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23484), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23484), { 0, 6, height },
                         { 32, 20, 7 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(23476), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(23476), { 0, 6, height },
                         { 32, 20, 3 });
                     break;
             }
@@ -4011,49 +4011,49 @@ static void wooden_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23828), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23828), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24694), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24694), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23831), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23831), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24697), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24697), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23840), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23840), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24706), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24706), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23834), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23834), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24700), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24700), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23825), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23825), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24691), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24691), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23837), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23837), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24703), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24703), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4073,46 +4073,46 @@ static void wooden_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23827), { 16, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23827), { 16, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24693), { 16, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24693), { 16, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23830), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23830), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24696), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24696), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23839), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23839), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24705), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24705), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23833), { 0, 16, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23833), { 0, 16, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24699), { 0, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24699), { 0, 16, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23824), { 16, 16, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23824), { 16, 16, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24690), { 16, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24690), { 16, 16, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23836), { 16, 16, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23836), { 16, 16, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24702), { 16, 16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24702), { 16, 16, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
@@ -4125,49 +4125,49 @@ static void wooden_rc_track_left_quarter_turn_3(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23826), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23826), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24692), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24692), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23829), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23829), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24695), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24695), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23838), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23838), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24704), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24704), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23832), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23832), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24698), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24698), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23823), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23823), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24689), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24689), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23835), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23835), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24701), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24701), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4211,54 +4211,54 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_5),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_5),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24712), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24712), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_8),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_8),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24715), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24715), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_17),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_17),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24724), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24724), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_11),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_11),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24718), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24718), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_2),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_2),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24709), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24709), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_14),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_14),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24721), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24721), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4279,51 +4279,51 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_4),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_4),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24711), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24711), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_7),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_7),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24714), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24714), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_16),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_16),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24723), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24723), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_10),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_10),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24717), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24717), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_1),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_1),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24708), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24708), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_13),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_13),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24720), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24720), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
@@ -4337,54 +4337,54 @@ static void wooden_rc_track_left_quarter_turn_3_bank(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_3),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_3),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24710), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24710), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_6),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_6),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24713), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24713), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_15),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_15),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24722), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24722), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_9),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_9),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24716), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24716), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_0),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_0),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24707), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24707), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_12),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_12),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24719), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24719), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4428,49 +4428,49 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23906), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23906), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24772), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24772), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23908), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23908), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24774), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24774), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23919), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23919), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24785), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24785), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23910), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23910), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24776), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24776), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23904), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23904), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24770), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24770), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23917), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23917), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24783), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24783), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4495,55 +4495,55 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23905), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23905), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24771), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24771), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23907), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23907), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24773), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24773), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23918), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23918), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24784), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24784), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23909), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23909), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24775), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24775), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23920), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23920), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24786), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24786), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23903), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23903), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24769), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24769), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23916), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23916), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24782), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24782), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4576,49 +4576,49 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23895), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23895), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24761), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24761), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23911), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23911), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24777), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24777), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23897), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23897), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24763), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24763), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23899), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23899), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24765), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24765), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23914), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23914), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24780), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24780), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23901), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23901), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24767), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24767), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4643,55 +4643,55 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23896), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23896), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24762), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24762), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23912), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23912), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24778), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24778), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23898), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23898), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24764), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24764), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23913), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23913), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24779), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24779), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23900), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23900), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24766), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24766), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23915), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23915), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24781), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24781), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23902), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23902), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24768), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24768), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4747,54 +4747,54 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24748), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24748), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24751), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24751), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24760), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24760), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24754), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24754), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24745), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24745), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24757), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24757), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4834,51 +4834,51 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24747), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24747), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24750), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24750), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24759), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24759), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24753), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24753), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24744), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24744), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24756), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24756), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
@@ -4892,54 +4892,54 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24746), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24746), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24749), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24749), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24758), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24758), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24752), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24752), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24743), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24743), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24755), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24755), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -4966,54 +4966,54 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24745), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24745), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24757), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24757), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24748), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24748), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24751), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24751), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24760), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24760), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24754), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24754), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5058,51 +5058,51 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24744), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24744), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24756), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24756), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24747), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24747), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24750), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24750), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24759), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24759), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24753), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24753), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     break;
             }
@@ -5116,54 +5116,54 @@ static void wooden_rc_track_left_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24743), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24743), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24755), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24755), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24746), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24746), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24749), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24749), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24758), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24758), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24752), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24752), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5196,54 +5196,54 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24725), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24725), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24737), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24737), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24728), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24728), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24731), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24731), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24740), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24740), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24734), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24734), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5283,51 +5283,51 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_19),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_19),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24726), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24726), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24738), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24738), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24729), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24729), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24732), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24732), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24741), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24741), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24735), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24735), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     break;
             }
@@ -5341,54 +5341,54 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24727), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24727), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24739), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24739), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24730), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24730), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24733), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24733), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24742), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24742), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24736), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24736), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5415,54 +5415,54 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24728), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24728), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24731), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24731), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24740), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24740), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24734), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24734), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18),
                         { 0, 0, height }, { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24725), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24725), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30),
                         { 0, 0, height }, { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24737), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24737), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5507,50 +5507,50 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22),
                         { 0, 0, height }, { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24729), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24729), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24732), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24732), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34),
                         { 0, 0, height }, { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24741), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24741), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28),
                         { 0, 0, height }, { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24735), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24735), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23860), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23860), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24726), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24726), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31),
                         { 0, 0, height }, { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24738), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24738), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     break;
             }
@@ -5564,54 +5564,54 @@ static void wooden_rc_track_right_half_banked_helix_up_small(
                 case 0:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24730), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24730), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24733), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24733), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24742), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24742), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24736), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24736), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20),
                         { 0, 0, height }, { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24727), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24727), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
                         session, direction,
-                        wooden_rc_get_track_colour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32),
+                        WoodenRcGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32),
                         { 0, 0, height }, { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24739), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24739), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5675,49 +5675,49 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23704), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23704), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24570), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24570), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23709), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23709), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24575), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24575), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23724), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23724), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24590), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24590), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23714), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23714), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24580), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24580), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23699), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23699), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24565), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24565), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23719), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23719), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24585), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24585), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5743,49 +5743,49 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23703), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23703), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24569), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24569), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23708), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23708), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24574), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24574), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23723), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23723), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24589), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24589), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23713), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23713), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24579), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24579), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23698), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23698), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24564), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24564), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23718), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23718), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24584), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24584), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5801,49 +5801,49 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23702), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23702), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24568), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24568), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23707), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23707), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24573), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24573), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23722), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23722), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24588), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24588), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23712), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23712), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24578), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24578), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23697), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23697), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24563), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24563), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23717), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23717), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24583), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24583), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5864,49 +5864,49 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23701), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23701), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24567), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24567), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23706), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23706), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24572), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24572), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23721), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23721), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24587), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24587), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23711), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23711), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24577), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24577), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23696), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23696), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24562), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24562), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23716), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23716), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24582), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24582), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5922,49 +5922,49 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23700), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23700), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24566), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24566), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23705), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23705), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24571), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24571), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23720), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23720), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24586), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24586), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23710), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23710), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24576), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24576), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23695), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23695), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24561), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24561), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23715), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23715), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24581), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24581), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -5990,49 +5990,49 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23699), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23699), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24565), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24565), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23719), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23719), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24585), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24585), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23704), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23704), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24570), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24570), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23709), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23709), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24575), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24575), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23724), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23724), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24590), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24590), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23714), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23714), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24580), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24580), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6063,49 +6063,49 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23698), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23698), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24564), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24564), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23718), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23718), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24584), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24584), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23703), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23703), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24569), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24569), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23708), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23708), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24574), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24574), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23723), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23723), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24589), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24589), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23713), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23713), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24579), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24579), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6121,49 +6121,49 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23697), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23697), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24563), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24563), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23717), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23717), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24583), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24583), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23702), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23702), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24568), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24568), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23707), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23707), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24573), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24573), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23722), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23722), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24588), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24588), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23712), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23712), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24578), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24578), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6184,49 +6184,49 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23696), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23696), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24562), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24562), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23716), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23716), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24582), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24582), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23701), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23701), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24567), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24567), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23706), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23706), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24572), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24572), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23721), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23721), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24587), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24587), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23711), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23711), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24577), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24577), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6242,49 +6242,49 @@ static void wooden_rc_track_left_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23695), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23695), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24561), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24561), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23715), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23715), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24581), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24581), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23700), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23700), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24566), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24566), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23705), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23705), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24571), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24571), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23720), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23720), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24586), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24586), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 33 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23710), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23710), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24576), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24576), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6316,49 +6316,49 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23665), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23665), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24531), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24531), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23685), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23685), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24551), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24551), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23670), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23670), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24536), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24536), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23675), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23675), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24541), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24541), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23690), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23690), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24556), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24556), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23680), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23680), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24546), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24546), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6384,49 +6384,49 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23666), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23666), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24532), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24532), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23686), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23686), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24552), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24552), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23671), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23671), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24537), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24537), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23676), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23676), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24542), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24542), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23691), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23691), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24557), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24557), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23681), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23681), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24547), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24547), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6442,49 +6442,49 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23667), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23667), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24533), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24533), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23687), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23687), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24553), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24553), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23672), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23672), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24538), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24538), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23677), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23677), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24543), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24543), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23692), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23692), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24558), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24558), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23682), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23682), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24548), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24548), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6505,49 +6505,49 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23668), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23668), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24534), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24534), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23688), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23688), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24554), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24554), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23673), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23673), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24539), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24539), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23678), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23678), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24544), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24544), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23693), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23693), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24559), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24559), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23683), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23683), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24549), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24549), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6563,49 +6563,49 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23669), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23669), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24535), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24535), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23689), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23689), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24555), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24555), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23674), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23674), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24540), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24540), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23679), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23679), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24545), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24545), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23694), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23694), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24560), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24560), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23684), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23684), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24550), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24550), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6631,49 +6631,49 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23670), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23670), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24536), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24536), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23675), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23675), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24541), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24541), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23690), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23690), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24556), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24556), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23680), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23680), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24546), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24546), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23665), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23665), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24531), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24531), { 0, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23685), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23685), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24551), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24551), { 0, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6704,49 +6704,49 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23671), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23671), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24537), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24537), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23676), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23676), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24542), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24542), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23691), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23691), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24557), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24557), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23681), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23681), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24547), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24547), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23666), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23666), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24532), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24532), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23686), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23686), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24552), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24552), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6762,49 +6762,49 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23672), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23672), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24538), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24538), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23677), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23677), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24543), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24543), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23692), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23692), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24558), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24558), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 29 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23682), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23682), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24548), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24548), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23667), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23667), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24533), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24533), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23687), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23687), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24553), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24553), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6825,49 +6825,49 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23673), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23673), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24539), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24539), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23678), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23678), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24544), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24544), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23693), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23693), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24559), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24559), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 33 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23683), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23683), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24549), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24549), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23668), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23668), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24534), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24534), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23688), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23688), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24554), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24554), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6883,49 +6883,49 @@ static void wooden_rc_track_right_half_banked_helix_up_large(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23674), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23674), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24540), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24540), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23679), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23679), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24545), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24545), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23694), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23694), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 33 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24560), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24560), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 33 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23684), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23684), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24550), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24550), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23669), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23669), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24535), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24535), { 0, 0, height },
                         { 32, 20, 2 }, { 0, 6, height + 8 });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23689), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23689), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24555), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24555), { 0, 0, height },
                         { 32, 20, 0 }, { 0, 6, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -6986,58 +6986,58 @@ static void wooden_rc_track_left_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24209), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24209), { 0, 0, height },
                 { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25075), { 0, 0, height }, { 28, 28, 3 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25075), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24217), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24217), { 0, 0, height },
                 { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25083), { 0, 0, height }, { 28, 28, 1 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25083), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24210), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24210), { 0, 0, height },
                 { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25076), { 0, 0, height }, { 28, 28, 3 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25076), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24218), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24218), { 0, 0, height },
                 { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25084), { 0, 0, height }, { 28, 28, 1 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25084), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24211), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24211), { 0, 0, height },
                 { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25077), { 0, 0, height }, { 28, 28, 3 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25077), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24219), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24219), { 0, 0, height },
                 { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25085), { 0, 0, height }, { 28, 28, 1 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25085), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24212), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24212), { 0, 0, height },
                 { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25078), { 0, 0, height }, { 28, 28, 3 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25078), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24220), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24220), { 0, 0, height },
                 { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25086), { 0, 0, height }, { 28, 28, 1 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25086), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -7056,58 +7056,58 @@ static void wooden_rc_track_right_quarter_turn_1_60_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24213), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24213), { 0, 0, height },
                 { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25079), { 0, 0, height }, { 28, 28, 3 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25079), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24221), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24221), { 0, 0, height },
                 { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25087), { 0, 0, height }, { 28, 28, 1 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25087), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24214), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24214), { 0, 0, height },
                 { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25080), { 0, 0, height }, { 28, 28, 3 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25080), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24222), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24222), { 0, 0, height },
                 { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25088), { 0, 0, height }, { 28, 28, 1 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25088), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24215), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24215), { 0, 0, height },
                 { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25081), { 0, 0, height }, { 28, 28, 3 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25081), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24223), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24223), { 0, 0, height },
                 { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25089), { 0, 0, height }, { 28, 28, 1 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25089), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24216), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24216), { 0, 0, height },
                 { 28, 28, 3 }, { 2, 2, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25082), { 0, 0, height }, { 28, 28, 3 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25082), { 0, 0, height }, { 28, 28, 3 },
                 { 2, 2, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24224), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24224), { 0, 0, height },
                 { 28, 28, 1 }, { 2, 2, height + 99 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25090), { 0, 0, height }, { 28, 28, 1 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25090), { 0, 0, height }, { 28, 28, 1 },
                 { 2, 2, height + 99 });
             break;
     }
@@ -7149,7 +7149,7 @@ static void wooden_rc_track_brakes(
         { SPR_WOODEN_RC_BRAKES_NW_SE, SPR_WOODEN_RC_BRAKES_RAILS_NW_SE },
     };
 
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[direction][0], imageIds[direction][1], direction, 0, 2, 32, 25, 2, height, 0, 3, height);
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -7167,49 +7167,49 @@ static void wooden_rc_track_25_deg_up_left_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24249), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24249), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25115), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25115), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24250), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24250), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25116), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25116), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24257), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24257), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25123), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25123), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24251), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24251), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25117), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25117), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24258), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24258), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25124), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25124), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24252), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24252), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25118), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25118), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -7236,49 +7236,49 @@ static void wooden_rc_track_25_deg_up_right_banked(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24253), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24253), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25119), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25119), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24254), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24254), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25120), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25120), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24259), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24259), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25125), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25125), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24255), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24255), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25121), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25121), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24260), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24260), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25126), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25126), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24256), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24256), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25122), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25122), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -7305,34 +7305,34 @@ static void wooden_rc_track_on_ride_photo(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23753), { 0, 2, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23753), { 0, 2, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(24619), { 0, 2, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(24619), { 0, 2, height }, { 32, 25, 2 },
                 { 0, 3, height });
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23754), { 0, 2, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23754), { 0, 2, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(24620), { 0, 2, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(24620), { 0, 2, height }, { 32, 25, 2 },
                 { 0, 3, height });
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23753), { 0, 2, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23753), { 0, 2, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(24619), { 0, 2, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(24619), { 0, 2, height }, { 32, 25, 2 },
                 { 0, 3, height });
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23754), { 0, 2, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23754), { 0, 2, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(24620), { 0, 2, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(24620), { 0, 2, height }, { 32, 25, 2 },
                 { 0, 3, height });
             break;
     }
@@ -7378,10 +7378,10 @@ static void wooden_rc_track_water_splash(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23989), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23989), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24855), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24855), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7394,18 +7394,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24863), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23993), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23993), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24859), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24859), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23990), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23990), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24856), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24856), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7418,18 +7418,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24864), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23994), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23994), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24860), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24860), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23987), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23987), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24853), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24853), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7442,18 +7442,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24861), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23991), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23991), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24857), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24857), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23988), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23988), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24854), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24854), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7466,10 +7466,10 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24862), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23992), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23992), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24858), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24858), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
             }
@@ -7483,10 +7483,10 @@ static void wooden_rc_track_water_splash(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23977), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23977), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24843), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24843), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7499,18 +7499,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24851), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23981), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23981), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24847), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24847), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23978), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23978), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24844), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24844), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7523,18 +7523,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24852), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23982), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23982), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24848), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24848), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23975), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23975), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24841), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24841), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7547,18 +7547,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24849), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23979), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23979), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24845), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24845), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23976), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23976), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24842), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24842), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7571,10 +7571,10 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24850), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23980), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23980), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24846), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24846), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
             }
@@ -7588,10 +7588,10 @@ static void wooden_rc_track_water_splash(
                 case 0:
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23999), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23999), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24865), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24865), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7604,19 +7604,19 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24869), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24001), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24001), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24867), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24867), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 1:
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24000), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24000), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24866), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24866), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7629,10 +7629,10 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24870), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24002), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24002), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24868), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24868), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
             }
@@ -7645,10 +7645,10 @@ static void wooden_rc_track_water_splash(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23975), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23975), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24841), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24841), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7661,18 +7661,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24849), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23979), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23979), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24845), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24845), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23976), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23976), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24842), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24842), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7685,18 +7685,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24850), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23980), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23980), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24846), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24846), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23977), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23977), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24843), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24843), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7709,18 +7709,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24851), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23981), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23981), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24847), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24847), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23978), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23978), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24844), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24844), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7733,10 +7733,10 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24852), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23982), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23982), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24848), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24848), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
             }
@@ -7749,10 +7749,10 @@ static void wooden_rc_track_water_splash(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23987), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23987), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24853), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24853), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7765,18 +7765,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24861), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23991), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23991), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24857), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24857), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23988), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23988), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24854), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24854), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7789,18 +7789,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24862), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23992), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23992), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24858), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24858), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23989), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23989), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24855), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24855), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7813,18 +7813,18 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24863), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23993), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23993), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24859), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24859), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23990), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23990), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24856), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24856), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
                         session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
@@ -7837,10 +7837,10 @@ static void wooden_rc_track_water_splash(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24864), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23994), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23994), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24860), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24860), { 0, 0, height },
                         { 32, 25, 2 }, { 0, 3, height });
                     break;
             }
@@ -7865,49 +7865,49 @@ static void wooden_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24137), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24137), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25003), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25003), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24141), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24141), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25007), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25007), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24153), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24153), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25019), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25019), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24145), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24145), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25011), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25011), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24149), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24149), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25015), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25015), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24157), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24157), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25023), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25023), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7924,49 +7924,49 @@ static void wooden_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24138), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24138), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25004), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25004), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24142), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24142), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25008), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25008), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24154), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24154), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25020), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25020), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24146), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24146), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25012), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25012), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24150), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24150), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25016), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25016), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24158), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24158), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25024), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25024), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -7979,49 +7979,49 @@ static void wooden_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24139), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24139), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25005), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25005), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24143), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24143), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25009), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25009), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24155), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24155), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25021), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25021), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24147), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24147), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25013), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25013), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24151), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24151), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25017), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25017), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24159), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24159), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25025), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25025), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8053,46 +8053,46 @@ static void wooden_rc_track_left_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24140), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24140), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25006), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25006), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24144), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24144), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25010), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25010), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24156), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24156), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25022), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25022), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24148), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24148), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25014), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25014), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24152), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24152), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25018), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25018), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24160), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24160), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25026), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25026), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
             }
@@ -8115,49 +8115,49 @@ static void wooden_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24113), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24113), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24979), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24979), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24129), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24129), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24995), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24995), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24117), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24117), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24983), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24983), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24121), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24121), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24987), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24987), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24133), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24133), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24999), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24999), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24125), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24125), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24991), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24991), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8174,49 +8174,49 @@ static void wooden_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24114), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24114), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24980), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24980), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24130), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24130), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24996), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24996), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24118), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24118), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24984), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24984), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24122), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24122), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24988), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24988), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24134), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24134), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25000), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25000), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24126), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24126), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24992), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24992), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8229,49 +8229,49 @@ static void wooden_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24115), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24115), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24981), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24981), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24131), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24131), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24997), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24997), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24119), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24119), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24985), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24985), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24123), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24123), { 0, 0, height },
                         { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24989), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24989), { 0, 0, height },
                         { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24135), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24135), { 0, 0, height },
                         { 28, 28, 0 }, { 4, 4, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25001), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25001), { 0, 0, height },
                         { 28, 28, 0 }, { 4, 4, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24127), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24127), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24993), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24993), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8303,46 +8303,46 @@ static void wooden_rc_track_right_eighth_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24116), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24116), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24982), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24982), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24132), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24132), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24998), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24998), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24120), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24120), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24986), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24986), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24124), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24124), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24990), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24990), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24136), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24136), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25002), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25002), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24128), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24128), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24994), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24994), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     break;
             }
@@ -8385,49 +8385,49 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24185), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24185), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25051), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25051), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24189), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24189), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25055), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25055), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24201), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24201), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25067), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25067), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24193), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24193), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25059), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25059), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24197), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24197), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25063), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25063), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24205), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24205), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25071), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25071), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8444,49 +8444,49 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24186), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24186), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25052), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25052), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24190), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24190), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25056), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25056), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24202), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24202), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25068), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25068), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24194), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24194), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25060), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25060), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24198), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24198), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25064), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25064), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24206), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24206), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25072), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25072), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8499,49 +8499,49 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24187), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24187), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25053), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25053), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24191), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24191), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25057), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25057), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24203), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24203), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25069), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25069), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24195), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24195), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25061), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25061), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24199), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24199), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25065), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25065), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24207), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24207), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25073), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25073), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8573,46 +8573,46 @@ static void wooden_rc_track_left_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24188), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24188), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25054), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25054), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24192), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24192), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25058), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25058), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24204), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24204), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25070), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25070), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24196), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24196), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25062), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25062), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24200), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24200), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25066), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25066), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24208), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24208), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25074), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25074), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
             }
@@ -8635,49 +8635,49 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24161), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24161), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25027), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25027), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24177), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24177), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25043), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25043), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24165), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24165), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25031), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25031), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24169), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24169), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25035), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25035), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24181), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24181), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25047), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25047), { 0, 0, height },
                         { 32, 32, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24173), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24173), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25039), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25039), { 0, 0, height },
                         { 32, 32, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8694,49 +8694,49 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24162), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24162), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25028), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25028), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24178), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24178), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25044), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25044), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24166), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24166), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25032), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25032), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24170), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24170), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25036), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25036), { 0, 0, height },
                         { 34, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24182), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24182), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25048), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25048), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24174), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24174), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25040), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25040), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8749,49 +8749,49 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24163), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24163), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25029), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25029), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24179), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24179), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25045), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25045), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24167), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24167), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25033), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25033), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24171), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24171), { 0, 0, height },
                         { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25037), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25037), { 0, 0, height },
                         { 28, 28, 2 }, { 4, 4, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24183), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24183), { 0, 0, height },
                         { 28, 28, 0 }, { 4, 4, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25049), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25049), { 0, 0, height },
                         { 28, 28, 0 }, { 4, 4, height + 27 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24175), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24175), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25041), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25041), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -8823,46 +8823,46 @@ static void wooden_rc_track_right_eighth_bank_to_diag(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24164), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24164), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25030), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25030), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24180), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24180), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25046), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25046), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 0, height + 27 });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24168), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24168), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25034), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25034), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24172), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24172), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25038), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25038), { 0, 0, height },
                         { 16, 18, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24184), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24184), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25050), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25050), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 16, height + 27 });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24176), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24176), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25042), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25042), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     break;
             }
@@ -8909,10 +8909,10 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24050),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24050),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24916), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24916), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -8923,10 +8923,10 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24008),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24008),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24874), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24874), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -8941,16 +8941,16 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24047),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24047),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24913), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24913), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24051),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24051),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24917), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24917), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 27 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -8971,16 +8971,16 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24005),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24005),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24871), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24871), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24009),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24009),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24875), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24875), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 27 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9011,16 +9011,16 @@ static void wooden_rc_track_diag_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24049),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24049),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24915), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24915), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24052),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24052),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24918), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24918), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 27 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9041,16 +9041,16 @@ static void wooden_rc_track_diag_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24007),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24007),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24873), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24873), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24010),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24010),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24876), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24876), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 27 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9069,10 +9069,10 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24048),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24048),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24914), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24914), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9083,10 +9083,10 @@ static void wooden_rc_track_diag_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24006),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24006),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24872), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24872), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9112,10 +9112,10 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24068),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24068),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24934), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24934), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9126,10 +9126,10 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24026),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24026),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24892), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24892), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9144,16 +9144,16 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24065),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24065),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24931), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24931), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24069),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24069),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24935), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24935), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9174,16 +9174,16 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24023),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24023),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24889), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24889), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24027),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24027),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24893), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24893), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9214,16 +9214,16 @@ static void wooden_rc_track_diag_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24067),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24067),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24933), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24933), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24070),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24070),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24936), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24936), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9244,16 +9244,16 @@ static void wooden_rc_track_diag_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24025),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24025),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24891), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24891), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24028),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24028),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24894), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24894), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9272,10 +9272,10 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24066),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24066),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24932), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24932), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9286,10 +9286,10 @@ static void wooden_rc_track_diag_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24024),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24024),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24890), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24890), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9313,10 +9313,10 @@ static void wooden_rc_track_diag_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24044),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24044),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24910), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24910), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -9328,16 +9328,16 @@ static void wooden_rc_track_diag_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24041),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24041),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24907), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24907), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24045),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24045),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24911), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24911), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 91 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -9365,16 +9365,16 @@ static void wooden_rc_track_diag_60_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24043),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24043),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24909), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24909), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24046),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24046),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24912), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24912), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 91 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -9390,10 +9390,10 @@ static void wooden_rc_track_diag_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24042),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24042),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24908), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24908), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -9418,10 +9418,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24056),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24056),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24922), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24922), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9432,10 +9432,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24014),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24014),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24880), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24880), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9450,16 +9450,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24053),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24053),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24919), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24919), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24057),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24057),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24923), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24923), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9480,16 +9480,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24011),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24011),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24877), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24877), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24015),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24015),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24881), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24881), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9520,16 +9520,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24055),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24055),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24921), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24921), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24058),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24058),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24924), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24924), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9550,16 +9550,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24013),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24013),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24879), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24879), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24016),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24016),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24882), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24882), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9578,10 +9578,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24054),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24054),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24920), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24920), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9592,10 +9592,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_up(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24012),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24012),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24878), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24878), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9619,10 +9619,10 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24032),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24032),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24898), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24898), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -9634,16 +9634,16 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24029),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24029),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24895), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24895), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24033),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24033),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24899), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24899), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -9671,16 +9671,16 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24031),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24031),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24897), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24897), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24034),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24034),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24900), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24900), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -9696,10 +9696,10 @@ static void wooden_rc_track_diag_25_deg_up_to_60_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24030),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24030),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24896), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24896), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -9722,10 +9722,10 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24038),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24038),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24904), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24904), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -9737,16 +9737,16 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24035),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24035),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24901), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24901), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24039),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24039),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24905), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24905), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -9774,16 +9774,16 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24037),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24037),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24903), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24903), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24040),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24040),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24906), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24906), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -9799,10 +9799,10 @@ static void wooden_rc_track_diag_60_deg_up_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24036),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24036),
                         { -16, -16, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24902), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24902), { -16, -16, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     break;
             }
@@ -9827,10 +9827,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24062),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24062),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24928), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24928), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9841,10 +9841,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24020),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24020),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24886), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24886), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -9859,16 +9859,16 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24059),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24059),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24925), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24925), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24063),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24063),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24929), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24929), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9889,16 +9889,16 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24017),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24017),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24883), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24883), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24021),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24021),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24887), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24887), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9929,16 +9929,16 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24061),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24061),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24927), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24927), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24064),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24064),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24930), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24930), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9959,16 +9959,16 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24019),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24019),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24885), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24885), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24022),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24022),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24888), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24888), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -9987,10 +9987,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24060),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24060),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24926), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24926), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10001,10 +10001,10 @@ static void wooden_rc_track_diag_25_deg_up_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24018),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24018),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24884), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24884), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10030,10 +10030,10 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24066),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24066),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24932), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24932), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10044,10 +10044,10 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24024),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24024),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24890), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24890), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10062,16 +10062,16 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24067),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24067),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24933), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24933), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24070),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24070),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24936), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24936), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10092,16 +10092,16 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24025),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24025),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24891), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24891), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24028),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24028),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24894), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24894), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10132,16 +10132,16 @@ static void wooden_rc_track_diag_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24065),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24065),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24931), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24931), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24069),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24069),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24935), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24935), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10162,16 +10162,16 @@ static void wooden_rc_track_diag_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24023),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24023),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24889), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24889), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24027),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24027),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 43 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24893), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24893), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 43 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10190,10 +10190,10 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24068),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24068),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24934), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24934), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10204,10 +10204,10 @@ static void wooden_rc_track_diag_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24026),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24026),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24892), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24892), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10231,10 +10231,10 @@ static void wooden_rc_track_diag_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24042),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24042),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24908), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24908), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -10246,16 +10246,16 @@ static void wooden_rc_track_diag_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24043),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24043),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24909), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24909), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24046),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24046),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24912), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24912), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 91 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -10283,16 +10283,16 @@ static void wooden_rc_track_diag_60_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24041),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24041),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24907), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24907), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24045),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24045),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 91 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24911), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24911), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 91 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -10308,10 +10308,10 @@ static void wooden_rc_track_diag_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24044),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24044),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24910), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24910), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -10336,10 +10336,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24060),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24060),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24926), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24926), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10350,10 +10350,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24018),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24018),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24884), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24884), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10366,16 +10366,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24061),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24061),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24927), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24927), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24064),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24064),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24930), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24930), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10396,16 +10396,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24019),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24019),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24885), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24885), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24022),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24022),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24888), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24888), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10434,16 +10434,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24059),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24059),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24925), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24925), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24063),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24063),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24929), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24929), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10464,16 +10464,16 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24017),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24017),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24883), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24883), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24021),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24021),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24887), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24887), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10490,10 +10490,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24062),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24062),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24928), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24928), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10504,10 +10504,10 @@ static void wooden_rc_track_diag_flat_to_25_deg_down(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24020),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24020),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24886), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24886), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10532,10 +10532,10 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24036),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24036),
                         { -16, -16, height }, { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24902), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24902), { -16, -16, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     break;
             }
@@ -10547,16 +10547,16 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24037),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24037),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24903), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24903), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24040),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24040),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24906), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24906), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -10584,16 +10584,16 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24035),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24035),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24901), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24901), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24039),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24039),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24905), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24905), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -10609,10 +10609,10 @@ static void wooden_rc_track_diag_25_deg_down_to_60_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24038),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24038),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24904), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24904), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -10635,10 +10635,10 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24030),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24030),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24896), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24896), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -10650,16 +10650,16 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24031),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24031),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24897), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24897), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24034),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24034),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24900), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24900), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -10687,16 +10687,16 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24029),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24029),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24895), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24895), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24033),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24033),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24899), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24899), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 59 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -10712,10 +10712,10 @@ static void wooden_rc_track_diag_60_deg_down_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24032),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24032),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24898), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24898), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -10740,10 +10740,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24054),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24054),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24920), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24920), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10754,10 +10754,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 3:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24012),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24012),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24878), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24878), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10772,16 +10772,16 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24055),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24055),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24921), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24921), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24058),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24058),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24924), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24924), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10802,16 +10802,16 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 0:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24013),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24013),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24879), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24879), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24016),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24016),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24882), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24882), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10842,16 +10842,16 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24053),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24053),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24919), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24919), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24057),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24057),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24923), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24923), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10872,16 +10872,16 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24011),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24011),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24877), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24877), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24015),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24015),
                             { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24881), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24881), { -16, -16, height },
                             { 32, 32, 0 }, { -16, -16, height + 35 });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
@@ -10900,10 +10900,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24056),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24056),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24922), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24922), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10914,10 +10914,10 @@ static void wooden_rc_track_diag_25_deg_down_to_flat(
                 {
                     case 1:
                         PaintAddImageAsParentRotated(
-                            session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24014),
+                            session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24014),
                             { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                         PaintAddImageAsChildRotated(
-                            session, direction, wooden_rc_get_rails_colour(session).WithIndex(24880), { -16, -16, height },
+                            session, direction, WoodenRcGetRailsColour(session).WithIndex(24880), { -16, -16, height },
                             { 32, 32, 2 }, { -16, -16, height });
                         break;
                 }
@@ -10941,10 +10941,10 @@ static void wooden_rc_track_diag_flat_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24080),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24080),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24946), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24946), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -10956,16 +10956,16 @@ static void wooden_rc_track_diag_flat_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24077),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24077),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24943), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24943), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24081),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24081),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24947), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24947), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -10993,16 +10993,16 @@ static void wooden_rc_track_diag_flat_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24079),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24079),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24945), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24945), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24082),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24082),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24948), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24948), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11018,10 +11018,10 @@ static void wooden_rc_track_diag_flat_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24078),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24078),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24944), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24944), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11044,10 +11044,10 @@ static void wooden_rc_track_diag_flat_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24086),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24086),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24952), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24952), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11059,16 +11059,16 @@ static void wooden_rc_track_diag_flat_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24083),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24083),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24949), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24949), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24087),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24087),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24953), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24953), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11096,16 +11096,16 @@ static void wooden_rc_track_diag_flat_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24085),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24085),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24951), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24951), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24088),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24088),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24954), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24954), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11121,10 +11121,10 @@ static void wooden_rc_track_diag_flat_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24084),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24084),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24950), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24950), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11147,10 +11147,10 @@ static void wooden_rc_track_diag_left_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24084),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24084),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24950), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24950), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11162,16 +11162,16 @@ static void wooden_rc_track_diag_left_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24085),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24085),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24951), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24951), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24088),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24088),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24954), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24954), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11199,16 +11199,16 @@ static void wooden_rc_track_diag_left_bank_to_flat(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24083),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24083),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24949), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24949), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24087),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24087),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24953), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24953), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11224,10 +11224,10 @@ static void wooden_rc_track_diag_left_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24086),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24086),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24952), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24952), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11250,10 +11250,10 @@ static void wooden_rc_track_diag_right_bank_to_flat(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24078),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24078),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24944), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24944), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11265,16 +11265,16 @@ static void wooden_rc_track_diag_right_bank_to_flat(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24079),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24079),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24945), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24945), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24082),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24082),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24948), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24948), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11302,16 +11302,16 @@ static void wooden_rc_track_diag_right_bank_to_flat(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24077),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24077),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24943), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24943), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24081),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24081),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24947), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24947), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11327,10 +11327,10 @@ static void wooden_rc_track_diag_right_bank_to_flat(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24080),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24080),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24946), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24946), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11353,10 +11353,10 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24104),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24104),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24970), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24970), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11368,16 +11368,16 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24101),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24101),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24967), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24967), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24105),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24105),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24971), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24971), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11405,16 +11405,16 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24103),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24103),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24969), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24969), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24106),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24106),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24972), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24972), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11430,10 +11430,10 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24102),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24102),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24968), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24968), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11456,10 +11456,10 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24110),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24110),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24976), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24976), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11471,16 +11471,16 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24107),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24107),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24973), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24973), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24111),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24111),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24977), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24977), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11508,16 +11508,16 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24109),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24109),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24975), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24975), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24112),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24112),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24978), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24978), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11533,10 +11533,10 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_up(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24108),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24108),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24974), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24974), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11559,10 +11559,10 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24092),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24092),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24958), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24958), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11574,16 +11574,16 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24089),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24089),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24955), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24955), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24093),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24093),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24959), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24959), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11611,16 +11611,16 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24091),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24091),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24957), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24957), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24094),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24094),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24960), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24960), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11636,10 +11636,10 @@ static void wooden_rc_track_diag_25_deg_up_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24090),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24090),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24956), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24956), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11662,10 +11662,10 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24098),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24098),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24964), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24964), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11677,16 +11677,16 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24095),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24095),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24961), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24961), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24099),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24099),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24965), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24965), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11714,16 +11714,16 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24097),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24097),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24963), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24963), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24100),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24100),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24966), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24966), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11739,10 +11739,10 @@ static void wooden_rc_track_diag_25_deg_up_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24096),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24096),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24962), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24962), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11765,10 +11765,10 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24096),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24096),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24962), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24962), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11778,16 +11778,16 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24097),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24097),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24963), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24963), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24100),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24100),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24966), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24966), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11813,16 +11813,16 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24095),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24095),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24961), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24961), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24099),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24099),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24965), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24965), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11836,10 +11836,10 @@ static void wooden_rc_track_diag_left_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24098),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24098),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24964), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24964), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11863,10 +11863,10 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24090),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24090),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24956), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24956), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11876,16 +11876,16 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24091),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24091),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24957), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24957), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24094),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24094),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24960), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24960), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11911,16 +11911,16 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24089),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24089),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24955), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24955), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24093),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24093),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24959), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24959), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -11934,10 +11934,10 @@ static void wooden_rc_track_diag_right_bank_to_25_deg_down(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24092),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24092),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24958), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24958), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11961,10 +11961,10 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24108),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24108),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24974), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24974), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -11976,16 +11976,16 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24109),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24109),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24975), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24975), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24112),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24112),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24978), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24978), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12013,16 +12013,16 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24107),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24107),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24973), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24973), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24111),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24111),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24977), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24977), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12038,10 +12038,10 @@ static void wooden_rc_track_diag_25_deg_down_to_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24110),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24110),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24976), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24976), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -12064,10 +12064,10 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24102),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24102),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24968), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24968), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -12079,16 +12079,16 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24103),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24103),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24969), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24969), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24106),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24106),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24972), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24972), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12116,16 +12116,16 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24101),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24101),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24967), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24967), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24105),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24105),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 35 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24971), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24971), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 35 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12141,10 +12141,10 @@ static void wooden_rc_track_diag_25_deg_down_to_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24104),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24104),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24970), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24970), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -12167,10 +12167,10 @@ static void wooden_rc_track_diag_left_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24074),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24074),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24940), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24940), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -12182,16 +12182,16 @@ static void wooden_rc_track_diag_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24071),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24071),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24937), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24937), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24075),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24075),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24941), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24941), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12219,16 +12219,16 @@ static void wooden_rc_track_diag_left_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24073),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24073),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24939), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24939), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24076),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24076),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24942), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24942), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12244,10 +12244,10 @@ static void wooden_rc_track_diag_left_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24072),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24072),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24938), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24938), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -12270,10 +12270,10 @@ static void wooden_rc_track_diag_right_bank(
             {
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24072),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24072),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24938), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24938), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -12285,16 +12285,16 @@ static void wooden_rc_track_diag_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24073),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24073),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24939), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24939), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24076),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24076),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24942), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24942), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12322,16 +12322,16 @@ static void wooden_rc_track_diag_right_bank(
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24071),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24071),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24937), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24937), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24075),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24075),
                         { -16, -16, height }, { 32, 32, 0 }, { -16, -16, height + 27 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24941), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24941), { -16, -16, height },
                         { 32, 32, 0 }, { -16, -16, height + 27 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12347,10 +12347,10 @@ static void wooden_rc_track_diag_right_bank(
             {
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24074),
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24074),
                         { -16, -16, height }, { 32, 32, 2 }, { -16, -16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24940), { -16, -16, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24940), { -16, -16, height },
                         { 32, 32, 2 }, { -16, -16, height });
                     break;
             }
@@ -12373,49 +12373,49 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23958), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23958), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24824), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24824), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23960), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23960), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24826), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24826), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23971), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23971), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24837), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24837), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23962), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23962), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24828), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24828), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23956), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23956), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24822), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24822), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23969), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23969), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24835), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24835), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12440,55 +12440,55 @@ static void wooden_rc_track_left_bank_to_left_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23957), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23957), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24823), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24823), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23959), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23959), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24825), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24825), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23970), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23970), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24836), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24836), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23961), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23961), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24827), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24827), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23972), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23972), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24838), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24838), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23955), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23955), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24821), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24821), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23968), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23968), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24834), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24834), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12521,49 +12521,49 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23947), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23947), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24813), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24813), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23963), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23963), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24829), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24829), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23949), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23949), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24815), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24815), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23951), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23951), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24817), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24817), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23966), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23966), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24832), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24832), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23953), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23953), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24819), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24819), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12588,55 +12588,55 @@ static void wooden_rc_track_right_bank_to_right_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23948), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23948), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24814), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24814), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23964), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23964), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24830), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24830), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23950), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23950), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24816), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24816), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23965), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23965), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24831), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24831), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23952), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23952), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24818), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24818), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23967), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23967), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24833), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24833), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23954), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23954), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24820), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24820), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12669,55 +12669,55 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23950), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23950), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24816), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24816), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23965), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23965), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24831), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24831), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23952), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23952), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24818), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24818), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23967), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23967), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24833), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24833), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23954), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23954), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24820), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24820), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23948), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23948), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24814), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24814), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23964), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23964), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24830), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24830), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12742,49 +12742,49 @@ static void wooden_rc_track_left_quarter_turn_3_25_deg_down_to_left_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23949), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23949), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24815), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24815), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23951), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23951), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24817), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24817), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23966), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23966), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24832), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24832), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23953), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23953), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24819), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24819), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23947), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23947), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24813), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24813), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23963), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23963), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24829), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24829), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12817,55 +12817,55 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23955), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23955), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24821), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24821), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23968), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23968), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24834), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24834), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23957), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23957), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24823), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24823), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23959), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23959), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24825), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24825), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23970), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23970), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24836), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24836), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23961), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23961), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24827), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24827), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23972), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23972), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24838), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24838), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12890,49 +12890,49 @@ static void wooden_rc_track_right_quarter_turn_3_25_deg_down_to_right_bank(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23956), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23956), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24822), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24822), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23969), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23969), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24835), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24835), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23958), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23958), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24824), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24824), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23960), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23960), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24826), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24826), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23971), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23971), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24837), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24837), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23962), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23962), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24828), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24828), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -12960,7 +12960,7 @@ static void wooden_rc_track_block_brakes(
 {
     const auto brakeImg = trackElement.IsBrakeClosed() ? _wooden_rc_block_brakes_image_ids[direction][1]
                                                        : _wooden_rc_block_brakes_image_ids[direction][0];
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, brakeImg, _wooden_rc_block_brakes_image_ids[direction][2], direction, 0, 2, 32, 25, 2, height, 0, 3, height);
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -12981,49 +12981,49 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23932), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23932), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24798), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24798), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23934), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23934), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24800), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24800), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23945), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23945), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24811), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24811), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23936), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23936), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24802), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24802), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23930), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23930), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24796), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24796), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23943), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23943), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24809), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24809), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13048,55 +13048,55 @@ static void wooden_rc_track_left_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23931), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23931), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24797), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24797), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23933), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23933), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24799), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24799), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23944), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23944), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24810), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24810), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23935), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23935), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24801), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24801), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23946), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23946), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24812), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24812), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23929), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23929), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24795), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24795), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23942), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23942), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24808), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24808), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13129,49 +13129,49 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23921), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23921), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24787), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24787), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23937), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23937), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24803), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24803), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23923), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23923), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24789), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24789), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23925), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23925), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24791), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24791), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23940), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23940), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24806), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24806), { 0, 6, height },
                         { 32, 20, 0 }, { 0, 6, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23927), { 0, 6, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23927), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24793), { 0, 6, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24793), { 0, 6, height },
                         { 32, 20, 2 }, { 0, 6, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13196,55 +13196,55 @@ static void wooden_rc_track_right_banked_quarter_turn_3_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23922), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23922), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24788), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24788), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23938), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23938), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24804), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24804), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23924), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23924), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24790), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24790), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23939), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23939), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24805), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24805), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23926), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23926), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24792), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24792), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23941), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23941), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24807), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24807), { 6, 0, height },
                         { 20, 32, 0 }, { 6, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(23928), { 6, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(23928), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(24794), { 6, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(24794), { 6, 0, height },
                         { 20, 32, 2 }, { 6, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13299,43 +13299,43 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24321), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24321), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25187), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25187), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24326), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24326), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25192), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25192), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24352), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24352), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25218), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25218), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24331), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24331), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25197), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25197), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24336), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24336), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25202), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25202), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13357,49 +13357,49 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24322), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24322), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25188), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25188), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24327), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24327), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25193), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25193), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24353), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24353), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25219), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25219), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24332), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24332), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25198), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25198), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24337), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24337), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25203), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25203), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24359), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24359), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25225), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25225), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13415,49 +13415,49 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24323), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24323), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25189), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25189), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24328), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24328), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25194), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25194), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24354), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24354), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25220), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25220), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24333), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24333), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25199), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25199), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24338), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24338), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25204), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25204), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24360), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24360), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25226), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25226), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13480,55 +13480,55 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24324), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24324), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25190), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25190), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24329), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24329), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25195), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25195), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24355), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24355), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25221), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25221), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24334), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24334), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25200), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25200), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24357), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24357), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25223), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25223), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24339), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24339), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25205), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25205), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24361), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24361), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25227), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25227), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13544,55 +13544,55 @@ static void wooden_rc_track_left_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24325), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24325), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25191), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25191), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24330), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24330), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25196), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25196), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24356), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24356), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25222), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25222), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24335), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24335), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25201), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25201), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24358), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24358), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25224), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25224), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24340), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24340), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25206), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25206), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24362), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24362), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25228), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25228), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13625,43 +13625,43 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24301), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24301), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25167), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25167), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24306), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24306), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25172), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25172), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24311), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24311), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25177), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25177), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24347), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24347), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25213), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25213), { 0, 0, height },
                         { 32, 27, 0 }, { 0, 2, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24316), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24316), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25182), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25182), { 0, 0, height },
                         { 32, 27, 2 }, { 0, 2, height });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13683,49 +13683,49 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24302), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24302), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25168), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25168), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24341), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24341), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25207), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25207), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 16, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24307), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24307), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25173), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25173), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24312), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24312), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25178), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25178), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24348), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24348), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25214), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25214), { 0, 0, height },
                         { 32, 16, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24317), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24317), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25183), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25183), { 0, 0, height },
                         { 32, 16, 2 }, { 0, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13741,49 +13741,49 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24303), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24303), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25169), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25169), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24342), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24342), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25208), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25208), { 0, 0, height },
                         { 16, 16, 0 }, { 0, 0, height + 59 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24308), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24308), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25174), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25174), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24313), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24313), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25179), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25179), { 0, 0, height },
                         { 16, 16, 2 }, { 16, 16, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24349), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24349), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25215), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25215), { 0, 0, height },
                         { 16, 16, 0 }, { 16, 16, height + 59 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24318), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24318), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25184), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25184), { 0, 0, height },
                         { 16, 16, 2 }, { 0, 16, height });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13806,55 +13806,55 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24304), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24304), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25170), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25170), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24343), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24343), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25209), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25209), { 0, 0, height },
                         { 16, 32, 0 }, { 16, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24309), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24309), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25175), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25175), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24345), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24345), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25211), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25211), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24314), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24314), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25180), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25180), { 0, 0, height },
                         { 16, 32, 2 }, { 0, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24350), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24350), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25216), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25216), { 0, 0, height },
                         { 16, 32, 0 }, { 0, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24319), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24319), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25185), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25185), { 0, 0, height },
                         { 16, 32, 2 }, { 16, 0, height });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13870,55 +13870,55 @@ static void wooden_rc_track_right_banked_quarter_turn_5_25_deg_up(
             {
                 case 0:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24305), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24305), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25171), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25171), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24344), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24344), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25210), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25210), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24310), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24310), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25176), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25176), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24346), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24346), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25212), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25212), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24315), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24315), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25181), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25181), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24351), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24351), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25217), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25217), { 0, 0, height },
                         { 27, 32, 0 }, { 2, 0, height + 67 });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
-                        session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24320), { 0, 0, height },
+                        session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24320), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     PaintAddImageAsChildRotated(
-                        session, direction, wooden_rc_get_rails_colour(session).WithIndex(25186), { 0, 0, height },
+                        session, direction, WoodenRcGetRailsColour(session).WithIndex(25186), { 0, 0, height },
                         { 27, 32, 2 }, { 2, 0, height });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
@@ -13970,37 +13970,37 @@ static void wooden_rc_track_25_deg_up_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24261), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24261), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25127), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25127), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24262), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24262), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25128), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25128), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24263), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24263), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25129), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25129), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24264), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24264), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25130), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25130), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14027,37 +14027,37 @@ static void wooden_rc_track_25_deg_up_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24265), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24265), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25131), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25131), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24266), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24266), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25132), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25132), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24267), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24267), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25133), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25133), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24268), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24268), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25134), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25134), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14084,37 +14084,37 @@ static void wooden_rc_track_left_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24269), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24269), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25135), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25135), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24270), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24270), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25136), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25136), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24271), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24271), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25137), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25137), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24272), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24272), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25138), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25138), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14141,37 +14141,37 @@ static void wooden_rc_track_right_banked_25_deg_up_to_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24273), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24273), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25139), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25139), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24274), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24274), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25140), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25140), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24275), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24275), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25141), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25141), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24276), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24276), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25142), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25142), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14238,49 +14238,49 @@ static void wooden_rc_track_left_banked_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24277), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24277), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25143), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25143), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24278), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24278), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25144), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25144), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24293), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24293), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25159), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25159), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24279), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24279), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25145), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25145), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24294), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24294), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25160), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25160), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24280), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24280), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25146), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25146), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14307,49 +14307,49 @@ static void wooden_rc_track_right_banked_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24281), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24281), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25147), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25147), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24282), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24282), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25148), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25148), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24295), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24295), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25161), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25161), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24283), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24283), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25149), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25149), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24296), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24296), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25162), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25162), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24284), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24284), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25150), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25150), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14376,49 +14376,49 @@ static void wooden_rc_track_left_banked_25_deg_up_to_left_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24285), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24285), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25151), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25151), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24286), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24286), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25152), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25152), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24297), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24297), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25163), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25163), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24287), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24287), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25153), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25153), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24298), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24298), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25164), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25164), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24288), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24288), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25154), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25154), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14445,49 +14445,49 @@ static void wooden_rc_track_right_banked_25_deg_up_to_right_banked_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24289), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24289), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25155), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25155), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24290), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24290), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25156), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25156), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24299), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24299), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25165), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25165), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24291), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24291), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25157), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25157), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24300), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24300), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25166), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25166), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24292), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24292), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25158), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25158), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14554,49 +14554,49 @@ static void wooden_rc_track_flat_to_left_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24225), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24225), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25091), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25091), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24226), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24226), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25092), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25092), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24241), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24241), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25107), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25107), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24227), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24227), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25093), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25093), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24242), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24242), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25108), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25108), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24228), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24228), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25094), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25094), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14623,49 +14623,49 @@ static void wooden_rc_track_flat_to_right_banked_25_deg_up(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24229), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24229), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25095), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25095), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24230), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24230), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25096), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25096), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24243), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24243), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25109), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25109), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24231), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24231), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25097), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25097), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24244), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24244), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25110), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25110), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24232), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24232), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25098), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25098), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14692,49 +14692,49 @@ static void wooden_rc_track_left_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24233), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24233), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25099), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25099), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24234), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24234), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25100), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25100), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24245), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24245), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25111), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25111), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24235), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24235), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25101), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25101), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24246), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24246), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25112), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25112), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24236), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24236), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25102), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25102), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14761,49 +14761,49 @@ static void wooden_rc_track_right_banked_25_deg_up_to_flat(
     {
         case 0:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24237), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24237), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25103), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25103), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24238), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24238), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25104), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25104), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24247), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24247), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25113), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25113), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24239), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24239), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25105), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25105), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24248), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24248), { 0, 0, height },
                 { 32, 1, 9 }, { 0, 26, height + 5 });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25114), { 0, 0, height }, { 32, 1, 9 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25114), { 0, 0, height }, { 32, 1, 9 },
                 { 0, 26, height + 5 });
             WoodenASupportsPaintSetup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
-                session, direction, wooden_rc_get_track_colour<isClassic>(session).WithIndex(24240), { 0, 0, height },
+                session, direction, WoodenRcGetTrackColour<isClassic>(session).WithIndex(24240), { 0, 0, height },
                 { 32, 25, 2 }, { 0, 3, height });
             PaintAddImageAsChildRotated(
-                session, direction, wooden_rc_get_rails_colour(session).WithIndex(25106), { 0, 0, height }, { 32, 25, 2 },
+                session, direction, WoodenRcGetRailsColour(session).WithIndex(25106), { 0, 0, height }, { 32, 25, 2 },
                 { 0, 3, height });
             WoodenASupportsPaintSetup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
@@ -14878,7 +14878,7 @@ static void wooden_rc_track_booster(
         SPR_WOODEN_RC_FLAT_CHAIN_RAILS_SE_NW,
     };
 
-    wooden_rc_track_paint<isClassic>(
+    WoodenRcTrackPaint<isClassic>(
         session, imageIds[direction], railsImageIds[direction], direction, 0, 2, 32, 25, 2, height, 0, 3, height);
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -15181,7 +15181,7 @@ TRACK_PAINT_FUNCTION get_track_paint_function_wooden_rc(int32_t trackType)
     return get_track_paint_function_wooden_and_classic_wooden_rc<false>(trackType);
 }
 
-TRACK_PAINT_FUNCTION get_track_paint_function_classic_wooden_rc_fallback(int32_t trackType)
+TRACK_PAINT_FUNCTION GetTrackPaintFunctionClassicWoodenRcFallback(int32_t trackType)
 {
     return get_track_paint_function_wooden_and_classic_wooden_rc<true>(trackType);
 }

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.h
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.h
@@ -24,7 +24,7 @@ struct sprite_bb_2
     CoordsXYZ bb_size;
 };
 
-template<bool isClassic> ImageId wooden_rc_get_track_colour(const PaintSession& session)
+template<bool isClassic> ImageId WoodenRcGetTrackColour(const PaintSession& session)
 {
     if (isClassic)
         return session.TrackColours[SCHEME_TRACK];
@@ -34,16 +34,16 @@ template<bool isClassic> ImageId wooden_rc_get_track_colour(const PaintSession& 
             : session.TrackColours[SCHEME_TRACK].WithPrimary(session.TrackColours[SCHEME_SUPPORTS].GetPrimary());
 }
 
-ImageId wooden_rc_get_rails_colour(PaintSession& session);
+ImageId WoodenRcGetRailsColour(PaintSession& session);
 
 template<bool isClassic>
-PaintStruct* wooden_rc_track_paint(
+PaintStruct* WoodenRcTrackPaint(
     PaintSession& session, uint32_t imageIdTrack, uint32_t imageIdRails, uint8_t direction, int8_t x_offset, int8_t y_offset,
     int16_t bound_box_length_x, int16_t bound_box_length_y, int8_t bound_box_length_z, int16_t z_offset,
     int16_t bound_box_offset_x, int16_t bound_box_offset_y, int16_t bound_box_offset_z)
 {
-    ImageId imageId = wooden_rc_get_track_colour<isClassic>(session).WithIndex(imageIdTrack);
-    ImageId railsImageId = wooden_rc_get_rails_colour(session).WithIndex(imageIdRails);
+    ImageId imageId = WoodenRcGetTrackColour<isClassic>(session).WithIndex(imageIdTrack);
+    ImageId railsImageId = WoodenRcGetRailsColour(session).WithIndex(imageIdRails);
 
     PaintAddImageAsParentRotated(
         session, direction, imageId, { x_offset, y_offset, z_offset },
@@ -55,22 +55,22 @@ PaintStruct* wooden_rc_track_paint(
         { bound_box_offset_x, bound_box_offset_y, bound_box_offset_z });
 }
 
-template<bool isClassic> void wooden_rc_track_paint_bb(PaintSession& session, const sprite_bb_2* bb, int16_t height)
+template<bool isClassic> void WoodenRcTrackPaintBb(PaintSession& session, const sprite_bb_2* bb, int16_t height)
 {
     if (bb->sprite_id_a == 0)
         return;
 
-    ImageId imageId = wooden_rc_get_track_colour<isClassic>(session).WithIndex(bb->sprite_id_a);
+    ImageId imageId = WoodenRcGetTrackColour<isClassic>(session).WithIndex(bb->sprite_id_a);
     PaintAddImageAsParent(
         session, imageId, { bb->offset.x, bb->offset.y, height + bb->offset.z }, bb->bb_size,
         { bb->bb_offset.x, bb->bb_offset.y, height + bb->bb_offset.z });
     if (bb->sprite_id_b != 0)
     {
-        ImageId railsImageId = wooden_rc_get_rails_colour(session).WithIndex(bb->sprite_id_b);
+        ImageId railsImageId = WoodenRcGetRailsColour(session).WithIndex(bb->sprite_id_b);
         PaintAddImageAsChild(
             session, railsImageId, { bb->offset.x, bb->offset.y, height + bb->offset.z },
             { { bb->bb_offset, height + bb->bb_offset.z }, bb->bb_size });
     }
 }
 
-TRACK_PAINT_FUNCTION get_track_paint_function_classic_wooden_rc_fallback(int32_t trackType);
+TRACK_PAINT_FUNCTION GetTrackPaintFunctionClassicWoodenRcFallback(int32_t trackType);

--- a/src/openrct2/ride/gentle/SpaceRings.cpp
+++ b/src/openrct2/ride/gentle/SpaceRings.cpp
@@ -40,7 +40,7 @@ static void PaintSpaceRingsStructure(
 
     if (ride.num_stations == 0 || vehicleIndex < ride.NumTrains)
     {
-        rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
+        rct_ride_entry* rideEntry = GetRideEntryByIndex(ride.subtype);
 
         int32_t frameNum = direction;
 

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -45,7 +45,7 @@ static void PaintEnterpriseRiders(
 static void PaintEnterpriseStructure(
     PaintSession& session, const Ride& ride, int8_t xOffset, int8_t yOffset, uint16_t height, const TrackElement& trackElement)
 {
-    const auto* rideEntry = get_ride_entry(ride.subtype);
+    const auto* rideEntry = GetRideEntryByIndex(ride.subtype);
     if (rideEntry == nullptr)
         return;
 

--- a/src/openrct2/ride/thrill/SwingingInverterShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingInverterShip.cpp
@@ -61,7 +61,7 @@ static constexpr const uint32_t SwingingInverterShipFrameSprites[] = {
 static void PaintSwingingInverterShipStructure(
     PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
 {
-    rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride.subtype);
     if (rideEntry == nullptr)
         return;
 

--- a/src/openrct2/ride/thrill/SwingingShip.cpp
+++ b/src/openrct2/ride/thrill/SwingingShip.cpp
@@ -86,7 +86,7 @@ static void PaintSwingingShipRiders(
 static void PaintSwingingShipStructure(
     PaintSession& session, const Ride& ride, uint8_t direction, int8_t axisOffset, uint16_t height)
 {
-    rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride.subtype);
     if (rideEntry == nullptr)
         return;
 

--- a/src/openrct2/ride/thrill/TopSpin.cpp
+++ b/src/openrct2/ride/thrill/TopSpin.cpp
@@ -119,7 +119,7 @@ static void PaintTopSpinVehicle(
     PaintSession& session, int32_t al, int32_t cl, const Ride& ride, uint8_t direction, int32_t height,
     const TrackElement& tileElement)
 {
-    const auto* rideEntry = get_ride_entry(ride.subtype);
+    const auto* rideEntry = GetRideEntryByIndex(ride.subtype);
     if (rideEntry == nullptr)
         return;
 

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -23,7 +23,7 @@
 static void paint_twist_structure(
     PaintSession& session, const Ride& ride, uint8_t direction, int8_t xOffset, int8_t yOffset, uint16_t height)
 {
-    rct_ride_entry* rideEntry = get_ride_entry(ride.subtype);
+    rct_ride_entry* rideEntry = GetRideEntryByIndex(ride.subtype);
     Vehicle* vehicle = nullptr;
 
     if (rideEntry == nullptr)

--- a/src/openrct2/ride/water/WaterCoaster.cpp
+++ b/src/openrct2/ride/water/WaterCoaster.cpp
@@ -18,7 +18,7 @@ static void water_rc_track_flat(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_flat(
+    JuniorRcPaintTrackFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -28,7 +28,7 @@ static void water_rc_track_25_deg_up(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_25_deg_up(
+    JuniorRcPaintTrack25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -38,7 +38,7 @@ static void water_rc_track_flat_to_25_deg_up(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_flat_to_25_deg_up(
+    JuniorRcPaintTrackFlatTo25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -48,7 +48,7 @@ static void water_rc_track_25_deg_up_to_flat(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_25_deg_up_to_flat(
+    JuniorRcPaintTrack25DegUpToFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -79,7 +79,7 @@ static void water_rc_track_diag_flat(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_flat(
+    JuniorRcPaintTrackDiagFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -89,7 +89,7 @@ static void water_rc_track_diag_25_deg_up(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_25_deg_up(
+    JuniorRcPaintTrackDiag25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -99,7 +99,7 @@ static void water_rc_track_diag_flat_to_25_deg_up(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_flat_to_25_deg_up(
+    JuniorRcPaintTrackDiagFlatTo25DegUp(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -109,7 +109,7 @@ static void water_rc_track_diag_25_deg_up_to_flat(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_25_deg_up_to_flat(
+    JuniorRcPaintTrackDiag25DegUpToFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -119,7 +119,7 @@ static void water_rc_track_diag_25_deg_down(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_25_deg_down(
+    JuniorRcPaintTrackDiag25DegDown(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -129,7 +129,7 @@ static void water_rc_track_diag_flat_to_25_deg_down(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_flat_to_25_deg_down(
+    JuniorRcPaintTrackDiagFlatTo25DegDown(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -139,7 +139,7 @@ static void water_rc_track_diag_25_deg_down_to_flat(
     const TrackElement& trackElement)
 {
     bool isChained = trackElement.HasChain();
-    junior_rc_paint_track_diag_25_deg_down_to_flat(
+    JuniorRcPaintTrackDiag25DegDownToFlat(
         session, ride, trackSequence, direction, height, trackElement,
         isChained ? JuniorRcChainType::ChainLift : JuniorRcChainType::None);
 }
@@ -148,21 +148,21 @@ static void water_rc_track_station(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_station(session, ride, trackSequence, direction, height, trackElement, false);
+    JuniorRcPaintStation(session, ride, trackSequence, direction, height, trackElement, false);
 }
 
 static void water_rc_track_60_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_60_deg_up(session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
+    JuniorRcPaintTrack60DegUp(session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_25_deg_up_to_60_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_25_deg_up_to_60_deg_up(
+    JuniorRcPaintTrack25DegUpTo60DegUp(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -170,7 +170,7 @@ static void water_rc_track_60_deg_up_to_25_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_60_deg_up_to_25_deg_up(
+    JuniorRcPaintTrack60DegUpTo25DegUp(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -201,7 +201,7 @@ static void water_rc_track_left_quarter_turn_5_tiles_25_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_left_quarter_turn_5_tiles_25_deg_up(
+    JuniorRcPaintTrackLeftQuarterTurn5Tiles25DegUp(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -209,7 +209,7 @@ static void water_rc_track_right_quarter_turn_5_tiles_25_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_right_quarter_turn_5_tiles_25_deg_up(
+    JuniorRcPaintTrackRightQuarterTurn5Tiles25DegUp(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -241,7 +241,7 @@ static void water_rc_track_right_quarter_turn_3_tiles_25_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_up(
+    juniorRcPaintTrackRightQuarterTurn3Tiles25DegUp(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -249,7 +249,7 @@ static void water_rc_track_right_quarter_turn_3_tiles_25_deg_down(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_right_quarter_turn_3_tiles_25_deg_down(
+    JuniorRcPaintTrackRightQuarterTurn3Tiles25DegDown(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -282,7 +282,7 @@ static void water_rc_track_diag_60_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_diag_60_deg_up(
+    JuniorRcPaintTrackDiag60DegUp(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -290,7 +290,7 @@ static void water_rc_track_diag_25_deg_up_to_60_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_diag_25_deg_up_to_60_deg_up(
+    JuniorRcPaintTrackDiag25DegUpTo60DegUp(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -298,7 +298,7 @@ static void water_rc_track_diag_60_deg_up_to_25_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_diag_60_deg_up_to_25_deg_up(
+    JuniorRcPaintTrackDiag60DegUpTo25DegUp(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -306,7 +306,7 @@ static void water_rc_track_diag_60_deg_down(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_diag_60_deg_down(
+    JuniorRcPaintTrackDiag60DegDown(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -314,7 +314,7 @@ static void water_rc_track_diag_25_deg_down_to_60_deg_down(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_diag_25_deg_down_to_60_deg_down(
+    JuniorRcPaintTrackDiag25DegDownTo60DegDown(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
@@ -322,7 +322,7 @@ static void water_rc_track_diag_60_deg_down_to_25_deg_down(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    junior_rc_paint_track_diag_60_deg_down_to_25_deg_down(
+    JuniorRcPaintTrackDiag60DegDownTo25DegDown(
         session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 

--- a/src/openrct2/ride/water/WaterCoaster.cpp
+++ b/src/openrct2/ride/water/WaterCoaster.cpp
@@ -162,16 +162,14 @@ static void water_rc_track_25_deg_up_to_60_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    JuniorRcPaintTrack25DegUpTo60DegUp(
-        session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
+    JuniorRcPaintTrack25DegUpTo60DegUp(session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_60_deg_up_to_25_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    JuniorRcPaintTrack60DegUpTo25DegUp(
-        session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
+    JuniorRcPaintTrack60DegUpTo25DegUp(session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_60_deg_down(
@@ -282,8 +280,7 @@ static void water_rc_track_diag_60_deg_up(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    JuniorRcPaintTrackDiag60DegUp(
-        session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
+    JuniorRcPaintTrackDiag60DegUp(session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_25_deg_up_to_60_deg_up(
@@ -306,8 +303,7 @@ static void water_rc_track_diag_60_deg_down(
     PaintSession& session, const Ride& ride, uint8_t trackSequence, uint8_t direction, int32_t height,
     const TrackElement& trackElement)
 {
-    JuniorRcPaintTrackDiag60DegDown(
-        session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
+    JuniorRcPaintTrackDiag60DegDown(session, ride, trackSequence, direction, height, trackElement, JuniorRcChainType::None);
 }
 
 static void water_rc_track_diag_25_deg_down_to_60_deg_down(


### PR DESCRIPTION
In `Ride.h`, `rct_ride_entry* get_ride_entry(ObjectEntryIndex index);` was renamed to `rct_ride_entry* GetRideEntryByIndex(ObjectEntryIndex index);` due to a conflict with the already existing `rct_ride_entry* GetRideEntry() const;`. This is only temporary since @duncanspumpkin wants to refactor the former anway.

Todo:
- RideRatings
- TrackPaint