### PR TITLE
Address all snake_case functions in ui/scripting

### DIFF
--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -1124,7 +1124,7 @@ namespace OpenRCT2::Ui::Windows
 
     rct_windownumber CustomWindow::_nextWindowNumber;
 
-    rct_window* window_custom_open(std::shared_ptr<Plugin> owner, DukValue dukDesc)
+    rct_window* WindowCustomOpen(std::shared_ptr<Plugin> owner, DukValue dukDesc)
     {
         auto desc = CustomWindowDesc::FromDukValue(dukDesc);
         uint16_t windowFlags = WF_RESIZABLE | WF_TRANSPARENT;

--- a/src/openrct2-ui/scripting/ScUi.hpp
+++ b/src/openrct2-ui/scripting/ScUi.hpp
@@ -35,7 +35,7 @@ namespace OpenRCT2::Scripting
 
 namespace OpenRCT2::Ui::Windows
 {
-    rct_window* window_custom_open(std::shared_ptr<OpenRCT2::Scripting::Plugin> owner, DukValue dukDesc);
+    rct_window* WindowCustomOpen(std::shared_ptr<OpenRCT2::Scripting::Plugin> owner, DukValue dukDesc);
 }
 
 namespace OpenRCT2::Scripting
@@ -173,7 +173,7 @@ namespace OpenRCT2::Scripting
             owner->ThrowIfStopping();
 
             std::shared_ptr<ScWindow> scWindow = nullptr;
-            auto w = window_custom_open(owner, desc);
+            auto w = WindowCustomOpen(owner, desc);
             if (w != nullptr)
             {
                 scWindow = std::make_shared<ScWindow>(w);


### PR DESCRIPTION
Nice and short this one.

Scripting has its own casing style for any function that is a property in JS. That style is `lowerCamelCase_get/set`