### PR TITLE
Replace format_string(4) with OpenRCT2::FormatStringLegacy()

### DIFF
--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -17,6 +17,7 @@
 #include <openrct2/Input.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
+#include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/sprites.h>
 #include <openrct2/util/Util.h>
@@ -487,7 +488,7 @@ static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetInde
             colour |= COLOUR_FLAG_INSET;
 
         utf8 buffer[512] = { 0 };
-        format_string(buffer, sizeof(buffer), stringId, formatArgs);
+        OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), stringId, formatArgs);
         auto ft = Formatter();
         ft.Add<utf8*>(buffer);
         DrawTextBasic(dpi, { l, t }, STR_STRING, ft, { colour });

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -17,6 +17,7 @@
 #    include <numeric>
 #    include <openrct2/Context.h>
 #    include <openrct2/localisation/Formatter.h>
+#    include <openrct2/localisation/Formatting.h>
 #    include <openrct2/localisation/Localisation.h>
 #    include <openrct2/util/Util.h>
 
@@ -714,7 +715,7 @@ void CustomListView::PaintSeperator(
         DrawTextBasic(dpi, { centreX, pos.y }, STR_STRING, ft, { baseColour, TextAlignment::CENTRE });
 
         // Get string dimensions
-        format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_STRING, ft.Data());
+        FormatStringLegacy(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_STRING, ft.Data());
         int32_t categoryStringHalfWidth = (GfxGetStringWidth(gCommonStringFormatBuffer, FontStyle::Medium) / 2) + 4;
         int32_t strLeft = centreX - categoryStringHalfWidth;
         int32_t strRight = centreX + categoryStringHalfWidth;

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -18,6 +18,7 @@
 #include <openrct2/core/FileSystem.hpp>
 #include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
+#include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/platform/Platform.h>
 #include <openrct2/ui/UiContext.h>
@@ -234,7 +235,7 @@ private:
             char version_info[256];
 
             const char* version_info_ptr = _newVersionInfo->name.c_str();
-            format_string(version_info, 256, STR_NEW_RELEASE_VERSION_INFO, &version_info_ptr);
+            FormatStringLegacy(version_info, 256, STR_NEW_RELEASE_VERSION_INFO, &version_info_ptr);
 
             _changelogLines.emplace_back(version_info);
             _changelogLines.emplace_back("");

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -17,6 +17,7 @@
 #include <openrct2/core/BitSet.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
+#include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/sprites.h>
 
@@ -352,7 +353,7 @@ void WindowDropdownShowText(const ScreenCoordsXY& screenPos, int32_t extray, uin
     max_string_width = 0;
     for (size_t i = 0; i < num_items; i++)
     {
-        format_string(buffer, 256, gDropdownItems[i].Format, static_cast<void*>(&gDropdownItems[i].Args));
+        FormatStringLegacy(buffer, 256, gDropdownItems[i].Format, static_cast<void*>(&gDropdownItems[i].Args));
         string_width = GfxGetStringWidth(buffer, FontStyle::Medium);
         max_string_width = std::max(string_width, max_string_width);
     }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -23,6 +23,7 @@
 #include <openrct2/entity/Guest.h>
 #include <openrct2/entity/Staff.h>
 #include <openrct2/localisation/Formatter.h>
+#include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/management/Marketing.h>
 #include <openrct2/network/network.h>
@@ -1850,17 +1851,17 @@ private:
             ft.Add<int32_t>(peep->NextLoc.x);
             ft.Add<int32_t>(peep->NextLoc.y);
             ft.Add<int32_t>(peep->NextLoc.z);
-            format_string(buffer, sizeof(buffer), STR_PEEP_DEBUG_NEXT, ft.Data());
+            OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), STR_PEEP_DEBUG_NEXT, ft.Data());
             if (peep->GetNextIsSurface())
             {
-                format_string(buffer2, sizeof(buffer2), STR_PEEP_DEBUG_NEXT_SURFACE, nullptr);
+                OpenRCT2::FormatStringLegacy(buffer2, sizeof(buffer2), STR_PEEP_DEBUG_NEXT_SURFACE, nullptr);
                 safe_strcat(buffer, buffer2, sizeof(buffer));
             }
             if (peep->GetNextIsSloped())
             {
                 auto ft2 = Formatter();
                 ft2.Add<int32_t>(peep->GetNextDirection());
-                format_string(buffer2, sizeof(buffer2), STR_PEEP_DEBUG_NEXT_SLOPE, ft2.Data());
+                OpenRCT2::FormatStringLegacy(buffer2, sizeof(buffer2), STR_PEEP_DEBUG_NEXT_SLOPE, ft2.Data());
                 safe_strcat(buffer, buffer2, sizeof(buffer));
             }
             GfxDrawString(&dpi, screenCoords, buffer, {});

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -18,6 +18,7 @@
 #include <openrct2/entity/EntityRegistry.h>
 #include <openrct2/entity/Guest.h>
 #include <openrct2/localisation/Formatter.h>
+#include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/ride/RideData.h>
 #include <openrct2/scenario/Scenario.h>
@@ -630,7 +631,7 @@ public:
 
                 Formatter ft;
                 peep->FormatNameTo(ft);
-                format_string(item.Name, sizeof(item.Name), STR_STRINGID, ft.Data());
+                OpenRCT2::FormatStringLegacy(item.Name, sizeof(item.Name), STR_STRINGID, ft.Data());
             }
 
             std::sort(_guestList.begin(), _guestList.end(), GetGuestCompareFunc());
@@ -784,7 +785,7 @@ private:
 
             Formatter ft;
             peep.FormatNameTo(ft);
-            format_string(name, sizeof(name), STR_STRINGID, ft.Data());
+            OpenRCT2::FormatStringLegacy(name, sizeof(name), STR_STRINGID, ft.Data());
             if (!String::Contains(name, _filterName.c_str(), true))
             {
                 return false;

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -16,6 +16,7 @@
 #include <openrct2/core/Json.hpp>
 #include <openrct2/core/String.hpp>
 #include <openrct2/localisation/Formatter.h>
+#include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/object/ObjectList.h>
 #include <openrct2/object/ObjectManager.h>
@@ -121,7 +122,8 @@ private:
                     ft.Add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Count));
                     ft.Add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Total));
                     ft.Add<char*>(_downloadStatusInfo.Name.c_str());
-                    format_string(str_downloading_objects, sizeof(str_downloading_objects), STR_DOWNLOADING_OBJECTS, ft.Data());
+                    OpenRCT2::FormatStringLegacy(
+                        str_downloading_objects, sizeof(str_downloading_objects), STR_DOWNLOADING_OBJECTS, ft.Data());
                 }
                 else
                 {
@@ -129,7 +131,7 @@ private:
                     ft.Add<char*>(_downloadStatusInfo.Source.c_str());
                     ft.Add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Count));
                     ft.Add<int16_t>(static_cast<int16_t>(_downloadStatusInfo.Total));
-                    format_string(
+                    OpenRCT2::FormatStringLegacy(
                         str_downloading_objects, sizeof(str_downloading_objects), STR_DOWNLOADING_OBJECTS_FROM, ft.Data());
                 }
 

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -16,6 +16,7 @@
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Date.h>
 #include <openrct2/localisation/Formatter.h>
+#include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/Localisation.h>
 #include <openrct2/localisation/LocalisationService.h>
 #include <openrct2/ride/RideData.h>
@@ -659,7 +660,7 @@ static void DrawCategoryHeading(
     // Get string dimensions
     utf8 buffer[CommonTextBufferSize];
     auto bufferPtr = buffer;
-    format_string(bufferPtr, sizeof(buffer), stringId, nullptr);
+    OpenRCT2::FormatStringLegacy(bufferPtr, sizeof(buffer), stringId, nullptr);
     int32_t categoryStringHalfWidth = (GfxGetStringWidth(bufferPtr, FontStyle::Medium) / 2) + 4;
     int32_t strLeft = centreX - categoryStringHalfWidth;
     int32_t strRight = centreX + categoryStringHalfWidth;

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -14,6 +14,7 @@
 #include <openrct2/Input.h>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/localisation/Formatter.h>
+#include <openrct2/localisation/Formatting.h>
 #include <openrct2/localisation/Localisation.h>
 
 // clang-format off
@@ -107,11 +108,11 @@ private:
     int32_t FormatTextForTooltip(const OpenRCT2String& message)
     {
         utf8 tempBuffer[CommonTextBufferSize];
-        format_string(tempBuffer, sizeof(tempBuffer), message.str, message.args.Data());
+        OpenRCT2::FormatStringLegacy(tempBuffer, sizeof(tempBuffer), message.str, message.args.Data());
 
         OpenRCT2String formattedMessage{ STR_STRING_TOOLTIP, Formatter() };
         formattedMessage.args.Add<const char*>(tempBuffer);
-        format_string(_tooltipText, sizeof(_tooltipText), formattedMessage.str, formattedMessage.args.Data());
+        OpenRCT2::FormatStringLegacy(_tooltipText, sizeof(_tooltipText), formattedMessage.str, formattedMessage.args.Data());
 
         auto textWidth = GfxGetStringWidthNewLined(_tooltipText, FontStyle::Small);
         textWidth = std::min(textWidth, 196);

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -274,7 +274,7 @@ void GfxDrawStringLeftCentred(
 {
     char buffer[CommonTextBufferSize];
     auto bufferPtr = buffer;
-    format_string(bufferPtr, sizeof(buffer), format, args);
+    FormatStringLegacy(bufferPtr, sizeof(buffer), format, args);
     int32_t height = StringGetHeightRaw(bufferPtr, FontStyle::Medium);
     GfxDrawString(dpi, coords - ScreenCoordsXY{ 0, (height / 2) }, bufferPtr, { colour });
 }
@@ -438,7 +438,7 @@ void DrawNewsTicker(
     ScreenCoordsXY screenCoords(dpi->x, dpi->y);
 
     GfxDrawString(dpi, screenCoords, "", { colour });
-    format_string(buffer, 256, format, args);
+    FormatStringLegacy(buffer, 256, format, args);
 
     GfxWrapString(buffer, width, FontStyle::Small, &numLines);
     lineHeight = FontGetLineHeight(FontStyle::Small);

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -154,7 +154,7 @@ static void ScrollingTextFormat(utf8* dst, size_t size, rct_draw_scroll_text* sc
     }
     else
     {
-        format_string(dst, size, scrollText->string_id, scrollText->string_args);
+        FormatStringLegacy(dst, size, scrollText->string_id, scrollText->string_args);
     }
 }
 

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -10,6 +10,7 @@
 #include "Text.h"
 
 #include "../localisation/Formatter.h"
+#include "../localisation/Formatting.h"
 #include "../localisation/Localisation.h"
 #include "Drawing.h"
 
@@ -120,7 +121,7 @@ static void DrawText(
     rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, StringId format, const void* args)
 {
     utf8 buffer[512];
-    format_string(buffer, sizeof(buffer), format, args);
+    OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), format, args);
     DrawText(dpi, coords, paint, buffer);
 }
 
@@ -149,7 +150,7 @@ void DrawTextEllipsised(
     TextPaint textPaint)
 {
     utf8 buffer[512];
-    format_string(buffer, sizeof(buffer), format, ft.Data());
+    OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
     GfxClipString(buffer, width, textPaint.FontStyle);
 
     DrawText(dpi, coords, textPaint, buffer);

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -23,6 +23,7 @@
 #include "../entity/Particle.h"
 #include "../interface/Window_internal.h"
 #include "../localisation/Formatter.h"
+#include "../localisation/Formatting.h"
 #include "../localisation/Localisation.h"
 #include "../management/Finance.h"
 #include "../management/Marketing.h"
@@ -581,7 +582,7 @@ int32_t Guest::GetEasterEggNameId() const
 
     Formatter ft;
     FormatNameTo(ft);
-    format_string(buffer, sizeof(buffer), STR_STRINGID, ft.Data());
+    FormatStringLegacy(buffer, sizeof(buffer), STR_STRINGID, ft.Data());
 
     for (uint32_t i = 0; i < std::size(gPeepEasterEggNames); i++)
         if (_stricmp(buffer, gPeepEasterEggNames[i]) == 0)
@@ -728,7 +729,7 @@ int32_t Guest::CheckEasterEggName(int32_t index) const
 
     Formatter ft;
     FormatNameTo(ft);
-    format_string(buffer, sizeof(buffer), STR_STRINGID, ft.Data());
+    FormatStringLegacy(buffer, sizeof(buffer), STR_STRINGID, ft.Data());
 
     return _stricmp(buffer, gPeepEasterEggNames[index]) == 0;
 }

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -13,6 +13,7 @@
 #include "../drawing/Drawing.h"
 #include "../interface/Viewport.h"
 #include "../interface/Window.h"
+#include "../localisation/Formatting.h"
 #include "../localisation/Localisation.h"
 #include "../network/network.h"
 #include "../paint/Paint.h"
@@ -59,7 +60,7 @@ void MoneyEffect::CreateAt(money64 value, const CoordsXYZ& effectPos, bool verti
     {
         auto [stringId, newValue] = moneyEffect->GetStringId();
         char buffer[128];
-        format_string(buffer, 128, stringId, &newValue);
+        OpenRCT2::FormatStringLegacy(buffer, 128, stringId, &newValue);
         offsetX = -(GfxGetStringWidth(buffer, FontStyle::Medium) / 2);
     }
     moneyEffect->OffsetX = offsetX;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -26,6 +26,7 @@
 #include "../entity/EntityTweener.h"
 #include "../interface/Window.h"
 #include "../localisation/Formatter.h"
+#include "../localisation/Formatting.h"
 #include "../localisation/Localisation.h"
 #include "../management/Finance.h"
 #include "../management/Marketing.h"
@@ -2602,12 +2603,12 @@ int32_t peep_compare(const EntityId sprite_index_a, const EntityId sprite_index_
     char nameA[256]{};
     Formatter ft;
     peep_a->FormatNameTo(ft);
-    format_string(nameA, sizeof(nameA), STR_STRINGID, ft.Data());
+    OpenRCT2::FormatStringLegacy(nameA, sizeof(nameA), STR_STRINGID, ft.Data());
 
     char nameB[256]{};
     ft.Rewind();
     peep_b->FormatNameTo(ft);
-    format_string(nameB, sizeof(nameB), STR_STRINGID, ft.Data());
+    OpenRCT2::FormatStringLegacy(nameB, sizeof(nameB), STR_STRINGID, ft.Data());
     return strlogicalcmp(nameA, nameB);
 }
 

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -304,7 +304,7 @@ int32_t ChatStringWrappedGetHeight(void* args, int32_t width)
 {
     char buffer[CommonTextBufferSize];
     auto bufferPtr = buffer;
-    format_string(bufferPtr, 256, STR_STRING, args);
+    FormatStringLegacy(bufferPtr, 256, STR_STRING, args);
 
     int32_t numLines;
     GfxWrapString(bufferPtr, width, FontStyle::Medium, &numLines);

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -38,6 +38,7 @@
 #include "../interface/Chat.h"
 #include "../interface/Colour.h"
 #include "../interface/Window_internal.h"
+#include "../localisation/Formatting.h"
 #include "../localisation/Localisation.h"
 #include "../management/Finance.h"
 #include "../management/NewsItem.h"
@@ -169,7 +170,7 @@ static int32_t ConsoleCommandRides(InteractiveConsole& console, const arguments_
                     {
                         char mode_name[128] = { 0 };
                         StringId mode_string_id = RideModeNames[i];
-                        format_string(mode_name, 128, mode_string_id, nullptr);
+                        OpenRCT2::FormatStringLegacy(mode_name, 128, mode_string_id, nullptr);
                         console.WriteFormatLine("%02d - %s", i, mode_name);
                     }
                 }
@@ -476,7 +477,7 @@ static int32_t ConsoleCommandStaff(InteractiveConsole& console, const arguments_
                 {
                     char costume_name[128] = { 0 };
                     StringId costume = StaffCostumeNames[i];
-                    format_string(costume_name, 128, STR_DROPDOWN_MENU_LABEL, &costume);
+                    OpenRCT2::FormatStringLegacy(costume_name, 128, STR_DROPDOWN_MENU_LABEL, &costume);
                     // That's a terrible hack here. Costume names include inline sprites
                     // that don't work well with the console, so manually skip past them.
                     console.WriteFormatLine("        costume %i: %s", i, costume_name + 7);

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -19,6 +19,7 @@
 #include "../core/Guard.hpp"
 #include "../drawing/Drawing.h"
 #include "../interface/Cursors.h"
+#include "../localisation/Formatting.h"
 #include "../localisation/Localisation.h"
 #include "../localisation/StringIds.h"
 #include "../platform/Platform.h"
@@ -1992,7 +1993,7 @@ void WindowStartTextbox(
     // Enter in the text input buffer any existing
     // text.
     if (existing_text != STR_NONE)
-        format_string(gTextBoxInput, TEXT_INPUT_SIZE, existing_text, &existing_args);
+        OpenRCT2::FormatStringLegacy(gTextBoxInput, TEXT_INPUT_SIZE, existing_text, &existing_args);
 
     // In order to prevent strings that exceed the maxLength
     // from crashing the game.

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -832,8 +832,3 @@ namespace OpenRCT2
     }
 
 } // namespace OpenRCT2
-
-void format_string(utf8* dest, size_t size, StringId format, const void* args)
-{
-    OpenRCT2::FormatStringLegacy(dest, size, format, args);
-}

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -27,6 +27,7 @@
 #include "../ride/Ride.h"
 #include "../util/Util.h"
 #include "Date.h"
+#include "Formatting.h"
 #include "Localisation.h"
 
 #include <algorithm>
@@ -334,7 +335,7 @@ std::string FormatStringID(StringId format, const void* args)
     size_t len{};
     for (;;)
     {
-        format_string(buffer.data(), buffer.size(), format, args);
+        OpenRCT2::FormatStringLegacy(buffer.data(), buffer.size(), format, args);
         len = buffer.find('\0');
         if (len == std::string::npos)
         {
@@ -375,7 +376,7 @@ void FormatStringToUpper(utf8* dest, size_t size, StringId format, const void* a
         return;
     }
 
-    format_string(dest, size, format, args);
+    OpenRCT2::FormatStringLegacy(dest, size, format, args);
 
     std::string upperString = String::ToUpper(dest);
 
@@ -405,7 +406,7 @@ void FormatReadableSize(char* buf, size_t bufSize, uint64_t sizeBytes)
     }
 
     char sizeType[128] = {};
-    format_string(sizeType, sizeof(sizeType), SizeTable[idx], nullptr);
+    OpenRCT2::FormatStringLegacy(sizeType, sizeof(sizeType), SizeTable[idx], nullptr);
 
     snprintf(buf, bufSize, "%.03f %s", size, sizeType);
 }
@@ -418,7 +419,7 @@ void FormatReadableSpeed(char* buf, size_t bufSize, uint64_t sizeBytes)
     const char* args[1] = {
         sizeText,
     };
-    format_string(buf, bufSize, STR_NETWORK_SPEED_SEC, args);
+    OpenRCT2::FormatStringLegacy(buf, bufSize, STR_NETWORK_SPEED_SEC, args);
 }
 
 money64 StringToMoney(const char* string_to_monetise)

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -19,7 +19,6 @@
 #include <string>
 
 std::string FormatStringID(StringId format, const void* args);
-void format_string(char* dest, size_t size, StringId format, const void* args);
 void FormatStringToUpper(char* dest, size_t size, StringId format, const void* args);
 void generate_string_file();
 

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -19,6 +19,7 @@
 #include "../interface/Window_internal.h"
 #include "../localisation/Date.h"
 #include "../localisation/Formatter.h"
+#include "../localisation/Formatting.h"
 #include "../localisation/Localisation.h"
 #include "../management/Research.h"
 #include "../profiling/Profiling.h"
@@ -310,7 +311,7 @@ News::Item* News::AddItemToQueue(News::ItemType type, StringId string_id, uint32
     utf8 buffer[256];
 
     // overflows possible?
-    format_string(buffer, 256, string_id, formatter.Data());
+    OpenRCT2::FormatStringLegacy(buffer, 256, string_id, formatter.Data());
     return News::AddItemToQueue(type, buffer, assoc);
 }
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -561,7 +561,7 @@ void NetworkBase::UpdateClient()
                     {
                         _lastConnectStatus = SocketStatus::Resolving;
                         char str_resolving[256];
-                        format_string(str_resolving, 256, STR_MULTIPLAYER_RESOLVING, nullptr);
+                        FormatStringLegacy(str_resolving, 256, STR_MULTIPLAYER_RESOLVING, nullptr);
 
                         auto intent = Intent(WindowClass::NetworkStatus);
                         intent.putExtra(INTENT_EXTRA_MESSAGE, std::string{ str_resolving });
@@ -576,7 +576,7 @@ void NetworkBase::UpdateClient()
                     {
                         _lastConnectStatus = SocketStatus::Connecting;
                         char str_connecting[256];
-                        format_string(str_connecting, 256, STR_MULTIPLAYER_CONNECTING, nullptr);
+                        FormatStringLegacy(str_connecting, 256, STR_MULTIPLAYER_CONNECTING, nullptr);
 
                         auto intent = Intent(WindowClass::NetworkStatus);
                         intent.putExtra(INTENT_EXTRA_MESSAGE, std::string{ str_connecting });
@@ -593,7 +593,7 @@ void NetworkBase::UpdateClient()
                     _serverConnection->ResetLastPacketTime();
                     Client_Send_TOKEN();
                     char str_authenticating[256];
-                    format_string(str_authenticating, 256, STR_MULTIPLAYER_AUTHENTICATING, nullptr);
+                    FormatStringLegacy(str_authenticating, 256, STR_MULTIPLAYER_AUTHENTICATING, nullptr);
 
                     auto intent = Intent(WindowClass::NetworkStatus);
                     intent.putExtra(INTENT_EXTRA_MESSAGE, std::string{ str_authenticating });
@@ -633,11 +633,11 @@ void NetworkBase::UpdateClient()
                     if (_serverConnection->GetLastDisconnectReason())
                     {
                         const char* disconnect_reason = _serverConnection->GetLastDisconnectReason();
-                        format_string(str_disconnected, 256, STR_MULTIPLAYER_DISCONNECTED_WITH_REASON, &disconnect_reason);
+                        FormatStringLegacy(str_disconnected, 256, STR_MULTIPLAYER_DISCONNECTED_WITH_REASON, &disconnect_reason);
                     }
                     else
                     {
-                        format_string(str_disconnected, 256, STR_MULTIPLAYER_DISCONNECTED_NO_REASON, nullptr);
+                        FormatStringLegacy(str_disconnected, 256, STR_MULTIPLAYER_DISCONNECTED_NO_REASON, nullptr);
                     }
 
                     auto intent = Intent(WindowClass::NetworkStatus);
@@ -790,7 +790,7 @@ bool NetworkBase::CheckDesynchronizaton()
         _serverState.desyncTick = gCurrentTicks;
 
         char str_desync[256];
-        format_string(str_desync, 256, STR_MULTIPLAYER_DESYNC, nullptr);
+        FormatStringLegacy(str_desync, 256, STR_MULTIPLAYER_DESYNC, nullptr);
 
         auto intent = Intent(WindowClass::NetworkStatus);
         intent.putExtra(INTENT_EXTRA_MESSAGE, std::string{ str_desync });
@@ -828,7 +828,7 @@ void NetworkBase::KickPlayer(int32_t playerId)
             // Disconnect the client gracefully
             client_connection->SetLastDisconnectReason(STR_MULTIPLAYER_KICKED);
             char str_disconnect_msg[256];
-            format_string(str_disconnect_msg, 256, STR_MULTIPLAYER_KICKED_REASON, nullptr);
+            FormatStringLegacy(str_disconnect_msg, 256, STR_MULTIPLAYER_KICKED_REASON, nullptr);
             Server_Send_SETDISCONNECTMSG(*client_connection, str_disconnect_msg);
             client_connection->Disconnect();
             break;
@@ -1133,11 +1133,11 @@ void NetworkBase::BeginServerLog()
     utf8 logMessage[256];
     if (GetMode() == NETWORK_MODE_CLIENT)
     {
-        format_string(logMessage, sizeof(logMessage), STR_LOG_CLIENT_STARTED, nullptr);
+        FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_CLIENT_STARTED, nullptr);
     }
     else if (GetMode() == NETWORK_MODE_SERVER)
     {
-        format_string(logMessage, sizeof(logMessage), STR_LOG_SERVER_STARTED, nullptr);
+        FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_SERVER_STARTED, nullptr);
     }
     else
     {
@@ -1161,11 +1161,11 @@ void NetworkBase::CloseServerLog()
     char logMessage[256];
     if (GetMode() == NETWORK_MODE_CLIENT)
     {
-        format_string(logMessage, sizeof(logMessage), STR_LOG_CLIENT_STOPPED, nullptr);
+        FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_CLIENT_STOPPED, nullptr);
     }
     else if (GetMode() == NETWORK_MODE_SERVER)
     {
-        format_string(logMessage, sizeof(logMessage), STR_LOG_SERVER_STOPPED, nullptr);
+        FormatStringLegacy(logMessage, sizeof(logMessage), STR_LOG_SERVER_STOPPED, nullptr);
     }
     else
     {
@@ -1967,11 +1967,11 @@ void NetworkBase::ServerClientDisconnected(std::unique_ptr<NetworkConnection>& c
     };
     if (has_disconnected_args[1] != nullptr)
     {
-        format_string(text, 256, STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_WITH_REASON, has_disconnected_args);
+        FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_WITH_REASON, has_disconnected_args);
     }
     else
     {
-        format_string(text, 256, STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_NO_REASON, &(has_disconnected_args[0]));
+        FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_DISCONNECTED_NO_REASON, &(has_disconnected_args[0]));
     }
 
     ChatAddHistory(text);
@@ -2269,7 +2269,7 @@ void NetworkBase::Server_Client_Joined(std::string_view name, const std::string&
     {
         char text[256];
         const char* player_name = static_cast<const char*>(player->Name.c_str());
-        format_string(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
+        FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
         ChatAddHistory(text);
 
         auto& context = GetContext();
@@ -2281,7 +2281,7 @@ void NetworkBase::Server_Client_Joined(std::string_view name, const std::string&
         // Log player joining event
         std::string playerNameHash = player->Name + " (" + keyhash + ")";
         player_name = static_cast<const char*>(playerNameHash.c_str());
-        format_string(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
+        FormatStringLegacy(text, 256, STR_MULTIPLAYER_PLAYER_HAS_JOINED_THE_GAME, &player_name);
         AppendServerLog(text);
 
         ProcessPlayerJoinedPluginHooks(player->Id);
@@ -2320,7 +2320,7 @@ void NetworkBase::Client_Handle_OBJECTS_LIST(NetworkConnection& connection, Netw
             index + 1,
             totalObjects,
         };
-        format_string(objectListMsg, 256, STR_MULTIPLAYER_RECEIVING_OBJECTS_LIST, &args);
+        FormatStringLegacy(objectListMsg, 256, STR_MULTIPLAYER_RECEIVING_OBJECTS_LIST, &args);
 
         auto intent = Intent(WindowClass::NetworkStatus);
         intent.putExtra(INTENT_EXTRA_MESSAGE, std::string{ objectListMsg });
@@ -2458,7 +2458,7 @@ void NetworkBase::Client_Handle_GAMESTATE(NetworkConnection& connection, Network
                 ft.Add<char*>(uniqueFileName);
 
                 char str_desync[1024];
-                format_string(str_desync, sizeof(str_desync), STR_DESYNC_REPORT, ft.Data());
+                FormatStringLegacy(str_desync, sizeof(str_desync), STR_DESYNC_REPORT, ft.Data());
 
                 auto intent = Intent(WindowClass::NetworkStatus);
                 intent.putExtra(INTENT_EXTRA_MESSAGE, std::string{ str_desync });
@@ -2666,7 +2666,7 @@ void NetworkBase::Client_Handle_MAP([[maybe_unused]] NetworkConnection& connecti
         (offset + chunksize) / 1024,
         size / 1024,
     };
-    format_string(str_downloading_map, 256, STR_MULTIPLAYER_DOWNLOADING_MAP, downloading_map_args);
+    FormatStringLegacy(str_downloading_map, 256, STR_MULTIPLAYER_DOWNLOADING_MAP, downloading_map_args);
 
     auto intent = Intent(WindowClass::NetworkStatus);
     intent.putExtra(INTENT_EXTRA_MESSAGE, std::string{ str_downloading_map });
@@ -3419,7 +3419,7 @@ void network_chat_show_connected_message()
     const char* sptr = s.c_str();
 
     utf8 buffer[256];
-    format_string(buffer, sizeof(buffer), STR_MULTIPLAYER_CONNECTED_CHAT_HINT, &sptr);
+    FormatStringLegacy(buffer, sizeof(buffer), STR_MULTIPLAYER_CONNECTED_CHAT_HINT, &sptr);
 
     NetworkPlayer server;
     server.Name = "Server";
@@ -3493,7 +3493,7 @@ GameActions::Result network_set_player_group(
             new_player_group->GetName().c_str(),
             game_command_player->Name.c_str(),
         };
-        format_string(log_msg, 256, STR_LOG_SET_PLAYER_GROUP, args);
+        FormatStringLegacy(log_msg, 256, STR_LOG_SET_PLAYER_GROUP, args);
         network_append_server_log(log_msg);
     }
     return GameActions::Result();

--- a/src/openrct2/network/NetworkConnection.cpp
+++ b/src/openrct2/network/NetworkConnection.cpp
@@ -12,6 +12,7 @@
 #    include "NetworkConnection.h"
 
 #    include "../core/String.hpp"
+#    include "../localisation/Formatting.h"
 #    include "../localisation/Localisation.h"
 #    include "../platform/Platform.h"
 #    include "Socket.h"
@@ -198,7 +199,7 @@ void NetworkConnection::SetLastDisconnectReason(std::string_view src)
 void NetworkConnection::SetLastDisconnectReason(const StringId string_id, void* args)
 {
     char buffer[NETWORK_DISCONNECT_REASON_BUFFER_SIZE];
-    format_string(buffer, NETWORK_DISCONNECT_REASON_BUFFER_SIZE, string_id, args);
+    OpenRCT2::FormatStringLegacy(buffer, NETWORK_DISCONNECT_REASON_BUFFER_SIZE, string_id, args);
     SetLastDisconnectReason(buffer);
 }
 

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -14,6 +14,7 @@
 #include "../core/Guard.hpp"
 #include "../drawing/Drawing.h"
 #include "../interface/Viewport.h"
+#include "../localisation/Formatting.h"
 #include "../localisation/Localisation.h"
 #include "../localisation/LocalisationService.h"
 #include "../paint/Painter.h"
@@ -907,7 +908,7 @@ void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, PaintStringStruct* ps)
     do
     {
         char buffer[256]{};
-        format_string(buffer, sizeof(buffer), ps->string_id, &ps->args);
+        FormatStringLegacy(buffer, sizeof(buffer), ps->string_id, &ps->args);
 
         // Use sprite font unless the currency contains characters unsupported by the sprite font
         auto forceSpriteFont = false;

--- a/src/openrct2/paint/tile_element/Paint.Banner.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Banner.cpp
@@ -13,6 +13,7 @@
 #include "../../config/Config.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Formatter.h"
+#include "../../localisation/Formatting.h"
 #include "../../localisation/Localisation.h"
 #include "../../profiling/Profiling.h"
 #include "../../ride/TrackDesign.h"
@@ -58,7 +59,7 @@ static void PaintBannerScrollingText(
     }
     else
     {
-        format_string(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
+        OpenRCT2::FormatStringLegacy(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
     }
 
     auto stringWidth = GfxGetStringWidth(text, FontStyle::Tiny);

--- a/src/openrct2/paint/tile_element/Paint.Entrance.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Entrance.cpp
@@ -16,6 +16,7 @@
 #include "../../drawing/LightFX.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Formatter.h"
+#include "../../localisation/Formatting.h"
 #include "../../localisation/Localisation.h"
 #include "../../object/EntranceObject.h"
 #include "../../object/ObjectManager.h"
@@ -67,7 +68,7 @@ static void PaintRideEntranceExitScrollingText(
     }
     else
     {
-        format_string(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
+        FormatStringLegacy(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
     }
     auto stringWidth = GfxGetStringWidth(text, FontStyle::Tiny);
     auto scroll = stringWidth > 0 ? (gCurrentTicks / 2) % stringWidth : 0;
@@ -238,7 +239,7 @@ static void PaintParkEntranceScrollingText(
     }
     else
     {
-        format_string(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
+        FormatStringLegacy(text, sizeof(text), STR_BANNER_TEXT_FORMAT, ft.Data());
     }
 
     auto stringWidth = GfxGetStringWidth(text, FontStyle::Tiny);

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -15,6 +15,7 @@
 #include "../../core/String.hpp"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Formatter.h"
+#include "../../localisation/Formatting.h"
 #include "../../localisation/Localisation.h"
 #include "../../object/LargeSceneryObject.h"
 #include "../../profiling/Profiling.h"
@@ -212,7 +213,7 @@ static void PaintLargeScenery3DText(
     char signString[256];
     auto ft = Formatter();
     banner->FormatTextTo(ft);
-    format_string(signString, sizeof(signString), STR_STRINGID, ft.Data());
+    OpenRCT2::FormatStringLegacy(signString, sizeof(signString), STR_STRINGID, ft.Data());
 
     auto offsetY = text->offset[(direction & 1)].y * 2;
     if (text->flags & LARGE_SCENERY_TEXT_FLAG_VERTICAL)
@@ -317,7 +318,7 @@ static void PaintLargeSceneryScrollingText(
     }
     else
     {
-        format_string(text, sizeof(text), STR_SCROLLING_SIGN_TEXT, ft.Data());
+        OpenRCT2::FormatStringLegacy(text, sizeof(text), STR_SCROLLING_SIGN_TEXT, ft.Data());
     }
 
     auto scrollMode = sceneryEntry.scrolling_mode + ((direction + 1) & 3);

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -20,6 +20,7 @@
 #include "../../entity/Staff.h"
 #include "../../interface/Viewport.h"
 #include "../../localisation/Formatter.h"
+#include "../../localisation/Formatting.h"
 #include "../../localisation/Localisation.h"
 #include "../../object/FootpathObject.h"
 #include "../../object/FootpathRailingsObject.h"
@@ -463,7 +464,8 @@ static void PathPaintFencesAndQueueBanners(
             }
             else
             {
-                format_string(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, ft.Data());
+                FormatStringLegacy(
+                    gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_BANNER_TEXT_FORMAT, ft.Data());
             }
 
             uint16_t stringWidth = GfxGetStringWidth(gCommonStringFormatBuffer, FontStyle::Tiny);

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -15,6 +15,7 @@
 #include "../../drawing/Drawing.h"
 #include "../../interface/Colour.h"
 #include "../../interface/Viewport.h"
+#include "../../localisation/Formatting.h"
 #include "../../localisation/Localisation.h"
 #include "../../profiling/Profiling.h"
 #include "../../ride/Track.h"
@@ -178,7 +179,7 @@ static void PaintWallScrollingText(
     }
     else
     {
-        format_string(signString, sizeof(signString), STR_SCROLLING_SIGN_TEXT, ft.Data());
+        OpenRCT2::FormatStringLegacy(signString, sizeof(signString), STR_SCROLLING_SIGN_TEXT, ft.Data());
     }
 
     auto stringWidth = GfxGetStringWidth(signString, FontStyle::Tiny);

--- a/src/openrct2/peep/GuestPathfinding.cpp
+++ b/src/openrct2/peep/GuestPathfinding.cpp
@@ -2317,7 +2317,7 @@ void PathfindLoggingEnable([[maybe_unused]] Peep& peep)
 {
 #    if defined(PATHFIND_DEBUG) && PATHFIND_DEBUG
     /* Determine if the pathfinding debugging is wanted for this peep. */
-    format_string(gPathFindDebugPeepName, sizeof(gPathFindDebugPeepName), peep.name_string_idx, &(peep.Id));
+    FormatStringLegacy(gPathFindDebugPeepName, sizeof(gPathFindDebugPeepName), peep.name_string_idx, &(peep.Id));
 
     /* For guests, use the existing PEEP_FLAGS_TRACKING flag to
      * determine for which guest(s) the pathfinding debugging will

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -33,6 +33,7 @@
 #include "../interface/Window.h"
 #include "../localisation/Date.h"
 #include "../localisation/Formatter.h"
+#include "../localisation/Formatting.h"
 #include "../localisation/Localisation.h"
 #include "../management/Finance.h"
 #include "../management/Marketing.h"
@@ -4112,7 +4113,7 @@ bool Ride::NameExists(std::string_view name, RideId excludeRideId)
         {
             Formatter ft;
             ride.FormatNameTo(ft);
-            format_string(buffer, 256, STR_STRINGID, ft.Data());
+            FormatStringLegacy(buffer, 256, STR_STRINGID, ft.Data());
             if (name == buffer && RideHasAnyTrackElements(ride))
             {
                 return true;
@@ -4207,7 +4208,7 @@ void Ride::SetNameToDefault()
         default_name_number++;
         Formatter ft;
         FormatNameTo(ft);
-        format_string(rideNameBuffer, 256, STR_STRINGID, ft.Data());
+        FormatStringLegacy(rideNameBuffer, 256, STR_STRINGID, ft.Data());
     } while (Ride::NameExists(rideNameBuffer, id));
 }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -5550,7 +5550,7 @@ std::string Ride::GetName() const
 {
     Formatter ft;
     FormatNameTo(ft);
-    return FormatStringID(STR_STRINGID, ft.Data());
+    return FormatStringID(STR_STRINGID, reinterpret_cast<const void*>(ft.Data()));
 }
 
 void Ride::FormatNameTo(Formatter& ft) const


### PR DESCRIPTION
`format_string(4)` was already an alias for `OpenRCT2::FormatStringLegacy()`, so replace its calls directly.