### PR TITLE
Rename classes with snakes OpenRCT2/A*-F*

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -142,7 +142,7 @@ public:
         _inGameConsole.Update();
     }
 
-    void Draw(rct_drawpixelinfo* dpi) override
+    void Draw(DrawPixelInfo* dpi) override
     {
         auto bgColour = ThemeGetColour(WindowClass::Chat, 0);
         ChatDraw(dpi, bgColour);
@@ -291,7 +291,7 @@ public:
         return std::make_shared<DrawingEngineFactory>();
     }
 
-    void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, rct_drawpixelinfo* dpi, DrawWeatherFunc drawFunc) override
+    void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, DrawPixelInfo* dpi, DrawWeatherFunc drawFunc) override
     {
         int32_t left = dpi->x;
         int32_t right = left + dpi->width;
@@ -887,7 +887,7 @@ private:
     }
 
     static void DrawWeatherWindow(
-        rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer, rct_window* original_w, int16_t left, int16_t right, int16_t top,
+        DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, rct_window* original_w, int16_t left, int16_t right, int16_t top,
         int16_t bottom, DrawWeatherFunc drawFunc)
     {
         rct_window* w{};

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -99,18 +99,18 @@ public:
     void ResetPalette();
     void StartNewDraw();
 
-    void Clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex) override;
-    void FillRect(rct_drawpixelinfo* dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
+    void Clear(DrawPixelInfo* dpi, uint8_t paletteIndex) override;
+    void FillRect(DrawPixelInfo* dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
     void FilterRect(
-        rct_drawpixelinfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
-    void DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, const ScreenLine& line) override;
-    void DrawSprite(rct_drawpixelinfo* dpi, const ImageId imageId, int32_t x, int32_t y) override;
+        DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
+    void DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line) override;
+    void DrawSprite(DrawPixelInfo* dpi, const ImageId imageId, int32_t x, int32_t y) override;
     void DrawSpriteRawMasked(
-        rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
-    void DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
-    void DrawGlyph(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) override;
+        DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
+    void DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
+    void DrawGlyph(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) override;
     void DrawBitmap(
-        rct_drawpixelinfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
+        DrawPixelInfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
         int32_t y) override;
 
     void FlushCommandBuffers();
@@ -118,7 +118,7 @@ public:
     void FlushLines();
     void FlushRectangles();
     void HandleTransparency();
-    void CalculcateClipping(rct_drawpixelinfo* dpi);
+    void CalculcateClipping(DrawPixelInfo* dpi);
 };
 
 class OpenGLWeatherDrawer final : public IWeatherDrawer
@@ -132,7 +132,7 @@ public:
     }
 
     virtual void Draw(
-        rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+        DrawPixelInfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
         const uint8_t* weatherpattern) override
     {
         const uint8_t* pattern = weatherpattern;
@@ -185,7 +185,7 @@ private:
     size_t _bitsSize = 0;
     std::unique_ptr<uint8_t[]> _bits;
 
-    rct_drawpixelinfo _bitsDPI = {};
+    DrawPixelInfo _bitsDPI = {};
 
     std::unique_ptr<OpenGLDrawingContext> _drawingContext;
 
@@ -355,7 +355,7 @@ public:
         return _drawingContext.get();
     }
 
-    rct_drawpixelinfo* GetDrawingPixelInfo() override
+    DrawPixelInfo* GetDrawingPixelInfo() override
     {
         return &_bitsDPI;
     }
@@ -370,7 +370,7 @@ public:
         _drawingContext->GetTextureCache()->InvalidateImage(image);
     }
 
-    rct_drawpixelinfo* GetDPI()
+    DrawPixelInfo* GetDPI()
     {
         return &_bitsDPI;
     }
@@ -430,7 +430,7 @@ private:
         _height = height;
         _pitch = pitch;
 
-        rct_drawpixelinfo* dpi = &_bitsDPI;
+        DrawPixelInfo* dpi = &_bitsDPI;
         dpi->bits = _bits.get();
         dpi->x = 0;
         dpi->y = 0;
@@ -509,7 +509,7 @@ void OpenGLDrawingContext::StartNewDraw()
     _swapFramebuffer->Clear();
 }
 
-void OpenGLDrawingContext::Clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex)
+void OpenGLDrawingContext::Clear(DrawPixelInfo* dpi, uint8_t paletteIndex)
 {
     CalculcateClipping(dpi);
 
@@ -517,7 +517,7 @@ void OpenGLDrawingContext::Clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex)
 }
 
 void OpenGLDrawingContext::FillRect(
-    rct_drawpixelinfo* dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    DrawPixelInfo* dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     CalculcateClipping(dpi);
 
@@ -552,7 +552,7 @@ void OpenGLDrawingContext::FillRect(
 }
 
 void OpenGLDrawingContext::FilterRect(
-    rct_drawpixelinfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     CalculcateClipping(dpi);
 
@@ -575,7 +575,7 @@ void OpenGLDrawingContext::FilterRect(
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, const ScreenLine& line)
+void OpenGLDrawingContext::DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line)
 {
     CalculcateClipping(dpi);
 
@@ -587,7 +587,7 @@ void OpenGLDrawingContext::DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, con
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawSprite(rct_drawpixelinfo* dpi, const ImageId imageId, int32_t x, int32_t y)
+void OpenGLDrawingContext::DrawSprite(DrawPixelInfo* dpi, const ImageId imageId, int32_t x, int32_t y)
 {
     CalculcateClipping(dpi);
 
@@ -601,7 +601,7 @@ void OpenGLDrawingContext::DrawSprite(rct_drawpixelinfo* dpi, const ImageId imag
     {
         if (g1Element->flags & G1_FLAG_HAS_ZOOM_SPRITE)
         {
-            rct_drawpixelinfo zoomedDPI;
+            DrawPixelInfo zoomedDPI;
             zoomedDPI.bits = dpi->bits;
             zoomedDPI.x = dpi->x >> 1;
             zoomedDPI.y = dpi->y >> 1;
@@ -738,7 +738,7 @@ void OpenGLDrawingContext::DrawSprite(rct_drawpixelinfo* dpi, const ImageId imag
 }
 
 void OpenGLDrawingContext::DrawSpriteRawMasked(
-    rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
+    DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
 {
     CalculcateClipping(dpi);
 
@@ -800,7 +800,7 @@ void OpenGLDrawingContext::DrawSpriteRawMasked(
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
+void OpenGLDrawingContext::DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
 {
     CalculcateClipping(dpi);
 
@@ -853,7 +853,7 @@ void OpenGLDrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId
 }
 
 void OpenGLDrawingContext::DrawGlyph(
-    rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette)
+    DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette)
 {
     CalculcateClipping(dpi);
 
@@ -909,7 +909,7 @@ void OpenGLDrawingContext::DrawGlyph(
 }
 
 void OpenGLDrawingContext::DrawBitmap(
-    rct_drawpixelinfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x, int32_t y)
+    DrawPixelInfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x, int32_t y)
 {
     CalculcateClipping(dpi);
 
@@ -1029,7 +1029,7 @@ void OpenGLDrawingContext::HandleTransparency()
     _commandBuffers.transparent.clear();
 }
 
-void OpenGLDrawingContext::CalculcateClipping(rct_drawpixelinfo* dpi)
+void OpenGLDrawingContext::CalculcateClipping(DrawPixelInfo* dpi)
 {
     auto screenDPI = _engine.GetDPI();
     auto bytesPerRow = screenDPI->GetBytesPerRow();

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -110,8 +110,7 @@ public:
     void DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
     void DrawGlyph(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) override;
     void DrawBitmap(
-        DrawPixelInfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
-        int32_t y) override;
+        DrawPixelInfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x, int32_t y) override;
 
     void FlushCommandBuffers();
 
@@ -852,8 +851,7 @@ void OpenGLDrawingContext::DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId ima
     command.depth = _drawCount++;
 }
 
-void OpenGLDrawingContext::DrawGlyph(
-    DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette)
+void OpenGLDrawingContext::DrawGlyph(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette)
 {
     CalculcateClipping(dpi);
 

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.cpp
@@ -85,7 +85,7 @@ void OpenGLFramebuffer::BindRead() const
     glBindFramebuffer(GL_READ_FRAMEBUFFER, _id);
 }
 
-void OpenGLFramebuffer::GetPixels(rct_drawpixelinfo& dpi) const
+void OpenGLFramebuffer::GetPixels(DrawPixelInfo& dpi) const
 {
     assert(dpi.width == _width && dpi.height == _height);
 

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.h
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLFramebuffer.h
@@ -54,7 +54,7 @@ public:
     void Bind() const;
     void BindDraw() const;
     void BindRead() const;
-    void GetPixels(rct_drawpixelinfo& dpi) const;
+    void GetPixels(DrawPixelInfo& dpi) const;
 
     void SwapColourBuffer(OpenGLFramebuffer& other);
     GLuint SwapDepthTexture(GLuint depth);

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -204,7 +204,7 @@ void TextureCache::GeneratePaletteTexture()
     static_assert(PALETTE_TO_G1_OFFSET_COUNT + 5 < 256, "Height of palette too large!");
     constexpr int32_t height = 256;
     constexpr int32_t width = height;
-    rct_drawpixelinfo dpi = CreateDPI(width, height);
+    DrawPixelInfo dpi = CreateDPI(width, height);
 
     // Init no-op palette
     for (int i = 0; i < width; ++i)
@@ -268,7 +268,7 @@ void TextureCache::EnlargeAtlasesTexture(GLuint newEntries)
 
 AtlasTextureInfo TextureCache::LoadImageTexture(const ImageId imageId)
 {
-    rct_drawpixelinfo dpi = GetImageAsDPI(ImageId(imageId.GetIndex()));
+    DrawPixelInfo dpi = GetImageAsDPI(ImageId(imageId.GetIndex()));
 
     auto cacheInfo = AllocateImage(dpi.width, dpi.height);
     cacheInfo.image = imageId.GetIndex();
@@ -285,7 +285,7 @@ AtlasTextureInfo TextureCache::LoadImageTexture(const ImageId imageId)
 
 AtlasTextureInfo TextureCache::LoadGlyphTexture(const ImageId imageId, const PaletteMap& paletteMap)
 {
-    rct_drawpixelinfo dpi = GetGlyphAsDPI(imageId, paletteMap);
+    DrawPixelInfo dpi = GetGlyphAsDPI(imageId, paletteMap);
 
     auto cacheInfo = AllocateImage(dpi.width, dpi.height);
     cacheInfo.image = imageId.GetIndex();
@@ -347,24 +347,24 @@ AtlasTextureInfo TextureCache::AllocateImage(int32_t imageWidth, int32_t imageHe
     return _atlases.back().Allocate(imageWidth, imageHeight);
 }
 
-rct_drawpixelinfo TextureCache::GetImageAsDPI(const ImageId imageId)
+DrawPixelInfo TextureCache::GetImageAsDPI(const ImageId imageId)
 {
     auto g1Element = GfxGetG1Element(imageId);
     int32_t width = g1Element->width;
     int32_t height = g1Element->height;
 
-    rct_drawpixelinfo dpi = CreateDPI(width, height);
+    DrawPixelInfo dpi = CreateDPI(width, height);
     GfxDrawSpriteSoftware(&dpi, imageId, { -g1Element->x_offset, -g1Element->y_offset });
     return dpi;
 }
 
-rct_drawpixelinfo TextureCache::GetGlyphAsDPI(const ImageId imageId, const PaletteMap& palette)
+DrawPixelInfo TextureCache::GetGlyphAsDPI(const ImageId imageId, const PaletteMap& palette)
 {
     auto g1Element = GfxGetG1Element(imageId);
     int32_t width = g1Element->width;
     int32_t height = g1Element->height;
 
-    rct_drawpixelinfo dpi = CreateDPI(width, height);
+    DrawPixelInfo dpi = CreateDPI(width, height);
 
     const auto glyphCoords = ScreenCoordsXY{ -g1Element->x_offset, -g1Element->y_offset };
     GfxDrawSpritePaletteSetSoftware(&dpi, imageId, glyphCoords, palette);
@@ -379,13 +379,13 @@ void TextureCache::FreeTextures()
     std::fill(_indexMap.begin(), _indexMap.end(), UNUSED_INDEX);
 }
 
-rct_drawpixelinfo TextureCache::CreateDPI(int32_t width, int32_t height)
+DrawPixelInfo TextureCache::CreateDPI(int32_t width, int32_t height)
 {
     size_t numPixels = width * height;
     auto pixels8 = new uint8_t[numPixels];
     std::fill_n(pixels8, numPixels, 0);
 
-    rct_drawpixelinfo dpi;
+    DrawPixelInfo dpi;
     dpi.bits = pixels8;
     dpi.pitch = 0;
     dpi.x = 0;
@@ -396,7 +396,7 @@ rct_drawpixelinfo TextureCache::CreateDPI(int32_t width, int32_t height)
     return dpi;
 }
 
-void TextureCache::DeleteDPI(rct_drawpixelinfo dpi)
+void TextureCache::DeleteDPI(DrawPixelInfo dpi)
 {
     delete[] dpi.bits;
 }

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.h
@@ -25,7 +25,7 @@
 #include <unordered_map>
 #include <vector>
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 struct PaletteMap;
 enum class FilterPaletteID : int32_t;
 
@@ -237,10 +237,10 @@ private:
     AtlasTextureInfo LoadGlyphTexture(const ImageId image, const PaletteMap& paletteMap);
     AtlasTextureInfo AllocateImage(int32_t imageWidth, int32_t imageHeight);
     AtlasTextureInfo LoadBitmapTexture(ImageIndex image, const void* pixels, size_t width, size_t height);
-    static rct_drawpixelinfo GetImageAsDPI(const ImageId imageId);
-    static rct_drawpixelinfo GetGlyphAsDPI(const ImageId imageId, const PaletteMap& paletteMap);
+    static DrawPixelInfo GetImageAsDPI(const ImageId imageId);
+    static DrawPixelInfo GetGlyphAsDPI(const ImageId imageId, const PaletteMap& paletteMap);
     void FreeTextures();
 
-    static rct_drawpixelinfo CreateDPI(int32_t width, int32_t height);
-    static void DeleteDPI(rct_drawpixelinfo dpi);
+    static DrawPixelInfo CreateDPI(int32_t width, int32_t height);
+    static void DeleteDPI(DrawPixelInfo dpi);
 };

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -15,7 +15,7 @@
 
 namespace Graph
 {
-    static void DrawMonths(rct_drawpixelinfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
+    static void DrawMonths(DrawPixelInfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
         int32_t currentMonth = DateGetMonth(gDateMonthsElapsed);
         int32_t currentDay = gDateMonthTicks;
@@ -41,7 +41,7 @@ namespace Graph
         }
     }
 
-    static void DrawLineA(rct_drawpixelinfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
+    static void DrawLineA(DrawPixelInfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
         auto lastCoords = ScreenCoordsXY{ -1, -1 };
         auto coords = origCoords;
@@ -69,7 +69,7 @@ namespace Graph
         }
     }
 
-    static void DrawLineB(rct_drawpixelinfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
+    static void DrawLineB(DrawPixelInfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
         auto lastCoords = ScreenCoordsXY{ -1, -1 };
         auto coords = origCoords;
@@ -94,7 +94,7 @@ namespace Graph
         }
     }
 
-    void Draw(rct_drawpixelinfo* dpi, uint8_t* history, int32_t count, const ScreenCoordsXY& screenPos)
+    void Draw(DrawPixelInfo* dpi, uint8_t* history, int32_t count, const ScreenCoordsXY& screenPos)
     {
         DrawMonths(dpi, history, count, screenPos);
         DrawLineA(dpi, history, count, screenPos);
@@ -150,7 +150,7 @@ static const FinancialTooltipInfo FinanceTooltipInfoFromMoney(
 
 namespace Graph
 {
-    static void DrawMonths(rct_drawpixelinfo* dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords)
+    static void DrawMonths(DrawPixelInfo* dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
         int32_t i, yearOver32, currentMonth, currentDay;
 
@@ -179,7 +179,7 @@ namespace Graph
     }
 
     static void DrawLineA(
-        rct_drawpixelinfo* dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords, int32_t modifier,
+        DrawPixelInfo* dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords, int32_t modifier,
         int32_t offset)
     {
         auto lastCoords = ScreenCoordsXY{ -1, -1 };
@@ -209,7 +209,7 @@ namespace Graph
     }
 
     static void DrawLineB(
-        rct_drawpixelinfo* dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords, int32_t modifier,
+        DrawPixelInfo* dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords, int32_t modifier,
         int32_t offset)
     {
         auto lastCoords = ScreenCoordsXY{ -1, -1 };
@@ -236,7 +236,7 @@ namespace Graph
     }
 
     static void DrawHoveredValue(
-        rct_drawpixelinfo* dpi, const money64* history, const int32_t historyCount, const ScreenCoordsXY& screenCoords,
+        DrawPixelInfo* dpi, const money64* history, const int32_t historyCount, const ScreenCoordsXY& screenCoords,
         const int32_t modifier, const int32_t offset)
     {
         const auto cursorPosition = ContextGetCursorPositionScaled();
@@ -272,7 +272,7 @@ namespace Graph
     }
 
     void Draw(
-        rct_drawpixelinfo* dpi, const money64* history, const int32_t count, const ScreenCoordsXY& screenCoords,
+        DrawPixelInfo* dpi, const money64* history, const int32_t count, const ScreenCoordsXY& screenCoords,
         const int32_t modifier, const int32_t offset)
     {
         DrawMonths(dpi, history, count, screenCoords);

--- a/src/openrct2-ui/interface/Graph.h
+++ b/src/openrct2-ui/interface/Graph.h
@@ -17,6 +17,6 @@ namespace Graph
 {
     void Draw(DrawPixelInfo* dpi, uint8_t* history, int32_t count, const ScreenCoordsXY& screenPos);
     void Draw(
-        DrawPixelInfo* dpi, const money64* history, const int32_t count, const ScreenCoordsXY& coords,
-        const int32_t modifier, const int32_t offset);
+        DrawPixelInfo* dpi, const money64* history, const int32_t count, const ScreenCoordsXY& coords, const int32_t modifier,
+        const int32_t offset);
 } // namespace Graph

--- a/src/openrct2-ui/interface/Graph.h
+++ b/src/openrct2-ui/interface/Graph.h
@@ -15,8 +15,8 @@
 
 namespace Graph
 {
-    void Draw(rct_drawpixelinfo* dpi, uint8_t* history, int32_t count, const ScreenCoordsXY& screenPos);
+    void Draw(DrawPixelInfo* dpi, uint8_t* history, int32_t count, const ScreenCoordsXY& screenPos);
     void Draw(
-        rct_drawpixelinfo* dpi, const money64* history, const int32_t count, const ScreenCoordsXY& coords,
+        DrawPixelInfo* dpi, const money64* history, const int32_t count, const ScreenCoordsXY& coords,
         const int32_t modifier, const int32_t offset);
 } // namespace Graph

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -268,7 +268,7 @@ void InGameConsole::Update()
     _consoleCaretTicks = (_consoleCaretTicks + 1) % 30;
 }
 
-void InGameConsole::Draw(rct_drawpixelinfo* dpi) const
+void InGameConsole::Draw(DrawPixelInfo* dpi) const
 {
     if (!_isOpen)
         return;

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -62,7 +62,7 @@ namespace OpenRCT2::Ui
         void Scroll(int32_t linesToScroll);
 
         void Update();
-        void Draw(rct_drawpixelinfo* dpi) const;
+        void Draw(DrawPixelInfo* dpi) const;
 
     private:
         void ClearInput();

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -22,32 +22,32 @@
 #include <openrct2/sprites.h>
 #include <openrct2/util/Util.h>
 
-static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetText(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetTextInset(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
-static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetFrameDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetResizeDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetButtonDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetTabDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetFlatButtonDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetTextButton(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetTextCentred(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetText(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetTextInset(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetTextBoxDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetGroupboxDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetCaptionDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetCheckboxDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetCloseboxDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+static void WidgetScrollDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
 static void WidgetHScrollbarDraw(
-    rct_drawpixelinfo* dpi, const rct_scroll& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour);
+    DrawPixelInfo* dpi, const rct_scroll& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour);
 static void WidgetVScrollbarDraw(
-    rct_drawpixelinfo* dpi, const rct_scroll& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour);
-static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+    DrawPixelInfo* dpi, const rct_scroll& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour);
+static void WidgetDrawImage(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
 
 /**
  *
  *  rct2: 0x006EB2A8
  */
-void WidgetDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+void WidgetDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     const auto* widget = GetWidgetByIndex(w, widgetIndex);
     if (widget == nullptr)
@@ -117,7 +117,7 @@ void WidgetDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
  *
  *  rct2: 0x006EB6CE
  */
-static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetFrameDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -151,7 +151,7 @@ static void WidgetFrameDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex w
  *
  *  rct2: 0x006EB765
  */
-static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetResizeDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -182,7 +182,7 @@ static void WidgetResizeDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex 
  *
  *  rct2: 0x006EB8E5
  */
-static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetButtonDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -214,7 +214,7 @@ static void WidgetButtonDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex 
  *
  *  rct2: 0x006EB806
  */
-static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetTabDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     auto& widget = w.widgets[widgetIndex];
@@ -263,7 +263,7 @@ static void WidgetTabDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex wid
  *
  *  rct2: 0x006EB861
  */
-static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetFlatButtonDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     if (!WidgetIsDisabled(w, widgetIndex) && WidgetIsHighlighted(w, widgetIndex))
     {
@@ -303,7 +303,7 @@ static void WidgetFlatButtonDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIn
  *
  *  rct2: 0x006EBBEB
  */
-static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetTextButton(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -334,7 +334,7 @@ static void WidgetTextButton(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex 
  *
  *  rct2: 0x006EBC41
  */
-static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetTextCentred(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -380,7 +380,7 @@ static void WidgetTextCentred(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex
  *
  *  rct2: 0x006EBD52
  */
-static void WidgetText(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetText(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -429,7 +429,7 @@ static void WidgetText(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widget
  *
  *  rct2: 0x006EBD1F
  */
-static void WidgetTextInset(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetTextInset(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -469,7 +469,7 @@ static std::pair<StringId, void*> WidgetGetStringidAndArgs(const Widget& widget)
  *
  *  rct2: 0x006EB535
  */
-static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetGroupboxDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -530,7 +530,7 @@ static void WidgetGroupboxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetInde
  *
  *  rct2: 0x006EB2F9
  */
-static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetCaptionDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto* widget = &w.widgets[widgetIndex];
@@ -579,7 +579,7 @@ static void WidgetCaptionDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex
  *
  *  rct2: 0x006EBB85
  */
-static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetCloseboxDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -616,7 +616,7 @@ static void WidgetCloseboxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetInde
  *
  *  rct2: 0x006EBAD9
  */
-static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetCheckboxDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -657,7 +657,7 @@ static void WidgetCheckboxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetInde
  *
  *  rct2: 0x006EBD96
  */
-static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetScrollDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     int32_t scrollIndex = WindowGetScrollDataIndex(w, widgetIndex);
@@ -703,7 +703,7 @@ static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex 
     bottomRight.x++;
 
     // Create a new inner scroll dpi
-    rct_drawpixelinfo scroll_dpi = *dpi;
+    DrawPixelInfo scroll_dpi = *dpi;
 
     // Clip the scroll dpi against the outer dpi
     int32_t cl = std::max<int32_t>(dpi->x, topLeft.x);
@@ -726,7 +726,7 @@ static void WidgetScrollDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex 
 }
 
 static void WidgetHScrollbarDraw(
-    rct_drawpixelinfo* dpi, const rct_scroll& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour)
+    DrawPixelInfo* dpi, const rct_scroll& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour)
 {
     colour &= 0x7F;
     // Trough
@@ -764,7 +764,7 @@ static void WidgetHScrollbarDraw(
 }
 
 static void WidgetVScrollbarDraw(
-    rct_drawpixelinfo* dpi, const rct_scroll& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour)
+    DrawPixelInfo* dpi, const rct_scroll& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour)
 {
     colour &= 0x7F;
     // Trough
@@ -799,7 +799,7 @@ static void WidgetVScrollbarDraw(
  *
  *  rct2: 0x006EB951
  */
-static void WidgetDrawImage(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetDrawImage(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -1121,7 +1121,7 @@ void WidgetSetCheckboxValue(rct_window& w, WidgetIndex widgetIndex, bool value)
     WidgetSetPressed(w, widgetIndex, value);
 }
 
-static void WidgetTextBoxDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex)
+static void WidgetTextBoxDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex)
 {
     int32_t no_lines = 0;
     char wrapped_string[TEXT_INPUT_SIZE];

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -615,7 +615,7 @@ void WindowInitScrollWidgets(rct_window& w)
  *
  *  rct2: 0x006EB15C
  */
-void WindowDrawWidgets(rct_window& w, rct_drawpixelinfo* dpi)
+void WindowDrawWidgets(rct_window& w, DrawPixelInfo* dpi)
 {
     Widget* widget;
     WidgetIndex widgetIndex;
@@ -694,12 +694,12 @@ bool Window::IsLegacy()
     return false;
 }
 
-void Window::OnDraw(rct_drawpixelinfo& dpi)
+void Window::OnDraw(DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*this, &dpi);
 }
 
-void Window::OnDrawWidget(WidgetIndex widgetIndex, rct_drawpixelinfo& dpi)
+void Window::OnDrawWidget(WidgetIndex widgetIndex, DrawPixelInfo& dpi)
 {
     WidgetDraw(&dpi, *this, widgetIndex);
 }
@@ -739,7 +739,7 @@ void Window::SetCheckboxValue(WidgetIndex widgetIndex, bool value)
     SetWidgetPressed(widgetIndex, value);
 }
 
-void Window::DrawWidgets(rct_drawpixelinfo& dpi)
+void Window::DrawWidgets(DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*this, &dpi);
 }

--- a/src/openrct2-ui/interface/Window.h
+++ b/src/openrct2-ui/interface/Window.h
@@ -15,8 +15,8 @@
 struct Window : rct_window
 {
     virtual bool IsLegacy() override;
-    virtual void OnDraw(rct_drawpixelinfo& dpi) override;
-    virtual void OnDrawWidget(WidgetIndex widgetIndex, rct_drawpixelinfo& dpi) override;
+    virtual void OnDraw(DrawPixelInfo& dpi) override;
+    virtual void OnDrawWidget(WidgetIndex widgetIndex, DrawPixelInfo& dpi) override;
 
     void InitScrollWidgets();
     void InvalidateWidget(WidgetIndex widgetIndex);
@@ -25,7 +25,7 @@ struct Window : rct_window
     void SetWidgetDisabled(WidgetIndex widgetIndex, bool value);
     void SetWidgetPressed(WidgetIndex widgetIndex, bool value);
     void SetCheckboxValue(WidgetIndex widgetIndex, bool value);
-    void DrawWidgets(rct_drawpixelinfo& dpi);
+    void DrawWidgets(DrawPixelInfo& dpi);
     void Close();
     void CloseOthers();
     void CloseOthersOfThisClass();

--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -70,7 +70,7 @@ namespace OpenRCT2::Scripting
                 delete[] g1->offset;
 
                 // Replace slot with empty element
-                rct_g1_element empty{};
+                G1Element empty{};
                 GfxSetG1Element(index, &empty);
             }
         }
@@ -79,7 +79,7 @@ namespace OpenRCT2::Scripting
 
     std::optional<ImageList> AllocateCustomImages(const std::shared_ptr<Plugin>& plugin, uint32_t count)
     {
-        std::vector<rct_g1_element> images;
+        std::vector<G1Element> images;
         images.resize(count);
 
         auto base = GfxObjectAllocateImages(images.data(), count);
@@ -171,7 +171,7 @@ namespace OpenRCT2::Scripting
         return obj.Take();
     }
 
-    static const char* GetPixelDataTypeForG1(const rct_g1_element& g1)
+    static const char* GetPixelDataTypeForG1(const G1Element& g1)
     {
         if (g1.flags & G1_FLAG_RLE_COMPRESSION)
             return "rle";
@@ -376,7 +376,7 @@ namespace OpenRCT2::Scripting
     static void ReplacePixelDataForImage(ImageIndex id, const PixelData& pixelData, std::vector<uint8_t>&& data)
     {
         // Setup the g1 element
-        rct_g1_element el{};
+        G1Element el{};
         auto* lastel = GfxGetG1Element(id);
         if (lastel != nullptr)
         {
@@ -420,7 +420,7 @@ namespace OpenRCT2::Scripting
         auto plugin = scriptEngine.GetExecInfo().GetCurrentPlugin();
 
         auto drawingEngine = std::make_unique<X8DrawingEngine>(GetContext()->GetUiContext());
-        rct_drawpixelinfo dpi;
+        DrawPixelInfo dpi;
         dpi.DrawingEngine = drawingEngine.get();
         dpi.width = size.width;
         dpi.height = size.height;
@@ -451,7 +451,7 @@ namespace OpenRCT2::Scripting
 
         if (createNewImage)
         {
-            rct_g1_element newg1{};
+            G1Element newg1{};
             if (g1 != nullptr)
             {
                 delete[] g1->offset;

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -549,7 +549,7 @@ void CustomListView::MouseUp(const ScreenCoordsXY& pos)
     }
 }
 
-void CustomListView::Paint(rct_window* w, rct_drawpixelinfo* dpi, const rct_scroll* scroll) const
+void CustomListView::Paint(rct_window* w, DrawPixelInfo* dpi, const rct_scroll* scroll) const
 {
     auto paletteIndex = ColourMapA[w->colours[1]].mid_light;
     GfxFillRect(dpi, { { dpi->x, dpi->y }, { dpi->x + dpi->width, dpi->y + dpi->height } }, paletteIndex);
@@ -665,7 +665,7 @@ void CustomListView::Paint(rct_window* w, rct_drawpixelinfo* dpi, const rct_scro
 }
 
 void CustomListView::PaintHeading(
-    rct_window* w, rct_drawpixelinfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
+    rct_window* w, DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
     ColumnSortOrder sortOrder, bool isPressed) const
 {
     auto boxFlags = 0;
@@ -694,7 +694,7 @@ void CustomListView::PaintHeading(
 }
 
 void CustomListView::PaintSeperator(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const
+    DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const
 {
     auto hasText = text != nullptr && text[0] != '\0';
     auto left = pos.x + 4;
@@ -753,7 +753,7 @@ void CustomListView::PaintSeperator(
 }
 
 void CustomListView::PaintCell(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const
+    DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const
 {
     StringId stringId = isHighlighted ? STR_WINDOW_COLOUR_2_STRINGID : STR_BLACK_STRING;
 

--- a/src/openrct2-ui/scripting/CustomListView.h
+++ b/src/openrct2-ui/scripting/CustomListView.h
@@ -136,15 +136,15 @@ namespace OpenRCT2::Ui::Windows
         void MouseOver(const ScreenCoordsXY& pos, bool isMouseDown);
         void MouseDown(const ScreenCoordsXY& pos);
         void MouseUp(const ScreenCoordsXY& pos);
-        void Paint(rct_window* w, rct_drawpixelinfo* dpi, const rct_scroll* scroll) const;
+        void Paint(rct_window* w, DrawPixelInfo* dpi, const rct_scroll* scroll) const;
 
     private:
         void PaintHeading(
-            rct_window* w, rct_drawpixelinfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
+            rct_window* w, DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
             ColumnSortOrder sortOrder, bool isPressed) const;
-        void PaintSeperator(rct_drawpixelinfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const;
+        void PaintSeperator(DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const;
         void PaintCell(
-            rct_drawpixelinfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text,
+            DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text,
             bool isHighlighted) const;
         std::optional<RowColumn> GetItemIndexAt(const ScreenCoordsXY& pos);
         Widget* GetWidget() const;

--- a/src/openrct2-ui/scripting/CustomListView.h
+++ b/src/openrct2-ui/scripting/CustomListView.h
@@ -144,8 +144,7 @@ namespace OpenRCT2::Ui::Windows
             ColumnSortOrder sortOrder, bool isPressed) const;
         void PaintSeperator(DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const;
         void PaintCell(
-            DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text,
-            bool isHighlighted) const;
+            DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const;
         std::optional<RowColumn> GetItemIndexAt(const ScreenCoordsXY& pos);
         Widget* GetWidget() const;
         void Invalidate();

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -528,7 +528,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDraw(rct_drawpixelinfo& dpi) override
+        void OnDraw(DrawPixelInfo& dpi) override
         {
             WindowDrawWidgets(*this, &dpi);
             DrawTabImages(dpi);
@@ -542,7 +542,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnDrawWidget(WidgetIndex widgetIndex, rct_drawpixelinfo& dpi) override
+        void OnDrawWidget(WidgetIndex widgetIndex, DrawPixelInfo& dpi) override
         {
             const auto& widget = widgets[widgetIndex];
             const auto& info = GetInfo(this);
@@ -552,7 +552,7 @@ namespace OpenRCT2::Ui::Windows
                 auto& onDraw = widgetDesc->OnDraw;
                 if (onDraw.is_function())
                 {
-                    rct_drawpixelinfo widgetDpi;
+                    DrawPixelInfo widgetDpi;
                     if (ClipDrawPixelInfo(
                             &widgetDpi, &dpi, { windowPos.x + widget.left, windowPos.y + widget.top }, widget.width(),
                             widget.height()))
@@ -746,7 +746,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+        void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
         {
             const auto& info = GetInfo(this);
             if (scrollIndex < static_cast<int32_t>(info.ListViews.size()))
@@ -847,7 +847,7 @@ namespace OpenRCT2::Ui::Windows
             }
         }
 
-        void DrawTabImages(rct_drawpixelinfo& dpi)
+        void DrawTabImages(DrawPixelInfo& dpi)
         {
             const auto& customInfo = GetInfo(this);
             const auto& tabs = customInfo.Desc.Tabs;

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -22,7 +22,7 @@ namespace OpenRCT2::Scripting
     {
     private:
         duk_context* _ctx{};
-        rct_drawpixelinfo _dpi{};
+        DrawPixelInfo _dpi{};
 
         std::optional<colour_t> _colour{};
         std::optional<colour_t> _secondaryColour{};
@@ -32,7 +32,7 @@ namespace OpenRCT2::Scripting
         uint8_t _fill{};
 
     public:
-        ScGraphicsContext(duk_context* ctx, const rct_drawpixelinfo& dpi)
+        ScGraphicsContext(duk_context* ctx, const DrawPixelInfo& dpi)
             : _ctx(ctx)
             , _dpi(dpi)
         {
@@ -180,7 +180,7 @@ namespace OpenRCT2::Scripting
 
         void clip(int32_t x, int32_t y, int32_t width, int32_t height)
         {
-            rct_drawpixelinfo newDpi;
+            DrawPixelInfo newDpi;
             ClipDrawPixelInfo(&newDpi, &_dpi, { x, y }, width, height);
             _dpi = newDpi;
         }

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -133,7 +133,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 
@@ -196,7 +196,7 @@ private:
     /**
      * @brief Draw OpenRCT2 info on open tab
      */
-    void DrawOpenRCT2Info(rct_drawpixelinfo& dpi)
+    void DrawOpenRCT2Info(DrawPixelInfo& dpi)
     {
         // Draw logo on placeholder widget
         ScreenCoordsXY logoCoords = windowPos
@@ -227,7 +227,7 @@ private:
     /**
      * @brief Draw RCT2 info on open tab
      */
-    void DrawRCT2Info(rct_drawpixelinfo& dpi)
+    void DrawRCT2Info(DrawPixelInfo& dpi)
     {
         int32_t yPage = windowPos.y + widgets[WIDX_PAGE_BACKGROUND].top + 5;
 

--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -184,12 +184,12 @@ public:
         widgets[WIDX_APPLY].top = widgets[WIDX_APPLY].bottom - 24;
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
         GfxFillRect(
@@ -233,7 +233,7 @@ public:
     }
 
 private:
-    void PaintItem(rct_drawpixelinfo& dpi, int32_t y, Formatter& ft, bool isChecked, bool isSelected, bool isHighlighted)
+    void PaintItem(DrawPixelInfo& dpi, int32_t y, Formatter& ft, bool isChecked, bool isSelected, bool isHighlighted)
     {
         auto listWidth = dpi.width - 1;
         auto stringId = STR_BLACK_STRING;
@@ -254,7 +254,7 @@ private:
         PaintCheckbox(dpi, { { 2, y + 1 }, { 2 + checkboxSize + 1, y + 1 + checkboxSize } }, isChecked);
     }
 
-    void PaintCheckbox(rct_drawpixelinfo& dpi, const ScreenRect& rect, bool checked)
+    void PaintCheckbox(DrawPixelInfo& dpi, const ScreenRect& rect, bool checked)
     {
         GfxFillRectInset(&dpi, rect, colours[1], INSET_RECT_F_E0);
         if (checked)

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -254,7 +254,7 @@ public:
         CreateViewport();
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/Changelog.cpp
+++ b/src/openrct2-ui/windows/Changelog.cpp
@@ -186,7 +186,7 @@ public:
         }
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         const int32_t lineHeight = FontGetLineHeight(FontStyle::Medium);
 

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -513,7 +513,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         UpdateTabPositions();
         DrawWidgets(dpi);
@@ -654,7 +654,7 @@ private:
         }
     }
 
-    void DrawTabImages(rct_drawpixelinfo& dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         // Money tab
         if (!IsWidgetDisabled(WIDX_TAB_1))

--- a/src/openrct2-ui/windows/ClearScenery.cpp
+++ b/src/openrct2-ui/windows/ClearScenery.cpp
@@ -171,7 +171,7 @@ public:
         window_clear_scenery_widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/CustomCurrency.cpp
+++ b/src/openrct2-ui/windows/CustomCurrency.cpp
@@ -184,7 +184,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         auto ft = Formatter::Common();
         ft.Add<money64>(10.00_GBP);

--- a/src/openrct2-ui/windows/DebugPaint.cpp
+++ b/src/openrct2-ui/windows/DebugPaint.cpp
@@ -137,7 +137,7 @@ public:
         WidgetSetCheckboxValue(*this, WIDX_TOGGLE_SHOW_DIRTY_VISUALS, gShowDirtyVisuals);
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
     }

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -74,7 +74,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         WindowDrawWidgets(*this, &dpi);
 

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -136,7 +136,7 @@ public:
         InputSetState(InputState::DropdownActive);
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 
@@ -160,7 +160,7 @@ public:
 
                 if (colours[0] & COLOUR_FLAG_TRANSLUCENT)
                 {
-                    translucent_window_palette palette = TranslucentWindowPalettes[BASE_COLOUR(colours[0])];
+                    TranslucentWindowPalette palette = TranslucentWindowPalettes[BASE_COLOUR(colours[0])];
                     GfxFilterRect(&dpi, { leftTop, rightBottom }, palette.highlight);
                     GfxFilterRect(&dpi, { leftTop + shadowOffset, rightBottom + shadowOffset }, palette.shadow);
                 }

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -107,7 +107,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         auto drawPreviousButton = widgets[WIDX_PREVIOUS_STEP_BUTTON].type != WindowWidgetType::Empty;
         auto drawNextButton = widgets[WIDX_NEXT_STEP_BUTTON].type != WindowWidgetType::Empty;
@@ -278,7 +278,7 @@ private:
         widgets[WIDX_NEXT_IMAGE].type = WindowWidgetType::Empty;
     }
 
-    void DrawLeftButtonBack(rct_drawpixelinfo& dpi)
+    void DrawLeftButtonBack(DrawPixelInfo& dpi)
     {
         auto previousWidget = widgets[WIDX_PREVIOUS_IMAGE];
         auto leftTop = windowPos + ScreenCoordsXY{ previousWidget.left, previousWidget.top };
@@ -286,7 +286,7 @@ private:
         GfxFilterRect(&dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
     }
 
-    void DrawLeftButton(rct_drawpixelinfo& dpi)
+    void DrawLeftButton(DrawPixelInfo& dpi)
     {
         const auto topLeft = windowPos
             + ScreenCoordsXY{ widgets[WIDX_PREVIOUS_IMAGE].left + 1, widgets[WIDX_PREVIOUS_IMAGE].top + 1 };
@@ -316,7 +316,7 @@ private:
         DrawTextBasic(&dpi, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::CENTRE });
     }
 
-    void DrawRightButtonBack(rct_drawpixelinfo& dpi)
+    void DrawRightButtonBack(DrawPixelInfo& dpi)
     {
         auto nextWidget = widgets[WIDX_NEXT_IMAGE];
         auto leftTop = windowPos + ScreenCoordsXY{ nextWidget.left, nextWidget.top };
@@ -324,7 +324,7 @@ private:
         GfxFilterRect(&dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
     }
 
-    void DrawRightButton(rct_drawpixelinfo& dpi)
+    void DrawRightButton(DrawPixelInfo& dpi)
     {
         const auto topLeft = windowPos + ScreenCoordsXY{ widgets[WIDX_NEXT_IMAGE].left + 1, widgets[WIDX_NEXT_IMAGE].top + 1 };
         const auto bottomRight = windowPos
@@ -354,7 +354,7 @@ private:
         DrawTextBasic(&dpi, { textX, textY + 10 }, stringId, {}, { textColour, TextAlignment::CENTRE });
     }
 
-    void DrawStepText(rct_drawpixelinfo& dpi)
+    void DrawStepText(DrawPixelInfo& dpi)
     {
         int16_t stateX = (widgets[WIDX_PREVIOUS_IMAGE].right + widgets[WIDX_NEXT_IMAGE].left) / 2 + windowPos.x;
         int16_t stateY = height - 0x0C + windowPos.y;

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -96,7 +96,7 @@ static void ResearchRidesSetup()
 }
 
 static void DrawResearchItem(
-    rct_drawpixelinfo& dpi, const ResearchItem& researchItem, const int16_t& width, const ScreenCoordsXY& screenCoords,
+    DrawPixelInfo& dpi, const ResearchItem& researchItem, const int16_t& width, const ScreenCoordsXY& screenCoords,
     StringId format, TextPaint textPaint)
 {
     const StringId itemNameId = researchItem.GetName();
@@ -263,7 +263,7 @@ public:
         WindowEditorInventionsListDragOpen(researchItem, windowPos, widgets[WIDX_PRE_RESEARCHED_SCROLL].right);
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         // Draw background
         uint8_t paletteIndex = ColourMapA[colours[1]].mid_light;
@@ -346,7 +346,7 @@ public:
         return fallback;
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 
@@ -392,7 +392,7 @@ public:
         const auto* object = ObjectEntryGetObject(objectEntryType, researchItem->entryIndex);
         if (object != nullptr)
         {
-            rct_drawpixelinfo clipDPI;
+            DrawPixelInfo clipDPI;
             screenPos = windowPos + ScreenCoordsXY{ bkWidget.left + 1, bkWidget.top + 1 };
             const auto clipWidth = bkWidget.width() - 1;
             const auto clipHeight = bkWidget.height() - 1;
@@ -638,7 +638,7 @@ public:
         Close();
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         auto screenCoords = windowPos + ScreenCoordsXY{ 0, 2 };
 

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -688,7 +688,7 @@ public:
         }
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         // ScrollPaint
         ScreenCoordsXY screenCoords;
@@ -952,7 +952,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         int32_t _width;
 
@@ -1051,7 +1051,7 @@ public:
 
         // Draw preview
         {
-            rct_drawpixelinfo clipDPI;
+            DrawPixelInfo clipDPI;
             auto screenPos = windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 };
             _width = previewWidget.width() - 1;
             int32_t _height = previewWidget.height() - 1;
@@ -1182,7 +1182,7 @@ private:
         _listItems.shrink_to_fit();
     }
 
-    void DrawDescriptions(rct_drawpixelinfo* dpi)
+    void DrawDescriptions(DrawPixelInfo* dpi)
     {
         const auto& widget = widgets[WIDX_PREVIEW];
         auto screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_LIST].right + 4, widget.bottom + 23 };
@@ -1246,7 +1246,7 @@ private:
         }
     }
 
-    void DrawDebugData(rct_drawpixelinfo* dpi)
+    void DrawDebugData(DrawPixelInfo* dpi)
     {
         ObjectListItem* listItem = &_listItems[selected_list_item];
         auto screenPos = windowPos + ScreenCoordsXY{ width - 5, height - (LIST_ROW_HEIGHT * 6) };

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -128,7 +128,7 @@ static void WindowEditorObjectiveOptionsMainDropdown(rct_window *w, WidgetIndex 
 static void WindowEditorObjectiveOptionsMainUpdate(rct_window *w);
 static void WindowEditorObjectiveOptionsMainTextinput(rct_window *w, WidgetIndex widgetIndex, char *text);
 static void WindowEditorObjectiveOptionsMainInvalidate(rct_window *w);
-static void WindowEditorObjectiveOptionsMainPaint(rct_window *w, rct_drawpixelinfo *dpi);
+static void WindowEditorObjectiveOptionsMainPaint(rct_window *w, DrawPixelInfo *dpi);
 
 static void WindowEditorObjectiveOptionsRidesMouseup(rct_window *w, WidgetIndex widgetIndex);
 static void WindowEditorObjectiveOptionsRidesResize(rct_window *w);
@@ -137,8 +137,8 @@ static void WindowEditorObjectiveOptionsRidesScrollgetheight(rct_window *w, int3
 static void WindowEditorObjectiveOptionsRidesScrollmousedown(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void WindowEditorObjectiveOptionsRidesScrollmouseover(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void WindowEditorObjectiveOptionsRidesInvalidate(rct_window *w);
-static void WindowEditorObjectiveOptionsRidesPaint(rct_window *w, rct_drawpixelinfo *dpi);
-static void WindowEditorObjectiveOptionsRidesScrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
+static void WindowEditorObjectiveOptionsRidesPaint(rct_window *w, DrawPixelInfo *dpi);
+static void WindowEditorObjectiveOptionsRidesScrollpaint(rct_window *w, DrawPixelInfo *dpi, int32_t scrollIndex);
 
 // 0x009A9DF4
 static WindowEventList window_objective_options_main_events([](auto& events)
@@ -228,7 +228,7 @@ static void WindowEditorObjectiveOptionsAnchorBorderWidgets(rct_window* w)
     w->ResizeFrameWithPage();
 }
 
-static void WindowEditorObjectiveOptionsDrawTabImages(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowEditorObjectiveOptionsDrawTabImages(rct_window* w, DrawPixelInfo* dpi)
 {
     Widget* widget;
     int32_t spriteIndex;
@@ -760,7 +760,7 @@ static void WindowEditorObjectiveOptionsMainInvalidate(rct_window* w)
  *
  *  rct2: 0x0067161C
  */
-static void WindowEditorObjectiveOptionsMainPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowEditorObjectiveOptionsMainPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     int32_t width;
     StringId stringId;
@@ -1035,7 +1035,7 @@ static void WindowEditorObjectiveOptionsRidesInvalidate(rct_window* w)
  *
  *  rct2: 0x00672340
  */
-static void WindowEditorObjectiveOptionsRidesPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowEditorObjectiveOptionsRidesPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowEditorObjectiveOptionsDrawTabImages(w, dpi);
@@ -1048,7 +1048,7 @@ static void WindowEditorObjectiveOptionsRidesPaint(rct_window* w, rct_drawpixeli
  *
  *  rct2: 0x0067236F
  */
-static void WindowEditorObjectiveOptionsRidesScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
+static void WindowEditorObjectiveOptionsRidesScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex)
 {
     int32_t colour = ColourMapA[w->colours[1]].mid_light;
     GfxFillRect(dpi, { { dpi->x, dpi->y }, { dpi->x + dpi->width - 1, dpi->y + dpi->height - 1 } }, colour);

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -284,7 +284,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         switch (page)
         {
@@ -320,7 +320,7 @@ private:
         ResizeFrameWithPage();
     }
 
-    void DrawTabImages(rct_drawpixelinfo& dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         Widget* widget;
         int32_t spriteIndex;
@@ -586,7 +586,7 @@ private:
         AnchorBorderWidgets();
     }
 
-    void FinancialDraw(rct_drawpixelinfo& dpi)
+    void FinancialDraw(DrawPixelInfo& dpi)
     {
         ScreenCoordsXY screenCoords{};
 
@@ -834,7 +834,7 @@ private:
         AnchorBorderWidgets();
     }
 
-    void GuestsDraw(rct_drawpixelinfo& dpi)
+    void GuestsDraw(DrawPixelInfo& dpi)
     {
         ScreenCoordsXY screenCoords{};
 
@@ -1153,7 +1153,7 @@ private:
         AnchorBorderWidgets();
     }
 
-    void ParkDraw(rct_drawpixelinfo& dpi)
+    void ParkDraw(DrawPixelInfo& dpi)
     {
         ScreenCoordsXY screenCoords{};
 

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -55,7 +55,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         ScreenCoordsXY leftTop{ windowPos };
         ScreenCoordsXY rightBottom{ windowPos + ScreenCoordsXY{ width - 1, height - 1 } };

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -318,7 +318,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -356,7 +356,7 @@ public:
         return {};
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         if (page != WINDOW_FINANCES_PAGE_SUMMARY)
             return;
@@ -526,7 +526,7 @@ public:
             InitialiseScrollPosition(WIDX_SUMMARY_SCROLL, 0);
     }
 
-    void OnDrawSummary(rct_drawpixelinfo& dpi)
+    void OnDrawSummary(DrawPixelInfo& dpi)
     {
         auto screenCoords = windowPos + ScreenCoordsXY{ 8, 51 };
 
@@ -598,7 +598,7 @@ public:
 
 #pragma region Financial Graph Events
 
-    void OnDrawFinancialGraph(rct_drawpixelinfo& dpi)
+    void OnDrawFinancialGraph(DrawPixelInfo& dpi)
     {
         Widget* pageWidget = &_windowFinancesCashWidgets[WIDX_PAGE_BACKGROUND];
         auto graphTopLeft = windowPos + ScreenCoordsXY{ pageWidget->left + 4, pageWidget->top + 15 };
@@ -661,7 +661,7 @@ public:
 
 #pragma region Park Value Graph Events
 
-    void OnDrawParkValueGraph(rct_drawpixelinfo& dpi)
+    void OnDrawParkValueGraph(DrawPixelInfo& dpi)
     {
         Widget* pageWidget = &_windowFinancesCashWidgets[WIDX_PAGE_BACKGROUND];
         auto graphTopLeft = windowPos + ScreenCoordsXY{ pageWidget->left + 4, pageWidget->top + 15 };
@@ -718,7 +718,7 @@ public:
 
 #pragma region Profit Graph Events
 
-    void OnDrawProfitGraph(rct_drawpixelinfo& dpi)
+    void OnDrawProfitGraph(DrawPixelInfo& dpi)
     {
         Widget* pageWidget = &_windowFinancesCashWidgets[WIDX_PAGE_BACKGROUND];
         auto graphTopLeft = windowPos + ScreenCoordsXY{ pageWidget->left + 4, pageWidget->top + 15 };
@@ -815,7 +815,7 @@ public:
         }
     }
 
-    void OnDrawMarketing(rct_drawpixelinfo& dpi)
+    void OnDrawMarketing(DrawPixelInfo& dpi)
     {
         auto screenCoords = windowPos + ScreenCoordsXY{ 8, 62 };
         int32_t noCampaignsActive = 1;
@@ -984,7 +984,7 @@ public:
         }
     }
 
-    void OnDrawResearch(rct_drawpixelinfo& dpi)
+    void OnDrawResearch(DrawPixelInfo& dpi)
     {
         WindowResearchFundingPagePaint(this, &dpi, WIDX_RESEARCH_FUNDING);
     }
@@ -999,7 +999,7 @@ public:
         WidgetScrollUpdateThumbs(*this, widgetIndex);
     }
 
-    void DrawTabImage(rct_drawpixelinfo& dpi, int32_t tabPage, int32_t spriteIndex)
+    void DrawTabImage(DrawPixelInfo& dpi, int32_t tabPage, int32_t spriteIndex)
     {
         WidgetIndex widgetIndex = WIDX_TAB_1 + tabPage;
 
@@ -1016,7 +1016,7 @@ public:
         }
     }
 
-    void DrawTabImages(rct_drawpixelinfo& dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         DrawTabImage(dpi, WINDOW_FINANCES_PAGE_SUMMARY, SPR_TAB_FINANCES_SUMMARY_0);
         DrawTabImage(dpi, WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH, SPR_TAB_FINANCES_FINANCIAL_GRAPH_0);

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -429,7 +429,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         ScreenCoordsXY screenCoords;
         WindowDrawWidgets(*this, &dpi);
@@ -466,7 +466,7 @@ public:
                     objManager.GetLoadedObject(ObjectType::Paths, gFootpathSelection.LegacyPath));
                 if (pathObj != nullptr)
                 {
-                    auto pathEntry = reinterpret_cast<const rct_footpath_entry*>(pathObj->GetLegacyData());
+                    auto pathEntry = reinterpret_cast<const FootpathEntry*>(pathObj->GetLegacyData());
                     if (gFootpathSelection.IsQueueSelected)
                         baseImage = pathEntry->GetQueueImage();
                     else
@@ -568,7 +568,7 @@ private:
         }
     }
 
-    void WindowFootpathDrawDropdownButtons(rct_drawpixelinfo* dpi)
+    void WindowFootpathDrawDropdownButtons(DrawPixelInfo* dpi)
     {
         if (gFootpathSelection.LegacyPath == OBJECT_ENTRY_INDEX_NULL)
         {
@@ -610,7 +610,7 @@ private:
                 objManager.GetLoadedObject(ObjectType::Paths, gFootpathSelection.LegacyPath));
             if (pathObj != nullptr)
             {
-                auto pathEntry = reinterpret_cast<rct_footpath_entry*>(pathObj->GetLegacyData());
+                auto pathEntry = reinterpret_cast<FootpathEntry*>(pathObj->GetLegacyData());
                 pathImage = pathEntry->GetPreviewImage();
                 queueImage = pathEntry->GetQueuePreviewImage();
             }
@@ -620,7 +620,7 @@ private:
         }
     }
 
-    void WindowFootpathDrawDropdownButton(rct_drawpixelinfo* dpi, WidgetIndex widgetIndex, ImageIndex image)
+    void WindowFootpathDrawDropdownButton(DrawPixelInfo* dpi, WidgetIndex widgetIndex, ImageIndex image)
     {
         const auto& widget = widgets[widgetIndex];
         GfxDrawSprite(dpi, ImageId(image), { windowPos.x + widget.left, windowPos.y + widget.top });
@@ -684,7 +684,7 @@ private:
                 continue;
             }
 
-            auto pathEntry = reinterpret_cast<const rct_footpath_entry*>(pathObj->GetLegacyData());
+            auto pathEntry = reinterpret_cast<const FootpathEntry*>(pathObj->GetLegacyData());
             if ((pathEntry->flags & FOOTPATH_ENTRY_FLAG_SHOW_ONLY_IN_SCENARIO_EDITOR) && !showEditorPaths)
             {
                 continue;

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -72,16 +72,16 @@ uint8_t gToolbarDirtyFlags;
 static void WindowGameBottomToolbarMouseup(rct_window *w, WidgetIndex widgetIndex);
 static OpenRCT2String WindowGameBottomToolbarTooltip(rct_window* w, const WidgetIndex widgetIndex, const StringId fallback);
 static void WindowGameBottomToolbarInvalidate(rct_window *w);
-static void WindowGameBottomToolbarPaint(rct_window *w, rct_drawpixelinfo *dpi);
+static void WindowGameBottomToolbarPaint(rct_window *w, DrawPixelInfo *dpi);
 static void WindowGameBottomToolbarUpdate(rct_window* w);
 static void WindowGameBottomToolbarCursor(rct_window *w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID *cursorId);
 static void WindowGameBottomToolbarUnknown05(rct_window *w);
 
-static void WindowGameBottomToolbarDrawLeftPanel(rct_drawpixelinfo *dpi, rct_window *w);
-static void WindowGameBottomToolbarDrawParkRating(rct_drawpixelinfo *dpi, rct_window *w, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor);
-static void WindowGameBottomToolbarDrawRightPanel(rct_drawpixelinfo *dpi, rct_window *w);
-static void WindowGameBottomToolbarDrawNewsItem(rct_drawpixelinfo *dpi, rct_window *w);
-static void WindowGameBottomToolbarDrawMiddlePanel(rct_drawpixelinfo *dpi, rct_window *w);
+static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo *dpi, rct_window *w);
+static void WindowGameBottomToolbarDrawParkRating(DrawPixelInfo *dpi, rct_window *w, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor);
+static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo *dpi, rct_window *w);
+static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo *dpi, rct_window *w);
+static void WindowGameBottomToolbarDrawMiddlePanel(DrawPixelInfo *dpi, rct_window *w);
 
 /**
  *
@@ -346,7 +346,7 @@ void WindowGameBottomToolbarInvalidateNewsItem()
  *
  *  rct2: 0x0066BC87
  */
-static void WindowGameBottomToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowGameBottomToolbarPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     auto leftWidget = window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET];
     auto rightWidget = window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET];
@@ -384,7 +384,7 @@ static void WindowGameBottomToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 }
 
-static void WindowGameBottomToolbarDrawLeftPanel(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo* dpi, rct_window* w)
 {
     const auto topLeft = w->windowPos
         + ScreenCoordsXY{ window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].left + 1,
@@ -458,7 +458,7 @@ static void WindowGameBottomToolbarDrawLeftPanel(rct_drawpixelinfo* dpi, rct_win
  *  rct2: 0x0066C76C
  */
 static void WindowGameBottomToolbarDrawParkRating(
-    rct_drawpixelinfo* dpi, rct_window* w, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor)
+    DrawPixelInfo* dpi, rct_window* w, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor)
 {
     int16_t bar_width;
 
@@ -478,7 +478,7 @@ static void WindowGameBottomToolbarDrawParkRating(
     GfxDrawSprite(dpi, ImageId(SPR_RATING_HIGH), coords + ScreenCoordsXY{ 114, 0 });
 }
 
-static void WindowGameBottomToolbarDrawRightPanel(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, rct_window* w)
 {
     const auto topLeft = w->windowPos
         + ScreenCoordsXY{ window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left + 1,
@@ -550,7 +550,7 @@ static void WindowGameBottomToolbarDrawRightPanel(rct_drawpixelinfo* dpi, rct_wi
  *
  *  rct2: 0x0066BFA5
  */
-static void WindowGameBottomToolbarDrawNewsItem(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, rct_window* w)
 {
     int32_t width;
     News::Item* newsItem;
@@ -586,7 +586,7 @@ static void WindowGameBottomToolbarDrawNewsItem(rct_drawpixelinfo* dpi, rct_wind
             if (newsItem->HasButton())
                 break;
 
-            rct_drawpixelinfo cliped_dpi;
+            DrawPixelInfo cliped_dpi;
             if (!ClipDrawPixelInfo(&cliped_dpi, dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
             {
                 break;
@@ -651,7 +651,7 @@ static void WindowGameBottomToolbarDrawNewsItem(rct_drawpixelinfo* dpi, rct_wind
     }
 }
 
-static void WindowGameBottomToolbarDrawMiddlePanel(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowGameBottomToolbarDrawMiddlePanel(DrawPixelInfo* dpi, rct_window* w)
 {
     Widget* middleOutsetWidget = &window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET];
 

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -319,7 +319,7 @@ public:
             OnViewportRotateOverview();
         }
     }
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         switch (page)
         {
@@ -382,7 +382,7 @@ public:
             OnScrollMouseDownRides(scrollIndex, screenCoords);
         }
     }
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         if (page == WINDOW_GUEST_RIDES)
         {
@@ -514,7 +514,7 @@ private:
 
 #pragma region Overview
 
-    void OverviewTabDraw(rct_drawpixelinfo& dpi)
+    void OverviewTabDraw(DrawPixelInfo& dpi)
     {
         if (WidgetIsDisabled(*this, WIDX_TAB_1))
             return;
@@ -526,7 +526,7 @@ private:
         if (page == WINDOW_GUEST_OVERVIEW)
             widgHeight++;
 
-        rct_drawpixelinfo clipDpi;
+        DrawPixelInfo clipDpi;
         if (!ClipDrawPixelInfo(&clipDpi, &dpi, screenCoords, widgWidth, widgHeight))
         {
             return;
@@ -738,7 +738,7 @@ private:
         Invalidate();
     }
 
-    void OnDrawOverview(rct_drawpixelinfo& dpi)
+    void OnDrawOverview(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         OverviewTabDraw(dpi);
@@ -782,7 +782,7 @@ private:
         int32_t left = marqueeWidget.left + 2 + windowPos.x;
         int32_t top = marqueeWidget.top + windowPos.y;
         int32_t marqHeight = marqueeWidget.height();
-        rct_drawpixelinfo dpiMarquee;
+        DrawPixelInfo dpiMarquee;
         if (!ClipDrawPixelInfo(&dpiMarquee, &dpi, { left, top }, marqWidth, marqHeight))
         {
             return;
@@ -985,7 +985,7 @@ private:
 #pragma endregion
 
 #pragma region Stats
-    void StatsTabDraw(rct_drawpixelinfo& dpi)
+    void StatsTabDraw(DrawPixelInfo& dpi)
     {
         if (WidgetIsDisabled(*this, WIDX_TAB_2))
             return;
@@ -1032,7 +1032,7 @@ private:
         Invalidate();
     }
 
-    void StatsBarsDraw(int32_t value, const ScreenCoordsXY& origCoords, rct_drawpixelinfo& dpi, int32_t colour, bool blinkFlag)
+    void StatsBarsDraw(int32_t value, const ScreenCoordsXY& origCoords, DrawPixelInfo& dpi, int32_t colour, bool blinkFlag)
     {
         auto coords = origCoords;
         if (FontGetLineHeight(FontStyle::Medium) > 10)
@@ -1066,7 +1066,7 @@ private:
         return std::clamp(newValue, newMin, 255);
     }
 
-    void OnDrawStats(rct_drawpixelinfo& dpi)
+    void OnDrawStats(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         OverviewTabDraw(dpi);
@@ -1204,7 +1204,7 @@ private:
 #pragma endregion
 
 #pragma region Rides
-    void RidesTabDraw(rct_drawpixelinfo& dpi)
+    void RidesTabDraw(DrawPixelInfo& dpi)
     {
         if (WidgetIsDisabled(*this, WIDX_TAB_3))
             return;
@@ -1312,7 +1312,7 @@ private:
         widgets[WIDX_RIDE_SCROLL].bottom = height - 15;
     }
 
-    void OnDrawRides(rct_drawpixelinfo& dpi)
+    void OnDrawRides(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         OverviewTabDraw(dpi);
@@ -1351,7 +1351,7 @@ private:
         DrawTextEllipsised(&dpi, screenCoords, width - 14, STR_FAVOURITE_RIDE, ft);
     }
 
-    void OnScrollDrawRides(int32_t scrollIndex, rct_drawpixelinfo& dpi)
+    void OnScrollDrawRides(int32_t scrollIndex, DrawPixelInfo& dpi)
     {
         auto colour = ColourMapA[colours[1]].mid_light;
         GfxFillRect(&dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, colour);
@@ -1379,7 +1379,7 @@ private:
 #pragma endregion
 
 #pragma region Finance
-    void FinanceTabDraw(rct_drawpixelinfo& dpi)
+    void FinanceTabDraw(DrawPixelInfo& dpi)
     {
         if (WidgetIsDisabled(*this, WIDX_TAB_4))
             return;
@@ -1405,7 +1405,7 @@ private:
         WidgetInvalidate(*this, WIDX_TAB_4);
     }
 
-    void OnDrawFinance(rct_drawpixelinfo& dpi)
+    void OnDrawFinance(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         OverviewTabDraw(dpi);
@@ -1517,7 +1517,7 @@ private:
 #pragma endregion
 
 #pragma region Thoughts
-    void ThoughtsTabDraw(rct_drawpixelinfo& dpi)
+    void ThoughtsTabDraw(DrawPixelInfo& dpi)
     {
         if (WidgetIsDisabled(*this, WIDX_TAB_5))
             return;
@@ -1554,7 +1554,7 @@ private:
         }
     }
 
-    void OnDrawThoughts(rct_drawpixelinfo& dpi)
+    void OnDrawThoughts(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         OverviewTabDraw(dpi);
@@ -1599,7 +1599,7 @@ private:
 #pragma endregion
 
 #pragma region Inventory
-    void InventoryTabDraw(rct_drawpixelinfo& dpi)
+    void InventoryTabDraw(DrawPixelInfo& dpi)
     {
         if (WidgetIsDisabled(*this, WIDX_TAB_6))
             return;
@@ -1741,7 +1741,7 @@ private:
         return std::make_pair(STR_GUEST_ITEM_FORMAT, ft);
     }
 
-    void OnDrawInventory(rct_drawpixelinfo& dpi)
+    void OnDrawInventory(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         OverviewTabDraw(dpi);
@@ -1788,7 +1788,7 @@ private:
 #pragma endregion
 
 #pragma region Debug
-    void DebugTabDraw(rct_drawpixelinfo& dpi)
+    void DebugTabDraw(DrawPixelInfo& dpi)
     {
         if (WidgetIsDisabled(*this, WIDX_TAB_7))
             return;
@@ -1811,7 +1811,7 @@ private:
         Invalidate();
     }
 
-    void OnDrawDebug(rct_drawpixelinfo& dpi)
+    void OnDrawDebug(DrawPixelInfo& dpi)
     {
         char buffer[512]{};
         char buffer2[512]{};

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -440,7 +440,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -586,7 +586,7 @@ public:
         }
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         GfxFillRect(
             &dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
@@ -639,7 +639,7 @@ public:
     }
 
 private:
-    void DrawTabImages(rct_drawpixelinfo& dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         // Tab 1 image
         auto i = (_selectedTab == TabId::Individual ? _tabAnimationIndex & ~3 : 0);
@@ -655,7 +655,7 @@ private:
             windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
     }
 
-    void DrawScrollIndividual(rct_drawpixelinfo& dpi)
+    void DrawScrollIndividual(DrawPixelInfo& dpi)
     {
         size_t index = 0;
         auto y = static_cast<int32_t>(_selectedPage) * -GUEST_PAGE_HEIGHT;
@@ -722,7 +722,7 @@ private:
         }
     }
 
-    void DrawScrollSummarised(rct_drawpixelinfo& dpi)
+    void DrawScrollSummarised(DrawPixelInfo& dpi)
     {
         size_t index = 0;
         auto y = 0;

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -146,7 +146,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 
@@ -156,7 +156,7 @@ public:
         int32_t colour = ColourMapA[colours[0]].darkest;
         GfxFillRect(&dpi, { screenPos, screenPos + ScreenCoordsXY{ 369, 216 } }, colour);
 
-        rct_g1_element g1temp = {};
+        G1Element g1temp = {};
         g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * TRACK_PREVIEW_IMAGE_SIZE);
         g1temp.width = 370;
         g1temp.height = 217;

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -230,7 +230,7 @@ public:
         widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         ScreenCoordsXY screenCoords;
         int32_t numTiles;
@@ -306,7 +306,7 @@ public:
     }
 
 private:
-    void DrawDropdownButtons(rct_drawpixelinfo& dpi)
+    void DrawDropdownButtons(DrawPixelInfo& dpi)
     {
         auto& objManager = GetContext()->GetObjectManager();
         const auto surfaceObj = static_cast<TerrainSurfaceObject*>(
@@ -331,7 +331,7 @@ private:
         DrawDropdownButton(dpi, WIDX_WALL, edgeImage);
     }
 
-    void DrawDropdownButton(rct_drawpixelinfo& dpi, WidgetIndex widgetIndex, ImageId image)
+    void DrawDropdownButton(DrawPixelInfo& dpi, WidgetIndex widgetIndex, ImageId image)
     {
         const auto& widget = widgets[widgetIndex];
         GfxDrawSprite(&dpi, image, { windowPos.x + widget.left, windowPos.y + widget.top });

--- a/src/openrct2-ui/windows/LandRights.cpp
+++ b/src/openrct2-ui/windows/LandRights.cpp
@@ -210,7 +210,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         auto screenCoords = ScreenCoordsXY{ windowPos.x + window_land_rights_widgets[WIDX_PREVIEW].midX(),
                                             windowPos.y + window_land_rights_widgets[WIDX_PREVIEW].midY() };

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -737,7 +737,7 @@ public:
         window_loadsave_widgets[WIDX_BROWSE].bottom = height - 6;
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 
@@ -973,7 +973,7 @@ public:
         }
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         GfxFillRect(
             &dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
@@ -1118,7 +1118,7 @@ static Widget window_overwrite_prompt_widgets[] = {
 };
 
 static void WindowOverwritePromptMouseup(rct_window* w, WidgetIndex widgetIndex);
-static void WindowOverwritePromptPaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowOverwritePromptPaint(rct_window* w, DrawPixelInfo* dpi);
 
 static WindowEventList window_overwrite_prompt_events([](auto& events) {
     events.mouse_up = &WindowOverwritePromptMouseup;
@@ -1170,7 +1170,7 @@ static void WindowOverwritePromptMouseup(rct_window* w, WidgetIndex widgetIndex)
     }
 }
 
-static void WindowOverwritePromptPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowOverwritePromptPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
 

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -43,7 +43,7 @@ public:
         WindowFootpathResetSelectedPath();
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         ViewportRender(&dpi, viewport, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } });
     }

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -703,11 +703,11 @@ public:
         OnScrollMouseDown(scrollIndex, screenCoords);
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         GfxClear(&dpi, PALETTE_INDEX_10);
 
-        rct_g1_element g1temp = {};
+        G1Element g1temp = {};
         g1temp.offset = _mapImageData.data();
         g1temp.width = MAP_WINDOW_MAP_SIZE;
         g1temp.height = MAP_WINDOW_MAP_SIZE;
@@ -852,7 +852,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTabImages(&dpi);
@@ -1161,7 +1161,7 @@ private:
         return colourB;
     }
 
-    void PaintPeepOverlay(rct_drawpixelinfo* dpi)
+    void PaintPeepOverlay(DrawPixelInfo* dpi)
     {
         auto flashColour = GetGuestFlashColour();
         for (auto guest : EntityList<Guest>())
@@ -1175,7 +1175,7 @@ private:
         }
     }
 
-    void DrawMapPeepPixel(Peep* peep, const uint8_t flashColour, rct_drawpixelinfo* dpi)
+    void DrawMapPeepPixel(Peep* peep, const uint8_t flashColour, DrawPixelInfo* dpi)
     {
         if (peep->x == LOCATION_NULL)
             return;
@@ -1221,7 +1221,7 @@ private:
         return colour;
     }
 
-    void PaintTrainOverlay(rct_drawpixelinfo* dpi)
+    void PaintTrainOverlay(DrawPixelInfo* dpi)
     {
         for (auto train : TrainManager::View())
         {
@@ -1241,7 +1241,7 @@ private:
      * The call to GfxFillRect was originally wrapped in Sub68DABD which made sure that arguments were ordered correctly,
      * but it doesn't look like it's ever necessary here so the call was removed.
      */
-    void PaintHudRectangle(rct_drawpixelinfo* dpi)
+    void PaintHudRectangle(DrawPixelInfo* dpi)
     {
         rct_window* mainWindow = WindowGetMain();
         if (mainWindow == nullptr)
@@ -1275,7 +1275,7 @@ private:
         GfxFillRect(dpi, { rightBottom - ScreenCoordsXY{ 0, 3 }, rightBottom }, PALETTE_INDEX_56);
     }
 
-    void DrawTabImages(rct_drawpixelinfo* dpi)
+    void DrawTabImages(DrawPixelInfo* dpi)
     {
         // Guest tab image (animated)
         uint32_t guestTabImage = SPR_TAB_GUESTS_0;

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -206,25 +206,25 @@ static void WindowMapgenBaseDropdown(rct_window* w, WidgetIndex widgetIndex, int
 static void WindowMapgenBaseUpdate(rct_window* w);
 static void WindowMapgenTextinput(rct_window* w, WidgetIndex widgetIndex, char* text);
 static void WindowMapgenBaseInvalidate(rct_window* w);
-static void WindowMapgenBasePaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowMapgenBasePaint(rct_window* w, DrawPixelInfo* dpi);
 
 static void WindowMapgenRandomMouseup(rct_window* w, WidgetIndex widgetIndex);
 static void WindowMapgenRandomMousedown(rct_window* w, WidgetIndex widgetIndex, Widget* widget);
 static void WindowMapgenRandomUpdate(rct_window* w);
 static void WindowMapgenRandomInvalidate(rct_window* w);
-static void WindowMapgenRandomPaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowMapgenRandomPaint(rct_window* w, DrawPixelInfo* dpi);
 
 static void WindowMapgenSimplexMouseup(rct_window* w, WidgetIndex widgetIndex);
 static void WindowMapgenSimplexMousedown(rct_window* w, WidgetIndex widgetIndex, Widget* widget);
 static void WindowMapgenSimplexDropdown(rct_window* w, WidgetIndex widgetIndex, int32_t dropdownIndex);
 static void WindowMapgenSimplexUpdate(rct_window* w);
 static void WindowMapgenSimplexInvalidate(rct_window* w);
-static void WindowMapgenSimplexPaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowMapgenSimplexPaint(rct_window* w, DrawPixelInfo* dpi);
 
 static void WindowMapgenHeightmapMouseup(rct_window* w, WidgetIndex widgetIndex);
 static void WindowMapgenHeightmapMousedown(rct_window* w, WidgetIndex widgetIndex, Widget* widget);
 static void WindowMapgenHeightmapInvalidate(rct_window* w);
-static void WindowMapgenHeightmapPaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowMapgenHeightmapPaint(rct_window* w, DrawPixelInfo* dpi);
 
 static WindowEventList BaseEvents([](auto& events) {
     events.close = &WindowMapgenSharedClose;
@@ -376,7 +376,7 @@ constexpr int32_t MAX_SMOOTH_ITERATIONS = 20;
 
 static void WindowMapgenSetPage(rct_window* w, int32_t page);
 static void WindowMapgenSetPressedTab(rct_window* w);
-static void WindowMapgenDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w);
+static void WindowMapgenDrawTabImages(DrawPixelInfo* dpi, rct_window* w);
 
 enum class ResizeDirection
 {
@@ -682,7 +682,7 @@ static void WindowMapgenBaseInvalidate(rct_window* w)
     ft.Add<uint16_t>(_mapSize.x - 2);
 }
 
-static void WindowMapgenDrawDropdownButton(rct_window* w, rct_drawpixelinfo* dpi, WidgetIndex widgetIndex, ImageId image)
+static void WindowMapgenDrawDropdownButton(rct_window* w, DrawPixelInfo* dpi, WidgetIndex widgetIndex, ImageId image)
 {
     const auto& widget = w->widgets[widgetIndex];
     ScreenCoordsXY pos = { w->windowPos.x + widget.left, w->windowPos.y + widget.top };
@@ -705,7 +705,7 @@ static void WindowMapgenDrawDropdownButton(rct_window* w, rct_drawpixelinfo* dpi
 }
 
 static void WindowMapgenDrawDropdownButtons(
-    rct_window* w, rct_drawpixelinfo* dpi, WidgetIndex floorWidgetIndex, WidgetIndex edgeWidgetIndex)
+    rct_window* w, DrawPixelInfo* dpi, WidgetIndex floorWidgetIndex, WidgetIndex edgeWidgetIndex)
 {
     auto& objManager = GetContext()->GetObjectManager();
     const auto surfaceObj = static_cast<TerrainSurfaceObject*>(
@@ -731,7 +731,7 @@ static void WindowMapgenDrawDropdownButtons(
     WindowMapgenDrawDropdownButton(w, dpi, edgeWidgetIndex, edgeImage);
 }
 
-static void WindowMapgenBasePaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowMapgenBasePaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowMapgenDrawTabImages(dpi, w);
@@ -829,7 +829,7 @@ static void WindowMapgenRandomInvalidate(rct_window* w)
     WindowMapgenSetPressedTab(w);
 }
 
-static void WindowMapgenRandomPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowMapgenRandomPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowMapgenDrawTabImages(dpi, w);
@@ -1045,7 +1045,7 @@ static void WindowMapgenSimplexInvalidate(rct_window* w)
     ft.Add<uint16_t>(_mapSize.x - 2);
 }
 
-static void WindowMapgenSimplexPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowMapgenSimplexPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowMapgenDrawTabImages(dpi, w);
@@ -1250,7 +1250,7 @@ static void WindowMapgenHeightmapInvalidate(rct_window* w)
     WindowMapgenSetPressedTab(w);
 }
 
-static void WindowMapgenHeightmapPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowMapgenHeightmapPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowMapgenDrawTabImages(dpi, w);
@@ -1357,7 +1357,7 @@ static void WindowMapgenSetPressedTab(rct_window* w)
     w->pressed_widgets |= 1LL << (WIDX_TAB_1 + w->page);
 }
 
-static void WindowMapgenDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int32_t page, int32_t spriteIndex)
+static void WindowMapgenDrawTabImage(DrawPixelInfo* dpi, rct_window* w, int32_t page, int32_t spriteIndex)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + page;
 
@@ -1375,7 +1375,7 @@ static void WindowMapgenDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int3
     }
 }
 
-static void WindowMapgenDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowMapgenDrawTabImages(DrawPixelInfo* dpi, rct_window* w)
 {
     WindowMapgenDrawTabImage(dpi, w, WINDOW_MAPGEN_PAGE_BASE, SPR_G2_TAB_LAND);
     WindowMapgenDrawTabImage(dpi, w, WINDOW_MAPGEN_PAGE_RANDOM, SPR_G2_TAB_TREE);

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -24,7 +24,7 @@ static Widget window_map_tooltip_widgets[] = {
 };
 
 static void WindowMapTooltipUpdate(rct_window *w);
-static void WindowMapTooltipPaint(rct_window *w, rct_drawpixelinfo *dpi);
+static void WindowMapTooltipPaint(rct_window *w, DrawPixelInfo *dpi);
 
 static WindowEventList window_map_tooltip_events([](auto& events)
 {
@@ -137,7 +137,7 @@ static void WindowMapTooltipUpdate(rct_window* w)
  *
  *  rct2: 0x006EE894
  */
-static void WindowMapTooltipPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowMapTooltipPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     StringId stringId;
     std::memcpy(&stringId, _mapTooltipArgs.Data(), sizeof(StringId));

--- a/src/openrct2-ui/windows/MazeConstruction.cpp
+++ b/src/openrct2-ui/windows/MazeConstruction.cpp
@@ -297,7 +297,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
     }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -124,7 +124,7 @@ static void WindowMultiplayerInformationMouseup(rct_window *w, WidgetIndex widge
 static void WindowMultiplayerInformationResize(rct_window *w);
 static void WindowMultiplayerInformationUpdate(rct_window *w);
 static void WindowMultiplayerInformationInvalidate(rct_window *w);
-static void WindowMultiplayerInformationPaint(rct_window *w, rct_drawpixelinfo *dpi);
+static void WindowMultiplayerInformationPaint(rct_window *w, DrawPixelInfo *dpi);
 
 static void WindowMultiplayerPlayersMouseup(rct_window *w, WidgetIndex widgetIndex);
 static void WindowMultiplayerPlayersResize(rct_window *w);
@@ -133,8 +133,8 @@ static void WindowMultiplayerPlayersScrollgetsize(rct_window *w, int32_t scrollI
 static void WindowMultiplayerPlayersScrollmousedown(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void WindowMultiplayerPlayersScrollmouseover(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void WindowMultiplayerPlayersInvalidate(rct_window *w);
-static void WindowMultiplayerPlayersPaint(rct_window *w, rct_drawpixelinfo *dpi);
-static void WindowMultiplayerPlayersScrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
+static void WindowMultiplayerPlayersPaint(rct_window *w, DrawPixelInfo *dpi);
+static void WindowMultiplayerPlayersScrollpaint(rct_window *w, DrawPixelInfo *dpi, int32_t scrollIndex);
 
 static void WindowMultiplayerGroupsMouseup(rct_window *w, WidgetIndex widgetIndex);
 static void WindowMultiplayerGroupsResize(rct_window *w);
@@ -146,14 +146,14 @@ static void WindowMultiplayerGroupsScrollmousedown(rct_window *w, int32_t scroll
 static void WindowMultiplayerGroupsScrollmouseover(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void WindowMultiplayerGroupsTextInput(rct_window *w, WidgetIndex widgetIndex, char *text);
 static void WindowMultiplayerGroupsInvalidate(rct_window *w);
-static void WindowMultiplayerGroupsPaint(rct_window *w, rct_drawpixelinfo *dpi);
-static void WindowMultiplayerGroupsScrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
+static void WindowMultiplayerGroupsPaint(rct_window *w, DrawPixelInfo *dpi);
+static void WindowMultiplayerGroupsScrollpaint(rct_window *w, DrawPixelInfo *dpi, int32_t scrollIndex);
 
 static void WindowMultiplayerOptionsMouseup(rct_window *w, WidgetIndex widgetIndex);
 static void WindowMultiplayerOptionsResize(rct_window *w);
 static void WindowMultiplayerOptionsUpdate(rct_window *w);
 static void WindowMultiplayerOptionsInvalidate(rct_window *w);
-static void WindowMultiplayerOptionsPaint(rct_window *w, rct_drawpixelinfo *dpi);
+static void WindowMultiplayerOptionsPaint(rct_window *w, DrawPixelInfo *dpi);
 
 static WindowEventList window_multiplayer_information_events([](auto& events)
 {
@@ -223,7 +223,7 @@ static constexpr const int32_t window_multiplayer_animation_frames[] = {
     4,
 };
 
-static void WindowMultiplayerDrawTabImages(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowMultiplayerDrawTabImages(rct_window* w, DrawPixelInfo* dpi);
 static void WindowMultiplayerSetPage(rct_window* w, int32_t page);
 
 static bool _windowInformationSizeDirty;
@@ -396,12 +396,12 @@ static void WindowMultiplayerInformationInvalidate(rct_window* w)
     WindowAlignTabs(w, WIDX_TAB1, WIDX_TAB4);
 }
 
-static void WindowMultiplayerInformationPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowMultiplayerInformationPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowMultiplayerDrawTabImages(w, dpi);
 
-    rct_drawpixelinfo clippedDPI;
+    DrawPixelInfo clippedDPI;
     if (ClipDrawPixelInfo(&clippedDPI, dpi, w->windowPos, w->width, w->height))
     {
         dpi = &clippedDPI;
@@ -558,7 +558,7 @@ static void WindowMultiplayerPlayersInvalidate(rct_window* w)
     WindowAlignTabs(w, WIDX_TAB1, WIDX_TAB4);
 }
 
-static void WindowMultiplayerPlayersPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowMultiplayerPlayersPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     StringId stringId;
 
@@ -573,7 +573,7 @@ static void WindowMultiplayerPlayersPaint(rct_window* w, rct_drawpixelinfo* dpi)
     DrawTextBasic(dpi, screenCoords, stringId, ft, { w->colours[2] });
 }
 
-static void WindowMultiplayerPlayersScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
+static void WindowMultiplayerPlayersScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex)
 {
     ScreenCoordsXY screenCoords;
     screenCoords.y = 0;
@@ -842,7 +842,7 @@ static void WindowMultiplayerGroupsInvalidate(rct_window* w)
     }
 }
 
-static void WindowMultiplayerGroupsPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowMultiplayerGroupsPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     thread_local std::string _buffer;
 
@@ -889,7 +889,7 @@ static void WindowMultiplayerGroupsPaint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 }
 
-static void WindowMultiplayerGroupsScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
+static void WindowMultiplayerGroupsScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex)
 {
     auto screenCoords = ScreenCoordsXY{ 0, 0 };
 
@@ -992,7 +992,7 @@ static void WindowMultiplayerOptionsInvalidate(rct_window* w)
     WidgetSetCheckboxValue(*w, WIDX_KNOWN_KEYS_ONLY_CHECKBOX, gConfigNetwork.KnownKeysOnly);
 }
 
-static void WindowMultiplayerOptionsPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowMultiplayerOptionsPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowMultiplayerDrawTabImages(w, dpi);
@@ -1000,7 +1000,7 @@ static void WindowMultiplayerOptionsPaint(rct_window* w, rct_drawpixelinfo* dpi)
 
 #pragma endregion
 
-static void WindowMultiplayerDrawTabImage(rct_window* w, rct_drawpixelinfo* dpi, int32_t page, int32_t spriteIndex)
+static void WindowMultiplayerDrawTabImage(rct_window* w, DrawPixelInfo* dpi, int32_t page, int32_t spriteIndex)
 {
     WidgetIndex widgetIndex = WIDX_TAB1 + page;
 
@@ -1022,7 +1022,7 @@ static void WindowMultiplayerDrawTabImage(rct_window* w, rct_drawpixelinfo* dpi,
     }
 }
 
-static void WindowMultiplayerDrawTabImages(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowMultiplayerDrawTabImages(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowMultiplayerDrawTabImage(w, dpi, WINDOW_MULTIPLAYER_PAGE_INFORMATION, SPR_TAB_KIOSKS_AND_FACILITIES_0);
     WindowMultiplayerDrawTabImage(w, dpi, WINDOW_MULTIPLAYER_PAGE_PLAYERS, SPR_TAB_GUESTS_0);

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -97,7 +97,7 @@ public:
         ResizeFrame();
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         WindowDrawWidgets(*this, &dpi);
         thread_local std::string _buffer;

--- a/src/openrct2-ui/windows/NewCampaign.cpp
+++ b/src/openrct2-ui/windows/NewCampaign.cpp
@@ -342,7 +342,7 @@ public:
             WidgetSetDisabled(*this, WIDX_START_BUTTON, true);
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         ScreenCoordsXY screenCoords{};
 

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -391,7 +391,7 @@ public:
         widgets[WIDX_GROUP_BY_TRACK_TYPE].left = width - 8 - localizedGroupByTrackTypeWidth;
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -448,7 +448,7 @@ public:
         Invalidate();
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         if (_currentTab == RESEARCH_TAB)
         {
@@ -822,7 +822,7 @@ private:
         WidgetScrollUpdateThumbs(*this, WIDX_RIDE_LIST);
     }
 
-    void DrawRideInformation(rct_drawpixelinfo& dpi, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
+    void DrawRideInformation(DrawPixelInfo& dpi, RideSelection item, const ScreenCoordsXY& screenPos, int32_t textWidth)
     {
         rct_ride_entry* rideEntry = GetRideEntryByIndex(item.EntryIndex);
         RideNaming rideNaming = GetRideNaming(item.Type, *rideEntry);
@@ -878,7 +878,7 @@ private:
         }
     }
 
-    void DrawTabImage(rct_drawpixelinfo& dpi, NewRideTabId tab, int32_t spriteIndex)
+    void DrawTabImage(DrawPixelInfo& dpi, NewRideTabId tab, int32_t spriteIndex)
     {
         WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(tab);
 
@@ -896,7 +896,7 @@ private:
         }
     }
 
-    void DrawTabImages(rct_drawpixelinfo& dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         DrawTabImage(dpi, TRANSPORT_TAB, SPR_TAB_RIDES_TRANSPORT_0);
         DrawTabImage(dpi, GENTLE_TAB, SPR_TAB_RIDES_GENTLE_0);

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -166,12 +166,12 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         int32_t lineHeight = FontGetLineHeight(FontStyle::Small);
         int32_t itemHeight = CalculateItemHeight();
@@ -231,7 +231,7 @@ public:
                     case News::ItemType::Peep:
                     case News::ItemType::PeepOnRide:
                     {
-                        rct_drawpixelinfo cliped_dpi;
+                        DrawPixelInfo cliped_dpi;
                         if (!ClipDrawPixelInfo(&cliped_dpi, &dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
                         {
                             break;

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -201,7 +201,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTabImages(&dpi);
@@ -218,14 +218,14 @@ private:
         }
     }
 
-    void DrawTabImages(rct_drawpixelinfo* dpi)
+    void DrawTabImages(DrawPixelInfo* dpi)
     {
         DrawTabImage(dpi, NOTIFICATION_CATEGORY_PARK, SPR_TAB_PARK);
         DrawTabImage(dpi, NOTIFICATION_CATEGORY_RIDE, SPR_TAB_RIDE_0);
         DrawTabImage(dpi, NOTIFICATION_CATEGORY_GUEST, SPR_TAB_GUESTS_0);
     }
 
-    void DrawTabImage(rct_drawpixelinfo* dpi, int32_t p, int32_t spriteIndex)
+    void DrawTabImage(DrawPixelInfo* dpi, int32_t p, int32_t spriteIndex)
     {
         WidgetIndex widgetIndex = WIDX_FIRST_TAB + p;
 

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -485,7 +485,7 @@ public:
         WidgetInvalidate(*this, WIDX_SCROLL);
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         WindowDrawWidgets(*this, &dpi);
 
@@ -501,7 +501,7 @@ public:
         DrawTextEllipsised(&dpi, { windowPos.x + 5, windowPos.y + 43 }, WW - 5, STR_BLACK_STRING, ft);
     }
 
-    void OnScrollDraw(const int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(const int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
         GfxFillRect(

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -552,7 +552,7 @@ public:
         CommonPrepareDrawAfter();
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTabImages(&dpi);
@@ -909,7 +909,7 @@ private:
         widgets[WIDX_DRAWING_ENGINE].text = DrawingEngineStringIds[EnumValue(gConfigGeneral.DrawingEngine)];
     }
 
-    void DisplayDraw(rct_drawpixelinfo* dpi)
+    void DisplayDraw(DrawPixelInfo* dpi)
     {
         auto ft = Formatter();
         ft.Add<int32_t>(static_cast<int32_t>(gConfigGeneral.WindowScale * 100));
@@ -1997,7 +1997,7 @@ private:
         widgets[WIDX_AUTOSAVE_FREQUENCY].text = AutosaveNames[gConfigGeneral.AutosaveFrequency];
     }
 
-    void AdvancedDraw(rct_drawpixelinfo* dpi)
+    void AdvancedDraw(DrawPixelInfo* dpi)
     {
         auto ft = Formatter();
         ft.Add<int32_t>(static_cast<int32_t>(gConfigGeneral.AutosaveAmount));
@@ -2068,7 +2068,7 @@ private:
             Dropdown::Flag::StayOpen, num_items, widget->width() - 3);
     }
 
-    void DrawTabImages(rct_drawpixelinfo* dpi)
+    void DrawTabImages(DrawPixelInfo* dpi)
     {
         DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_DISPLAY, SPR_TAB_PAINT_0);
         DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_RENDERING, SPR_G2_TAB_TREE);
@@ -2079,7 +2079,7 @@ private:
         DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_ADVANCED, SPR_TAB_WRENCH_0);
     }
 
-    void DrawTabImage(rct_drawpixelinfo* dpi, int32_t p, int32_t spriteIndex)
+    void DrawTabImage(DrawPixelInfo* dpi, int32_t p, int32_t spriteIndex)
     {
         WidgetIndex widgetIndex = WIDX_FIRST_TAB + p;
         Widget* widget = &widgets[widgetIndex];

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -362,7 +362,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         switch (page)
         {
@@ -585,7 +585,7 @@ private:
         }
     }
 
-    void OnDrawEntrance(rct_drawpixelinfo& dpi)
+    void OnDrawEntrance(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -685,7 +685,7 @@ private:
         AnchorBorderWidgets();
     }
 
-    void OnDrawRating(rct_drawpixelinfo& dpi)
+    void OnDrawRating(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -758,7 +758,7 @@ private:
         AnchorBorderWidgets();
     }
 
-    void OnDrawGuests(rct_drawpixelinfo& dpi)
+    void OnDrawGuests(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -888,7 +888,7 @@ private:
         AnchorBorderWidgets();
     }
 
-    void OnDrawPrice(rct_drawpixelinfo& dpi)
+    void OnDrawPrice(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -952,7 +952,7 @@ private:
         AnchorBorderWidgets();
     }
 
-    void OnDrawStats(rct_drawpixelinfo& dpi)
+    void OnDrawStats(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -1061,7 +1061,7 @@ private:
         AnchorBorderWidgets();
     }
 
-    void OnDrawObjective(rct_drawpixelinfo& dpi)
+    void OnDrawObjective(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -1151,7 +1151,7 @@ private:
         AnchorBorderWidgets();
     }
 
-    void OnDrawAwards(rct_drawpixelinfo& dpi)
+    void OnDrawAwards(DrawPixelInfo& dpi)
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -1213,7 +1213,7 @@ private:
         pressed_widgets |= 1LL << (WIDX_TAB_1 + page);
     }
 
-    void DrawTabImages(rct_drawpixelinfo& dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         // Entrance tab
         if (!WidgetIsDisabled(*this, WIDX_TAB_1))

--- a/src/openrct2-ui/windows/PatrolArea.cpp
+++ b/src/openrct2-ui/windows/PatrolArea.cpp
@@ -131,7 +131,7 @@ public:
         PatrolAreaWidgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -88,7 +88,7 @@ static void WindowPlayerOverviewMouseDown(rct_window *w, WidgetIndex widgetIndex
 static void WindowPlayerOverviewDropdown(rct_window *w, WidgetIndex widgetIndex, int32_t dropdownIndex);
 static void WindowPlayerOverviewUpdate(rct_window* w);
 static void WindowPlayerOverviewInvalidate(rct_window *w);
-static void WindowPlayerOverviewPaint(rct_window *w, rct_drawpixelinfo *dpi);
+static void WindowPlayerOverviewPaint(rct_window *w, DrawPixelInfo *dpi);
 
 static WindowEventList window_player_overview_events([](auto& events)
 {
@@ -107,7 +107,7 @@ static void WindowPlayerStatisticsMouseUp(rct_window *w, WidgetIndex widgetIndex
 static void WindowPlayerStatisticsResize(rct_window *w);
 static void WindowPlayerStatisticsUpdate(rct_window* w);
 static void WindowPlayerStatisticsInvalidate(rct_window *w);
-static void WindowPlayerStatisticsPaint(rct_window *w, rct_drawpixelinfo *dpi);
+static void WindowPlayerStatisticsPaint(rct_window *w, DrawPixelInfo *dpi);
 
 static WindowEventList window_player_statistics_events([](auto& events)
 {
@@ -129,7 +129,7 @@ static WindowEventList *window_player_page_events[] = {
 // clang-format on
 
 static void WindowPlayerSetPage(rct_window* w, int32_t page);
-static void WindowPlayerDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w);
+static void WindowPlayerDrawTabImages(DrawPixelInfo* dpi, rct_window* w);
 static void WindowPlayerUpdateViewport(rct_window* w, bool scroll);
 static void WindowPlayerUpdateTitle(rct_window* w);
 
@@ -300,7 +300,7 @@ void WindowPlayerOverviewUpdate(rct_window* w)
     WindowPlayerUpdateViewport(w, scroll);
 }
 
-void WindowPlayerOverviewPaint(rct_window* w, rct_drawpixelinfo* dpi)
+void WindowPlayerOverviewPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowPlayerDrawTabImages(dpi, w);
@@ -471,7 +471,7 @@ void WindowPlayerStatisticsInvalidate(rct_window* w)
     WindowAlignTabs(w, WIDX_TAB_1, WIDX_TAB_2);
 }
 
-void WindowPlayerStatisticsPaint(rct_window* w, rct_drawpixelinfo* dpi)
+void WindowPlayerStatisticsPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowPlayerDrawTabImages(dpi, w);
@@ -538,7 +538,7 @@ static void WindowPlayerSetPage(rct_window* w, int32_t page)
     }
 }
 
-static void WindowPlayerDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowPlayerDrawTabImages(DrawPixelInfo* dpi, rct_window* w)
 {
     Widget* widget;
 

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -73,7 +73,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         WindowDrawWidgets(*this, &dpi);
 

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -104,14 +104,14 @@ static Widget *window_research_page_widgets[] = {
 static void WindowResearchDevelopmentMouseup(rct_window *w, WidgetIndex widgetIndex);
 static void WindowResearchDevelopmentUpdate(rct_window *w);
 static void WindowResearchDevelopmentInvalidate(rct_window *w);
-static void WindowResearchDevelopmentPaint(rct_window *w, rct_drawpixelinfo *dpi);
+static void WindowResearchDevelopmentPaint(rct_window *w, DrawPixelInfo *dpi);
 
 static void WindowResearchFundingMouseup(rct_window *w, WidgetIndex widgetIndex);
 static void WindowResearchFundingMousedown(rct_window *w, WidgetIndex widgetIndex, Widget* widget);
 static void WindowResearchFundingDropdown(rct_window *w, WidgetIndex widgetIndex, int32_t dropdownIndex);
 static void WindowResearchFundingUpdate(rct_window *w);
 static void WindowResearchFundingInvalidate(rct_window *w);
-static void WindowResearchFundingPaint(rct_window *w, rct_drawpixelinfo *dpi);
+static void WindowResearchFundingPaint(rct_window *w, DrawPixelInfo *dpi);
 
 //
 static WindowEventList window_research_development_events([](auto& events)
@@ -156,7 +156,7 @@ static constexpr const StringId ResearchStageNames[] = {
 
 static void WindowResearchSetPage(rct_window* w, int32_t page);
 static void WindowResearchSetPressedTab(rct_window* w);
-static void WindowResearchDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w);
+static void WindowResearchDrawTabImages(DrawPixelInfo* dpi, rct_window* w);
 
 rct_window* WindowResearchOpen()
 {
@@ -253,7 +253,7 @@ static void WindowResearchDevelopmentInvalidate(rct_window* w)
  *
  *  rct2: 0x006B689B
  */
-static void WindowResearchDevelopmentPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowResearchDevelopmentPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowResearchDrawTabImages(dpi, w);
@@ -261,7 +261,7 @@ static void WindowResearchDevelopmentPaint(rct_window* w, rct_drawpixelinfo* dpi
     WindowResearchDevelopmentPagePaint(w, dpi, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
 }
 
-void WindowResearchDevelopmentPagePaint(rct_window* w, rct_drawpixelinfo* dpi, WidgetIndex baseWidgetIndex)
+void WindowResearchDevelopmentPagePaint(rct_window* w, DrawPixelInfo* dpi, WidgetIndex baseWidgetIndex)
 {
     baseWidgetIndex = baseWidgetIndex - WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP;
 
@@ -528,7 +528,7 @@ static void WindowResearchFundingInvalidate(rct_window* w)
  *
  *  rct2: 0x0069DAF0
  */
-static void WindowResearchFundingPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowResearchFundingPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowResearchDrawTabImages(dpi, w);
@@ -536,7 +536,7 @@ static void WindowResearchFundingPaint(rct_window* w, rct_drawpixelinfo* dpi)
     WindowResearchFundingPagePaint(w, dpi, WIDX_RESEARCH_FUNDING);
 }
 
-void WindowResearchFundingPagePaint(rct_window* w, rct_drawpixelinfo* dpi, WidgetIndex baseWidgetIndex)
+void WindowResearchFundingPagePaint(rct_window* w, DrawPixelInfo* dpi, WidgetIndex baseWidgetIndex)
 {
     if (gParkFlags & PARK_FLAGS_NO_MONEY)
         return;
@@ -593,7 +593,7 @@ static void WindowResearchSetPressedTab(rct_window* w)
     w->pressed_widgets |= 1LL << (WIDX_TAB_1 + w->page);
 }
 
-static void WindowResearchDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int32_t page, int32_t spriteIndex)
+static void WindowResearchDrawTabImage(DrawPixelInfo* dpi, rct_window* w, int32_t page, int32_t spriteIndex)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + page;
 
@@ -613,7 +613,7 @@ static void WindowResearchDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, in
     }
 }
 
-static void WindowResearchDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowResearchDrawTabImages(DrawPixelInfo* dpi, rct_window* w)
 {
     WindowResearchDrawTabImage(dpi, w, WINDOW_RESEARCH_PAGE_DEVELOPMENT, SPR_TAB_FINANCES_RESEARCH_0);
     WindowResearchDrawTabImage(dpi, w, WINDOW_RESEARCH_PAGE_FUNDING, SPR_TAB_FINANCES_SUMMARY_0);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -439,7 +439,7 @@ static void WindowRideMainUpdate(rct_window* w);
 static void WindowRideMainTextinput(rct_window* w, WidgetIndex widgetIndex, char* text);
 static void WindowRideMainViewportRotate(rct_window* w);
 static void WindowRideMainInvalidate(rct_window* w);
-static void WindowRideMainPaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowRideMainPaint(rct_window* w, DrawPixelInfo* dpi);
 static void WindowRideMainFollowRide(rct_window* w);
 
 static void WindowRideVehicleMouseup(rct_window* w, WidgetIndex widgetIndex);
@@ -449,8 +449,8 @@ static void WindowRideVehicleDropdown(rct_window* w, WidgetIndex widgetIndex, in
 static void WindowRideVehicleUpdate(rct_window* w);
 static OpenRCT2String WindowRideVehicleTooltip(rct_window* const w, const WidgetIndex widgetIndex, StringId fallback);
 static void WindowRideVehicleInvalidate(rct_window* w);
-static void WindowRideVehiclePaint(rct_window* w, rct_drawpixelinfo* dpi);
-static void WindowRideVehicleScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex);
+static void WindowRideVehiclePaint(rct_window* w, DrawPixelInfo* dpi);
+static void WindowRideVehicleScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex);
 
 static void WindowRideOperatingMouseup(rct_window* w, WidgetIndex widgetIndex);
 static void WindowRideOperatingResize(rct_window* w);
@@ -461,7 +461,7 @@ static void WindowRideOperatingDropdown(rct_window* w, WidgetIndex widgetIndex, 
 static void WindowRideOperatingUpdate(rct_window* w);
 static void WindowRideOperatingTextinput(rct_window* w, WidgetIndex widgetIndex, char* text);
 static void WindowRideOperatingInvalidate(rct_window* w);
-static void WindowRideOperatingPaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowRideOperatingPaint(rct_window* w, DrawPixelInfo* dpi);
 
 static void WindowRideMaintenanceMouseup(rct_window* w, WidgetIndex widgetIndex);
 static void WindowRideMaintenanceResize(rct_window* w);
@@ -469,7 +469,7 @@ static void WindowRideMaintenanceMousedown(rct_window* w, WidgetIndex widgetInde
 static void WindowRideMaintenanceDropdown(rct_window* w, WidgetIndex widgetIndex, int32_t dropdownIndex);
 static void WindowRideMaintenanceUpdate(rct_window* w);
 static void WindowRideMaintenanceInvalidate(rct_window* w);
-static void WindowRideMaintenancePaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowRideMaintenancePaint(rct_window* w, DrawPixelInfo* dpi);
 
 static void WindowRideColourClose(rct_window* w);
 static void WindowRideColourMouseup(rct_window* w, WidgetIndex widgetIndex);
@@ -480,8 +480,8 @@ static void WindowRideColourUpdate(rct_window* w);
 static void WindowRideColourTooldown(rct_window* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
 static void WindowRideColourTooldrag(rct_window* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
 static void WindowRideColourInvalidate(rct_window* w);
-static void WindowRideColourPaint(rct_window* w, rct_drawpixelinfo* dpi);
-static void WindowRideColourScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex);
+static void WindowRideColourPaint(rct_window* w, DrawPixelInfo* dpi);
+static void WindowRideColourScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex);
 
 static void WindowRideMusicMouseup(rct_window* w, WidgetIndex widgetIndex);
 static void WindowRideMusicResize(rct_window* w);
@@ -489,7 +489,7 @@ static void WindowRideMusicMousedown(rct_window* w, WidgetIndex widgetIndex, Wid
 static void WindowRideMusicDropdown(rct_window* w, WidgetIndex widgetIndex, int32_t dropdownIndex);
 static void WindowRideMusicUpdate(rct_window* w);
 static void WindowRideMusicInvalidate(rct_window* w);
-static void WindowRideMusicPaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowRideMusicPaint(rct_window* w, DrawPixelInfo* dpi);
 
 static void WindowRideMeasurementsClose(rct_window* w);
 static void WindowRideMeasurementsMouseup(rct_window* w, WidgetIndex widgetIndex);
@@ -501,7 +501,7 @@ static void WindowRideMeasurementsTooldown(rct_window* w, WidgetIndex widgetInde
 static void WindowRideMeasurementsTooldrag(rct_window* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
 static void WindowRideMeasurementsToolabort(rct_window* w, WidgetIndex widgetIndex);
 static void WindowRideMeasurementsInvalidate(rct_window* w);
-static void WindowRideMeasurementsPaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowRideMeasurementsPaint(rct_window* w, DrawPixelInfo* dpi);
 
 static void WindowRideGraphsMouseup(rct_window* w, WidgetIndex widgetIndex);
 static void WindowRideGraphsResize(rct_window* w);
@@ -511,8 +511,8 @@ static void WindowRideGraphsScrollgetheight(rct_window* w, int32_t scrollIndex, 
 static void WindowRideGraphs15(rct_window* w, int32_t scrollIndex, int32_t scrollAreaType);
 static OpenRCT2String WindowRideGraphsTooltip(rct_window* w, const WidgetIndex widgetIndex, const StringId fallback);
 static void WindowRideGraphsInvalidate(rct_window* w);
-static void WindowRideGraphsPaint(rct_window* w, rct_drawpixelinfo* dpi);
-static void WindowRideGraphsScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex);
+static void WindowRideGraphsPaint(rct_window* w, DrawPixelInfo* dpi);
+static void WindowRideGraphsScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex);
 
 static void WindowRideIncomeMouseup(rct_window* w, WidgetIndex widgetIndex);
 static void WindowRideIncomeResize(rct_window* w);
@@ -520,14 +520,14 @@ static void WindowRideIncomeMousedown(rct_window* w, WidgetIndex widgetIndex, Wi
 static void WindowRideIncomeUpdate(rct_window* w);
 static void WindowRideIncomeTextinput(rct_window* w, WidgetIndex widgetIndex, char* text);
 static void WindowRideIncomeInvalidate(rct_window* w);
-static void WindowRideIncomePaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowRideIncomePaint(rct_window* w, DrawPixelInfo* dpi);
 static bool WindowRideIncomeCanModifyPrimaryPrice(rct_window* w);
 
 static void WindowRideCustomerMouseup(rct_window* w, WidgetIndex widgetIndex);
 static void WindowRideCustomerResize(rct_window* w);
 static void WindowRideCustomerUpdate(rct_window* w);
 static void WindowRideCustomerInvalidate(rct_window* w);
-static void WindowRideCustomerPaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowRideCustomerPaint(rct_window* w, DrawPixelInfo* dpi);
 
 static void WindowRideSetPage(rct_window* w, int32_t page);
 
@@ -862,7 +862,7 @@ static rct_ride_entry* VehicleDropdownRideType = nullptr;
 static bool VehicleDropdownExpanded = false;
 static std::vector<VehicleTypeLabel> VehicleDropdownData;
 
-static void WindowRideDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int32_t page, int32_t spriteIndex)
+static void WindowRideDrawTabImage(DrawPixelInfo* dpi, rct_window* w, int32_t page, int32_t spriteIndex)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + page;
 
@@ -883,7 +883,7 @@ static void WindowRideDrawTabImage(rct_drawpixelinfo* dpi, rct_window* w, int32_
  *
  *  rct2: 0x006B2E88
  */
-static void WindowRideDrawTabMain(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowRideDrawTabMain(DrawPixelInfo* dpi, rct_window* w)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_MAIN);
     if (!WidgetIsDisabled(*w, widgetIndex))
@@ -921,7 +921,7 @@ static void WindowRideDrawTabMain(rct_drawpixelinfo* dpi, rct_window* w)
  *
  *  rct2: 0x006B2B68
  */
-static void WindowRideDrawTabVehicle(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowRideDrawTabVehicle(DrawPixelInfo* dpi, rct_window* w)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_VEHICLE);
     const auto& widget = w->widgets[widgetIndex];
@@ -936,7 +936,7 @@ static void WindowRideDrawTabVehicle(rct_drawpixelinfo* dpi, rct_window* w)
 
         screenCoords += w->windowPos;
 
-        rct_drawpixelinfo clipDPI;
+        DrawPixelInfo clipDPI;
         if (!ClipDrawPixelInfo(&clipDPI, dpi, screenCoords, width, height))
         {
             return;
@@ -992,7 +992,7 @@ static void WindowRideDrawTabVehicle(rct_drawpixelinfo* dpi, rct_window* w)
  *
  *  rct2: 0x006B2F42
  */
-static void WindowRideDrawTabCustomer(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowRideDrawTabCustomer(DrawPixelInfo* dpi, rct_window* w)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_CUSTOMER);
 
@@ -1015,7 +1015,7 @@ static void WindowRideDrawTabCustomer(rct_drawpixelinfo* dpi, rct_window* w)
  *
  *  rct2: 0x006B2B35
  */
-static void WindowRideDrawTabImages(rct_drawpixelinfo* dpi, rct_window* w)
+static void WindowRideDrawTabImages(DrawPixelInfo* dpi, rct_window* w)
 {
     WindowRideDrawTabVehicle(dpi, w);
     WindowRideDrawTabImage(dpi, w, WINDOW_RIDE_PAGE_OPERATING, SPR_TAB_GEARS_0);
@@ -2559,7 +2559,7 @@ static StringId WindowRideGetStatus(rct_window* w, Formatter& ft)
  *
  *  rct2: 0x006AEE73
  */
-static void WindowRideMainPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowRideMainPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     Widget* widget;
 
@@ -2865,7 +2865,7 @@ static void WindowRideVehicleInvalidate(rct_window* w)
  *
  *  rct2: 0x006B23DC
  */
-static void WindowRideVehiclePaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowRideVehiclePaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -2943,7 +2943,7 @@ struct VehicleDrawInfo
  *
  *  rct2: 0x006B2502
  */
-static void WindowRideVehicleScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
+static void WindowRideVehicleScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex)
 {
     auto ride = GetRide(w->rideId);
     if (ride == nullptr)
@@ -3701,7 +3701,7 @@ static void WindowRideOperatingInvalidate(rct_window* w)
  *
  *  rct2: 0x006B1001
  */
-static void WindowRideOperatingPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowRideOperatingPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -3764,7 +3764,7 @@ static void WindowRideLocateMechanic(rct_window* w)
  *  rct2: 0x006B7D08
  */
 static void WindowRideMaintenanceDrawBar(
-    rct_window* w, rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t value, int32_t colour)
+    rct_window* w, DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t value, int32_t colour)
 {
     GfxFillRectInset(dpi, { coords, coords + ScreenCoordsXY{ 149, 8 } }, w->colours[1], INSET_RECT_F_30);
     if (colour & BAR_BLINK)
@@ -4098,7 +4098,7 @@ static void WindowRideMaintenanceInvalidate(rct_window* w)
  *
  *  rct2: 0x006B1877
  */
-static void WindowRideMaintenancePaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowRideMaintenancePaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -4857,10 +4857,10 @@ static void WindowRideColourInvalidate(rct_window* w)
  *
  *  rct2: 0x006AFF3E
  */
-static void WindowRideColourPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowRideColourPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     // TODO: This should use lists and identified sprites
-    rct_drawpixelinfo clippedDpi;
+    DrawPixelInfo clippedDpi;
 
     auto ride = GetRide(w->rideId);
     if (ride == nullptr)
@@ -4977,7 +4977,7 @@ static void WindowRideColourPaint(rct_window* w, rct_drawpixelinfo* dpi)
  *
  *  rct2: 0x006B0192
  */
-static void WindowRideColourScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
+static void WindowRideColourScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex)
 {
     auto ride = GetRide(w->rideId);
     if (ride == nullptr)
@@ -5240,7 +5240,7 @@ static void WindowRideMusicInvalidate(rct_window* w)
  *
  *  rct2: 0x006B1ECC
  */
-static void WindowRideMusicPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowRideMusicPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -5620,7 +5620,7 @@ static void WindowRideMeasurementsInvalidate(rct_window* w)
  *
  *  rct2: 0x006ACF07
  */
-static void WindowRideMeasurementsPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowRideMeasurementsPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -6107,7 +6107,7 @@ static void WindowRideGraphsInvalidate(rct_window* w)
  *
  *  rct2: 0x006AE4BC
  */
-static void WindowRideGraphsPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowRideGraphsPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -6117,7 +6117,7 @@ static void WindowRideGraphsPaint(rct_window* w, rct_drawpixelinfo* dpi)
  *
  *  rct2: 0x006AE4C7
  */
-static void WindowRideGraphsScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
+static void WindowRideGraphsScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex)
 {
     GfxClear(dpi, ColourMapA[COLOUR_SATURATED_GREEN].darker);
 
@@ -6724,7 +6724,7 @@ static void WindowRideIncomeInvalidate(rct_window* w)
  *
  *  rct2: 0x006ADCE5
  */
-static void WindowRideIncomePaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowRideIncomePaint(rct_window* w, DrawPixelInfo* dpi)
 {
     StringId stringId;
     money64 profit;
@@ -6951,7 +6951,7 @@ static void WindowRideCustomerInvalidate(rct_window* w)
  *
  *  rct2: 0x006AD6CD
  */
-static void WindowRideCustomerPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowRideCustomerPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     ShopItem shopItem;
     int16_t popularity, satisfaction, queueTime;

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1483,9 +1483,9 @@ public:
         currentRide->FormatNameTo(ft);
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
-        rct_drawpixelinfo clipdpi;
+        DrawPixelInfo clipdpi;
         Widget* widget;
         int32_t widgetWidth, widgetHeight;
 
@@ -2588,7 +2588,7 @@ private:
     }
 
     void DrawTrackPiece(
-        rct_drawpixelinfo* dpi, RideId rideIndex, int32_t trackType, int32_t trackDirection, int32_t liftHillAndInvertedState,
+        DrawPixelInfo* dpi, RideId rideIndex, int32_t trackType, int32_t trackDirection, int32_t liftHillAndInvertedState,
         int32_t widgetWidth, int32_t widgetHeight)
     {
         auto currentRide = GetRide(rideIndex);
@@ -2627,7 +2627,7 @@ private:
     }
 
     void DrawTrackPieceHelper(
-        rct_drawpixelinfo* dpi, RideId rideIndex, int32_t trackType, int32_t trackDirection, int32_t liftHillAndInvertedState,
+        DrawPixelInfo* dpi, RideId rideIndex, int32_t trackType, int32_t trackDirection, int32_t liftHillAndInvertedState,
         const CoordsXY& originCoords, int32_t originZ)
     {
         TileElement tempSideTrackTileElement{ 0x80, 0x8F, 128, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -507,7 +507,7 @@ public:
      *
      *  rct2: 0x006B3235
      */
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         WindowDrawWidgets(*this, &dpi);
         DrawTabImages(&dpi);
@@ -523,7 +523,7 @@ public:
      *
      *  rct2: 0x006B3240
      */
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
         GfxFillRect(&dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width, dpi.height } }, ColourMapA[colours[1]].mid_light);
@@ -739,7 +739,7 @@ private:
      *
      *  rct2: 0x006B38EA
      */
-    void DrawTabImages(rct_drawpixelinfo* dpi)
+    void DrawTabImages(DrawPixelInfo* dpi)
     {
         int32_t sprite_idx;
 

--- a/src/openrct2-ui/windows/SavePrompt.cpp
+++ b/src/openrct2-ui/windows/SavePrompt.cpp
@@ -181,7 +181,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
     }

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -121,8 +121,8 @@ static void WindowScenarioselectScrollgetsize(rct_window *w, int32_t scrollIndex
 static void WindowScenarioselectScrollmousedown(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void WindowScenarioselectScrollmouseover(rct_window *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void WindowScenarioselectInvalidate(rct_window *w);
-static void WindowScenarioselectPaint(rct_window *w, rct_drawpixelinfo *dpi);
-static void WindowScenarioselectScrollpaint(rct_window *w, rct_drawpixelinfo *dpi, int32_t scrollIndex);
+static void WindowScenarioselectPaint(rct_window *w, DrawPixelInfo *dpi);
+static void WindowScenarioselectScrollpaint(rct_window *w, DrawPixelInfo *dpi, int32_t scrollIndex);
 
 static bool ScenarioSelectUseSmallFont()
 {
@@ -144,7 +144,7 @@ static WindowEventList window_scenarioselect_events([](auto& events)
 // clang-format on
 
 static void DrawCategoryHeading(
-    rct_window* w, rct_drawpixelinfo* dpi, int32_t left, int32_t right, int32_t y, StringId stringId);
+    rct_window* w, DrawPixelInfo* dpi, int32_t left, int32_t right, int32_t y, StringId stringId);
 static void InitialiseListItems(rct_window* w);
 static bool IsScenarioVisible(rct_window* w, const scenario_index_entry* scenario);
 static bool IsLockingEnabled(rct_window* w);
@@ -424,7 +424,7 @@ static void WindowScenarioselectInvalidate(rct_window* w)
     window_scenarioselect_widgets[WIDX_SCENARIOLIST].bottom = w->height - bottomMargin;
 }
 
-static void WindowScenarioselectPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowScenarioselectPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     int32_t format;
     const scenario_index_entry* scenario;
@@ -553,7 +553,7 @@ static void WindowScenarioselectPaint(rct_window* w, rct_drawpixelinfo* dpi)
     }
 }
 
-static void WindowScenarioselectScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
+static void WindowScenarioselectScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex)
 {
     uint8_t paletteIndex = ColourMapA[w->colours[1]].mid_light;
     GfxClear(dpi, paletteIndex);
@@ -647,7 +647,7 @@ static void WindowScenarioselectScrollpaint(rct_window* w, rct_drawpixelinfo* dp
 }
 
 static void DrawCategoryHeading(
-    rct_window* w, rct_drawpixelinfo* dpi, int32_t left, int32_t right, int32_t y, StringId stringId)
+    rct_window* w, DrawPixelInfo* dpi, int32_t left, int32_t right, int32_t y, StringId stringId)
 {
     colour_t baseColour = w->colours[1];
     colour_t lightColour = ColourMapA[baseColour].lighter;

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -143,8 +143,7 @@ static WindowEventList window_scenarioselect_events([](auto& events)
 });
 // clang-format on
 
-static void DrawCategoryHeading(
-    rct_window* w, DrawPixelInfo* dpi, int32_t left, int32_t right, int32_t y, StringId stringId);
+static void DrawCategoryHeading(rct_window* w, DrawPixelInfo* dpi, int32_t left, int32_t right, int32_t y, StringId stringId);
 static void InitialiseListItems(rct_window* w);
 static bool IsScenarioVisible(rct_window* w, const scenario_index_entry* scenario);
 static bool IsLockingEnabled(rct_window* w);
@@ -646,8 +645,7 @@ static void WindowScenarioselectScrollpaint(rct_window* w, DrawPixelInfo* dpi, i
     }
 }
 
-static void DrawCategoryHeading(
-    rct_window* w, DrawPixelInfo* dpi, int32_t left, int32_t right, int32_t y, StringId stringId)
+static void DrawCategoryHeading(rct_window* w, DrawPixelInfo* dpi, int32_t left, int32_t right, int32_t y, StringId stringId)
 {
     colour_t baseColour = w->colours[1];
     colour_t lightColour = ColourMapA[baseColour].lighter;

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -645,7 +645,7 @@ public:
         widgets[WIDX_SCENERY_TERTIARY_COLOUR_BUTTON].right = windowWidth - 8;
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTabs(dpi, windowPos);
@@ -679,7 +679,7 @@ public:
         DrawTextEllipsised(&dpi, { windowPos.x + 3, windowPos.y + height - 13 }, width - 19, STR_BLACK_STRING, ft);
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         if (scrollIndex == SceneryContentScrollIndex)
         {
@@ -1169,7 +1169,7 @@ private:
         return { name, price };
     }
 
-    void DrawTabs(rct_drawpixelinfo& dpi, const ScreenCoordsXY& offset)
+    void DrawTabs(DrawPixelInfo& dpi, const ScreenCoordsXY& offset)
     {
         for (size_t tabIndex = 0; tabIndex < _tabEntries.size(); tabIndex++)
         {
@@ -1184,7 +1184,7 @@ private:
         }
     }
 
-    void DrawSceneryItem(rct_drawpixelinfo& dpi, ScenerySelection scenerySelection)
+    void DrawSceneryItem(DrawPixelInfo& dpi, ScenerySelection scenerySelection)
     {
         if (scenerySelection.SceneryType == SCENERY_TYPE_BANNER)
         {
@@ -1287,7 +1287,7 @@ private:
         }
     }
 
-    void ContentScrollDraw(rct_drawpixelinfo& dpi)
+    void ContentScrollDraw(DrawPixelInfo& dpi)
     {
         GfxClear(&dpi, ColourMapA[colours[1]].mid_light);
 
@@ -1330,7 +1330,7 @@ private:
                 }
             }
 
-            rct_drawpixelinfo clipdpi;
+            DrawPixelInfo clipdpi;
             if (ClipDrawPixelInfo(
                     &clipdpi, &dpi, topLeft + ScreenCoordsXY{ 1, 1 }, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2))
             {

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -176,7 +176,7 @@ public:
         widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gWindowSceneryScatterSize));
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         WindowDrawWidgets(*this, &dpi);
 

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -84,8 +84,8 @@ static void WindowServerListScrollMouseover(rct_window* w, int32_t scrollIndex, 
 static void WindowServerListTextinput(rct_window* w, WidgetIndex widgetIndex, char* text);
 static OpenRCT2String WindowServerListTooltip(rct_window* const w, const WidgetIndex widgetIndex, StringId fallback);
 static void WindowServerListInvalidate(rct_window* w);
-static void WindowServerListPaint(rct_window* w, rct_drawpixelinfo* dpi);
-static void WindowServerListScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex);
+static void WindowServerListPaint(rct_window* w, DrawPixelInfo* dpi);
+static void WindowServerListScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex);
 
 static WindowEventList window_server_list_events([](auto& events) {
     events.close = &WindowServerListClose;
@@ -374,7 +374,7 @@ static void WindowServerListInvalidate(rct_window* w)
     w->no_list_items = static_cast<uint16_t>(_serverList.GetCount());
 }
 
-static void WindowServerListPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowServerListPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     WindowDrawWidgets(*w, dpi);
 
@@ -394,7 +394,7 @@ static void WindowServerListPaint(rct_window* w, rct_drawpixelinfo* dpi)
     DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ 8, w->height - 15 }, _statusText, ft, { COLOUR_WHITE });
 }
 
-static void WindowServerListScrollpaint(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
+static void WindowServerListScrollpaint(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex)
 {
     uint8_t paletteIndex = ColourMapA[w->colours[1]].mid_light;
     GfxClear(dpi, paletteIndex);

--- a/src/openrct2-ui/windows/ServerStart.cpp
+++ b/src/openrct2-ui/windows/ServerStart.cpp
@@ -258,7 +258,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTextBasic(&dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PORT_INPUT].top }, STR_PORT, {}, { colours[1] });

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -119,7 +119,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 
@@ -249,7 +249,7 @@ public:
         SetWidgetPressed(static_cast<WidgetIndex>(WIDX_TAB_0 + _currentTabIndex), true);
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -295,7 +295,7 @@ public:
         }
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
         GfxFillRect(
@@ -468,7 +468,7 @@ private:
         RefreshBindings();
     }
 
-    void DrawTabImages(rct_drawpixelinfo& dpi) const
+    void DrawTabImages(DrawPixelInfo& dpi) const
     {
         for (size_t i = 0; i < _tabs.size(); i++)
         {
@@ -476,7 +476,7 @@ private:
         }
     }
 
-    void DrawTabImage(rct_drawpixelinfo& dpi, size_t tabIndex) const
+    void DrawTabImage(DrawPixelInfo& dpi, size_t tabIndex) const
     {
         const auto& tabDesc = _tabs[tabIndex];
         auto widgetIndex = static_cast<WidgetIndex>(WIDX_TAB_0 + tabIndex);
@@ -497,7 +497,7 @@ private:
         }
     }
 
-    void DrawSeparator(rct_drawpixelinfo& dpi, int32_t y, int32_t scrollWidth)
+    void DrawSeparator(DrawPixelInfo& dpi, int32_t y, int32_t scrollWidth)
     {
         const int32_t top = y + (SCROLLABLE_ROW_HEIGHT / 2) - 1;
         GfxFillRect(&dpi, { { 0, top }, { scrollWidth, top } }, ColourMapA[colours[0]].mid_dark);
@@ -505,7 +505,7 @@ private:
     }
 
     void DrawItem(
-        rct_drawpixelinfo& dpi, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
+        DrawPixelInfo& dpi, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
     {
         auto format = STR_BLACK_STRING;
         if (isHighlighted)

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -504,8 +504,7 @@ private:
         GfxFillRect(&dpi, { { 0, top + 1 }, { scrollWidth, top + 1 } }, ColourMapA[colours[0]].lightest);
     }
 
-    void DrawItem(
-        DrawPixelInfo& dpi, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
+    void DrawItem(DrawPixelInfo& dpi, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
     {
         auto format = STR_BLACK_STRING;
         if (isHighlighted)

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -279,7 +279,7 @@ public:
         text_colour_btn->image = GetColourButtonImage(_textColour);
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -203,7 +203,7 @@ public:
         CommonPrepareDrawAfter();
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTabImages(&dpi);
@@ -514,7 +514,7 @@ private:
         widgets[WIDX_FIRE].right = width - 2;
     }
 
-    void OverviewDraw(rct_drawpixelinfo* dpi)
+    void OverviewDraw(DrawPixelInfo* dpi)
     {
         // Draw the viewport no sound sprite
         if (viewport != nullptr)
@@ -541,7 +541,7 @@ private:
         DrawTextEllipsised(dpi, screenPos, widgetWidth, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
     }
 
-    void DrawOverviewTabImage(rct_drawpixelinfo* dpi)
+    void DrawOverviewTabImage(DrawPixelInfo* dpi)
     {
         if (IsWidgetDisabled(WIDX_TAB_1))
             return;
@@ -553,7 +553,7 @@ private:
         if (page == WINDOW_STAFF_OVERVIEW)
             widgetHeight++;
 
-        rct_drawpixelinfo clip_dpi;
+        DrawPixelInfo clip_dpi;
         if (!ClipDrawPixelInfo(&clip_dpi, dpi, screenCoords, widgetWidth, widgetHeight))
         {
             return;
@@ -915,7 +915,7 @@ private:
 #pragma endregion
 
 #pragma region Statistics tab events
-    void StatsDraw(rct_drawpixelinfo* dpi)
+    void StatsDraw(DrawPixelInfo* dpi)
     {
         auto staff = GetStaff();
         if (staff == nullptr)
@@ -1193,14 +1193,14 @@ private:
         WindowFollowSprite(*main, EntityId::FromUnderlying(number));
     }
 
-    void DrawTabImages(rct_drawpixelinfo* dpi)
+    void DrawTabImages(DrawPixelInfo* dpi)
     {
         DrawOverviewTabImage(dpi);
         DrawTabImage(dpi, WINDOW_STAFF_OPTIONS, SPR_TAB_STAFF_OPTIONS_0);
         DrawTabImage(dpi, WINDOW_STAFF_STATISTICS, SPR_TAB_STATS_0);
     }
 
-    void DrawTabImage(rct_drawpixelinfo* dpi, int32_t p, int32_t baseImageId)
+    void DrawTabImage(DrawPixelInfo* dpi, int32_t p, int32_t baseImageId)
     {
         WidgetIndex widgetIndex = WIDX_TAB_1 + p;
         Widget* widget = &widgets[widgetIndex];

--- a/src/openrct2-ui/windows/StaffFirePrompt.cpp
+++ b/src/openrct2-ui/windows/StaffFirePrompt.cpp
@@ -72,7 +72,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -275,7 +275,7 @@ public:
         widgets[WIDX_STAFF_LIST_HIRE_BUTTON].right = width - 11;
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         DrawTabImages(dpi);
@@ -366,7 +366,7 @@ public:
         }
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
         GfxFillRect(
@@ -541,7 +541,7 @@ private:
         return static_cast<StaffType>(_selectedTab);
     }
 
-    void DrawTabImages(rct_drawpixelinfo& dpi) const
+    void DrawTabImages(DrawPixelInfo& dpi) const
     {
         DrawTabImage(dpi, WINDOW_STAFF_LIST_TAB_HANDYMEN, PeepSpriteType::Handyman, gStaffHandymanColour);
         DrawTabImage(dpi, WINDOW_STAFF_LIST_TAB_MECHANICS, PeepSpriteType::Mechanic, gStaffMechanicColour);
@@ -549,7 +549,7 @@ private:
         DrawTabImage(dpi, WINDOW_STAFF_LIST_TAB_ENTERTAINERS, PeepSpriteType::EntertainerElephant);
     }
 
-    void DrawTabImage(rct_drawpixelinfo& dpi, int32_t tabIndex, PeepSpriteType type, colour_t colour) const
+    void DrawTabImage(DrawPixelInfo& dpi, int32_t tabIndex, PeepSpriteType type, colour_t colour) const
     {
         auto widgetIndex = WIDX_STAFF_LIST_HANDYMEN_TAB + tabIndex;
         const auto& widget = widgets[widgetIndex];
@@ -559,11 +559,11 @@ private:
             &dpi, ImageId(imageId, colour), windowPos + ScreenCoordsXY{ (widget.left + widget.right) / 2, widget.bottom - 6 });
     }
 
-    void DrawTabImage(rct_drawpixelinfo& dpi, int32_t tabIndex, PeepSpriteType type) const
+    void DrawTabImage(DrawPixelInfo& dpi, int32_t tabIndex, PeepSpriteType type) const
     {
         auto widgetIndex = WIDX_STAFF_LIST_HANDYMEN_TAB + tabIndex;
         const auto& widget = widgets[widgetIndex];
-        rct_drawpixelinfo clippedDpi;
+        DrawPixelInfo clippedDpi;
         if (ClipDrawPixelInfo(
                 &clippedDpi, &dpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 },
                 widget.right - widget.left - 1, widget.bottom - widget.top - 1))

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -193,7 +193,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 
@@ -315,7 +315,7 @@ public:
     }
 
 private:
-    static void DrawIMEComposition(rct_drawpixelinfo& dpi, int32_t cursorX, int32_t cursorY)
+    static void DrawIMEComposition(DrawPixelInfo& dpi, int32_t cursorX, int32_t cursorY)
     {
         int compositionWidth = GfxGetStringWidth(gTextInput->ImeBuffer, FontStyle::Medium);
         ScreenCoordsXY screenCoords(cursorX - (compositionWidth / 2), cursorY + 13);

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -444,7 +444,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         // Widgets
         WindowDrawWidgets(*this, &dpi);
@@ -758,7 +758,7 @@ public:
         }
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         ScreenCoordsXY screenCoords;
 
@@ -789,7 +789,7 @@ public:
 
                     if (colour & COLOUR_FLAG_TRANSLUCENT)
                     {
-                        translucent_window_palette windowPalette = TranslucentWindowPalettes[BASE_COLOUR(colour)];
+                        TranslucentWindowPalette windowPalette = TranslucentWindowPalettes[BASE_COLOUR(colour)];
 
                         GfxFilterRect(&dpi, { leftTop, rightBottom }, windowPalette.highlight);
                         GfxFilterRect(&dpi, { leftTop + yPixelOffset, rightBottom + yPixelOffset }, windowPalette.shadow);
@@ -867,7 +867,7 @@ public:
         return 0;
     }
 
-    void WindowThemesDrawTabImages(rct_drawpixelinfo* dpi)
+    void WindowThemesDrawTabImages(DrawPixelInfo* dpi)
     {
         for (int32_t i = 0; i < WINDOW_THEMES_TAB_COUNT; i++)
         {

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1000,7 +1000,7 @@ public:
         InvalidateWidget(WIDX_LIST);
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         ScreenCoordsXY screenCoords(windowPos.x, windowPos.y);
@@ -1134,7 +1134,7 @@ public:
                     else
                     {
                         // Legacy path name
-                        auto footpathEntry = reinterpret_cast<const rct_footpath_entry*>(footpathObj->GetLegacyData());
+                        auto footpathEntry = reinterpret_cast<const FootpathEntry*>(footpathObj->GetLegacyData());
                         auto ft = Formatter();
                         ft.Add<StringId>(footpathEntry->string_idx);
                         DrawTextBasic(&dpi, screenCoords, STR_TILE_INSPECTOR_PATH_NAME, ft, { COLOUR_WHITE });
@@ -1528,7 +1528,7 @@ public:
         }
     }
 
-    void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         const int32_t listWidth = widgets[WIDX_LIST].width();
         GfxFillRect(

--- a/src/openrct2-ui/windows/TitleExit.cpp
+++ b/src/openrct2-ui/windows/TitleExit.cpp
@@ -48,7 +48,7 @@ class TitleExitWindow final : public Window
         };
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
     }

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -57,7 +57,7 @@ public:
      *
      *  rct2: 0x0066B872
      */
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         auto screenCoords = windowPos + ScreenCoordsXY{ 2, 2 };
         GfxDrawSprite(&dpi, ImageId(SPR_G2_LOGO), screenCoords);

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -269,7 +269,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         GfxFilterRect(&dpi, _filterRect, FilterPaletteID::Palette51);
         DrawWidgets(dpi);

--- a/src/openrct2-ui/windows/TitleOptions.cpp
+++ b/src/openrct2-ui/windows/TitleOptions.cpp
@@ -44,7 +44,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
     }

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -74,7 +74,7 @@ public:
         ResetTooltipNotShown();
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         int32_t left = windowPos.x;
         int32_t top = windowPos.y;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -287,7 +287,7 @@ static void WindowTopToolbarToolDrag(rct_window* w, WidgetIndex widgetIndex, con
 static void WindowTopToolbarToolUp(rct_window* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoordsy);
 static void WindowTopToolbarToolAbort(rct_window* w, WidgetIndex widgetIndex);
 static void WindowTopToolbarInvalidate(rct_window* w);
-static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi);
+static void WindowTopToolbarPaint(rct_window* w, DrawPixelInfo* dpi);
 
 static WindowEventList window_top_toolbar_events([](auto& events) {
     events.mouse_up = &WindowTopToolbarMouseup;
@@ -870,7 +870,7 @@ static void WindowTopToolbarInvalidate(rct_window* w)
  *
  *  rct2: 0x0066C8EC
  */
-static void WindowTopToolbarPaint(rct_window* w, rct_drawpixelinfo* dpi)
+static void WindowTopToolbarPaint(rct_window* w, DrawPixelInfo* dpi)
 {
     int32_t imgId;
 

--- a/src/openrct2-ui/windows/TrackDesignManage.cpp
+++ b/src/openrct2-ui/windows/TrackDesignManage.cpp
@@ -66,7 +66,7 @@ class TrackDesignManageWindow final : public Window
         void OnClose() override;
         void OnMouseUp(WidgetIndex widgetIndex) override;
         void OnTextInput(WidgetIndex widgetIndex, std::string_view text) override;
-        void OnDraw(rct_drawpixelinfo& dpi) override;
+        void OnDraw(DrawPixelInfo& dpi) override;
 };
 
 class TrackDeletePromptWindow final : public Window
@@ -79,7 +79,7 @@ class TrackDeletePromptWindow final : public Window
 
         void OnOpen() override;
         void OnMouseUp(WidgetIndex widgetIndex) override;
-        void OnDraw(rct_drawpixelinfo& dpi) override;
+        void OnDraw(DrawPixelInfo& dpi) override;
 };
 
 static void WindowTrackDeletePromptOpen(TrackDesignFileRef* tdFileRef);
@@ -169,7 +169,7 @@ void TrackDesignManageWindow::OnTextInput(WidgetIndex widgetIndex, std::string_v
     }
 }
 
-void TrackDesignManageWindow::OnDraw(rct_drawpixelinfo& dpi)
+void TrackDesignManageWindow::OnDraw(DrawPixelInfo& dpi)
 {
     Formatter::Common().Add<const utf8*>(_trackDesignFileReference->name.c_str());
     DrawWidgets(dpi);
@@ -223,7 +223,7 @@ void TrackDeletePromptWindow::OnMouseUp(WidgetIndex widgetIndex)
     }
 }
 
-void TrackDeletePromptWindow::OnDraw(rct_drawpixelinfo& dpi)
+void TrackDeletePromptWindow::OnDraw(DrawPixelInfo& dpi)
 {
     DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -284,17 +284,17 @@ public:
         DrawMiniPreview(_trackDesign.get());
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         auto ft = Formatter::Common();
         ft.Add<char*>(_trackDesign->name.c_str());
         WindowDrawWidgets(*this, &dpi);
 
         // Draw mini tile preview
-        rct_drawpixelinfo clippedDpi;
+        DrawPixelInfo clippedDpi;
         if (ClipDrawPixelInfo(&clippedDpi, &dpi, this->windowPos + ScreenCoordsXY{ 4, 18 }, 168, 78))
         {
-            rct_g1_element g1temp = {};
+            G1Element g1temp = {};
             g1temp.offset = _miniPreview.data();
             g1temp.width = TRACK_MINI_PREVIEW_WIDTH;
             g1temp.height = TRACK_MINI_PREVIEW_HEIGHT;

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -433,7 +433,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 
@@ -495,7 +495,7 @@ public:
         auto trackPreview = screenPos;
         screenPos = windowPos + ScreenCoordsXY{ tdWidget.midX(), tdWidget.midY() };
 
-        rct_g1_element g1temp = {};
+        G1Element g1temp = {};
         g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * TRACK_PREVIEW_IMAGE_SIZE);
         g1temp.width = 370;
         g1temp.height = 217;
@@ -665,7 +665,7 @@ public:
         }
     }
 
-    void OnScrollDraw(const int32_t scrollIndex, rct_drawpixelinfo& dpi) override
+    void OnScrollDraw(const int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         uint8_t paletteIndex = ColourMapA[colours[0]].mid_light;
         GfxClear(&dpi, paletteIndex);

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -145,7 +145,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
         // Locate mechanic button image

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -272,7 +272,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         WindowDrawWidgets(*this, &dpi);
 

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -150,7 +150,7 @@ public:
         }
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
 

--- a/src/openrct2-ui/windows/Water.cpp
+++ b/src/openrct2-ui/windows/Water.cpp
@@ -138,7 +138,7 @@ public:
         widgets[WIDX_PREVIEW].image = ImageId(LandTool::SizeToSpriteIndex(gLandToolSize));
     }
 
-    void OnDraw(rct_drawpixelinfo& dpi) override
+    void OnDraw(DrawPixelInfo& dpi) override
     {
         auto screenCoords = ScreenCoordsXY{ windowPos.x + window_water_widgets[WIDX_PREVIEW].midX(),
                                             windowPos.y + window_water_widgets[WIDX_PREVIEW].midY() };

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -120,8 +120,8 @@ rct_window* WindowMapOpen();
 void WindowMapReset();
 
 rct_window* WindowResearchOpen();
-void WindowResearchDevelopmentPagePaint(rct_window* w, rct_drawpixelinfo* dpi, WidgetIndex baseWidgetIndex);
-void WindowResearchFundingPagePaint(rct_window* w, rct_drawpixelinfo* dpi, WidgetIndex baseWidgetIndex);
+void WindowResearchDevelopmentPagePaint(rct_window* w, DrawPixelInfo* dpi, WidgetIndex baseWidgetIndex);
+void WindowResearchFundingPagePaint(rct_window* w, DrawPixelInfo* dpi, WidgetIndex baseWidgetIndex);
 
 rct_window* WindowNewRideOpen();
 rct_window* WindowNewRideOpenResearch();

--- a/src/openrct2/CmdlineSprite.cpp
+++ b/src/openrct2/CmdlineSprite.cpp
@@ -36,8 +36,8 @@ using namespace OpenRCT2::Drawing;
 class SpriteFile
 {
 public:
-    rct_g1_header Header{};
-    std::vector<rct_g1_element> Entries;
+    RCTG1Header Header{};
+    std::vector<G1Element> Entries;
     std::vector<uint8_t> Data;
     void AddImage(ImageImporter::ImportResult& image);
     bool Save(const utf8* path);
@@ -115,7 +115,7 @@ std::optional<SpriteFile> SpriteFile::Open(const utf8* path)
         OpenRCT2::FileStream stream(path, OpenRCT2::FILE_MODE_OPEN);
 
         SpriteFile spriteFile;
-        stream.Read(&spriteFile.Header, sizeof(rct_g1_header));
+        stream.Read(&spriteFile.Header, sizeof(RCTG1Header));
 
         if (spriteFile.Header.num_entries > 0)
         {
@@ -123,9 +123,9 @@ std::optional<SpriteFile> SpriteFile::Open(const utf8* path)
 
             for (uint32_t i = 0; i < spriteFile.Header.num_entries; ++i)
             {
-                rct_g1_element_32bit entry32bit{};
+                RCTG1Element entry32bit{};
                 stream.Read(&entry32bit, sizeof(entry32bit));
-                rct_g1_element entry{};
+                G1Element entry{};
 
                 entry.offset = reinterpret_cast<uint8_t*>(static_cast<uintptr_t>(entry32bit.offset));
                 entry.width = entry32bit.width;
@@ -153,7 +153,7 @@ bool SpriteFile::Save(const utf8* path)
     try
     {
         OpenRCT2::FileStream stream(path, OpenRCT2::FILE_MODE_WRITE);
-        stream.Write(&Header, sizeof(rct_g1_header));
+        stream.Write(&Header, sizeof(RCTG1Header));
 
         if (Header.num_entries > 0)
         {
@@ -161,7 +161,7 @@ bool SpriteFile::Save(const utf8* path)
 
             for (const auto& entry : Entries)
             {
-                rct_g1_element_32bit entry32bit{};
+                RCTG1Element entry32bit{};
 
                 entry32bit.offset = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(const_cast<uint8_t*>(entry.offset)));
                 entry32bit.width = entry.width;
@@ -183,13 +183,13 @@ bool SpriteFile::Save(const utf8* path)
     }
 }
 
-static bool SpriteImageExport(const rct_g1_element& spriteElement, u8string_view outPath)
+static bool SpriteImageExport(const G1Element& spriteElement, u8string_view outPath)
 {
     const size_t pixelBufferSize = static_cast<size_t>(spriteElement.width) * spriteElement.height;
     auto pixelBuffer = std::make_unique<uint8_t[]>(pixelBufferSize);
     auto pixels = pixelBuffer.get();
 
-    rct_drawpixelinfo dpi;
+    DrawPixelInfo dpi;
     dpi.bits = pixels;
     dpi.x = 0;
     dpi.y = 0;
@@ -307,7 +307,7 @@ int32_t CmdLineForSprite(const char** argv, int32_t argc)
             return -1;
         }
 
-        rct_g1_element* g1 = &spriteFile->Entries[spriteIndex];
+        G1Element* g1 = &spriteFile->Entries[spriteIndex];
         printf("width: %d\n", g1->width);
         printf("height: %d\n", g1->height);
         printf("x offset: %d\n", g1->x_offset);

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -159,7 +159,7 @@ void UpdatePaletteEffects()
         {
             palette = water_type->image_id;
         }
-        const rct_g1_element* g1 = GfxGetG1Element(palette);
+        const G1Element* g1 = GfxGetG1Element(palette);
         if (g1 != nullptr)
         {
             int32_t xoffset = g1->x_offset;
@@ -187,7 +187,7 @@ void UpdatePaletteEffects()
                 palette = water_type->image_id;
             }
 
-            const rct_g1_element* g1 = GfxGetG1Element(palette);
+            const G1Element* g1 = GfxGetG1Element(palette);
             if (g1 != nullptr)
             {
                 int32_t xoffset = g1->x_offset;
@@ -223,7 +223,7 @@ void UpdatePaletteEffects()
         {
             waterId = water_type->palette_index_1;
         }
-        const rct_g1_element* g1 = GfxGetG1Element(shade + waterId);
+        const G1Element* g1 = GfxGetG1Element(shade + waterId);
         if (g1 != nullptr)
         {
             uint8_t* vs = &g1->offset[j * 3];

--- a/src/openrct2/Intro.cpp
+++ b/src/openrct2/Intro.cpp
@@ -38,7 +38,7 @@ static bool _chainLiftFinished;
 static void ScreenIntroProcessMouseInput();
 static void ScreenIntroProcessKeyboardInput();
 static void ScreenIntroSkipPart();
-static void ScreenIntroDrawLogo(rct_drawpixelinfo* dpi);
+static void ScreenIntroDrawLogo(DrawPixelInfo* dpi);
 
 // rct2: 0x0068E966
 void IntroUpdate()
@@ -168,7 +168,7 @@ void IntroUpdate()
     }
 }
 
-void IntroDraw(rct_drawpixelinfo* dpi)
+void IntroDraw(DrawPixelInfo* dpi)
 {
     int32_t screenWidth = ContextGetWidth();
 
@@ -280,7 +280,7 @@ static void ScreenIntroSkipPart()
     }
 }
 
-static void ScreenIntroDrawLogo(rct_drawpixelinfo* dpi)
+static void ScreenIntroDrawLogo(DrawPixelInfo* dpi)
 {
     int32_t screenWidth = ContextGetWidth();
     int32_t imageWidth = 640;

--- a/src/openrct2/Intro.h
+++ b/src/openrct2/Intro.h
@@ -11,7 +11,7 @@
 
 #include "common.h"
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 
 enum class IntroState : uint8_t
 {
@@ -32,4 +32,4 @@ enum class IntroState : uint8_t
 extern IntroState gIntroState;
 
 void IntroUpdate();
-void IntroDraw(rct_drawpixelinfo* dpi);
+void IntroDraw(DrawPixelInfo* dpi);

--- a/src/openrct2/cmdline/BenchSpriteSort.cpp
+++ b/src/openrct2/cmdline/BenchSpriteSort.cpp
@@ -113,7 +113,7 @@ static std::vector<RecordedPaintSession> extract_paint_session(std::string_view 
         // Ensure sprites appear regardless of rotation
         ResetAllSpriteQuadrantPlacements();
 
-        rct_drawpixelinfo dpi;
+        DrawPixelInfo dpi;
         dpi.x = 0;
         dpi.y = 0;
         dpi.width = resolutionWidth;

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -976,7 +976,7 @@ bool RCT1DataPresentAtLocation(u8string_view path)
     return Csg1datPresentAtLocation(path) && Csg1idatPresentAtLocation(path) && CsgAtLocationIsUsable(path);
 }
 
-bool CsgIsUsable(const rct_gx& csg)
+bool CsgIsUsable(const Gx& csg)
 {
     return csg.header.total_size == RCT1::Limits::LL_CSG1_DAT_FileSize
         && csg.header.num_entries == RCT1::Limits::Num_LL_CSG_Entries;
@@ -1001,8 +1001,8 @@ bool CsgAtLocationIsUsable(u8string_view path)
     size_t fileHeaderSize = fileHeader.GetLength();
     size_t fileDataSize = fileData.GetLength();
 
-    rct_gx csg = {};
-    csg.header.num_entries = static_cast<uint32_t>(fileHeaderSize / sizeof(rct_g1_element_32bit));
+    Gx csg = {};
+    csg.header.num_entries = static_cast<uint32_t>(fileHeaderSize / sizeof(RCTG1Element));
     csg.header.total_size = static_cast<uint32_t>(fileDataSize);
     return CsgIsUsable(csg);
 }

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -276,5 +276,5 @@ std::string FindCsg1datAtLocation(u8string_view path);
 bool Csg1datPresentAtLocation(u8string_view path);
 std::string FindCsg1idatAtLocation(u8string_view path);
 bool Csg1idatPresentAtLocation(u8string_view path);
-bool CsgIsUsable(const rct_gx& csg);
+bool CsgIsUsable(const Gx& csg);
 bool CsgAtLocationIsUsable(u8string_view path);

--- a/src/openrct2/core/DataSerialiserTraits.h
+++ b/src/openrct2/core/DataSerialiserTraits.h
@@ -31,14 +31,14 @@
 #include <sstream>
 #include <stdexcept>
 
-template<typename T> struct DataSerializerTraits_t
+template<typename T> struct DataSerializerTraitsT
 {
     static void encode(OpenRCT2::IStream* stream, const T& v) = delete;
     static void decode(OpenRCT2::IStream* stream, T& val) = delete;
     static void log(OpenRCT2::IStream* stream, const T& val) = delete;
 };
 
-template<typename T> struct DataSerializerTraits_enum
+template<typename T> struct DataSerializerTraitsEnum
 {
     using TUnderlying = std::underlying_type_t<T>;
 
@@ -64,7 +64,7 @@ template<typename T> struct DataSerializerTraits_enum
 };
 
 template<typename T>
-using DataSerializerTraits = std::conditional_t<std::is_enum_v<T>, DataSerializerTraits_enum<T>, DataSerializerTraits_t<T>>;
+using DataSerializerTraits = std::conditional_t<std::is_enum_v<T>, DataSerializerTraitsEnum<T>, DataSerializerTraitsT<T>>;
 
 template<typename T> struct DataSerializerTraitsIntegral
 {
@@ -89,7 +89,7 @@ template<typename T> struct DataSerializerTraitsIntegral
     }
 };
 
-template<> struct DataSerializerTraits_t<bool>
+template<> struct DataSerializerTraitsT<bool>
 {
     static void encode(OpenRCT2::IStream* stream, const bool& val)
     {
@@ -108,43 +108,43 @@ template<> struct DataSerializerTraits_t<bool>
     }
 };
 
-template<> struct DataSerializerTraits_t<uint8_t> : public DataSerializerTraitsIntegral<uint8_t>
+template<> struct DataSerializerTraitsT<uint8_t> : public DataSerializerTraitsIntegral<uint8_t>
 {
 };
 
-template<> struct DataSerializerTraits_t<int8_t> : public DataSerializerTraitsIntegral<int8_t>
+template<> struct DataSerializerTraitsT<int8_t> : public DataSerializerTraitsIntegral<int8_t>
 {
 };
 
-template<> struct DataSerializerTraits_t<utf8> : public DataSerializerTraitsIntegral<utf8>
+template<> struct DataSerializerTraitsT<utf8> : public DataSerializerTraitsIntegral<utf8>
 {
 };
 
-template<> struct DataSerializerTraits_t<uint16_t> : public DataSerializerTraitsIntegral<uint16_t>
+template<> struct DataSerializerTraitsT<uint16_t> : public DataSerializerTraitsIntegral<uint16_t>
 {
 };
 
-template<> struct DataSerializerTraits_t<int16_t> : public DataSerializerTraitsIntegral<int16_t>
+template<> struct DataSerializerTraitsT<int16_t> : public DataSerializerTraitsIntegral<int16_t>
 {
 };
 
-template<> struct DataSerializerTraits_t<uint32_t> : public DataSerializerTraitsIntegral<uint32_t>
+template<> struct DataSerializerTraitsT<uint32_t> : public DataSerializerTraitsIntegral<uint32_t>
 {
 };
 
-template<> struct DataSerializerTraits_t<int32_t> : public DataSerializerTraitsIntegral<int32_t>
+template<> struct DataSerializerTraitsT<int32_t> : public DataSerializerTraitsIntegral<int32_t>
 {
 };
 
-template<> struct DataSerializerTraits_t<uint64_t> : public DataSerializerTraitsIntegral<uint64_t>
+template<> struct DataSerializerTraitsT<uint64_t> : public DataSerializerTraitsIntegral<uint64_t>
 {
 };
 
-template<> struct DataSerializerTraits_t<int64_t> : public DataSerializerTraitsIntegral<int64_t>
+template<> struct DataSerializerTraitsT<int64_t> : public DataSerializerTraitsIntegral<int64_t>
 {
 };
 
-template<> struct DataSerializerTraits_t<std::string>
+template<> struct DataSerializerTraitsT<std::string>
 {
     static void encode(OpenRCT2::IStream* stream, const std::string& str)
     {
@@ -181,7 +181,7 @@ template<> struct DataSerializerTraits_t<std::string>
     }
 };
 
-template<> struct DataSerializerTraits_t<NetworkPlayerId_t>
+template<> struct DataSerializerTraitsT<NetworkPlayerId_t>
 {
     static void encode(OpenRCT2::IStream* stream, const NetworkPlayerId_t& val)
     {
@@ -216,7 +216,7 @@ template<> struct DataSerializerTraits_t<NetworkPlayerId_t>
     }
 };
 
-template<typename T> struct DataSerializerTraits_t<DataSerialiserTag<T>>
+template<typename T> struct DataSerializerTraitsT<DataSerialiserTag<T>>
 {
     static void encode(OpenRCT2::IStream* stream, const DataSerialiserTag<T>& tag)
     {
@@ -241,7 +241,7 @@ template<typename T> struct DataSerializerTraits_t<DataSerialiserTag<T>>
     }
 };
 
-template<> struct DataSerializerTraits_t<OpenRCT2::MemoryStream>
+template<> struct DataSerializerTraitsT<OpenRCT2::MemoryStream>
 {
     static void encode(OpenRCT2::IStream* stream, const OpenRCT2::MemoryStream& val)
     {
@@ -309,33 +309,33 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraitsPODArray
     }
 };
 
-template<size_t _Size> struct DataSerializerTraits_t<uint8_t[_Size]> : public DataSerializerTraitsPODArray<uint8_t, _Size>
+template<size_t _Size> struct DataSerializerTraitsT<uint8_t[_Size]> : public DataSerializerTraitsPODArray<uint8_t, _Size>
 {
 };
 
-template<size_t _Size> struct DataSerializerTraits_t<utf8[_Size]> : public DataSerializerTraitsPODArray<utf8, _Size>
+template<size_t _Size> struct DataSerializerTraitsT<utf8[_Size]> : public DataSerializerTraitsPODArray<utf8, _Size>
 {
 };
 
-template<size_t _Size> struct DataSerializerTraits_t<uint16_t[_Size]> : public DataSerializerTraitsPODArray<uint16_t, _Size>
+template<size_t _Size> struct DataSerializerTraitsT<uint16_t[_Size]> : public DataSerializerTraitsPODArray<uint16_t, _Size>
 {
 };
 
-template<size_t _Size> struct DataSerializerTraits_t<uint32_t[_Size]> : public DataSerializerTraitsPODArray<uint32_t, _Size>
+template<size_t _Size> struct DataSerializerTraitsT<uint32_t[_Size]> : public DataSerializerTraitsPODArray<uint32_t, _Size>
 {
 };
 
-template<size_t _Size> struct DataSerializerTraits_t<uint64_t[_Size]> : public DataSerializerTraitsPODArray<uint64_t, _Size>
+template<size_t _Size> struct DataSerializerTraitsT<uint64_t[_Size]> : public DataSerializerTraitsPODArray<uint64_t, _Size>
 {
 };
 
 template<typename T, T TNullValue, typename TTag, size_t _Size>
-struct DataSerializerTraits_t<TIdentifier<T, TNullValue, TTag>[_Size]>
+struct DataSerializerTraitsT<TIdentifier<T, TNullValue, TTag>[_Size]>
     : public DataSerializerTraitsPODArray<TIdentifier<T, TNullValue, TTag>, _Size>
 {
 };
 
-template<typename _Ty, size_t _Size> struct DataSerializerTraits_t<std::array<_Ty, _Size>>
+template<typename _Ty, size_t _Size> struct DataSerializerTraitsT<std::array<_Ty, _Size>>
 {
     static void encode(OpenRCT2::IStream* stream, const std::array<_Ty, _Size>& val)
     {
@@ -377,7 +377,7 @@ template<typename _Ty, size_t _Size> struct DataSerializerTraits_t<std::array<_T
     }
 };
 
-template<typename _Ty> struct DataSerializerTraits_t<std::vector<_Ty>>
+template<typename _Ty> struct DataSerializerTraitsT<std::vector<_Ty>>
 {
     static void encode(OpenRCT2::IStream* stream, const std::vector<_Ty>& val)
     {
@@ -418,7 +418,7 @@ template<typename _Ty> struct DataSerializerTraits_t<std::vector<_Ty>>
     }
 };
 
-template<> struct DataSerializerTraits_t<MapRange>
+template<> struct DataSerializerTraitsT<MapRange>
 {
     static void encode(OpenRCT2::IStream* stream, const MapRange& v)
     {
@@ -446,7 +446,7 @@ template<> struct DataSerializerTraits_t<MapRange>
     }
 };
 
-template<> struct DataSerializerTraits_t<TileElement>
+template<> struct DataSerializerTraitsT<TileElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TileElement& tileElement)
     {
@@ -490,7 +490,7 @@ template<> struct DataSerializerTraits_t<TileElement>
     }
 };
 
-template<> struct DataSerializerTraits_t<TileCoordsXY>
+template<> struct DataSerializerTraitsT<TileCoordsXY>
 {
     static void encode(OpenRCT2::IStream* stream, const TileCoordsXY& coords)
     {
@@ -511,7 +511,7 @@ template<> struct DataSerializerTraits_t<TileCoordsXY>
     }
 };
 
-template<> struct DataSerializerTraits_t<CoordsXY>
+template<> struct DataSerializerTraitsT<CoordsXY>
 {
     static void encode(OpenRCT2::IStream* stream, const CoordsXY& coords)
     {
@@ -532,7 +532,7 @@ template<> struct DataSerializerTraits_t<CoordsXY>
     }
 };
 
-template<> struct DataSerializerTraits_t<CoordsXYZ>
+template<> struct DataSerializerTraitsT<CoordsXYZ>
 {
     static void encode(OpenRCT2::IStream* stream, const CoordsXYZ& coord)
     {
@@ -557,7 +557,7 @@ template<> struct DataSerializerTraits_t<CoordsXYZ>
     }
 };
 
-template<> struct DataSerializerTraits_t<CoordsXYZD>
+template<> struct DataSerializerTraitsT<CoordsXYZD>
 {
     static void encode(OpenRCT2::IStream* stream, const CoordsXYZD& coord)
     {
@@ -585,7 +585,7 @@ template<> struct DataSerializerTraits_t<CoordsXYZD>
     }
 };
 
-template<> struct DataSerializerTraits_t<NetworkCheatType_t>
+template<> struct DataSerializerTraitsT<NetworkCheatType_t>
 {
     static void encode(OpenRCT2::IStream* stream, const NetworkCheatType_t& val)
     {
@@ -605,7 +605,7 @@ template<> struct DataSerializerTraits_t<NetworkCheatType_t>
     }
 };
 
-template<> struct DataSerializerTraits_t<rct_object_entry>
+template<> struct DataSerializerTraitsT<rct_object_entry>
 {
     static void encode(OpenRCT2::IStream* stream, const rct_object_entry& val)
     {
@@ -627,7 +627,7 @@ template<> struct DataSerializerTraits_t<rct_object_entry>
     }
 };
 
-template<> struct DataSerializerTraits_t<ObjectEntryDescriptor>
+template<> struct DataSerializerTraitsT<ObjectEntryDescriptor>
 {
     static void encode(OpenRCT2::IStream* stream, const ObjectEntryDescriptor& val)
     {
@@ -671,7 +671,7 @@ template<> struct DataSerializerTraits_t<ObjectEntryDescriptor>
     }
 };
 
-template<> struct DataSerializerTraits_t<TrackDesignTrackElement>
+template<> struct DataSerializerTraitsT<TrackDesignTrackElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackDesignTrackElement& val)
     {
@@ -691,7 +691,7 @@ template<> struct DataSerializerTraits_t<TrackDesignTrackElement>
     }
 };
 
-template<> struct DataSerializerTraits_t<TrackDesignMazeElement>
+template<> struct DataSerializerTraitsT<TrackDesignMazeElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackDesignMazeElement& val)
     {
@@ -712,7 +712,7 @@ template<> struct DataSerializerTraits_t<TrackDesignMazeElement>
     }
 };
 
-template<> struct DataSerializerTraits_t<TrackDesignEntranceElement>
+template<> struct DataSerializerTraitsT<TrackDesignEntranceElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackDesignEntranceElement& val)
     {
@@ -740,7 +740,7 @@ template<> struct DataSerializerTraits_t<TrackDesignEntranceElement>
     }
 };
 
-template<> struct DataSerializerTraits_t<TrackDesignSceneryElement>
+template<> struct DataSerializerTraitsT<TrackDesignSceneryElement>
 {
     static void encode(OpenRCT2::IStream* stream, const TrackDesignSceneryElement& val)
     {
@@ -773,7 +773,7 @@ template<> struct DataSerializerTraits_t<TrackDesignSceneryElement>
     }
 };
 
-template<> struct DataSerializerTraits_t<VehicleColour>
+template<> struct DataSerializerTraitsT<VehicleColour>
 {
     static void encode(OpenRCT2::IStream* stream, const VehicleColour& val)
     {
@@ -795,7 +795,7 @@ template<> struct DataSerializerTraits_t<VehicleColour>
     }
 };
 
-template<> struct DataSerializerTraits_t<IntensityRange>
+template<> struct DataSerializerTraitsT<IntensityRange>
 {
     static void encode(OpenRCT2::IStream* stream, const IntensityRange& val)
     {
@@ -815,7 +815,7 @@ template<> struct DataSerializerTraits_t<IntensityRange>
     }
 };
 
-template<> struct DataSerializerTraits_t<PeepThought>
+template<> struct DataSerializerTraitsT<PeepThought>
 {
     static void encode(OpenRCT2::IStream* stream, const PeepThought& val)
     {
@@ -841,7 +841,7 @@ template<> struct DataSerializerTraits_t<PeepThought>
     }
 };
 
-template<> struct DataSerializerTraits_t<TileCoordsXYZD>
+template<> struct DataSerializerTraitsT<TileCoordsXYZD>
 {
     static void encode(OpenRCT2::IStream* stream, const TileCoordsXYZD& coord)
     {
@@ -870,7 +870,7 @@ template<> struct DataSerializerTraits_t<TileCoordsXYZD>
     }
 };
 
-template<typename T, T TNull, typename TTag> struct DataSerializerTraits_t<TIdentifier<T, TNull, TTag>>
+template<typename T, T TNull, typename TTag> struct DataSerializerTraitsT<TIdentifier<T, TNull, TTag>>
 {
     static void encode(OpenRCT2::IStream* stream, const TIdentifier<T, TNull, TTag>& id)
     {

--- a/src/openrct2/core/Imaging.h
+++ b/src/openrct2/core/Imaging.h
@@ -18,7 +18,7 @@
 #include <string_view>
 #include <vector>
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 
 enum class IMAGE_FORMAT
 {

--- a/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.BMP.cpp
@@ -9,7 +9,7 @@
 
 #include "Drawing.h"
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMagnify(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto& g1 = args.SourceImage;
     auto src = g1.offset + ((static_cast<size_t>(g1.width) * args.SrcY) + args.SrcX);
@@ -35,7 +35,7 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMagnify(rct_dra
     }
 }
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMinify(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMinify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto& g1 = args.SourceImage;
     auto src = g1.offset + ((static_cast<size_t>(g1.width) * args.SrcY) + args.SrcX);
@@ -60,7 +60,7 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSpriteMinify(rct_draw
     }
 }
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSprite(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSprite(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     if (dpi.zoom_level < ZoomLevel{ 0 })
     {
@@ -78,7 +78,7 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawBMPSprite(rct_drawpixeli
  *  rct2: 0x0067A690
  * @param imageId Only flags are used.
  */
-void FASTCALL GfxBmpSpriteToBuffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
+void FASTCALL GfxBmpSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto imageId = args.Image;
 

--- a/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
+++ b/src/openrct2/drawing/Drawing.Sprite.RLE.cpp
@@ -13,7 +13,7 @@
 #include <cstring>
 
 template<DrawBlendOp TBlendOp, size_t TZoom>
-static void FASTCALL DrawRLESpriteMagnify(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawRLESpriteMagnify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto src0 = args.SourceImage.offset;
     auto dst0 = args.DestinationBits;
@@ -84,7 +84,7 @@ static void FASTCALL DrawRLESpriteMagnify(rct_drawpixelinfo& dpi, const DrawSpri
 }
 
 template<DrawBlendOp TBlendOp, size_t TZoom>
-static void FASTCALL DrawRLESpriteMinify(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
+static void FASTCALL DrawRLESpriteMinify(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto src0 = args.SourceImage.offset;
     auto dst0 = args.DestinationBits;
@@ -178,7 +178,7 @@ static void FASTCALL DrawRLESpriteMinify(rct_drawpixelinfo& dpi, const DrawSprit
     }
 }
 
-template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESprite(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
+template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESprite(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     auto zoom_level = static_cast<int8_t>(dpi.zoom_level);
     switch (zoom_level)
@@ -213,7 +213,7 @@ template<DrawBlendOp TBlendOp> static void FASTCALL DrawRLESprite(rct_drawpixeli
  *  rct2: 0x0067AA18
  * @param imageId Only flags are used.
  */
-void FASTCALL GfxRleSpriteToBuffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args)
+void FASTCALL GfxRleSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args)
 {
     if (args.Image.HasPrimary())
     {

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -269,8 +269,7 @@ int32_t GfxWrapString(utf8* text, int32_t width, FontStyle fontStyle, int32_t* o
 /**
  * Draws text that is left aligned and vertically centred.
  */
-void GfxDrawStringLeftCentred(
-    DrawPixelInfo* dpi, StringId format, void* args, colour_t colour, const ScreenCoordsXY& coords)
+void GfxDrawStringLeftCentred(DrawPixelInfo* dpi, StringId format, void* args, colour_t colour, const ScreenCoordsXY& coords)
 {
     char buffer[CommonTextBufferSize];
     auto bufferPtr = buffer;
@@ -334,8 +333,7 @@ static void ColourCharacterWindow(uint8_t colour, const uint16_t* current_font_f
  * text     : esi
  * dpi      : edi
  */
-void DrawStringCentredRaw(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text, FontStyle fontStyle)
+void DrawStringCentredRaw(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text, FontStyle fontStyle)
 {
     ScreenCoordsXY screenCoords(dpi->x, dpi->y);
     GfxDrawString(dpi, screenCoords, "", { COLOUR_BLACK, fontStyle });

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -670,8 +670,7 @@ void GfxInvalidateScreen()
  * height (dx)
  * drawpixelinfo (edi)
  */
-bool ClipDrawPixelInfo(
-    DrawPixelInfo* dst, DrawPixelInfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height)
+bool ClipDrawPixelInfo(DrawPixelInfo* dst, DrawPixelInfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height)
 {
     int32_t right = coords.x + width;
     int32_t bottom = coords.y + height;

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -492,7 +492,7 @@ static const uint16_t palette_to_g1_offset[PALETTE_TO_G1_OFFSET_COUNT] = {
 #define WINDOW_PALETTE_BRIGHT_RED           {FilterPaletteID::PaletteTranslucentBrightRed,            FilterPaletteID::PaletteTranslucentBrightRedHighlight,       FilterPaletteID::PaletteTranslucentBrightRedShadow}
 #define WINDOW_PALETTE_BRIGHT_PINK          {FilterPaletteID::PaletteTranslucentBrightPink,           FilterPaletteID::PaletteTranslucentBrightPinkHighlight,      FilterPaletteID::PaletteTranslucentBrightPinkShadow}
 
-const translucent_window_palette TranslucentWindowPalettes[COLOUR_COUNT] = {
+const TranslucentWindowPalette TranslucentWindowPalettes[COLOUR_COUNT] = {
     WINDOW_PALETTE_GREY,                    // COLOUR_BLACK
     WINDOW_PALETTE_GREY,                    // COLOUR_GREY
     {FilterPaletteID::PaletteTranslucentWhite,             FilterPaletteID::PaletteTranslucentWhiteHighlight,            FilterPaletteID::PaletteTranslucentWhiteShadow},
@@ -578,7 +578,7 @@ void MaskInit()
     }
 }
 
-void GfxFilterPixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, FilterPaletteID palette)
+void GfxFilterPixel(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, FilterPaletteID palette)
 {
     GfxFilterRect(dpi, { coords, coords }, palette);
 }
@@ -591,7 +591,7 @@ void GfxFilterPixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, Filter
  */
 void GfxTransposePalette(int32_t pal, uint8_t product)
 {
-    const rct_g1_element* g1 = GfxGetG1Element(pal);
+    const G1Element* g1 = GfxGetG1Element(pal);
     if (g1 != nullptr)
     {
         int32_t width = g1->width;
@@ -632,7 +632,7 @@ void LoadPalette()
         palette = water_type->image_id;
     }
 
-    const rct_g1_element* g1 = GfxGetG1Element(palette);
+    const G1Element* g1 = GfxGetG1Element(palette);
     if (g1 != nullptr)
     {
         int32_t width = g1->width;
@@ -671,7 +671,7 @@ void GfxInvalidateScreen()
  * drawpixelinfo (edi)
  */
 bool ClipDrawPixelInfo(
-    rct_drawpixelinfo* dst, rct_drawpixelinfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height)
+    DrawPixelInfo* dst, DrawPixelInfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height)
 {
     int32_t right = coords.x + width;
     int32_t bottom = coords.y + height;
@@ -737,7 +737,7 @@ void GfxInvalidatePickedUpPeep()
     }
 }
 
-void GfxDrawPickedUpPeep(rct_drawpixelinfo* dpi)
+void GfxDrawPickedUpPeep(DrawPixelInfo* dpi)
 {
     if (gPickupPeepImage.HasValue())
     {
@@ -768,19 +768,19 @@ std::optional<PaletteMap> GetPaletteMapForColour(colour_t paletteId)
     return std::nullopt;
 }
 
-size_t rct_drawpixelinfo::GetBytesPerRow() const
+size_t DrawPixelInfo::GetBytesPerRow() const
 {
     return static_cast<size_t>(width) + pitch;
 }
 
-uint8_t* rct_drawpixelinfo::GetBitsOffset(const ScreenCoordsXY& pos) const
+uint8_t* DrawPixelInfo::GetBitsOffset(const ScreenCoordsXY& pos) const
 {
     return bits + pos.x + (pos.y * GetBytesPerRow());
 }
 
-rct_drawpixelinfo rct_drawpixelinfo::Crop(const ScreenCoordsXY& pos, const ScreenSize& size) const
+DrawPixelInfo DrawPixelInfo::Crop(const ScreenCoordsXY& pos, const ScreenSize& size) const
 {
-    rct_drawpixelinfo result = *this;
+    DrawPixelInfo result = *this;
     result.bits = GetBitsOffset(pos);
     result.x = static_cast<int16_t>(pos.x);
     result.y = static_cast<int16_t>(pos.y);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -468,8 +468,7 @@ extern int32_t gPickupPeepY;
 
 extern bool gTinyFontAntiAliased;
 
-bool ClipDrawPixelInfo(
-    DrawPixelInfo* dst, DrawPixelInfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height);
+bool ClipDrawPixelInfo(DrawPixelInfo* dst, DrawPixelInfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height);
 void GfxSetDirtyBlocks(const ScreenRect& rect);
 void GfxInvalidateScreen();
 
@@ -510,8 +509,7 @@ void FASTCALL GfxSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL GfxBmpSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL GfxRleSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL GfxDrawSprite(DrawPixelInfo* dpi, const ImageId image_id, const ScreenCoordsXY& coords);
-void FASTCALL
-    GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+void FASTCALL GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
 void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
 void FASTCALL GfxDrawSpriteRawMasked(
     DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
@@ -523,13 +521,10 @@ void FASTCALL GfxDrawSpriteRawMaskedSoftware(
 
 // string
 void GfxDrawString(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint = {});
-void GfxDrawStringNoFormatting(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint);
+void GfxDrawStringNoFormatting(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint);
 
-void GfxDrawStringLeftCentred(
-    DrawPixelInfo* dpi, StringId format, void* args, colour_t colour, const ScreenCoordsXY& coords);
-void DrawStringCentredRaw(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text, FontStyle fontStyle);
+void GfxDrawStringLeftCentred(DrawPixelInfo* dpi, StringId format, void* args, colour_t colour, const ScreenCoordsXY& coords);
+void DrawStringCentredRaw(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text, FontStyle fontStyle);
 void DrawNewsTicker(
     DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, void* args,
     int32_t ticks);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -77,7 +77,7 @@ struct GamePalette
     }
 };
 
-struct rct_g1_element
+struct G1Element
 {
     uint8_t* offset = nullptr; // 0x00
     int16_t width = 0;         // 0x04
@@ -89,22 +89,22 @@ struct rct_g1_element
 };
 
 #pragma pack(push, 1)
-struct rct_g1_header
+struct RCTG1Header
 {
     uint32_t num_entries = 0;
     uint32_t total_size = 0;
 };
-assert_struct_size(rct_g1_header, 8);
+assert_struct_size(RCTG1Header, 8);
 #pragma pack(pop)
 
-struct rct_gx
+struct Gx
 {
-    rct_g1_header header;
-    std::vector<rct_g1_element> elements;
+    RCTG1Header header;
+    std::vector<G1Element> elements;
     std::unique_ptr<uint8_t[]> data;
 };
 
-struct rct_drawpixelinfo
+struct DrawPixelInfo
 {
     uint8_t* bits{};
     int32_t x{};
@@ -129,10 +129,10 @@ struct rct_drawpixelinfo
 
     size_t GetBytesPerRow() const;
     uint8_t* GetBitsOffset(const ScreenCoordsXY& pos) const;
-    rct_drawpixelinfo Crop(const ScreenCoordsXY& pos, const ScreenSize& size) const;
+    DrawPixelInfo Crop(const ScreenCoordsXY& pos, const ScreenSize& size) const;
 };
 
-struct rct_g1_element_32bit
+struct RCTG1Element
 {
     uint32_t offset;        // 0x00 note: uint32_t always!
     int16_t width;          // 0x04
@@ -142,7 +142,7 @@ struct rct_g1_element_32bit
     uint16_t flags;         // 0x0C
     uint16_t zoomed_offset; // 0x0E
 };
-assert_struct_size(rct_g1_element_32bit, 0x10);
+assert_struct_size(RCTG1Element, 0x10);
 
 enum
 {
@@ -298,17 +298,11 @@ enum class FilterPaletteID : int32_t
     PaletteGlassLightPink = PaletteGlass + COLOUR_LIGHT_PINK,
 };
 
-struct translucent_window_palette
+struct TranslucentWindowPalette
 {
     FilterPaletteID base;
     FilterPaletteID highlight;
     FilterPaletteID shadow;
-};
-
-struct rct_size16
-{
-    int16_t width;
-    int16_t height;
 };
 
 /**
@@ -357,7 +351,7 @@ struct DrawSpriteArgs
 {
     ImageId Image;
     const PaletteMap& PalMap;
-    const rct_g1_element& SourceImage;
+    const G1Element& SourceImage;
     int32_t SrcX;
     int32_t SrcY;
     int32_t Width;
@@ -365,7 +359,7 @@ struct DrawSpriteArgs
     uint8_t* DestinationBits;
 
     DrawSpriteArgs(
-        ImageId image, const PaletteMap& palMap, const rct_g1_element& sourceImage, int32_t srcX, int32_t srcY, int32_t width,
+        ImageId image, const PaletteMap& palMap, const G1Element& sourceImage, int32_t srcX, int32_t srcY, int32_t width,
         int32_t height, uint8_t* destinationBits)
         : Image(image)
         , PalMap(palMap)
@@ -466,7 +460,7 @@ extern const FilterPaletteID GlassPaletteIds[COLOUR_COUNT];
 extern thread_local uint8_t gPeepPalette[256];
 extern thread_local uint8_t gOtherPalette[256];
 extern uint8_t gTextPalette[];
-extern const translucent_window_palette TranslucentWindowPalettes[COLOUR_COUNT];
+extern const TranslucentWindowPalette TranslucentWindowPalettes[COLOUR_COUNT];
 
 extern ImageId gPickupPeepImage;
 extern int32_t gPickupPeepX;
@@ -475,7 +469,7 @@ extern int32_t gPickupPeepY;
 extern bool gTinyFontAntiAliased;
 
 bool ClipDrawPixelInfo(
-    rct_drawpixelinfo* dst, rct_drawpixelinfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height);
+    DrawPixelInfo* dst, DrawPixelInfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height);
 void GfxSetDirtyBlocks(const ScreenRect& rect);
 void GfxInvalidateScreen();
 
@@ -484,21 +478,21 @@ void GfxTransposePalette(int32_t pal, uint8_t product);
 void LoadPalette();
 
 // other
-void GfxClear(rct_drawpixelinfo* dpi, uint8_t paletteIndex);
-void GfxFilterPixel(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, FilterPaletteID palette);
+void GfxClear(DrawPixelInfo* dpi, uint8_t paletteIndex);
+void GfxFilterPixel(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, FilterPaletteID palette);
 void GfxInvalidatePickedUpPeep();
-void GfxDrawPickedUpPeep(rct_drawpixelinfo* dpi);
+void GfxDrawPickedUpPeep(DrawPixelInfo* dpi);
 
 // line
-void GfxDrawLine(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colour);
-void GfxDrawLineSoftware(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colour);
+void GfxDrawLine(DrawPixelInfo* dpi, const ScreenLine& line, int32_t colour);
+void GfxDrawLineSoftware(DrawPixelInfo* dpi, const ScreenLine& line, int32_t colour);
 void GfxDrawDashedLine(
-    rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);
+    DrawPixelInfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);
 
 // rect
-void GfxFillRect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colour);
-void GfxFillRectInset(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colour, uint8_t flags);
-void GfxFilterRect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FilterPaletteID palette);
+void GfxFillRect(DrawPixelInfo* dpi, const ScreenRect& rect, int32_t colour);
+void GfxFillRectInset(DrawPixelInfo* dpi, const ScreenRect& rect, int32_t colour, uint8_t flags);
+void GfxFilterRect(DrawPixelInfo* dpi, const ScreenRect& rect, FilterPaletteID palette);
 
 // sprite
 bool GfxLoadG1(const OpenRCT2::IPlatformEnvironment& env);
@@ -507,40 +501,40 @@ bool GfxLoadCsg();
 void GfxUnloadG1();
 void GfxUnloadG2();
 void GfxUnloadCsg();
-const rct_g1_element* GfxGetG1Element(const ImageId imageId);
-const rct_g1_element* GfxGetG1Element(ImageIndex image_id);
-void GfxSetG1Element(ImageIndex imageId, const rct_g1_element* g1);
-std::optional<rct_gx> GfxLoadGx(const std::vector<uint8_t>& buffer);
+const G1Element* GfxGetG1Element(const ImageId imageId);
+const G1Element* GfxGetG1Element(ImageIndex image_id);
+void GfxSetG1Element(ImageIndex imageId, const G1Element* g1);
+std::optional<Gx> GfxLoadGx(const std::vector<uint8_t>& buffer);
 bool IsCsgLoaded();
-void FASTCALL GfxSpriteToBuffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
-void FASTCALL GfxBmpSpriteToBuffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
-void FASTCALL GfxRleSpriteToBuffer(rct_drawpixelinfo& dpi, const DrawSpriteArgs& args);
-void FASTCALL GfxDrawSprite(rct_drawpixelinfo* dpi, const ImageId image_id, const ScreenCoordsXY& coords);
+void FASTCALL GfxSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
+void FASTCALL GfxBmpSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
+void FASTCALL GfxRleSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
+void FASTCALL GfxDrawSprite(DrawPixelInfo* dpi, const ImageId image_id, const ScreenCoordsXY& coords);
 void FASTCALL
-    GfxDrawGlyph(rct_drawpixelinfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
-void FASTCALL GfxDrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
+    GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
 void FASTCALL GfxDrawSpriteRawMasked(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
-void FASTCALL GfxDrawSpriteSoftware(rct_drawpixelinfo* dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
+void FASTCALL GfxDrawSpriteSoftware(DrawPixelInfo* dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
 void FASTCALL GfxDrawSpritePaletteSetSoftware(
-    rct_drawpixelinfo* dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+    DrawPixelInfo* dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
 void FASTCALL GfxDrawSpriteRawMaskedSoftware(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage);
+    DrawPixelInfo* dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage);
 
 // string
-void GfxDrawString(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint = {});
+void GfxDrawString(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint = {});
 void GfxDrawStringNoFormatting(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint);
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint);
 
 void GfxDrawStringLeftCentred(
-    rct_drawpixelinfo* dpi, StringId format, void* args, colour_t colour, const ScreenCoordsXY& coords);
+    DrawPixelInfo* dpi, StringId format, void* args, colour_t colour, const ScreenCoordsXY& coords);
 void DrawStringCentredRaw(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text, FontStyle fontStyle);
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text, FontStyle fontStyle);
 void DrawNewsTicker(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, void* args,
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, void* args,
     int32_t ticks);
 void GfxDrawStringWithYOffsets(
-    rct_drawpixelinfo* dpi, const utf8* text, int32_t colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
+    DrawPixelInfo* dpi, const utf8* text, int32_t colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
     bool forceSpriteFont, FontStyle fontStyle);
 
 int32_t GfxWrapString(char* buffer, int32_t width, FontStyle fontStyle, int32_t* num_lines);
@@ -551,7 +545,7 @@ int32_t StringGetHeightRaw(std::string_view text, FontStyle fontStyle);
 int32_t GfxClipString(char* buffer, int32_t width, FontStyle fontStyle);
 void ShortenPath(utf8* buffer, size_t bufferSize, const utf8* path, int32_t availableWidth, FontStyle fontStyle);
 void TTFDrawString(
-    rct_drawpixelinfo* dpi, const_utf8string text, int32_t colour, const ScreenCoordsXY& coords, bool noFormatting,
+    DrawPixelInfo* dpi, const_utf8string text, int32_t colour, const ScreenCoordsXY& coords, bool noFormatting,
     FontStyle fontStyle, TextDarkness darkness);
 
 // scrolling text
@@ -563,7 +557,7 @@ class Formatter;
 ImageId ScrollingTextSetup(
     struct PaintSession& session, StringId stringId, Formatter& ft, uint16_t scroll, uint16_t scrollingMode, colour_t colour);
 
-size_t G1CalculateDataSize(const rct_g1_element* g1);
+size_t G1CalculateDataSize(const G1Element* g1);
 
 void MaskScalar(
     int32_t width, int32_t height, const uint8_t* RESTRICT maskSrc, const uint8_t* RESTRICT colourSrc, uint8_t* RESTRICT dst,

--- a/src/openrct2/drawing/Font.cpp
+++ b/src/openrct2/drawing/Font.cpp
@@ -250,7 +250,7 @@ void FontSpriteInitialiseCharacters()
         int32_t glyphOffset = EnumValue(fontStyle) * FONT_SPRITE_GLYPH_COUNT;
         for (uint8_t glyphIndex = 0; glyphIndex < FONT_SPRITE_GLYPH_COUNT; glyphIndex++)
         {
-            const rct_g1_element* g1 = GfxGetG1Element(glyphIndex + SPR_CHAR_START + glyphOffset);
+            const G1Element* g1 = GfxGetG1Element(glyphIndex + SPR_CHAR_START + glyphOffset);
             int32_t width = 0;
             if (g1 != nullptr)
             {
@@ -266,7 +266,7 @@ void FontSpriteInitialiseCharacters()
         int32_t glyphOffset = EnumValue(fontStyle) * SPR_G2_GLYPH_COUNT;
         for (int32_t glyphIndex = 0; glyphIndex < SPR_G2_GLYPH_COUNT; glyphIndex++)
         {
-            const rct_g1_element* g1 = GfxGetG1Element(glyphIndex + SPR_G2_CHAR_BEGIN + glyphOffset);
+            const G1Element* g1 = GfxGetG1Element(glyphIndex + SPR_G2_CHAR_BEGIN + glyphOffset);
             int32_t width = 0;
             if (g1 != nullptr)
             {

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -20,21 +20,21 @@ namespace OpenRCT2::Drawing
     {
         virtual ~IDrawingContext() = default;
 
-        virtual void Clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex) abstract;
+        virtual void Clear(DrawPixelInfo* dpi, uint8_t paletteIndex) abstract;
         virtual void FillRect(
-            rct_drawpixelinfo* dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom) abstract;
+            DrawPixelInfo* dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom) abstract;
         virtual void FilterRect(
-            rct_drawpixelinfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) abstract;
-        virtual void DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, const ScreenLine& line) abstract;
-        virtual void DrawSprite(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y) abstract;
+            DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) abstract;
+        virtual void DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line) abstract;
+        virtual void DrawSprite(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y) abstract;
         virtual void DrawSpriteRawMasked(
-            rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) abstract;
+            DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) abstract;
         virtual void DrawSpriteSolid(
-            rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) abstract;
+            DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) abstract;
         virtual void DrawGlyph(
-            rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) abstract;
+            DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) abstract;
         virtual void DrawBitmap(
-            rct_drawpixelinfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
+            DrawPixelInfo* dpi, ImageIndex image, const void* pixels, int32_t width, int32_t height, int32_t x,
             int32_t y) abstract;
     };
 

--- a/src/openrct2/drawing/IDrawingContext.h
+++ b/src/openrct2/drawing/IDrawingContext.h
@@ -29,8 +29,7 @@ namespace OpenRCT2::Drawing
         virtual void DrawSprite(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y) abstract;
         virtual void DrawSpriteRawMasked(
             DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) abstract;
-        virtual void DrawSpriteSolid(
-            DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) abstract;
+        virtual void DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) abstract;
         virtual void DrawGlyph(
             DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& palette) abstract;
         virtual void DrawBitmap(

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -39,7 +39,7 @@ enum DRAWING_ENGINE_FLAGS
     DEF_PARALLEL_DRAWING = 1 << 1,
 };
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 struct GamePalette;
 
 namespace OpenRCT2::Ui
@@ -72,7 +72,7 @@ namespace OpenRCT2::Drawing
         virtual std::string Screenshot() abstract;
 
         virtual IDrawingContext* GetDrawingContext() abstract;
-        virtual rct_drawpixelinfo* GetDrawingPixelInfo() abstract;
+        virtual DrawPixelInfo* GetDrawingPixelInfo() abstract;
 
         virtual DRAWING_ENGINE_FLAGS GetFlags() abstract;
 
@@ -92,7 +92,7 @@ namespace OpenRCT2::Drawing
     {
         virtual ~IWeatherDrawer() = default;
         virtual void Draw(
-            rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+            DrawPixelInfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
             const uint8_t* weatherpattern) abstract;
     };
 } // namespace OpenRCT2::Drawing

--- a/src/openrct2/drawing/Image.cpp
+++ b/src/openrct2/drawing/Image.cpp
@@ -186,7 +186,7 @@ static void FreeImageList(uint32_t baseImageId, uint32_t count)
     _freeLists.push_back({ baseImageId, count });
 }
 
-uint32_t GfxObjectAllocateImages(const rct_g1_element* images, uint32_t count)
+uint32_t GfxObjectAllocateImages(const G1Element* images, uint32_t count)
 {
     if (count == 0 || gOpenRCT2NoGraphics)
     {
@@ -220,7 +220,7 @@ void GfxObjectFreeImages(uint32_t baseImageId, uint32_t count)
         for (uint32_t i = 0; i < count; i++)
         {
             uint32_t imageId = baseImageId + i;
-            rct_g1_element g1 = {};
+            G1Element g1 = {};
             GfxSetG1Element(imageId, &g1);
             DrawingEngineInvalidateImage(imageId);
         }

--- a/src/openrct2/drawing/Image.h
+++ b/src/openrct2/drawing/Image.h
@@ -15,7 +15,7 @@
 #include <cstdint>
 #include <list>
 
-struct rct_g1_element;
+struct G1Element;
 
 struct ImageList
 {
@@ -55,7 +55,7 @@ constexpr bool operator!=(const ImageList& lhs, const ImageList& rhs)
     return !(lhs == rhs);
 }
 
-uint32_t GfxObjectAllocateImages(const rct_g1_element* images, uint32_t count);
+uint32_t GfxObjectAllocateImages(const G1Element* images, uint32_t count);
 void GfxObjectFreeImages(uint32_t baseImageId, uint32_t count);
 void GfxObjectCheckAllImagesFreed();
 size_t ImageListGetUsedCount();

--- a/src/openrct2/drawing/ImageImporter.cpp
+++ b/src/openrct2/drawing/ImageImporter.cpp
@@ -43,7 +43,7 @@ ImportResult ImageImporter::Import(
     auto pixels = GetPixels(image.Pixels.data(), image.Stride, srcX, srcY, width, height, palette, flags, mode);
     auto buffer = flags & ImportFlags::RLE ? EncodeRLE(pixels.data(), width, height) : EncodeRaw(pixels.data(), width, height);
 
-    rct_g1_element outElement;
+    G1Element outElement;
     outElement.width = width;
     outElement.height = height;
     outElement.flags = (flags & ImportFlags::RLE ? G1_FLAG_RLE_COMPRESSION : G1_FLAG_HAS_TRANSPARENCY);

--- a/src/openrct2/drawing/ImageImporter.h
+++ b/src/openrct2/drawing/ImageImporter.h
@@ -27,7 +27,7 @@ namespace OpenRCT2::Drawing
     public:
         struct ImportResult
         {
-            rct_g1_element Element{};
+            G1Element Element{};
             std::vector<uint8_t> Buffer;
         };
 

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -37,7 +37,7 @@ static uint8_t _bakedLightTexture_spot_0[32 * 32];
 static uint8_t _bakedLightTexture_spot_1[64 * 64];
 static uint8_t _bakedLightTexture_spot_2[128 * 128];
 static uint8_t _bakedLightTexture_spot_3[256 * 256];
-static rct_drawpixelinfo _pixelInfo;
+static DrawPixelInfo _pixelInfo;
 static bool _lightfxAvailable = false;
 
 static void* _light_rendered_buffer_back = nullptr;
@@ -180,7 +180,7 @@ void LightFXInit()
     CalcRescaleLightHalf(_bakedLightTexture_spot_0, _bakedLightTexture_spot_1, 32, 32);
 }
 
-void LightFXUpdateBuffers(rct_drawpixelinfo* info)
+void LightFXUpdateBuffers(DrawPixelInfo* info)
 {
     _light_rendered_buffer_front = realloc(_light_rendered_buffer_front, info->width * info->height);
     _light_rendered_buffer_back = realloc(_light_rendered_buffer_back, info->width * info->height);
@@ -298,7 +298,7 @@ void LightFXPrepareLightList()
                 if (w != nullptr)
                 {
                     // based on GetMapCoordinatesFromPosWindow
-                    rct_drawpixelinfo dpi;
+                    DrawPixelInfo dpi;
                     dpi.x = entry->ViewCoords.x + offsetPattern[0 + pat * 2] / mapFrontDiv;
                     dpi.y = entry->ViewCoords.y + offsetPattern[1 + pat * 2] / mapFrontDiv;
                     dpi.height = 1;

--- a/src/openrct2/drawing/LightFX.h
+++ b/src/openrct2/drawing/LightFX.h
@@ -13,7 +13,7 @@
 
 struct CoordsXY;
 struct Vehicle;
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 struct GamePalette;
 struct CoordsXYZ;
 struct EntityBase;
@@ -48,7 +48,7 @@ bool LightFXForVehiclesIsAvailable();
 
 void LightFXInit();
 
-void LightFXUpdateBuffers(rct_drawpixelinfo*);
+void LightFXUpdateBuffers(DrawPixelInfo*);
 
 void LightFXPrepareLightList();
 void LightFXSwapBuffers();

--- a/src/openrct2/drawing/Line.cpp
+++ b/src/openrct2/drawing/Line.cpp
@@ -16,7 +16,7 @@
  * Draws a horizontal line of specified colour to a buffer.
  *  rct2: 0x0068474C
  */
-static void GfxDrawLineOnBuffer(rct_drawpixelinfo* dpi, char colour, const ScreenCoordsXY& coords, int32_t no_pixels)
+static void GfxDrawLineOnBuffer(DrawPixelInfo* dpi, char colour, const ScreenCoordsXY& coords, int32_t no_pixels)
 {
     ScreenCoordsXY offset{ coords.x - dpi->x, coords.y - dpi->y };
 
@@ -72,7 +72,7 @@ static void GfxDrawLineOnBuffer(rct_drawpixelinfo* dpi, char colour, const Scree
  * colour (ebp)
  */
 
-void GfxDrawLineSoftware(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colour)
+void GfxDrawLineSoftware(DrawPixelInfo* dpi, const ScreenLine& line, int32_t colour)
 {
     int32_t x1 = line.GetX1();
     int32_t x2 = line.GetX2();

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -243,8 +243,7 @@ void FASTCALL GfxDrawSprite(DrawPixelInfo* dpi, const ImageId imageId, const Scr
     }
 }
 
-void FASTCALL
-    GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+void FASTCALL GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -254,8 +253,8 @@ void FASTCALL
     }
 }
 
-void FASTCALL GfxDrawSpriteRawMasked(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
+void FASTCALL
+    GfxDrawSpriteRawMasked(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -115,7 +115,7 @@ void DrawingEngineDispose()
     }
 }
 
-rct_drawpixelinfo* DrawingEngineGetDpi()
+DrawPixelInfo* DrawingEngineGetDpi()
 {
     auto context = GetContext();
     auto drawingEngine = context->GetDrawingEngine();
@@ -160,7 +160,7 @@ void GfxSetDirtyBlocks(const ScreenRect& rect)
     }
 }
 
-void GfxClear(rct_drawpixelinfo* dpi, uint8_t paletteIndex)
+void GfxClear(DrawPixelInfo* dpi, uint8_t paletteIndex)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -170,7 +170,7 @@ void GfxClear(rct_drawpixelinfo* dpi, uint8_t paletteIndex)
     }
 }
 
-void GfxFillRect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colour)
+void GfxFillRect(DrawPixelInfo* dpi, const ScreenRect& rect, int32_t colour)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -180,7 +180,7 @@ void GfxFillRect(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colour)
     }
 }
 
-void GfxFilterRect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FilterPaletteID palette)
+void GfxFilterRect(DrawPixelInfo* dpi, const ScreenRect& rect, FilterPaletteID palette)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -190,7 +190,7 @@ void GfxFilterRect(rct_drawpixelinfo* dpi, const ScreenRect& rect, FilterPalette
     }
 }
 
-void GfxDrawLine(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colour)
+void GfxDrawLine(DrawPixelInfo* dpi, const ScreenLine& line, int32_t colour)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -201,7 +201,7 @@ void GfxDrawLine(rct_drawpixelinfo* dpi, const ScreenLine& line, int32_t colour)
 }
 
 void GfxDrawDashedLine(
-    rct_drawpixelinfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
+    DrawPixelInfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
 {
     assert(dashedLineSegmentLength > 0);
 
@@ -233,7 +233,7 @@ void GfxDrawDashedLine(
     }
 }
 
-void FASTCALL GfxDrawSprite(rct_drawpixelinfo* dpi, const ImageId imageId, const ScreenCoordsXY& coords)
+void FASTCALL GfxDrawSprite(DrawPixelInfo* dpi, const ImageId imageId, const ScreenCoordsXY& coords)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -244,7 +244,7 @@ void FASTCALL GfxDrawSprite(rct_drawpixelinfo* dpi, const ImageId imageId, const
 }
 
 void FASTCALL
-    GfxDrawGlyph(rct_drawpixelinfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+    GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -255,7 +255,7 @@ void FASTCALL
 }
 
 void FASTCALL GfxDrawSpriteRawMasked(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)
@@ -265,7 +265,7 @@ void FASTCALL GfxDrawSpriteRawMasked(
     }
 }
 
-void FASTCALL GfxDrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour)
+void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour)
 {
     auto drawingEngine = dpi->DrawingEngine;
     if (drawingEngine != nullptr)

--- a/src/openrct2/drawing/NewDrawing.h
+++ b/src/openrct2/drawing/NewDrawing.h
@@ -11,7 +11,7 @@
 
 #include "../common.h"
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 struct GamePalette;
 enum class DrawingEngine : int32_t;
 
@@ -25,7 +25,7 @@ void DrawingEngineSetPalette(const GamePalette& colours);
 void DrawingEngineCopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy);
 void DrawingEngineDispose();
 
-rct_drawpixelinfo* DrawingEngineGetDpi();
+DrawPixelInfo* DrawingEngineGetDpi();
 bool DrawingEngineHasDirtyOptimisations();
 void DrawingEngineInvalidateImage(uint32_t image);
 void DrawingEngineSetVSync(bool vsync);

--- a/src/openrct2/drawing/Rect.cpp
+++ b/src/openrct2/drawing/Rect.cpp
@@ -24,7 +24,7 @@
  * colour (ebp)
  * flags (si)
  */
-void GfxFillRectInset(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t colour, uint8_t flags)
+void GfxFillRectInset(DrawPixelInfo* dpi, const ScreenRect& rect, int32_t colour, uint8_t flags)
 {
     const auto leftTop = ScreenCoordsXY{ rect.GetLeft(), rect.GetTop() };
     const auto leftBottom = ScreenCoordsXY{ rect.GetLeft(), rect.GetBottom() };
@@ -32,7 +32,7 @@ void GfxFillRectInset(rct_drawpixelinfo* dpi, const ScreenRect& rect, int32_t co
     const auto rightBottom = ScreenCoordsXY{ rect.GetRight(), rect.GetBottom() };
     if (colour & (COLOUR_FLAG_TRANSLUCENT | COLOUR_FLAG_8))
     {
-        translucent_window_palette palette;
+        TranslucentWindowPalette palette;
         if (colour & COLOUR_FLAG_8)
         {
             // TODO: This can't be added up

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -50,7 +50,7 @@ static void ScrollingTextSetBitmapForTTF(
 static void ScrollingTextInitialiseCharacterBitmaps(uint32_t glyphStart, uint16_t offset, uint16_t count, bool isAntiAliased)
 {
     uint8_t drawingSurface[64];
-    rct_drawpixelinfo dpi;
+    DrawPixelInfo dpi;
     dpi.bits = reinterpret_cast<uint8_t*>(&drawingSurface);
     dpi.width = 8;
     dpi.height = 8;
@@ -84,7 +84,7 @@ static void ScrollingTextInitialiseScrollingText()
         const int32_t imageId = SPR_SCROLLING_TEXT_START + i;
 
         // Initialize the scrolling text sprite.
-        rct_g1_element g1{};
+        G1Element g1{};
         g1.offset = _drawScrollTextList[i].bitmap;
         g1.x_offset = -32;
         g1.y_offset = 0;
@@ -1440,7 +1440,7 @@ ImageId ScrollingTextSetup(
 
     assert(scrollingMode < MAX_SCROLLING_TEXT_MODES);
 
-    rct_drawpixelinfo* dpi = &session.DPI;
+    DrawPixelInfo* dpi = &session.DPI;
 
     if (dpi->zoom_level > ZoomLevel{ 0 })
         return ImageId(SPR_SCROLLING_TEXT_DEFAULT);

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -15,8 +15,7 @@
 #include "Drawing.h"
 
 static void DrawText(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text,
-    bool noFormatting = false);
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting = false);
 static void DrawText(
     DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, StringId format, const void* args);
 
@@ -132,8 +131,7 @@ void DrawTextBasic(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, StringId fo
     DrawTextBasic(dpi, coords, format, ft, textPaint);
 }
 
-void DrawTextBasic(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint)
+void DrawTextBasic(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     DrawText(dpi, coords, textPaint, format, ft.Data());
 }
@@ -146,8 +144,7 @@ void DrawTextEllipsised(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_
 }
 
 void DrawTextEllipsised(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
-    TextPaint textPaint)
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     utf8 buffer[512];
     OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), format, ft.Data());
@@ -161,8 +158,7 @@ void GfxDrawString(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8s
     DrawText(dpi, coords, textPaint, buffer);
 }
 
-void GfxDrawStringNoFormatting(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint)
+void GfxDrawStringNoFormatting(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint)
 {
     DrawText(dpi, coords, textPaint, buffer, true);
 }
@@ -175,8 +171,7 @@ int32_t DrawTextWrapped(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_
 }
 
 int32_t DrawTextWrapped(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
-    TextPaint textPaint)
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     const void* args = ft.Data();
 

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -15,10 +15,10 @@
 #include "Drawing.h"
 
 static void DrawText(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text,
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text,
     bool noFormatting = false);
 static void DrawText(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, StringId format, const void* args);
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, StringId format, const void* args);
 
 class StaticLayout
 {
@@ -40,7 +40,7 @@ public:
         LineHeight = FontGetLineHeight(paint.FontStyle);
     }
 
-    void Draw(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords)
+    void Draw(DrawPixelInfo* dpi, const ScreenCoordsXY& coords)
     {
         TextPaint tempPaint = Paint;
 
@@ -83,7 +83,7 @@ public:
 };
 
 static void DrawText(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting)
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, const_utf8string text, bool noFormatting)
 {
     int32_t width = noFormatting ? GfxGetStringWidthNoFormatting(text, paint.FontStyle)
                                  : GfxGetStringWidth(text, paint.FontStyle);
@@ -118,14 +118,14 @@ static void DrawText(
 }
 
 static void DrawText(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, StringId format, const void* args)
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const TextPaint& paint, StringId format, const void* args)
 {
     utf8 buffer[512];
     OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), format, args);
     DrawText(dpi, coords, paint, buffer);
 }
 
-void DrawTextBasic(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, StringId format)
+void DrawTextBasic(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, StringId format)
 {
     Formatter ft{};
     TextPaint textPaint{};
@@ -133,12 +133,12 @@ void DrawTextBasic(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, StringI
 }
 
 void DrawTextBasic(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint)
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint)
 {
     DrawText(dpi, coords, textPaint, format, ft.Data());
 }
 
-void DrawTextEllipsised(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format)
+void DrawTextEllipsised(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format)
 {
     Formatter ft{};
     TextPaint textPaint{};
@@ -146,7 +146,7 @@ void DrawTextEllipsised(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, in
 }
 
 void DrawTextEllipsised(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
     TextPaint textPaint)
 {
     utf8 buffer[512];
@@ -156,18 +156,18 @@ void DrawTextEllipsised(
     DrawText(dpi, coords, textPaint, buffer);
 }
 
-void GfxDrawString(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint)
+void GfxDrawString(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint)
 {
     DrawText(dpi, coords, textPaint, buffer);
 }
 
 void GfxDrawStringNoFormatting(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint)
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint)
 {
     DrawText(dpi, coords, textPaint, buffer, true);
 }
 
-int32_t DrawTextWrapped(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format)
+int32_t DrawTextWrapped(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format)
 {
     Formatter ft{};
     TextPaint textPaint{};
@@ -175,7 +175,7 @@ int32_t DrawTextWrapped(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, in
 }
 
 int32_t DrawTextWrapped(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
     TextPaint textPaint)
 {
     const void* args = ft.Data();

--- a/src/openrct2/drawing/Text.h
+++ b/src/openrct2/drawing/Text.h
@@ -14,7 +14,7 @@
 #include "Font.h"
 
 struct ScreenCoordsXY;
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 class Formatter;
 
 enum class TextAlignment
@@ -142,15 +142,15 @@ struct TextPaint
     }
 };
 
-void DrawTextBasic(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, StringId format);
-void DrawTextEllipsised(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
-int32_t DrawTextWrapped(rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
+void DrawTextBasic(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, StringId format);
+void DrawTextEllipsised(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
+int32_t DrawTextWrapped(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format);
 
 void DrawTextBasic(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint = {});
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, StringId format, const Formatter& ft, TextPaint textPaint = {});
 void DrawTextEllipsised(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
     TextPaint textPaint = {});
 int32_t DrawTextWrapped(
-    rct_drawpixelinfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, StringId format, const Formatter& ft,
     TextPaint textPaint = {});

--- a/src/openrct2/drawing/Weather.cpp
+++ b/src/openrct2/drawing/Weather.cpp
@@ -23,13 +23,13 @@ using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
 
 static void DrawLightRain(
-    rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawHeavyRain(
-    rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawLightSnow(
-    rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawHeavySnow(
-    rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 
 /**
  *
@@ -51,7 +51,7 @@ const DrawWeatherFunc DrawSnowFunctions[] = {
  *
  *  rct2: 0x00684218
  */
-void DrawWeather(rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer)
+void DrawWeather(DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer)
 {
     if (gConfigGeneral.RenderWeatherEffects)
     {
@@ -81,7 +81,7 @@ void DrawWeather(rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer)
  *  rct2: 0x00684114
  */
 static void DrawLightRain(
-    rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     int32_t x_start = -static_cast<int32_t>(gCurrentTicks) + 8;
     int32_t y_start = (gCurrentTicks * 3) + 7;
@@ -103,7 +103,7 @@ static void DrawLightRain(
  *  rct2: 0x0068416D
  */
 static void DrawHeavyRain(
-    rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     int32_t x_start = -static_cast<int32_t>(gCurrentTicks);
     int32_t y_start = gCurrentTicks * 5;
@@ -135,7 +135,7 @@ static void DrawHeavyRain(
 }
 
 static void DrawLightSnow(
-    rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const uint32_t t = gCurrentTicks / 2;
     const int32_t negT = -static_cast<int32_t>(t);
@@ -157,7 +157,7 @@ static void DrawLightSnow(
 }
 
 static void DrawHeavySnow(
-    rct_drawpixelinfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     int32_t x_start = -static_cast<int32_t>(gCurrentTicks * 3) + 1;
     int32_t y_start = gCurrentTicks + 23;

--- a/src/openrct2/drawing/Weather.h
+++ b/src/openrct2/drawing/Weather.h
@@ -11,7 +11,7 @@
 
 #include "../common.h"
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 
 namespace OpenRCT2::Drawing
 {
@@ -37,4 +37,4 @@ static constexpr const uint8_t SnowPattern[] =
 
 // clang-format on
 
-void DrawWeather(rct_drawpixelinfo* dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer);
+void DrawWeather(DrawPixelInfo* dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer);

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -44,7 +44,7 @@ X8WeatherDrawer::~X8WeatherDrawer()
 }
 
 void X8WeatherDrawer::Draw(
-    rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+    DrawPixelInfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
     const uint8_t* weatherpattern)
 {
     const uint8_t* pattern = weatherpattern;
@@ -92,7 +92,7 @@ void X8WeatherDrawer::Draw(
     }
 }
 
-void X8WeatherDrawer::Restore(rct_drawpixelinfo* dpi)
+void X8WeatherDrawer::Restore(DrawPixelInfo* dpi)
 {
     if (_weatherPixelsCount > 0)
     {
@@ -267,7 +267,7 @@ IDrawingContext* X8DrawingEngine::GetDrawingContext()
     return _drawingContext;
 }
 
-rct_drawpixelinfo* X8DrawingEngine::GetDrawingPixelInfo()
+DrawPixelInfo* X8DrawingEngine::GetDrawingPixelInfo()
 {
     return &_bitsDPI;
 }
@@ -282,7 +282,7 @@ void X8DrawingEngine::InvalidateImage([[maybe_unused]] uint32_t image)
     // Not applicable for this engine
 }
 
-rct_drawpixelinfo* X8DrawingEngine::GetDPI()
+DrawPixelInfo* X8DrawingEngine::GetDPI()
 {
     return &_bitsDPI;
 }
@@ -328,7 +328,7 @@ void X8DrawingEngine::ConfigureBits(uint32_t width, uint32_t height, uint32_t pi
     _height = height;
     _pitch = pitch;
 
-    rct_drawpixelinfo* dpi = &_bitsDPI;
+    DrawPixelInfo* dpi = &_bitsDPI;
     dpi->bits = _bits;
     dpi->x = 0;
     dpi->y = 0;
@@ -449,7 +449,7 @@ X8DrawingContext::X8DrawingContext(X8DrawingEngine* engine)
     _engine = engine;
 }
 
-void X8DrawingContext::Clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex)
+void X8DrawingContext::Clear(DrawPixelInfo* dpi, uint8_t paletteIndex)
 {
     int32_t w = dpi->zoom_level.ApplyInversedTo(dpi->width);
     int32_t h = dpi->zoom_level.ApplyInversedTo(dpi->height);
@@ -511,7 +511,7 @@ static constexpr const uint16_t* Patterns[] = {
 // clang-format on
 
 void X8DrawingContext::FillRect(
-    rct_drawpixelinfo* dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    DrawPixelInfo* dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     if (left > right)
         return;
@@ -631,7 +631,7 @@ void X8DrawingContext::FillRect(
 }
 
 void X8DrawingContext::FilterRect(
-    rct_drawpixelinfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
+    DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     if (left > right)
         return;
@@ -703,23 +703,23 @@ void X8DrawingContext::FilterRect(
     }
 }
 
-void X8DrawingContext::DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, const ScreenLine& line)
+void X8DrawingContext::DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line)
 {
     GfxDrawLineSoftware(dpi, line, colour);
 }
 
-void X8DrawingContext::DrawSprite(rct_drawpixelinfo* dpi, const ImageId imageId, int32_t x, int32_t y)
+void X8DrawingContext::DrawSprite(DrawPixelInfo* dpi, const ImageId imageId, int32_t x, int32_t y)
 {
     GfxDrawSpriteSoftware(dpi, imageId, { x, y });
 }
 
 void X8DrawingContext::DrawSpriteRawMasked(
-    rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
+    DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
 {
     GfxDrawSpriteRawMaskedSoftware(dpi, { x, y }, maskImage, colourImage);
 }
 
-void X8DrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
+void X8DrawingContext::DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
 {
     uint8_t palette[256];
     std::fill_n(palette, sizeof(palette), colour);
@@ -730,7 +730,7 @@ void X8DrawingContext::DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId ima
 }
 
 void X8DrawingContext::DrawGlyph(
-    rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap)
+    DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap)
 {
     GfxDrawSpritePaletteSetSoftware(dpi, image, { x, y }, paletteMap);
 }

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -510,8 +510,7 @@ static constexpr const uint16_t* Patterns[] = {
 };
 // clang-format on
 
-void X8DrawingContext::FillRect(
-    DrawPixelInfo* dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
+void X8DrawingContext::FillRect(DrawPixelInfo* dpi, uint32_t colour, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     if (left > right)
         return;
@@ -729,8 +728,7 @@ void X8DrawingContext::DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, 
     GfxDrawSpritePaletteSetSoftware(dpi, ImageId(image.GetIndex(), 0), spriteCoords, PaletteMap(palette));
 }
 
-void X8DrawingContext::DrawGlyph(
-    DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap)
+void X8DrawingContext::DrawGlyph(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap)
 {
     GfxDrawSpritePaletteSetSoftware(dpi, image, { x, y }, paletteMap);
 }

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -56,9 +56,9 @@ namespace OpenRCT2
             X8WeatherDrawer();
             ~X8WeatherDrawer();
             void Draw(
-                rct_drawpixelinfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+                DrawPixelInfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
                 const uint8_t* weatherpattern) override;
-            void Restore(rct_drawpixelinfo* dpi);
+            void Restore(DrawPixelInfo* dpi);
         };
 
 #ifdef __WARN_SUGGEST_FINAL_TYPES__
@@ -76,7 +76,7 @@ namespace OpenRCT2
 
             DirtyGrid _dirtyGrid = {};
 
-            rct_drawpixelinfo _bitsDPI = {};
+            DrawPixelInfo _bitsDPI = {};
 
             bool _lastLightFXenabled = false;
 
@@ -108,11 +108,11 @@ namespace OpenRCT2
             void CopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy) override;
             std::string Screenshot() override;
             IDrawingContext* GetDrawingContext() override;
-            rct_drawpixelinfo* GetDrawingPixelInfo() override;
+            DrawPixelInfo* GetDrawingPixelInfo() override;
             DRAWING_ENGINE_FLAGS GetFlags() override;
             void InvalidateImage(uint32_t image) override;
 
-            rct_drawpixelinfo* GetDPI();
+            DrawPixelInfo* GetDPI();
 
         protected:
             void ConfigureBits(uint32_t width, uint32_t height, uint32_t pitch);
@@ -136,20 +136,20 @@ namespace OpenRCT2
         public:
             explicit X8DrawingContext(X8DrawingEngine* engine);
 
-            void Clear(rct_drawpixelinfo* dpi, uint8_t paletteIndex) override;
-            void FillRect(rct_drawpixelinfo* dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
+            void Clear(DrawPixelInfo* dpi, uint8_t paletteIndex) override;
+            void FillRect(DrawPixelInfo* dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
             void FilterRect(
-                rct_drawpixelinfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right,
+                DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right,
                 int32_t bottom) override;
-            void DrawLine(rct_drawpixelinfo* dpi, uint32_t colour, const ScreenLine& line) override;
-            void DrawSprite(rct_drawpixelinfo* dpi, const ImageId imageId, int32_t x, int32_t y) override;
+            void DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line) override;
+            void DrawSprite(DrawPixelInfo* dpi, const ImageId imageId, int32_t x, int32_t y) override;
             void DrawSpriteRawMasked(
-                rct_drawpixelinfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
-            void DrawSpriteSolid(rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
+                DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage) override;
+            void DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour) override;
             void DrawGlyph(
-                rct_drawpixelinfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
+                DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap) override;
             void DrawBitmap(
-                rct_drawpixelinfo* dpi, uint32_t image, const void* pixels, int32_t width, int32_t height, int32_t x,
+                DrawPixelInfo* dpi, uint32_t image, const void* pixels, int32_t width, int32_t height, int32_t x,
                 int32_t y) override
             {
             }

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -139,8 +139,7 @@ namespace OpenRCT2
             void Clear(DrawPixelInfo* dpi, uint8_t paletteIndex) override;
             void FillRect(DrawPixelInfo* dpi, uint32_t colour, int32_t x, int32_t y, int32_t w, int32_t h) override;
             void FilterRect(
-                DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right,
-                int32_t bottom) override;
+                DrawPixelInfo* dpi, FilterPaletteID palette, int32_t left, int32_t top, int32_t right, int32_t bottom) override;
             void DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line) override;
             void DrawSprite(DrawPixelInfo* dpi, const ImageId imageId, int32_t x, int32_t y) override;
             void DrawSpriteRawMasked(

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -369,7 +369,7 @@ void Duck::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
-    rct_drawpixelinfo& dpi = session.DPI;
+    DrawPixelInfo& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 1 })
         return;
 

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -404,7 +404,7 @@ void JumpingFountain::Paint(PaintSession& session, int32_t imageDirection) const
     constexpr uint32_t JumpingFountainSnowBaseImage = 23037;
     constexpr uint32_t JumpingFountainWaterBaseImage = 22973;
 
-    rct_drawpixelinfo& dpi = session.DPI;
+    DrawPixelInfo& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 0 })
     {
         return;

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -174,7 +174,7 @@ void Litter::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
-    rct_drawpixelinfo& dpi = session.DPI;
+    DrawPixelInfo& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 0 })
         return; // If zoomed at all no litter drawn
 

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -172,7 +172,7 @@ void MoneyEffect::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
 
-    rct_drawpixelinfo& dpi = session.DPI;
+    DrawPixelInfo& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 0 })
     {
         return;

--- a/src/openrct2/entity/Particle.cpp
+++ b/src/openrct2/entity/Particle.cpp
@@ -155,7 +155,7 @@ void VehicleCrashParticle::Paint(PaintSession& session, int32_t imageDirection) 
 {
     PROFILED_FUNCTION();
 
-    rct_drawpixelinfo& dpi = session.DPI;
+    DrawPixelInfo& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 0 })
     {
         return;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -2803,7 +2803,7 @@ void Peep::Paint(PaintSession& session, int32_t imageDirection) const
         }
     }
 
-    rct_drawpixelinfo* dpi = &session.DPI;
+    DrawPixelInfo* dpi = &session.DPI;
     if (dpi->zoom_level > ZoomLevel{ 2 })
     {
         return;

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -44,7 +44,7 @@ static const char* ChatGetHistory(uint32_t index);
 static uint32_t ChatHistoryGetTime(uint32_t index);
 static void ChatClearInput();
 static int32_t ChatHistoryDrawString(
-    rct_drawpixelinfo* dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width);
+    DrawPixelInfo* dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width);
 
 bool ChatAvailable()
 {
@@ -88,7 +88,7 @@ void ChatUpdate()
     _chatCaretTicks = (_chatCaretTicks + 1) % 30;
 }
 
-void ChatDraw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColor)
+void ChatDraw(DrawPixelInfo* dpi, uint8_t chatBackgroundColor)
 {
     thread_local std::string lineBuffer;
 
@@ -272,7 +272,7 @@ static void ChatClearInput()
 // This method is the same as gfx_draw_string_left_wrapped.
 // But this adjusts the initial Y coordinate depending of the number of lines.
 static int32_t ChatHistoryDrawString(
-    rct_drawpixelinfo* dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width)
+    DrawPixelInfo* dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width)
 {
     char buffer[CommonTextBufferSize];
     auto bufferPtr = buffer;

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -43,8 +43,7 @@ static TextInputSession* _chatTextInputSession;
 static const char* ChatGetHistory(uint32_t index);
 static uint32_t ChatHistoryGetTime(uint32_t index);
 static void ChatClearInput();
-static int32_t ChatHistoryDrawString(
-    DrawPixelInfo* dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width);
+static int32_t ChatHistoryDrawString(DrawPixelInfo* dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width);
 
 bool ChatAvailable()
 {
@@ -271,8 +270,7 @@ static void ChatClearInput()
 
 // This method is the same as gfx_draw_string_left_wrapped.
 // But this adjusts the initial Y coordinate depending of the number of lines.
-static int32_t ChatHistoryDrawString(
-    DrawPixelInfo* dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width)
+static int32_t ChatHistoryDrawString(DrawPixelInfo* dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width)
 {
     char buffer[CommonTextBufferSize];
     auto bufferPtr = buffer;

--- a/src/openrct2/interface/Chat.h
+++ b/src/openrct2/interface/Chat.h
@@ -18,7 +18,7 @@
 #define CHAT_MAX_MESSAGE_LENGTH 200
 #define CHAT_MAX_WINDOW_WIDTH 600
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 struct ScreenCoordsXY;
 
 enum class ChatInput : uint8_t
@@ -37,7 +37,7 @@ void ChatToggle();
 
 void ChatInit();
 void ChatUpdate();
-void ChatDraw(rct_drawpixelinfo* dpi, uint8_t chatBackgroundColour);
+void ChatDraw(DrawPixelInfo* dpi, uint8_t chatBackgroundColour);
 
 void ChatAddHistory(std::string_view s);
 void ChatInput(ChatInput input);

--- a/src/openrct2/interface/Colour.cpp
+++ b/src/openrct2/interface/Colour.cpp
@@ -16,7 +16,7 @@
 #include <algorithm>
 #include <cmath>
 
-rct_colour_map ColourMapA[COLOUR_COUNT] = {};
+ColourShadeMap ColourMapA[COLOUR_COUNT] = {};
 
 enum
 {
@@ -39,7 +39,7 @@ void ColoursInitMaps()
     // Get colour maps from g1
     for (int32_t i = 0; i < COLOUR_COUNT; i++)
     {
-        const rct_g1_element* g1 = GfxGetG1Element(SPR_PALETTE_2_START + i);
+        const G1Element* g1 = GfxGetG1Element(SPR_PALETTE_2_START + i);
         if (g1 != nullptr)
         {
             ColourMapA[i].colour_0 = g1->offset[INDEX_COLOUR_0];

--- a/src/openrct2/interface/Colour.h
+++ b/src/openrct2/interface/Colour.h
@@ -193,7 +193,7 @@ enum
 #define NOT_TRANSLUCENT(x) ((x) & ~static_cast<uint8_t>(COLOUR_FLAG_TRANSLUCENT))
 #define BASE_COLOUR(x) ((x)&0x1F)
 
-struct rct_colour_map
+struct ColourShadeMap
 {
     uint8_t colour_0;
     uint8_t colour_1;
@@ -209,7 +209,7 @@ struct rct_colour_map
     uint8_t colour_11;
 };
 
-extern rct_colour_map ColourMapA[COLOUR_COUNT];
+extern ColourShadeMap ColourMapA[COLOUR_COUNT];
 
 void ColoursInitMaps();
 

--- a/src/openrct2/interface/InteractiveConsole.h
+++ b/src/openrct2/interface/InteractiveConsole.h
@@ -17,7 +17,7 @@
 #include <queue>
 #include <string>
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 struct TextInputSession;
 
 enum class ConsoleInput : uint8_t

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -51,7 +51,7 @@ extern uint8_t gClipHeight;
 
 uint8_t gScreenshotCountdown = 0;
 
-static bool WriteDpiToFile(std::string_view path, const rct_drawpixelinfo* dpi, const GamePalette& palette)
+static bool WriteDpiToFile(std::string_view path, const DrawPixelInfo* dpi, const GamePalette& palette)
 {
     auto const pixels8 = dpi->bits;
     auto const pixelsLen = (dpi->width + dpi->pitch) * dpi->height;
@@ -164,7 +164,7 @@ static std::optional<std::string> ScreenshotGetNextPath()
     return std::nullopt;
 };
 
-std::string ScreenshotDumpPNG(rct_drawpixelinfo* dpi)
+std::string ScreenshotDumpPNG(DrawPixelInfo* dpi)
 {
     // Get a free screenshot path
     auto path = ScreenshotGetNextPath();
@@ -249,9 +249,9 @@ static int32_t GetTallestVisibleTileTop(
     return minViewY - 64;
 }
 
-static rct_drawpixelinfo CreateDPI(const rct_viewport& viewport)
+static DrawPixelInfo CreateDPI(const rct_viewport& viewport)
 {
-    rct_drawpixelinfo dpi;
+    DrawPixelInfo dpi;
     dpi.width = viewport.width;
     dpi.height = viewport.height;
     dpi.bits = new (std::nothrow) uint8_t[dpi.width * dpi.height];
@@ -268,7 +268,7 @@ static rct_drawpixelinfo CreateDPI(const rct_viewport& viewport)
     return dpi;
 }
 
-static void ReleaseDPI(rct_drawpixelinfo& dpi)
+static void ReleaseDPI(DrawPixelInfo& dpi)
 {
     if (dpi.bits != nullptr)
         delete[] dpi.bits;
@@ -324,7 +324,7 @@ static rct_viewport GetGiantViewport(int32_t rotation, ZoomLevel zoom)
     return viewport;
 }
 
-static void RenderViewport(IDrawingEngine* drawingEngine, const rct_viewport& viewport, rct_drawpixelinfo& dpi)
+static void RenderViewport(IDrawingEngine* drawingEngine, const rct_viewport& viewport, DrawPixelInfo& dpi)
 {
     // Ensure sprites appear regardless of rotation
     ResetAllSpriteQuadrantPlacements();
@@ -341,7 +341,7 @@ static void RenderViewport(IDrawingEngine* drawingEngine, const rct_viewport& vi
 
 void ScreenshotGiant()
 {
-    rct_drawpixelinfo dpi{};
+    DrawPixelInfo dpi{};
     try
     {
         auto path = ScreenshotGetNextPath();
@@ -414,7 +414,7 @@ static void BenchgfxRenderScreenshots(const char* inputPath, std::unique_ptr<ICo
     // rotation.
     constexpr int32_t NUM_ROTATIONS = 4;
     constexpr auto NUM_ZOOM_LEVELS = static_cast<int8_t>(ZoomLevel::max());
-    std::array<rct_drawpixelinfo, NUM_ROTATIONS * NUM_ZOOM_LEVELS> dpis;
+    std::array<DrawPixelInfo, NUM_ROTATIONS * NUM_ZOOM_LEVELS> dpis;
     std::array<rct_viewport, NUM_ROTATIONS * NUM_ZOOM_LEVELS> viewports;
 
     for (ZoomLevel zoom{ 0 }; zoom < ZoomLevel::max(); zoom++)
@@ -584,7 +584,7 @@ int32_t CmdlineForScreenshot(const char** argv, int32_t argc, ScreenshotOptions*
     }
 
     int32_t exitCode = 1;
-    rct_drawpixelinfo dpi;
+    DrawPixelInfo dpi;
     try
     {
         Platform::CoreInit();

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -18,7 +18,7 @@
 #include <optional>
 #include <string>
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 
 extern uint8_t gScreenshotCountdown;
 
@@ -54,7 +54,7 @@ struct CaptureOptions
 
 void ScreenshotCheck();
 std::string ScreenshotDump();
-std::string ScreenshotDumpPNG(rct_drawpixelinfo* dpi);
+std::string ScreenshotDumpPNG(DrawPixelInfo* dpi);
 std::string ScreenshotDumpPNG32bpp(int32_t width, int32_t height, const void* pixels);
 
 void ScreenshotGiant();

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -402,8 +402,7 @@ static void ViewportRedrawAfterShift(
     }
 }
 
-static void ViewportShiftPixels(
-    DrawPixelInfo* dpi, rct_window* window, rct_viewport* viewport, int32_t x_diff, int32_t y_diff)
+static void ViewportShiftPixels(DrawPixelInfo* dpi, rct_window* window, rct_viewport* viewport, int32_t x_diff, int32_t y_diff)
 {
     auto it = WindowGetIterator(window);
     for (; it != g_window_list.end(); it++)
@@ -808,8 +807,7 @@ void ViewportUpdateSmartFollowVehicle(rct_window* window)
  *  ebp: bottom
  */
 void ViewportRender(
-    DrawPixelInfo* dpi, const rct_viewport* viewport, const ScreenRect& screenRect,
-    std::vector<RecordedPaintSession>* sessions)
+    DrawPixelInfo* dpi, const rct_viewport* viewport, const ScreenRect& screenRect, std::vector<RecordedPaintSession>* sessions)
 {
     auto [topLeft, bottomRight] = screenRect;
 

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -77,7 +77,7 @@ InteractionInfo::InteractionInfo(const PaintStruct* ps)
     , SpriteType(ps->sprite_type)
 {
 }
-static void ViewportPaintWeatherGloom(rct_drawpixelinfo* dpi);
+static void ViewportPaintWeatherGloom(DrawPixelInfo* dpi);
 
 /**
  * This is not a viewport function. It is used to setup many variables for
@@ -280,7 +280,7 @@ CoordsXYZ ViewportAdjustForMapHeight(const ScreenCoordsXY& startCoords)
  *  rct2: 0x006E7FF3
  */
 static void ViewportRedrawAfterShift(
-    rct_drawpixelinfo* dpi, rct_window* window, rct_viewport* viewport, const ScreenCoordsXY& coords)
+    DrawPixelInfo* dpi, rct_window* window, rct_viewport* viewport, const ScreenCoordsXY& coords)
 {
     // sub-divide by intersecting windows
     if (window != nullptr)
@@ -403,7 +403,7 @@ static void ViewportRedrawAfterShift(
 }
 
 static void ViewportShiftPixels(
-    rct_drawpixelinfo* dpi, rct_window* window, rct_viewport* viewport, int32_t x_diff, int32_t y_diff)
+    DrawPixelInfo* dpi, rct_window* window, rct_viewport* viewport, int32_t x_diff, int32_t y_diff)
 {
     auto it = WindowGetIterator(window);
     for (; it != g_window_list.end(); it++)
@@ -480,7 +480,7 @@ static void ViewportMove(const ScreenCoordsXY& coords, rct_window* w, rct_viewpo
 
         if (DrawingEngineHasDirtyOptimisations())
         {
-            rct_drawpixelinfo* dpi = DrawingEngineGetDpi();
+            DrawPixelInfo* dpi = DrawingEngineGetDpi();
             WindowDrawAll(dpi, left, top, right, bottom);
             return;
         }
@@ -532,7 +532,7 @@ static void ViewportMove(const ScreenCoordsXY& coords, rct_window* w, rct_viewpo
 
     if (DrawingEngineHasDirtyOptimisations())
     {
-        rct_drawpixelinfo* dpi = DrawingEngineGetDpi();
+        DrawPixelInfo* dpi = DrawingEngineGetDpi();
         ViewportShiftPixels(dpi, w, viewport, x_diff, y_diff);
     }
 
@@ -808,7 +808,7 @@ void ViewportUpdateSmartFollowVehicle(rct_window* window)
  *  ebp: bottom
  */
 void ViewportRender(
-    rct_drawpixelinfo* dpi, const rct_viewport* viewport, const ScreenRect& screenRect,
+    DrawPixelInfo* dpi, const rct_viewport* viewport, const ScreenRect& screenRect,
     std::vector<RecordedPaintSession>* sessions)
 {
     auto [topLeft, bottomRight] = screenRect;
@@ -962,7 +962,7 @@ static void ViewportPaintColumn(PaintSession& session)
  *  ebp: bottom
  */
 void ViewportPaint(
-    const rct_viewport* viewport, rct_drawpixelinfo* dpi, const ScreenRect& screenRect,
+    const rct_viewport* viewport, DrawPixelInfo* dpi, const ScreenRect& screenRect,
     std::vector<RecordedPaintSession>* recorded_sessions)
 {
     PROFILED_FUNCTION();
@@ -986,7 +986,7 @@ void ViewportPaint(
     y = viewport->zoom.ApplyInversedTo(y);
     y += viewport->pos.y;
 
-    rct_drawpixelinfo dpi1;
+    DrawPixelInfo dpi1;
     dpi1.DrawingEngine = dpi->DrawingEngine;
     dpi1.bits = dpi->bits + (x - dpi->x) + ((y - dpi->y) * (dpi->width + dpi->pitch));
     dpi1.x = topLeft.x;
@@ -1036,7 +1036,7 @@ void ViewportPaint(
         PaintSession* session = PaintSessionAlloc(&dpi1, viewFlags);
         _paintColumns.push_back(session);
 
-        rct_drawpixelinfo& dpi2 = session->DPI;
+        DrawPixelInfo& dpi2 = session->DPI;
         if (x >= dpi2.x)
         {
             auto leftPitch = x - dpi2.x;
@@ -1095,7 +1095,7 @@ void ViewportPaint(
     }
 }
 
-static void ViewportPaintWeatherGloom(rct_drawpixelinfo* dpi)
+static void ViewportPaintWeatherGloom(DrawPixelInfo* dpi)
 {
     auto paletteId = ClimateGetWeatherGloomPaletteId(gClimateCurrent);
     if (paletteId != FilterPaletteID::PaletteNull)
@@ -1532,7 +1532,7 @@ static bool PSSpriteTypeIsInFilter(PaintStruct* ps, uint16_t filter)
 /**
  * rct2: 0x00679236, 0x00679662, 0x00679B0D, 0x00679FF1
  */
-static bool IsPixelPresentBMP(uint32_t imageType, const rct_g1_element* g1, const uint8_t* index, const PaletteMap& paletteMap)
+static bool IsPixelPresentBMP(uint32_t imageType, const G1Element* g1, const uint8_t* index, const PaletteMap& paletteMap)
 {
     PROFILED_FUNCTION();
 
@@ -1653,11 +1653,11 @@ static bool IsPixelPresentRLE(const uint8_t* esi, int32_t x_start_point, int32_t
  * @return value originally stored in 0x00141F569
  */
 static bool IsSpriteInteractedWithPaletteSet(
-    rct_drawpixelinfo* dpi, ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
+    DrawPixelInfo* dpi, ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap)
 {
     PROFILED_FUNCTION();
 
-    const rct_g1_element* g1 = GfxGetG1Element(imageId);
+    const G1Element* g1 = GfxGetG1Element(imageId);
     if (g1 == nullptr)
     {
         return false;
@@ -1673,7 +1673,7 @@ static bool IsSpriteInteractedWithPaletteSet(
         if (g1->flags & G1_FLAG_HAS_ZOOM_SPRITE)
         {
             // TODO: SAR in dpi done with `>> 1`, in coordinates with `/ 2`
-            rct_drawpixelinfo zoomed_dpi = {
+            DrawPixelInfo zoomed_dpi = {
                 /* .bits = */ dpi->bits,
                 /* .x = */ dpi->x >> 1,
                 /* .y = */ dpi->y >> 1,
@@ -1799,7 +1799,7 @@ static bool IsSpriteInteractedWithPaletteSet(
  *  rct2: 0x00679023
  */
 
-static bool IsSpriteInteractedWith(rct_drawpixelinfo* dpi, ImageId imageId, const ScreenCoordsXY& coords)
+static bool IsSpriteInteractedWith(DrawPixelInfo* dpi, ImageId imageId, const ScreenCoordsXY& coords)
 {
     PROFILED_FUNCTION();
 
@@ -1837,7 +1837,7 @@ InteractionInfo SetInteractionInfoFromPaintSession(PaintSession* session, uint32
     PROFILED_FUNCTION();
 
     PaintStruct* ps = &session->PaintHead;
-    rct_drawpixelinfo* dpi = &session->DPI;
+    DrawPixelInfo* dpi = &session->DPI;
     InteractionInfo info{};
 
     while ((ps = ps->next_quadrant_ps) != nullptr)
@@ -1916,7 +1916,7 @@ InteractionInfo GetMapCoordinatesFromPosWindow(rct_window* window, const ScreenC
             viewLoc.x &= myviewport->zoom.ApplyTo(0xFFFFFFFF) & 0xFFFFFFFF;
             viewLoc.y &= myviewport->zoom.ApplyTo(0xFFFFFFFF) & 0xFFFFFFFF;
         }
-        rct_drawpixelinfo dpi;
+        DrawPixelInfo dpi;
         dpi.x = viewLoc.x;
         dpi.y = viewLoc.y;
         dpi.height = 1;

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -19,7 +19,7 @@
 struct PaintSession;
 struct RecordedPaintSession;
 struct PaintStruct;
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 struct TileElement;
 struct rct_window;
 struct EntityBase;
@@ -132,10 +132,10 @@ void ViewportUpdateSmartFollowGuest(rct_window* window, const Guest* peep);
 void ViewportUpdateSmartFollowStaff(rct_window* window, const Staff* peep);
 void ViewportUpdateSmartFollowVehicle(rct_window* window);
 void ViewportRender(
-    rct_drawpixelinfo* dpi, const rct_viewport* viewport, const ScreenRect& screenRect,
+    DrawPixelInfo* dpi, const rct_viewport* viewport, const ScreenRect& screenRect,
     std::vector<RecordedPaintSession>* sessions = nullptr);
 void ViewportPaint(
-    const rct_viewport* viewport, rct_drawpixelinfo* dpi, const ScreenRect& screenRect,
+    const rct_viewport* viewport, DrawPixelInfo* dpi, const ScreenRect& screenRect,
     std::vector<RecordedPaintSession>* sessions = nullptr);
 
 CoordsXYZ ViewportAdjustForMapHeight(const ScreenCoordsXY& startCoords);

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -162,7 +162,7 @@ constexpr Widget MakeDropdownButtonWidget(
 }
 
 void WidgetScrollUpdateThumbs(rct_window& w, WidgetIndex widget_index);
-void WidgetDraw(rct_drawpixelinfo* dpi, rct_window& w, WidgetIndex widgetIndex);
+void WidgetDraw(DrawPixelInfo* dpi, rct_window& w, WidgetIndex widgetIndex);
 
 bool WidgetIsDisabled(const rct_window& w, WidgetIndex widgetIndex);
 bool WidgetIsHoldable(const rct_window& w, WidgetIndex widgetIndex);

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -84,8 +84,8 @@ namespace WindowCloseFlags
     static constexpr uint32_t CloseSingle = (1 << 1);
 } // namespace WindowCloseFlags
 
-static void WindowDrawCore(rct_drawpixelinfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
-static void WindowDrawSingle(rct_drawpixelinfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+static void WindowDrawCore(DrawPixelInfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+static void WindowDrawSingle(DrawPixelInfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
 
 std::list<std::shared_ptr<rct_window>>::iterator WindowGetIterator(const rct_window* w)
 {
@@ -1130,7 +1130,7 @@ void MainWindowZoom(bool zoomIn, bool atCursor)
  * Splits a drawing of a window into regions that can be seen and are not hidden
  * by other opaque overlapping windows.
  */
-void WindowDraw(rct_drawpixelinfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
+void WindowDraw(DrawPixelInfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     if (!WindowIsVisible(w))
         return;
@@ -1185,7 +1185,7 @@ void WindowDraw(rct_drawpixelinfo* dpi, rct_window& w, int32_t left, int32_t top
 /**
  * Draws the given window and any other overlapping transparent windows.
  */
-static void WindowDrawCore(rct_drawpixelinfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
+static void WindowDrawCore(DrawPixelInfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     // Clamp region
     left = std::max<int32_t>(left, w.windowPos.x);
@@ -1208,10 +1208,10 @@ static void WindowDrawCore(rct_drawpixelinfo* dpi, rct_window& w, int32_t left, 
     }
 }
 
-static void WindowDrawSingle(rct_drawpixelinfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
+static void WindowDrawSingle(DrawPixelInfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     // Copy dpi so we can crop it
-    rct_drawpixelinfo copy = *dpi;
+    DrawPixelInfo copy = *dpi;
     dpi = &copy;
 
     // Clamp left to 0
@@ -1276,7 +1276,7 @@ static void WindowDrawSingle(rct_drawpixelinfo* dpi, rct_window& w, int32_t left
  * @param dpi (edi)
  * @param w (esi)
  */
-void WindowDrawViewport(rct_drawpixelinfo* dpi, rct_window& w)
+void WindowDrawViewport(DrawPixelInfo* dpi, rct_window& w)
 {
     ViewportRender(dpi, w.viewport, { { dpi->x, dpi->y }, { dpi->x + dpi->width, dpi->y + dpi->height } });
 }
@@ -1647,7 +1647,7 @@ void WindowEventInvalidateCall(rct_window* w)
         w->event_handlers->invalidate(w);
 }
 
-void WindowEventPaintCall(rct_window* w, rct_drawpixelinfo* dpi)
+void WindowEventPaintCall(rct_window* w, DrawPixelInfo* dpi)
 {
     if (w->event_handlers == nullptr)
         w->OnDraw(*dpi);
@@ -1655,7 +1655,7 @@ void WindowEventPaintCall(rct_window* w, rct_drawpixelinfo* dpi)
         w->event_handlers->paint(w, dpi);
 }
 
-void WindowEventScrollPaintCall(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex)
+void WindowEventScrollPaintCall(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex)
 {
     if (w->event_handlers == nullptr)
         w->OnScrollDraw(scrollIndex, *dpi);
@@ -2089,7 +2089,7 @@ bool WindowIsVisible(rct_window& w)
  * right (dx)
  * bottom (bp)
  */
-void WindowDrawAll(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom)
+void WindowDrawAll(DrawPixelInfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     auto windowDPI = dpi->Crop({ left, top }, { right - left, bottom - top });
     WindowVisitEach([&windowDPI, left, top, right, bottom](rct_window* w) {

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -25,7 +25,7 @@
 #include <utility>
 #include <variant>
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 struct rct_window;
 struct TrackDesignFileRef;
 struct TextInputSession;
@@ -246,8 +246,8 @@ struct WindowEventList
     void (*cursor)(struct rct_window*, WidgetIndex, const ScreenCoordsXY&, CursorID*){};
     void (*moved)(struct rct_window*, const ScreenCoordsXY&){};
     void (*invalidate)(struct rct_window*){};
-    void (*paint)(struct rct_window*, rct_drawpixelinfo*){};
-    void (*scroll_paint)(struct rct_window*, rct_drawpixelinfo*, int32_t){};
+    void (*paint)(struct rct_window*, DrawPixelInfo*){};
+    void (*scroll_paint)(struct rct_window*, DrawPixelInfo*, int32_t){};
 
     typedef void (*fnEventInitializer)(WindowEventList&);
     WindowEventList(fnEventInitializer fn)
@@ -660,10 +660,10 @@ void WindowZoomIn(rct_window& w, bool atCursor);
 void WindowZoomOut(rct_window& w, bool atCursor);
 void MainWindowZoom(bool zoomIn, bool atCursor);
 
-void WindowDrawAll(rct_drawpixelinfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
-void WindowDraw(rct_drawpixelinfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
-void WindowDrawWidgets(rct_window& w, rct_drawpixelinfo* dpi);
-void WindowDrawViewport(rct_drawpixelinfo* dpi, rct_window& w);
+void WindowDrawAll(DrawPixelInfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
+void WindowDraw(DrawPixelInfo* dpi, rct_window& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+void WindowDrawWidgets(rct_window& w, DrawPixelInfo* dpi);
+void WindowDrawViewport(DrawPixelInfo* dpi, rct_window& w);
 
 void WindowSetPosition(rct_window& w, const ScreenCoordsXY& screenCoords);
 void WindowMovePosition(rct_window& w, const ScreenCoordsXY& screenCoords);
@@ -711,8 +711,8 @@ OpenRCT2String WindowEventTooltipCall(rct_window* w, const WidgetIndex widgetInd
 CursorID WindowEventCursorCall(rct_window* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
 void WindowEventMovedCall(rct_window* w, const ScreenCoordsXY& screenCoords);
 void WindowEventInvalidateCall(rct_window* w);
-void WindowEventPaintCall(rct_window* w, rct_drawpixelinfo* dpi);
-void WindowEventScrollPaintCall(rct_window* w, rct_drawpixelinfo* dpi, int32_t scrollIndex);
+void WindowEventPaintCall(rct_window* w, DrawPixelInfo* dpi);
+void WindowEventScrollPaintCall(rct_window* w, DrawPixelInfo* dpi, int32_t scrollIndex);
 
 void InvalidateAllWindowsAfterInput();
 void TextinputCancel();

--- a/src/openrct2/interface/Window_internal.h
+++ b/src/openrct2/interface/Window_internal.h
@@ -131,10 +131,10 @@ struct rct_window
     virtual void OnPrepareDraw()
     {
     }
-    virtual void OnDraw(rct_drawpixelinfo& dpi)
+    virtual void OnDraw(DrawPixelInfo& dpi)
     {
     }
-    virtual void OnDrawWidget(WidgetIndex widgetIndex, rct_drawpixelinfo& dpi)
+    virtual void OnDrawWidget(WidgetIndex widgetIndex, DrawPixelInfo& dpi)
     {
     }
     virtual OpenRCT2String OnTooltip(WidgetIndex widgetIndex, StringId fallback)
@@ -169,7 +169,7 @@ struct rct_window
     virtual void OnScrollMouseDown(int32_t scrollIndex, const ScreenCoordsXY& screenCoords)
     {
     }
-    virtual void OnScrollDraw(int32_t scrollIndex, rct_drawpixelinfo& dpi)
+    virtual void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi)
     {
     }
     virtual void OnToolUpdate(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords)

--- a/src/openrct2/localisation/Currency.cpp
+++ b/src/openrct2/localisation/Currency.cpp
@@ -14,7 +14,7 @@
 #include "StringIds.h"
 
 // clang-format off
-currency_descriptor CurrencyDescriptors[EnumValue(CurrencyType::Count)] = {
+CurrencyDescriptor CurrencyDescriptors[EnumValue(CurrencyType::Count)] = {
     {   "GBP",  10,     CurrencyAffix::Prefix,    "\xC2\xA3",     CurrencyAffix::Suffix,    "GBP",  STR_POUNDS          },  // British Pound
     {   "USD",  10,     CurrencyAffix::Prefix,    "$",            CurrencyAffix::Prefix,    "$",    STR_DOLLARS         },  // US Dollar
     {   "FRF",  10,     CurrencyAffix::Suffix,    "F",            CurrencyAffix::Suffix,    "F",    STR_FRANC           },  // French Franc

--- a/src/openrct2/localisation/Currency.h
+++ b/src/openrct2/localisation/Currency.h
@@ -48,7 +48,7 @@ enum class CurrencyAffix
 #define CURRENCY_RATE_MAX_NUM_DIGITS 9
 
 // Currency format specification - inspired by OpenTTD
-struct currency_descriptor
+struct CurrencyDescriptor
 {
     char isoCode[4];
     // Rate is relative to 0.10 GBP
@@ -61,7 +61,7 @@ struct currency_descriptor
 };
 
 // List of currency formats
-extern currency_descriptor CurrencyDescriptors[static_cast<uint8_t>(CurrencyType::Count)];
+extern CurrencyDescriptor CurrencyDescriptors[static_cast<uint8_t>(CurrencyType::Count)];
 
 /**
  * Loads custom currency saved parameters into {@link CurrencyDescriptors}'

--- a/src/openrct2/localisation/Date.h
+++ b/src/openrct2/localisation/Date.h
@@ -36,7 +36,7 @@ enum
     DATE_FORMAT_YEAR_DAY_MONTH
 };
 
-struct openrct2_timeofday
+struct TimeOfDay
 {
     uint8_t second;
     uint8_t minute;
@@ -50,7 +50,7 @@ extern const StringId DateFormatStringFormatIds[];
 extern uint16_t gDateMonthTicks;
 extern int32_t gDateMonthsElapsed;
 
-extern openrct2_timeofday gRealTimeOfDay;
+extern TimeOfDay gRealTimeOfDay;
 
 int32_t DateGetMonth(int32_t months);
 int32_t DateGetYear(int32_t months);

--- a/src/openrct2/localisation/Formatting.cpp
+++ b/src/openrct2/localisation/Formatting.cpp
@@ -53,24 +53,24 @@ namespace OpenRCT2
         return std::nullopt;
     }
 
-    FmtString::token::token(FormatToken k, std::string_view s, uint32_t p)
+    FmtString::Token::Token(FormatToken k, std::string_view s, uint32_t p)
         : kind(k)
         , text(s)
         , parameter(p)
     {
     }
 
-    bool FmtString::token::IsLiteral() const
+    bool FmtString::Token::IsLiteral() const
     {
         return kind == FormatToken::Literal;
     }
 
-    bool FmtString::token::IsCodepoint() const
+    bool FmtString::Token::IsCodepoint() const
     {
         return kind == FormatToken::Escaped;
     }
 
-    codepoint_t FmtString::token::GetCodepoint() const
+    codepoint_t FmtString::Token::GetCodepoint() const
     {
         if (kind == FormatToken::Escaped)
         {
@@ -92,7 +92,7 @@ namespace OpenRCT2
         auto i = index;
         if (i >= str.size())
         {
-            current = token();
+            current = Token();
             return;
         }
 
@@ -129,7 +129,7 @@ namespace OpenRCT2
                     {
                         p = *p0;
                     }
-                    current = token(FormatToken::Move, str.substr(startIndex, i - startIndex), p);
+                    current = Token(FormatToken::Move, str.substr(startIndex, i - startIndex), p);
                     return;
                 }
 
@@ -147,7 +147,7 @@ namespace OpenRCT2
                         p |= (*p2) << 16;
                         p |= (*p3) << 24;
                     }
-                    current = token(FormatToken::InlineSprite, str.substr(startIndex, i - startIndex), p);
+                    current = Token(FormatToken::InlineSprite, str.substr(startIndex, i - startIndex), p);
                     return;
                 }
             }
@@ -172,32 +172,32 @@ namespace OpenRCT2
         return index != rhs.index;
     }
 
-    FmtString::token FmtString::iterator::CreateToken(size_t len)
+    FmtString::Token FmtString::iterator::CreateToken(size_t len)
     {
         std::string_view sztoken = str.substr(index, len);
 
         if (sztoken.size() >= 2 && ((sztoken[0] == '{' && sztoken[1] == '{') || (sztoken[0] == '}' && sztoken[1] == '}')))
         {
-            return token(FormatToken::Escaped, sztoken);
+            return Token(FormatToken::Escaped, sztoken);
         }
         if (sztoken.size() >= 2 && sztoken[0] == '{' && sztoken[1] != '{')
         {
             auto kind = FormatTokenFromString(sztoken.substr(1, len - 2));
-            return token(kind, sztoken);
+            return Token(kind, sztoken);
         }
         if (sztoken == "\n" || sztoken == "\r")
         {
-            return token(FormatToken::Newline, sztoken);
+            return Token(FormatToken::Newline, sztoken);
         }
-        return token(FormatToken::Literal, sztoken);
+        return Token(FormatToken::Literal, sztoken);
     }
 
-    const FmtString::token* FmtString::iterator::operator->() const
+    const FmtString::Token* FmtString::iterator::operator->() const
     {
         return &current;
     }
 
-    const FmtString::token& FmtString::iterator::operator*()
+    const FmtString::Token& FmtString::iterator::operator*()
     {
         return current;
     }

--- a/src/openrct2/localisation/Formatting.h
+++ b/src/openrct2/localisation/Formatting.h
@@ -154,14 +154,14 @@ namespace OpenRCT2
         std::string _strOwned;
 
     public:
-        struct token
+        struct Token
         {
             FormatToken kind{};
             std::string_view text;
             uint32_t parameter{};
 
-            token() = default;
-            token(FormatToken k, std::string_view s, uint32_t p = 0);
+            Token() = default;
+            Token(FormatToken k, std::string_view s, uint32_t p = 0);
             bool IsLiteral() const;
             bool IsCodepoint() const;
             codepoint_t GetCodepoint() const;
@@ -172,7 +172,7 @@ namespace OpenRCT2
         private:
             std::string_view str;
             size_t index;
-            token current;
+            Token current;
 
             void update();
 
@@ -180,9 +180,9 @@ namespace OpenRCT2
             iterator(std::string_view s, size_t i);
             bool operator==(iterator& rhs);
             bool operator!=(iterator& rhs);
-            token CreateToken(size_t len);
-            const token* operator->() const;
-            const token& operator*();
+            Token CreateToken(size_t len);
+            const Token* operator->() const;
+            const Token& operator*();
             iterator& operator++();
             iterator operator++(int);
             bool eol() const;

--- a/src/openrct2/localisation/Localisation.Date.cpp
+++ b/src/openrct2/localisation/Localisation.Date.cpp
@@ -38,7 +38,7 @@ const StringId DateFormatStringFormatIds[] = {
     STR_DATE_FORMAT_YDM,
 };
 
-openrct2_timeofday gRealTimeOfDay;
+TimeOfDay gRealTimeOfDay;
 
 int32_t DateGetMonth(int32_t months)
 {

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -425,7 +425,7 @@ void FormatReadableSpeed(char* buf, size_t bufSize, uint64_t sizeBytes)
 money64 StringToMoney(const char* string_to_monetise)
 {
     const char* decimal_char = LanguageGetString(STR_LOCALE_DECIMAL_POINT);
-    const currency_descriptor* currencyDesc = &CurrencyDescriptors[EnumValue(gConfigGeneral.CurrencyFormat)];
+    const CurrencyDescriptor* currencyDesc = &CurrencyDescriptors[EnumValue(gConfigGeneral.CurrencyFormat)];
     char processedString[128] = {};
 
     Guard::Assert(strlen(string_to_monetise) < sizeof(processedString));
@@ -519,7 +519,7 @@ void MoneyToString(money64 amount, char* buffer_to_put_value_to, size_t buffer_l
         return;
     }
 
-    const currency_descriptor& currencyDesc = CurrencyDescriptors[EnumValue(gConfigGeneral.CurrencyFormat)];
+    const CurrencyDescriptor& currencyDesc = CurrencyDescriptors[EnumValue(gConfigGeneral.CurrencyFormat)];
 
     const char* sign = amount >= 0 ? "" : "-";
     const uint64_t a = std::abs(amount) * currencyDesc.rate;

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -74,7 +74,7 @@ void BannerObject::Unload()
     _legacyType.image = 0;
 }
 
-void BannerObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void BannerObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 

--- a/src/openrct2/object/BannerObject.h
+++ b/src/openrct2/object/BannerObject.h
@@ -29,5 +29,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/EntranceObject.cpp
+++ b/src/openrct2/object/EntranceObject.cpp
@@ -42,7 +42,7 @@ void EntranceObject::Unload()
     _legacyType.image_id = 0;
 }
 
-void EntranceObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void EntranceObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 

--- a/src/openrct2/object/EntranceObject.h
+++ b/src/openrct2/object/EntranceObject.h
@@ -16,7 +16,7 @@
 class EntranceObject final : public Object
 {
 private:
-    rct_entrance_type _legacyType = {};
+    EntranceEntry _legacyType = {};
 
 public:
     void* GetLegacyData() override
@@ -29,7 +29,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 
     ImageIndex GetImage(uint8_t sequence, Direction direction) const;
     uint8_t GetScrollingMode() const;

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -80,7 +80,7 @@ void FootpathItemObject::Unload()
     _legacyType.image = 0;
 }
 
-void FootpathItemObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void FootpathItemObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
     GfxDrawSprite(dpi, ImageId(_legacyType.image), screenCoords - ScreenCoordsXY{ 22, 24 });

--- a/src/openrct2/object/FootpathItemObject.h
+++ b/src/openrct2/object/FootpathItemObject.h
@@ -28,5 +28,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/FootpathObject.cpp
+++ b/src/openrct2/object/FootpathObject.cpp
@@ -69,7 +69,7 @@ void FootpathObject::Unload()
     _legacyType.image = 0;
 }
 
-void FootpathObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void FootpathObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
     GfxDrawSprite(dpi, ImageId(_pathSurfaceDescriptor.PreviewImage), screenCoords - ScreenCoordsXY{ 49, 17 });

--- a/src/openrct2/object/FootpathObject.h
+++ b/src/openrct2/object/FootpathObject.h
@@ -15,7 +15,7 @@
 class FootpathObject final : public Object
 {
 private:
-    rct_footpath_entry _legacyType = {};
+    FootpathEntry _legacyType = {};
     PathSurfaceDescriptor _pathSurfaceDescriptor = {};
     PathSurfaceDescriptor _queueSurfaceDescriptor = {};
     PathRailingsDescriptor _pathRailingsDescriptor = {};
@@ -51,5 +51,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/FootpathRailingsObject.cpp
+++ b/src/openrct2/object/FootpathRailingsObject.cpp
@@ -47,7 +47,7 @@ void FootpathRailingsObject::Unload()
     RailingsImageId = 0;
 }
 
-void FootpathRailingsObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void FootpathRailingsObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto x = width / 2;
     auto y = height / 2;

--- a/src/openrct2/object/FootpathRailingsObject.h
+++ b/src/openrct2/object/FootpathRailingsObject.h
@@ -30,7 +30,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 
     const PathRailingsDescriptor& GetDescriptor() const
     {

--- a/src/openrct2/object/FootpathSurfaceObject.cpp
+++ b/src/openrct2/object/FootpathSurfaceObject.cpp
@@ -42,7 +42,7 @@ void FootpathSurfaceObject::Unload()
     BaseImageId = 0;
 }
 
-void FootpathSurfaceObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void FootpathSurfaceObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2 - 16, height / 2 };
     GfxDrawSprite(dpi, ImageId(BaseImageId + 3), screenCoords);

--- a/src/openrct2/object/FootpathSurfaceObject.h
+++ b/src/openrct2/object/FootpathSurfaceObject.h
@@ -26,7 +26,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -34,7 +34,7 @@ static thread_local std::map<u8string, std::unique_ptr<Object>> _objDataCache = 
 
 struct ImageTable::RequiredImage
 {
-    rct_g1_element g1{};
+    G1Element g1{};
     std::unique_ptr<RequiredImage> next_zoom;
 
     bool HasData() const
@@ -45,7 +45,7 @@ struct ImageTable::RequiredImage
     RequiredImage() = default;
     RequiredImage(const RequiredImage&) = delete;
 
-    RequiredImage(const rct_g1_element& orig)
+    RequiredImage(const G1Element& orig)
     {
         auto length = G1CalculateDataSize(&orig);
         g1 = orig;
@@ -54,7 +54,7 @@ struct ImageTable::RequiredImage
         g1.flags &= ~G1_FLAG_HAS_ZOOM_SPRITE;
     }
 
-    RequiredImage(uint32_t idx, std::function<const rct_g1_element*(uint32_t)> getter)
+    RequiredImage(uint32_t idx, std::function<const G1Element*(uint32_t)> getter)
     {
         auto orig = getter(idx);
         if (orig != nullptr)
@@ -100,7 +100,7 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
                 {
                     result.push_back(std::make_unique<RequiredImage>(
                         static_cast<uint32_t>(SPR_CSG_BEGIN + i),
-                        [](uint32_t idx) -> const rct_g1_element* { return GfxGetG1Element(idx); }));
+                        [](uint32_t idx) -> const G1Element* { return GfxGetG1Element(idx); }));
                 }
             }
             else
@@ -123,7 +123,7 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::ParseImages(
             for (auto i : range)
             {
                 result.push_back(std::make_unique<RequiredImage>(
-                    static_cast<uint32_t>(i), [](uint32_t idx) -> const rct_g1_element* { return GfxGetG1Element(idx); }));
+                    static_cast<uint32_t>(i), [](uint32_t idx) -> const G1Element* { return GfxGetG1Element(idx); }));
             }
         }
     }
@@ -242,7 +242,7 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::LoadImageArc
 {
     std::vector<std::unique_ptr<RequiredImage>> result;
     auto gxRaw = context->GetData(path);
-    std::optional<rct_gx> gxData = GfxLoadGx(gxRaw);
+    std::optional<Gx> gxData = GfxLoadGx(gxRaw);
     if (gxData.has_value())
     {
         // Fix entry data offsets
@@ -282,7 +282,7 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::LoadImageArc
     }
     else
     {
-        auto msg = String::StdFormat("Unable to load rct_gx '%s'", path.c_str());
+        auto msg = String::StdFormat("Unable to load Gx '%s'", path.c_str());
         context->LogWarning(ObjectError::BadImageTable, msg.c_str());
         for (size_t i = 0; i < range.size(); i++)
         {
@@ -323,7 +323,7 @@ std::vector<std::unique_ptr<ImageTable::RequiredImage>> ImageTable::LoadObjectIm
             if (i >= 0 && i < numImages)
             {
                 result.push_back(std::make_unique<RequiredImage>(
-                    static_cast<uint32_t>(i), [images](uint32_t idx) -> const rct_g1_element* { return &images[idx]; }));
+                    static_cast<uint32_t>(i), [images](uint32_t idx) -> const G1Element* { return &images[idx]; }));
             }
             else
             {
@@ -467,10 +467,10 @@ void ImageTable::Read(IReadObjectContext* context, OpenRCT2::IStream* stream)
 
         // Read g1 element headers
         uintptr_t imageDataBase = reinterpret_cast<uintptr_t>(data.get());
-        std::vector<rct_g1_element> newEntries;
+        std::vector<G1Element> newEntries;
         for (uint32_t i = 0; i < numImages; i++)
         {
-            rct_g1_element g1Element{};
+            G1Element g1Element{};
 
             uintptr_t imageDataOffset = static_cast<uintptr_t>(stream->ReadValue<uint32_t>());
             g1Element.offset = reinterpret_cast<uint8_t*>(imageDataBase + imageDataOffset);
@@ -586,7 +586,7 @@ bool ImageTable::ReadJson(IReadObjectContext* context, json_t& root)
                 img = img->next_zoom.get();
 
                 // Set old image zoom offset to zoom image which we are about to add
-                auto g1a = const_cast<rct_g1_element*>(&GetImages()[tableIndex]);
+                auto g1a = const_cast<G1Element*>(&GetImages()[tableIndex]);
                 g1a->zoomed_offset = static_cast<int32_t>(tableIndex) - static_cast<int32_t>(GetCount());
 
                 while (img != nullptr)
@@ -608,9 +608,9 @@ bool ImageTable::ReadJson(IReadObjectContext* context, json_t& root)
     return usesFallbackSprites;
 }
 
-void ImageTable::AddImage(const rct_g1_element* g1)
+void ImageTable::AddImage(const G1Element* g1)
 {
-    rct_g1_element newg1 = *g1;
+    G1Element newg1 = *g1;
     auto length = G1CalculateDataSize(g1);
     if (length == 0)
     {

--- a/src/openrct2/object/ImageTable.h
+++ b/src/openrct2/object/ImageTable.h
@@ -27,7 +27,7 @@ class ImageTable
 {
 private:
     std::unique_ptr<uint8_t[]> _data;
-    std::vector<rct_g1_element> _entries;
+    std::vector<G1Element> _entries;
 
     /**
      * Container for a G1 image, additional information and RAII. Used by ReadJson
@@ -59,7 +59,7 @@ public:
      * @note root is deliberately left non-const: json_t behaviour changes when const
      */
     bool ReadJson(IReadObjectContext* context, json_t& root);
-    const rct_g1_element* GetImages() const
+    const G1Element* GetImages() const
     {
         return _entries.data();
     }
@@ -67,5 +67,5 @@ public:
     {
         return static_cast<uint32_t>(_entries.size());
     }
-    void AddImage(const rct_g1_element* g1);
+    void AddImage(const G1Element* g1);
 };

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -138,7 +138,7 @@ void LargeSceneryObject::Unload()
     _baseImageId = _legacyType.image = 0;
 }
 
-void LargeSceneryObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void LargeSceneryObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, (height / 2) - 39 };
 

--- a/src/openrct2/object/LargeSceneryObject.h
+++ b/src/openrct2/object/LargeSceneryObject.h
@@ -34,7 +34,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
     const rct_large_scenery_tile* GetTileForSequence(uint8_t SequenceIndex) const;
 
 private:

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -83,7 +83,7 @@ void MusicObject::Unload()
     NameStringId = 0;
 }
 
-void MusicObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void MusicObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     // Write (no image)
     int32_t x = width / 2;

--- a/src/openrct2/object/MusicObject.h
+++ b/src/openrct2/object/MusicObject.h
@@ -59,7 +59,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 
     std::optional<uint8_t> GetOriginalStyleId() const;
     bool SupportsRideType(ride_type_t rideType);

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -217,7 +217,7 @@ namespace OpenRCT2
     struct IStream;
 }
 struct ObjectRepositoryItem;
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 
 enum class ObjectError : uint32_t
 {
@@ -353,7 +353,7 @@ public:
     virtual void Load() abstract;
     virtual void Unload() abstract;
 
-    virtual void DrawPreview(rct_drawpixelinfo* /*dpi*/, int32_t /*width*/, int32_t /*height*/) const
+    virtual void DrawPreview(DrawPixelInfo* /*dpi*/, int32_t /*width*/, int32_t /*height*/) const
     {
     }
 

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -32,7 +32,7 @@ namespace OpenRCT2::Localisation
     class LocalisationService;
 }
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 
 struct ObjectRepositoryItem
 {

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -283,7 +283,7 @@ void RideObject::Unload()
     _legacyType.images_offset = 0;
 }
 
-void RideObject::DrawPreview(rct_drawpixelinfo* dpi, [[maybe_unused]] int32_t width, [[maybe_unused]] int32_t height) const
+void RideObject::DrawPreview(DrawPixelInfo* dpi, [[maybe_unused]] int32_t width, [[maybe_unused]] int32_t height) const
 {
     uint32_t imageId = _legacyType.images_offset;
 

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -36,7 +36,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 
     std::string GetDescription() const;
     std::string GetCapacity() const;

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -70,7 +70,7 @@ void SceneryGroupObject::Unload()
     _legacyType.image = 0;
 }
 
-void SceneryGroupObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void SceneryGroupObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -36,7 +36,7 @@ public:
     void Unload() override;
     void UpdateEntryIndexes();
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -96,7 +96,7 @@ void SmallSceneryObject::Unload()
     _legacyType.image = 0;
 }
 
-void SmallSceneryObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void SmallSceneryObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto imageId = ImageId(_legacyType.image);
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_PRIMARY_COLOUR))

--- a/src/openrct2/object/SmallSceneryObject.h
+++ b/src/openrct2/object/SmallSceneryObject.h
@@ -31,7 +31,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 
 private:
     static std::vector<uint8_t> ReadFrameOffsets(OpenRCT2::IStream* stream);

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -45,7 +45,7 @@ void StationObject::Unload()
     ShelterImageId = ImageIndexUndefined;
 }
 
-void StationObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void StationObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, (height / 2) + 16 };
 

--- a/src/openrct2/object/StationObject.h
+++ b/src/openrct2/object/StationObject.h
@@ -35,5 +35,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/TerrainEdgeObject.cpp
+++ b/src/openrct2/object/TerrainEdgeObject.cpp
@@ -38,7 +38,7 @@ void TerrainEdgeObject::Unload()
     BaseImageId = 0;
 }
 
-void TerrainEdgeObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void TerrainEdgeObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 

--- a/src/openrct2/object/TerrainEdgeObject.h
+++ b/src/openrct2/object/TerrainEdgeObject.h
@@ -24,7 +24,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 
     static TerrainEdgeObject* GetById(ObjectEntryIndex entryIndex);
 };

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -50,7 +50,7 @@ void TerrainSurfaceObject::Unload()
     NumEntries = 0;
 }
 
-void TerrainSurfaceObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void TerrainSurfaceObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto imageId = ImageId(GetImageId({}, 1, 0, 0, false, false));
     if (Colour != 255)

--- a/src/openrct2/object/TerrainSurfaceObject.h
+++ b/src/openrct2/object/TerrainSurfaceObject.h
@@ -59,7 +59,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 
     uint32_t GetImageId(
         const CoordsXY& position, int32_t length, int32_t rotation, int32_t offset, bool grid, bool underground) const;

--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -68,7 +68,7 @@ void WallObject::Unload()
     _legacyType.image = 0;
 }
 
-void WallObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void WallObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 

--- a/src/openrct2/object/WallObject.h
+++ b/src/openrct2/object/WallObject.h
@@ -28,5 +28,5 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 };

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -54,7 +54,7 @@ void WaterObject::Unload()
     _legacyType.image_id = 0;
 }
 
-void WaterObject::DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const
+void WaterObject::DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const
 {
     // Write (no image)
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
@@ -119,7 +119,7 @@ void WaterObject::ReadJsonPalette(json_t& jPalette)
         dataIndex += 3;
     }
 
-    rct_g1_element g1 = {};
+    G1Element g1 = {};
     g1.offset = data.get();
     g1.width = static_cast<int16_t>(numColours);
     g1.x_offset = Json::GetNumber<int16_t>(jPalette["index"]);

--- a/src/openrct2/object/WaterObject.h
+++ b/src/openrct2/object/WaterObject.h
@@ -30,7 +30,7 @@ public:
     void Load() override;
     void Unload() override;
 
-    void DrawPreview(rct_drawpixelinfo* dpi, int32_t width, int32_t height) const override;
+    void DrawPreview(DrawPixelInfo* dpi, int32_t width, int32_t height) const override;
 
 private:
     void ReadJsonPalette(json_t& jPalette);

--- a/src/openrct2/paint/Paint.Entity.cpp
+++ b/src/openrct2/paint/Paint.Entity.cpp
@@ -47,7 +47,7 @@ void EntityPaintSetup(PaintSession& session, const CoordsXY& pos)
         return;
     }
 
-    rct_drawpixelinfo* dpi = &session.DPI;
+    DrawPixelInfo* dpi = &session.DPI;
     if (dpi->zoom_level > ZoomLevel{ 2 })
     {
         return;

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -56,8 +56,8 @@ bool gShowDirtyVisuals;
 bool gPaintBoundingBoxes;
 bool gPaintBlockedTiles;
 
-static void PaintAttachedPS(rct_drawpixelinfo* dpi, PaintStruct* ps, uint32_t viewFlags);
-static void PaintPSImageWithBoundingBoxes(rct_drawpixelinfo* dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y);
+static void PaintAttachedPS(DrawPixelInfo* dpi, PaintStruct* ps, uint32_t viewFlags);
+static void PaintPSImageWithBoundingBoxes(DrawPixelInfo* dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y);
 static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uint32_t viewFlags);
 
 static int32_t RemapPositionToQuadrant(const PaintStruct& ps, uint8_t rotation)
@@ -101,7 +101,7 @@ static void PaintSessionAddPSToQuadrant(PaintSession& session, PaintStruct* ps)
     session.QuadrantFrontIndex = std::max(session.QuadrantFrontIndex, paintQuadrantIndex);
 }
 
-static constexpr bool ImageWithinDPI(const ScreenCoordsXY& imagePos, const rct_g1_element& g1, const rct_drawpixelinfo& dpi)
+static constexpr bool ImageWithinDPI(const ScreenCoordsXY& imagePos, const G1Element& g1, const DrawPixelInfo& dpi)
 {
     int32_t left = imagePos.x + g1.x_offset;
     int32_t bottom = imagePos.y + g1.y_offset;
@@ -484,7 +484,7 @@ void PaintSessionArrange(PaintSessionCore& session)
 
 static void PaintDrawStruct(PaintSession& session, PaintStruct* ps)
 {
-    rct_drawpixelinfo* dpi = &session.DPI;
+    DrawPixelInfo* dpi = &session.DPI;
 
     auto x = ps->x;
     auto y = ps->y;
@@ -546,7 +546,7 @@ void PaintDrawStructs(PaintSession& session)
  *  rct2: 0x00688596
  *  Part of 0x688485
  */
-static void PaintAttachedPS(rct_drawpixelinfo* dpi, PaintStruct* ps, uint32_t viewFlags)
+static void PaintAttachedPS(DrawPixelInfo* dpi, PaintStruct* ps, uint32_t viewFlags)
 {
     AttachedPaintStruct* attached_ps = ps->attached_ps;
     for (; attached_ps != nullptr; attached_ps = attached_ps->next)
@@ -565,7 +565,7 @@ static void PaintAttachedPS(rct_drawpixelinfo* dpi, PaintStruct* ps, uint32_t vi
     }
 }
 
-static void PaintPSImageWithBoundingBoxes(rct_drawpixelinfo* dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y)
+static void PaintPSImageWithBoundingBoxes(DrawPixelInfo* dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y)
 {
     const uint8_t colour = BoundBoxDebugColours[EnumValue(ps->sprite_type)];
     const uint8_t rotation = GetCurrentRotation();
@@ -665,7 +665,7 @@ static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uin
     }
 }
 
-PaintSession* PaintSessionAlloc(rct_drawpixelinfo* dpi, uint32_t viewFlags)
+PaintSession* PaintSessionAlloc(DrawPixelInfo* dpi, uint32_t viewFlags)
 {
     return GetContext()->GetPainter()->CreateSession(dpi, viewFlags);
 }
@@ -903,7 +903,7 @@ void PaintFloatingMoneyEffect(
  *
  *  rct2: 0x006860C3
  */
-void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, PaintStringStruct* ps)
+void PaintDrawMoneyStructs(DrawPixelInfo* dpi, PaintStringStruct* ps)
 {
     do
     {

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -214,7 +214,7 @@ struct PaintSessionCore
 
 struct PaintSession : public PaintSessionCore
 {
-    rct_drawpixelinfo DPI;
+    DrawPixelInfo DPI;
     PaintEntryPool::Chain PaintEntryChain;
 
     PaintStruct* AllocateNormalPaintEntry() noexcept
@@ -325,9 +325,9 @@ void PaintFloatingMoneyEffect(
     PaintSession& session, money64 amount, StringId string_id, int32_t y, int32_t z, int8_t y_offsets[], int32_t offset_x,
     uint32_t rotation);
 
-PaintSession* PaintSessionAlloc(rct_drawpixelinfo* dpi, uint32_t viewFlags);
+PaintSession* PaintSessionAlloc(DrawPixelInfo* dpi, uint32_t viewFlags);
 void PaintSessionFree(PaintSession* session);
 void PaintSessionGenerate(PaintSession& session);
 void PaintSessionArrange(PaintSessionCore& session);
 void PaintDrawStructs(PaintSession& session);
-void PaintDrawMoneyStructs(rct_drawpixelinfo* dpi, PaintStringStruct* ps);
+void PaintDrawMoneyStructs(DrawPixelInfo* dpi, PaintStringStruct* ps);

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -83,7 +83,7 @@ void Painter::Paint(IDrawingEngine& de)
     gCurrentDrawCount++;
 }
 
-void Painter::PaintReplayNotice(rct_drawpixelinfo* dpi, const char* text)
+void Painter::PaintReplayNotice(DrawPixelInfo* dpi, const char* text)
 {
     ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, _uiContext->GetHeight() - 44);
 
@@ -100,7 +100,7 @@ void Painter::PaintReplayNotice(rct_drawpixelinfo* dpi, const char* text)
     GfxSetDirtyBlocks({ screenCoords, screenCoords + ScreenCoordsXY{ stringWidth, 16 } });
 }
 
-void Painter::PaintFPS(rct_drawpixelinfo* dpi)
+void Painter::PaintFPS(DrawPixelInfo* dpi)
 {
     ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, 2);
 
@@ -131,7 +131,7 @@ void Painter::MeasureFPS()
     _lastSecond = currentTime;
 }
 
-PaintSession* Painter::CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags)
+PaintSession* Painter::CreateSession(DrawPixelInfo* dpi, uint32_t viewFlags)
 {
     PROFILED_FUNCTION();
 

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -16,7 +16,7 @@
 #include <memory>
 #include <vector>
 
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 
 namespace OpenRCT2
 {
@@ -47,13 +47,13 @@ namespace OpenRCT2
             explicit Painter(const std::shared_ptr<Ui::IUiContext>& uiContext);
             void Paint(Drawing::IDrawingEngine& de);
 
-            PaintSession* CreateSession(rct_drawpixelinfo* dpi, uint32_t viewFlags);
+            PaintSession* CreateSession(DrawPixelInfo* dpi, uint32_t viewFlags);
             void ReleaseSession(PaintSession* session);
             ~Painter();
 
         private:
-            void PaintReplayNotice(rct_drawpixelinfo* dpi, const char* text);
-            void PaintFPS(rct_drawpixelinfo* dpi);
+            void PaintReplayNotice(DrawPixelInfo* dpi, const char* text);
+            void PaintFPS(DrawPixelInfo* dpi);
             void MeasureFPS();
         };
     } // namespace Paint

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -273,7 +273,7 @@ static void PathBitBenchesPaint(
 
 /* rct2: 0x006A6008 */
 static void PathBitJumpingFountainsPaint(
-    PaintSession& session, const PathBitEntry& pathBitEntry, int32_t height, ImageId imageTemplate, rct_drawpixelinfo* dpi)
+    PaintSession& session, const PathBitEntry& pathBitEntry, int32_t height, ImageId imageTemplate, DrawPixelInfo* dpi)
 {
     if (dpi->zoom_level > ZoomLevel{ 0 })
         return;
@@ -727,7 +727,7 @@ static void Sub6A3F61(
     // Probably drawing benches etc.
     PROFILED_FUNCTION();
 
-    rct_drawpixelinfo* dpi = &session.DPI;
+    DrawPixelInfo* dpi = &session.DPI;
 
     if (dpi->zoom_level <= ZoomLevel{ 1 })
     {

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1019,7 +1019,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
 {
     PROFILED_FUNCTION();
 
-    rct_drawpixelinfo* dpi = &session.DPI;
+    DrawPixelInfo* dpi = &session.DPI;
     session.InteractionType = ViewportInteractionItem::Terrain;
     session.Flags |= PaintSessionFlags::PassedSurface;
     session.SurfaceElement = reinterpret_cast<const TileElement*>(&tileElement);

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -94,7 +94,7 @@ static void BlankTilesPaint(PaintSession& session, int32_t x, int32_t y)
     dx -= 16;
     int32_t bx = dx + 32;
 
-    rct_drawpixelinfo* dpi = &session.DPI;
+    DrawPixelInfo* dpi = &session.DPI;
     if (bx <= dpi->y)
         return;
     dx -= 20;
@@ -119,7 +119,7 @@ static void PaintTileElementBase(PaintSession& session, const CoordsXY& origCoor
     PROFILED_FUNCTION();
 
     CoordsXY coords = origCoords;
-    rct_drawpixelinfo* dpi = &session.DPI;
+    DrawPixelInfo* dpi = &session.DPI;
 
     if ((session.ViewFlags & VIEWPORT_FLAG_CLIP_VIEW))
     {

--- a/src/openrct2/ride/CarEntry.cpp
+++ b/src/openrct2/ride/CarEntry.cpp
@@ -48,7 +48,7 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
 {
     uint8_t bitmap[200][200] = { 0 };
 
-    rct_drawpixelinfo dpi = {
+    DrawPixelInfo dpi = {
         /*.bits = */ reinterpret_cast<uint8_t*>(bitmap),
         /*.x = */ -100,
         /*.y = */ -100,

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -2154,7 +2154,7 @@ void TrackDesignDrawPreview(TrackDesign* td6, uint8_t* pixels)
     view.zoom = zoom_level;
     view.flags = VIEWPORT_FLAG_HIDE_BASE | VIEWPORT_FLAG_HIDE_ENTITIES;
 
-    rct_drawpixelinfo dpi;
+    DrawPixelInfo dpi;
     dpi.zoom_level = zoom_level;
     dpi.x = 0;
     dpi.y = 0;

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -1190,7 +1190,7 @@ void VehicleVisualMiniGolfPlayer(
         return;
     }
 
-    rct_drawpixelinfo* edi = &session.DPI;
+    DrawPixelInfo* edi = &session.DPI;
     if (edi->zoom_level >= ZoomLevel{ 2 })
     {
         return;
@@ -1227,7 +1227,7 @@ void VehicleVisualMiniGolfBall(
         return;
     }
 
-    rct_drawpixelinfo* edi = &session.DPI;
+    DrawPixelInfo* edi = &session.DPI;
     if (edi->zoom_level >= ZoomLevel{ 1 })
     {
         return;

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -134,7 +134,7 @@ static void SpiralSlidePaintTileFront(
         PaintAddImageAsParent(session, imageId, { 16, 16, height }, { 8, 16, 108 }, { 8, 0, height + 3 });
     }
 
-    rct_drawpixelinfo* dpi = &session.DPI;
+    DrawPixelInfo* dpi = &session.DPI;
     if (dpi->zoom_level <= ZoomLevel{ 0 } && ride.slide_in_use != 0)
     {
         uint8_t slide_progress = ride.spiral_slide_progress;

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -434,7 +434,7 @@ bool TitleIsPreviewingSequence()
     return false;
 }
 
-void DrawOpenRCT2(rct_drawpixelinfo* dpi, const ScreenCoordsXY& screenCoords)
+void DrawOpenRCT2(DrawPixelInfo* dpi, const ScreenCoordsXY& screenCoords)
 {
     thread_local std::string buffer;
     buffer.clear();

--- a/src/openrct2/title/TitleScreen.h
+++ b/src/openrct2/title/TitleScreen.h
@@ -65,4 +65,4 @@ size_t TitleGetCurrentSequence();
 bool TitlePreviewSequence(size_t value);
 void TitleStopPreviewingSequence();
 bool TitleIsPreviewingSequence();
-void DrawOpenRCT2(rct_drawpixelinfo* dpi, const ScreenCoordsXY& screenCoords);
+void DrawOpenRCT2(DrawPixelInfo* dpi, const ScreenCoordsXY& screenCoords);

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -31,7 +31,7 @@ namespace OpenRCT2::Ui
         void Tick() override
         {
         }
-        void Draw(rct_drawpixelinfo* /*dpi*/) override
+        void Draw(DrawPixelInfo* /*dpi*/) override
         {
         }
 
@@ -173,7 +173,7 @@ namespace OpenRCT2::Ui
         {
             return std::make_shared<X8DrawingEngineFactory>();
         }
-        void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, rct_drawpixelinfo* dpi, DrawWeatherFunc drawFunc) override
+        void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, DrawPixelInfo* dpi, DrawWeatherFunc drawFunc) override
         {
         }
 

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 struct ScreenCoordsXY;
-struct rct_drawpixelinfo;
+struct DrawPixelInfo;
 struct ITitleSequencePlayer;
 
 namespace OpenRCT2
@@ -29,7 +29,7 @@ namespace OpenRCT2
         struct IDrawingEngineFactory;
         struct IWeatherDrawer;
         using DrawWeatherFunc = void (*)(
-            rct_drawpixelinfo* dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width,
+            DrawPixelInfo* dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width,
             int32_t height);
     } // namespace Drawing
 
@@ -101,7 +101,7 @@ namespace OpenRCT2
 
             virtual void Initialise() abstract;
             virtual void Tick() abstract;
-            virtual void Draw(rct_drawpixelinfo* dpi) abstract;
+            virtual void Draw(DrawPixelInfo* dpi) abstract;
 
             // Window
             virtual void CreateWindow() abstract;
@@ -149,7 +149,7 @@ namespace OpenRCT2
             // Drawing
             [[nodiscard]] virtual std::shared_ptr<Drawing::IDrawingEngineFactory> GetDrawingEngineFactory() abstract;
             virtual void DrawWeatherAnimation(
-                OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, rct_drawpixelinfo* dpi,
+                OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, DrawPixelInfo* dpi,
                 OpenRCT2::Drawing::DrawWeatherFunc drawFunc) abstract;
 
             // Text input

--- a/src/openrct2/world/Entrance.h
+++ b/src/openrct2/world/Entrance.h
@@ -17,14 +17,14 @@
 #include <vector>
 
 #pragma pack(push, 1)
-struct rct_entrance_type
+struct EntranceEntry
 {
     StringId string_idx;    // 0x00
     uint32_t image_id;      // 0x02
     uint8_t scrolling_mode; // 0x06
     uint8_t text_height;    // 0x07
 };
-assert_struct_size(rct_entrance_type, 8);
+assert_struct_size(EntranceEntry, 8);
 #pragma pack(pop)
 
 struct TileElement;

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -560,7 +560,7 @@ static void FootpathConnectCorners(const CoordsXY& footpathPos, PathElement* ini
     }
 }
 
-struct rct_neighbour
+struct FootpathNeighbour
 {
     uint8_t order;
     uint8_t direction;
@@ -568,23 +568,23 @@ struct rct_neighbour
     StationIndex entrance_index;
 };
 
-struct rct_neighbour_list
+struct FootpathNeighbourList
 {
-    rct_neighbour items[8];
+    FootpathNeighbour items[8];
     size_t count;
 };
 
 static int32_t FootpathNeighbourCompare(const void* a, const void* b)
 {
-    uint8_t va = (static_cast<const rct_neighbour*>(a))->order;
-    uint8_t vb = (static_cast<const rct_neighbour*>(b))->order;
+    uint8_t va = (static_cast<const FootpathNeighbour*>(a))->order;
+    uint8_t vb = (static_cast<const FootpathNeighbour*>(b))->order;
     if (va < vb)
         return 1;
     if (va > vb)
         return -1;
 
-    uint8_t da = (static_cast<const rct_neighbour*>(a))->direction;
-    uint8_t db = (static_cast<const rct_neighbour*>(b))->direction;
+    uint8_t da = (static_cast<const FootpathNeighbour*>(a))->direction;
+    uint8_t db = (static_cast<const FootpathNeighbour*>(b))->direction;
     if (da < db)
         return -1;
     if (da > db)
@@ -592,13 +592,13 @@ static int32_t FootpathNeighbourCompare(const void* a, const void* b)
     return 0;
 }
 
-static void FootpathNeighbourListInit(rct_neighbour_list* neighbourList)
+static void FootpathNeighbourListInit(FootpathNeighbourList* neighbourList)
 {
     neighbourList->count = 0;
 }
 
 static void FootpathNeighbourListPush(
-    rct_neighbour_list* neighbourList, int32_t order, int32_t direction, RideId rideIndex, ::StationIndex entrance_index)
+    FootpathNeighbourList* neighbourList, int32_t order, int32_t direction, RideId rideIndex, ::StationIndex entrance_index)
 {
     Guard::Assert(neighbourList->count < std::size(neighbourList->items));
     neighbourList->items[neighbourList->count].order = order;
@@ -608,7 +608,7 @@ static void FootpathNeighbourListPush(
     neighbourList->count++;
 }
 
-static bool FootpathNeighbourListPop(rct_neighbour_list* neighbourList, rct_neighbour* outNeighbour)
+static bool FootpathNeighbourListPop(FootpathNeighbourList* neighbourList, FootpathNeighbour* outNeighbour)
 {
     if (neighbourList->count == 0)
         return false;
@@ -620,20 +620,20 @@ static bool FootpathNeighbourListPop(rct_neighbour_list* neighbourList, rct_neig
     return true;
 }
 
-static void FootpathNeighbourListRemove(rct_neighbour_list* neighbourList, size_t index)
+static void FootpathNeighbourListRemove(FootpathNeighbourList* neighbourList, size_t index)
 {
     Guard::ArgumentInRange<size_t>(index, 0, neighbourList->count - 1);
     int32_t itemsRemaining = static_cast<int32_t>(neighbourList->count - index) - 1;
     if (itemsRemaining > 0)
     {
-        memmove(&neighbourList->items[index], &neighbourList->items[index + 1], sizeof(rct_neighbour) * itemsRemaining);
+        memmove(&neighbourList->items[index], &neighbourList->items[index + 1], sizeof(FootpathNeighbour) * itemsRemaining);
     }
     neighbourList->count--;
 }
 
-static void FoopathNeighbourListSort(rct_neighbour_list* neighbourList)
+static void FoopathNeighbourListSort(FootpathNeighbourList* neighbourList)
 {
-    qsort(neighbourList->items, neighbourList->count, sizeof(rct_neighbour), FootpathNeighbourCompare);
+    qsort(neighbourList->items, neighbourList->count, sizeof(FootpathNeighbour), FootpathNeighbourCompare);
 }
 
 static TileElement* FootpathGetElement(const CoordsXYRangedZ& footpathPos, int32_t direction)
@@ -766,7 +766,7 @@ static void Loc6A6FD2(const CoordsXYZ& initialTileElementPos, int32_t direction,
 
 static void Loc6A6F1F(
     const CoordsXYZ& initialTileElementPos, int32_t direction, TileElement* tileElement, TileElement* initialTileElement,
-    const CoordsXY& targetPos, int32_t flags, bool query, rct_neighbour_list* neighbourList)
+    const CoordsXY& targetPos, int32_t flags, bool query, FootpathNeighbourList* neighbourList)
 {
     if (query)
     {
@@ -819,7 +819,7 @@ static void Loc6A6F1F(
 
 static void Loc6A6D7E(
     const CoordsXYZ& initialTileElementPos, int32_t direction, TileElement* initialTileElement, int32_t flags, bool query,
-    rct_neighbour_list* neighbourList)
+    FootpathNeighbourList* neighbourList)
 {
     auto targetPos = CoordsXY{ initialTileElementPos } + CoordsDirectionDelta[direction];
     if (((gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) || gCheatsSandboxMode) && MapIsEdge(targetPos))
@@ -933,7 +933,7 @@ static void Loc6A6D7E(
 // TODO: Change this into a simple check that validates if the direction should be fully checked with Loc6A6D7E and move the
 // calling of Loc6A6D7E into the parent function.
 static void Loc6A6C85(
-    const CoordsXYE& tileElementPos, int32_t direction, int32_t flags, bool query, rct_neighbour_list* neighbourList)
+    const CoordsXYE& tileElementPos, int32_t direction, int32_t flags, bool query, FootpathNeighbourList* neighbourList)
 {
     if (query
         && WallInTheWay(
@@ -1001,8 +1001,8 @@ static void Loc6A6C85(
  */
 void FootpathConnectEdges(const CoordsXY& footpathPos, TileElement* tileElement, int32_t flags)
 {
-    rct_neighbour_list neighbourList;
-    rct_neighbour neighbour;
+    FootpathNeighbourList neighbourList;
+    FootpathNeighbour neighbour;
 
     FootpathUpdateQueueChains();
 
@@ -2388,7 +2388,7 @@ static bool FootpathIsLegacyPathEntryOkay(ObjectEntryIndex index)
     auto footpathObj = static_cast<FootpathObject*>(objManager.GetLoadedObject(ObjectType::Paths, index));
     if (footpathObj != nullptr)
     {
-        auto pathEntry = reinterpret_cast<rct_footpath_entry*>(footpathObj->GetLegacyData());
+        auto pathEntry = reinterpret_cast<FootpathEntry*>(footpathObj->GetLegacyData());
         return showEditorPaths || !(pathEntry->flags & FOOTPATH_ENTRY_FLAG_SHOW_ONLY_IN_SCENARIO_EDITOR);
     }
     return false;

--- a/src/openrct2/world/Footpath.h
+++ b/src/openrct2/world/Footpath.h
@@ -45,7 +45,7 @@ enum
 };
 
 #pragma pack(push, 1)
-struct rct_footpath_entry
+struct FootpathEntry
 {
     StringId string_idx;                  // 0x00
     uint32_t image;                       // 0x02
@@ -77,7 +77,7 @@ struct rct_footpath_entry
         return image + 73;
     }
 };
-assert_struct_size(rct_footpath_entry, 13);
+assert_struct_size(FootpathEntry, 13);
 #pragma pack(pop)
 
 struct PathSurfaceDescriptor

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -24,7 +24,7 @@ struct SmallSceneryEntry;
 struct WallSceneryEntry;
 struct PathBitEntry;
 struct BannerSceneryEntry;
-struct rct_footpath_entry;
+struct FootpathEntry;
 class LargeSceneryObject;
 class TerrainSurfaceObject;
 class TerrainEdgeObject;


### PR DESCRIPTION
This renames a couple of the heavy hitter classes draw_pixel_info and g1_element. Dpi has always been a bit of a rubbish name for the class so perhaps we could rename it right now.