### PR TITLE
fix #19112 text boxes not updated with empty strings

### DIFF
--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -305,7 +305,7 @@ static void WindowServerListScrollMouseover(rct_window* w, int32_t scrollIndex, 
 
 static void WindowServerListTextinput(rct_window* w, WidgetIndex widgetIndex, char* text)
 {
-    if (text == nullptr || text[0] == 0)
+    if (text == nullptr)
         return;
 
     switch (widgetIndex)
@@ -314,12 +314,9 @@ static void WindowServerListTextinput(rct_window* w, WidgetIndex widgetIndex, ch
             if (strcmp(_playerName, text) == 0)
                 return;
 
-            std::fill_n(_playerName, sizeof(_playerName), 0x00);
-            if (text[0] != '\0')
-            {
-                safe_strcpy(_playerName, text, sizeof(_playerName));
-            }
+            safe_strcpy(_playerName, text, sizeof(_playerName));
 
+            // Don't allow empty player names
             if (_playerName[0] != '\0')
             {
                 gConfigNetwork.PlayerName = _playerName;

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -167,10 +167,8 @@ public:
     }
     void OnTextInput(WidgetIndex widgetIndex, std::string_view text) override
     {
-        if (text.empty())
-            return;
-
         std::string temp = static_cast<std::string>(text);
+        int tempPort = 0;
 
         switch (widgetIndex)
         {
@@ -178,27 +176,25 @@ public:
                 if (strcmp(_port, temp.c_str()) == 0)
                     return;
 
-                std::fill_n(_port, sizeof(_port), 0x00);
-                if (text[0] != '\0')
+                safe_strcpy(_port, temp.c_str(), sizeof(_port));
+
+                // Don't allow negative/zero for port number
+                tempPort = atoi(_port);
+                if (tempPort > 0)
                 {
-                    safe_strcpy(_port, temp.c_str(), sizeof(_port));
+                    gConfigNetwork.DefaultPort = tempPort;
+                    ConfigSaveDefault();
                 }
 
-                gConfigNetwork.DefaultPort = atoi(_port);
-                ConfigSaveDefault();
-
-                WidgetInvalidate(*this, WIDX_NAME_INPUT);
+                WidgetInvalidate(*this, WIDX_PORT_INPUT);
                 break;
             case WIDX_NAME_INPUT:
                 if (strcmp(_name, temp.c_str()) == 0)
                     return;
 
-                std::fill_n(_name, sizeof(_name), 0x00);
-                if (text[0] != '\0')
-                {
-                    safe_strcpy(_name, temp.c_str(), sizeof(_name));
-                }
+                safe_strcpy(_name, temp.c_str(), sizeof(_name));
 
+                // Don't allow empty server names
                 if (_name[0] != '\0')
                 {
                     gConfigNetwork.ServerName = _name;
@@ -211,17 +207,9 @@ public:
                 if (strcmp(_description, temp.c_str()) == 0)
                     return;
 
-                std::fill_n(_description, sizeof(_description), 0x00);
-                if (text[0] != '\0')
-                {
-                    safe_strcpy(_description, temp.c_str(), sizeof(_description));
-                }
-
-                if (_description[0] != '\0')
-                {
-                    gConfigNetwork.ServerDescription = _description;
-                    ConfigSaveDefault();
-                }
+                safe_strcpy(_description, temp.c_str(), sizeof(_description));
+                gConfigNetwork.ServerDescription = _description;
+                ConfigSaveDefault();
 
                 WidgetInvalidate(*this, WIDX_DESCRIPTION_INPUT);
                 break;
@@ -229,17 +217,9 @@ public:
                 if (strcmp(_greeting, temp.c_str()) == 0)
                     return;
 
-                std::fill_n(_greeting, sizeof(_greeting), 0x00);
-                if (text[0] != '\0')
-                {
-                    safe_strcpy(_greeting, temp.c_str(), sizeof(_greeting));
-                }
-
-                if (_greeting[0] != '\0')
-                {
-                    gConfigNetwork.ServerGreeting = _greeting;
-                    ConfigSaveDefault();
-                }
+                safe_strcpy(_greeting, temp.c_str(), sizeof(_greeting));
+                gConfigNetwork.ServerGreeting = _greeting;
+                ConfigSaveDefault();
 
                 WidgetInvalidate(*this, WIDX_GREETING_INPUT);
                 break;
@@ -247,11 +227,7 @@ public:
                 if (strcmp(_password, temp.c_str()) == 0)
                     return;
 
-                std::fill_n(_password, sizeof(_password), 0x00);
-                if (text[0] != '\0')
-                {
-                    safe_strcpy(_password, temp.c_str(), sizeof(_password));
-                }
+                safe_strcpy(_password, temp.c_str(), sizeof(_password));
 
                 WidgetInvalidate(*this, WIDX_PASSWORD_INPUT);
                 break;

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -344,7 +344,7 @@ public:
 
     void OnTextInput(const WidgetIndex widgetIndex, std::string_view text) override
     {
-        if (widgetIndex != WIDX_FILTER_STRING || text.empty())
+        if (widgetIndex != WIDX_FILTER_STRING)
             return;
 
         if (String::Equals(_filterString, std::string(text).c_str()))


### PR DESCRIPTION
We might want to think a little bit more about the cases in ServerStart.cpp and ServerList.cpp if we want to allow blank values for some of the affected properties.