### PR TITLE
Rename entity-related stuff in RCT12.h

### DIFF
--- a/src/openrct2/rct1/RCT1.h
+++ b/src/openrct2/rct1/RCT1.h
@@ -284,7 +284,7 @@ namespace RCT1
     };
     assert_struct_size(Ride, 0x260);
 
-    struct UnkEntity : RCT12SpriteBase
+    struct UnkEntity : RCT12EntityBase
     {
         uint8_t Pad1F[3];      // 0x1f
         StringId NameStringID; // 0x22
@@ -296,7 +296,7 @@ namespace RCT1
         uint8_t Var71;
     };
 
-    struct Vehicle : RCT12SpriteBase
+    struct Vehicle : RCT12EntityBase
     {
         uint8_t Pitch;        // 0x1F
         uint8_t BankRotation; // 0x20
@@ -435,7 +435,7 @@ namespace RCT1
         ToffeeApple = 30
     };
 
-    struct Peep : RCT12SpriteBase
+    struct Peep : RCT12EntityBase
     {
         uint8_t Pad1F[3];
         StringId NameStringID;     // 0x22
@@ -587,14 +587,14 @@ namespace RCT1
         UnkEntity Unknown;
         RCT1::Vehicle Vehicle;
         RCT1::Peep Peep;
-        RCT12SpriteLitter Litter;
-        RCT12SpriteBalloon Balloon;
-        RCT12SpriteDuck Duck;
-        RCT12SpriteJumpingFountain JumpingFountain;
-        RCT12SpriteMoneyEffect MoneyEffect;
-        RCT12SpriteCrashedVehicleParticle CrashedVehicleParticle;
-        RCT12SpriteCrashSplash CrashSplash;
-        RCT12SpriteSteamParticle SteamParticle;
+        RCT12EntityLitter Litter;
+        RCT12EntityBalloon Balloon;
+        RCT12EntityDuck Duck;
+        RCT12EntityJumpingFountain JumpingFountain;
+        RCT12EntityMoneyEffect MoneyEffect;
+        RCT12EntityCrashedVehicleParticle CrashedVehicleParticle;
+        RCT12EntityCrashSplash CrashSplash;
+        RCT12EntitySteamParticle SteamParticle;
     };
     assert_struct_size(Entity, 0x100);
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1198,8 +1198,8 @@ namespace RCT1
             }
         }
 
-        void ImportEntity(const RCT12SpriteBase& src);
-        template<typename T> void ImportEntity(const RCT12SpriteBase& src);
+        void ImportEntity(const RCT12EntityBase& src);
+        template<typename T> void ImportEntity(const RCT12EntityBase& src);
 
         void ImportSprites()
         {
@@ -1282,7 +1282,7 @@ namespace RCT1
 
             dst->MoveTo({ src->x, src->y, src->z });
 
-            dst->sprite_direction = src->sprite_direction;
+            dst->sprite_direction = src->EntityDirection;
 
             // Peep name
             if (IsUserStringID(src->NameStringID))
@@ -1366,12 +1366,12 @@ namespace RCT1
             }
         }
 
-        void ImportEntityCommonProperties(EntityBase* dst, const RCT12SpriteBase* src)
+        void ImportEntityCommonProperties(EntityBase* dst, const RCT12EntityBase* src)
         {
-            dst->sprite_direction = src->sprite_direction;
-            dst->sprite_width = src->sprite_width;
-            dst->sprite_height_negative = src->sprite_height_negative;
-            dst->sprite_height_positive = src->sprite_height_positive;
+            dst->sprite_direction = src->EntityDirection;
+            dst->sprite_width = src->SpriteWidth;
+            dst->sprite_height_negative = src->SpriteHeightNegative;
+            dst->sprite_height_positive = src->SpriteHeightPositive;
             dst->x = src->x;
             dst->y = src->y;
             dst->z = src->z;
@@ -2639,15 +2639,15 @@ namespace RCT1
     };
 
     // Very similar but not the same as S6Importer version (due to peeps)
-    constexpr EntityType GetEntityTypeFromRCT1Sprite(const RCT12SpriteBase& src)
+    constexpr EntityType GetEntityTypeFromRCT1Sprite(const RCT12EntityBase& src)
     {
         EntityType output = EntityType::Null;
-        switch (src.sprite_identifier)
+        switch (src.EntityIdentifier)
         {
-            case RCT12SpriteIdentifier::Vehicle:
+            case RCT12EntityIdentifier::Vehicle:
                 output = EntityType::Vehicle;
                 break;
-            case RCT12SpriteIdentifier::Peep:
+            case RCT12EntityIdentifier::Peep:
             {
                 const auto& peep = static_cast<const RCT1::Peep&>(src);
                 if (peep.PeepType == RCT12PeepType::Guest)
@@ -2660,7 +2660,7 @@ namespace RCT1
                 }
                 break;
             }
-            case RCT12SpriteIdentifier::Misc:
+            case RCT12EntityIdentifier::Misc:
 
                 switch (RCT12MiscEntityType(src.type))
                 {
@@ -2696,7 +2696,7 @@ namespace RCT1
                         break;
                 }
                 break;
-            case RCT12SpriteIdentifier::Litter:
+            case RCT12EntityIdentifier::Litter:
                 output = EntityType::Litter;
                 break;
             default:
@@ -2705,9 +2705,9 @@ namespace RCT1
         return output;
     }
 
-    template<> void S4Importer::ImportEntity<::Vehicle>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<::Vehicle>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<::Vehicle>(EntityId::FromUnderlying(srcBase.sprite_index));
+        auto* dst = CreateEntityAt<::Vehicle>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT1::Vehicle*>(&srcBase);
         const auto* ride = GetRide(RideId::FromUnderlying(src->Ride));
         if (ride == nullptr)
@@ -2725,12 +2725,12 @@ namespace RCT1
         dst->remaining_distance = src->RemainingDistance;
 
         // Properties from vehicle entry
-        dst->sprite_width = src->sprite_width;
-        dst->sprite_height_negative = src->sprite_height_negative;
-        dst->sprite_height_positive = src->sprite_height_positive;
-        dst->sprite_direction = src->sprite_direction;
+        dst->sprite_width = src->SpriteWidth;
+        dst->sprite_height_negative = src->SpriteHeightNegative;
+        dst->sprite_height_positive = src->SpriteHeightPositive;
+        dst->sprite_direction = src->EntityDirection;
 
-        dst->SpriteRect = ScreenRect(src->sprite_left, src->sprite_top, src->sprite_right, src->sprite_bottom);
+        dst->SpriteRect = ScreenRect(src->SpriteLeft, src->SpriteTop, src->SpriteRight, src->SpriteBottom);
 
         dst->mass = src->Mass;
         dst->num_seats = src->NumSeats;
@@ -2815,12 +2815,12 @@ namespace RCT1
 
         dst->num_peeps = src->NumPeeps;
         dst->next_free_seat = src->NextFreeSeat;
-        dst->IsCrashedVehicle = src->flags & RCT12_SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
+        dst->IsCrashedVehicle = src->flags & RCT12_ENTITY_FLAGS_IS_CRASHED_VEHICLE_ENTITY;
     }
 
-    template<> void S4Importer::ImportEntity<Guest>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<Guest>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<Guest>(EntityId::FromUnderlying(srcBase.sprite_index));
+        auto* dst = CreateEntityAt<Guest>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT1::Peep*>(&srcBase);
         ImportPeep(dst, src);
 
@@ -2918,9 +2918,9 @@ namespace RCT1
         }
     }
 
-    template<> void S4Importer::ImportEntity<Staff>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<Staff>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<Staff>(EntityId::FromUnderlying(srcBase.sprite_index));
+        auto* dst = CreateEntityAt<Staff>(EntityId::FromUnderlying(srcBase.EntityIndex));
         auto* src = static_cast<const RCT1::Peep*>(&srcBase);
         ImportPeep(dst, src);
         dst->AssignedStaffType = StaffType(src->StaffType);
@@ -2936,28 +2936,28 @@ namespace RCT1
         ImportStaffPatrolArea(dst, src->StaffID);
     }
 
-    template<> void S4Importer::ImportEntity<Litter>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<Litter>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<Litter>(EntityId::FromUnderlying(srcBase.sprite_index));
-        auto* src = static_cast<const RCT12SpriteLitter*>(&srcBase);
+        auto* dst = CreateEntityAt<Litter>(EntityId::FromUnderlying(srcBase.EntityIndex));
+        auto* src = static_cast<const RCT12EntityLitter*>(&srcBase);
         ImportEntityCommonProperties(dst, src);
 
         dst->SubType = Litter::Type(src->type);
     }
 
-    template<> void S4Importer::ImportEntity<SteamParticle>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<SteamParticle>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<SteamParticle>(EntityId::FromUnderlying(srcBase.sprite_index));
-        auto* src = static_cast<const RCT12SpriteSteamParticle*>(&srcBase);
+        auto* dst = CreateEntityAt<SteamParticle>(EntityId::FromUnderlying(srcBase.EntityIndex));
+        auto* src = static_cast<const RCT12EntitySteamParticle*>(&srcBase);
 
         ImportEntityCommonProperties(dst, src);
         dst->frame = src->frame;
     }
 
-    template<> void S4Importer::ImportEntity<MoneyEffect>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<MoneyEffect>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<MoneyEffect>(EntityId::FromUnderlying(srcBase.sprite_index));
-        auto* src = static_cast<const RCT12SpriteMoneyEffect*>(&srcBase);
+        auto* dst = CreateEntityAt<MoneyEffect>(EntityId::FromUnderlying(srcBase.EntityIndex));
+        auto* src = static_cast<const RCT12EntityMoneyEffect*>(&srcBase);
 
         ImportEntityCommonProperties(dst, src);
         dst->MoveDelay = src->move_delay;
@@ -2967,38 +2967,38 @@ namespace RCT1
         dst->Wiggle = src->wiggle;
     }
 
-    template<> void S4Importer::ImportEntity<VehicleCrashParticle>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<VehicleCrashParticle>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<VehicleCrashParticle>(EntityId::FromUnderlying(srcBase.sprite_index));
-        auto* src = static_cast<const RCT12SpriteCrashedVehicleParticle*>(&srcBase);
+        auto* dst = CreateEntityAt<VehicleCrashParticle>(EntityId::FromUnderlying(srcBase.EntityIndex));
+        auto* src = static_cast<const RCT12EntityCrashedVehicleParticle*>(&srcBase);
         ImportEntityCommonProperties(dst, src);
     }
 
-    template<> void S4Importer::ImportEntity<ExplosionCloud>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<ExplosionCloud>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<ExplosionCloud>(EntityId::FromUnderlying(srcBase.sprite_index));
-        auto* src = static_cast<const RCT12SpriteParticle*>(&srcBase);
+        auto* dst = CreateEntityAt<ExplosionCloud>(EntityId::FromUnderlying(srcBase.EntityIndex));
+        auto* src = static_cast<const RCT12EntityParticle*>(&srcBase);
         ImportEntityCommonProperties(dst, src);
     }
 
-    template<> void S4Importer::ImportEntity<ExplosionFlare>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<ExplosionFlare>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<ExplosionFlare>(EntityId::FromUnderlying(srcBase.sprite_index));
-        auto* src = static_cast<const RCT12SpriteParticle*>(&srcBase);
+        auto* dst = CreateEntityAt<ExplosionFlare>(EntityId::FromUnderlying(srcBase.EntityIndex));
+        auto* src = static_cast<const RCT12EntityParticle*>(&srcBase);
         ImportEntityCommonProperties(dst, src);
     }
 
-    template<> void S4Importer::ImportEntity<CrashSplashParticle>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<CrashSplashParticle>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<CrashSplashParticle>(EntityId::FromUnderlying(srcBase.sprite_index));
-        auto* src = static_cast<const RCT12SpriteParticle*>(&srcBase);
+        auto* dst = CreateEntityAt<CrashSplashParticle>(EntityId::FromUnderlying(srcBase.EntityIndex));
+        auto* src = static_cast<const RCT12EntityParticle*>(&srcBase);
         ImportEntityCommonProperties(dst, src);
     }
 
-    template<> void S4Importer::ImportEntity<JumpingFountain>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<JumpingFountain>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<JumpingFountain>(EntityId::FromUnderlying(srcBase.sprite_index));
-        auto* src = static_cast<const RCT12SpriteJumpingFountain*>(&srcBase);
+        auto* dst = CreateEntityAt<JumpingFountain>(EntityId::FromUnderlying(srcBase.EntityIndex));
+        auto* src = static_cast<const RCT12EntityJumpingFountain*>(&srcBase);
 
         ImportEntityCommonProperties(dst, src);
         dst->FountainFlags = src->fountain_flags;
@@ -3008,10 +3008,10 @@ namespace RCT1
         dst->FountainType = JumpingFountainType::Water;
     }
 
-    template<> void S4Importer::ImportEntity<Balloon>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<Balloon>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<Balloon>(EntityId::FromUnderlying(srcBase.sprite_index));
-        auto* src = static_cast<const RCT12SpriteBalloon*>(&srcBase);
+        auto* dst = CreateEntityAt<Balloon>(EntityId::FromUnderlying(srcBase.EntityIndex));
+        auto* src = static_cast<const RCT12EntityBalloon*>(&srcBase);
 
         ImportEntityCommonProperties(dst, src);
         // Balloons were always blue in RCT1 without AA/LL
@@ -3025,17 +3025,17 @@ namespace RCT1
         }
     }
 
-    template<> void S4Importer::ImportEntity<Duck>(const RCT12SpriteBase& srcBase)
+    template<> void S4Importer::ImportEntity<Duck>(const RCT12EntityBase& srcBase)
     {
-        auto* dst = CreateEntityAt<Duck>(EntityId::FromUnderlying(srcBase.sprite_index));
-        auto* src = static_cast<const RCT12SpriteDuck*>(&srcBase);
+        auto* dst = CreateEntityAt<Duck>(EntityId::FromUnderlying(srcBase.EntityIndex));
+        auto* src = static_cast<const RCT12EntityDuck*>(&srcBase);
 
         ImportEntityCommonProperties(dst, src);
         dst->frame = src->frame;
         dst->state = static_cast<Duck::DuckState>(src->state);
     }
 
-    void S4Importer::ImportEntity(const RCT12SpriteBase& src)
+    void S4Importer::ImportEntity(const RCT12EntityBase& src)
     {
         switch (GetEntityTypeFromRCT1Sprite(src))
         {

--- a/src/openrct2/rct12/RCT12.h
+++ b/src/openrct2/rct12/RCT12.h
@@ -161,7 +161,7 @@ enum
 
 enum
 {
-    RCT12_SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE = 1 << 7,
+    RCT12_ENTITY_FLAGS_IS_CRASHED_VEHICLE_ENTITY = 1 << 7,
 };
 
 #pragma pack(push, 1)
@@ -609,7 +609,7 @@ struct RCT12EightCarsCorruptElement15 : RCT12TileElementBase
 };
 assert_struct_size(RCT12EightCarsCorruptElement15, 8);
 
-// Offset into sprite_lists_head and sprite_lists_count
+// Offset into EntityListHead and EntityListCount
 enum class RCT12EntityLinkListOffset : uint8_t
 {
     Free = 0,
@@ -620,7 +620,7 @@ enum class RCT12EntityLinkListOffset : uint8_t
     Vehicle = 5 * sizeof(uint16_t),
 };
 
-enum class RCT12SpriteIdentifier : uint8_t
+enum class RCT12EntityIdentifier : uint8_t
 {
     Vehicle = 0,
     Peep = 1,
@@ -651,31 +651,31 @@ enum class RCT12PeepType : uint8_t
     Invalid = 0xFF
 };
 
-struct RCT12SpriteBase
+struct RCT12EntityBase
 {
-    RCT12SpriteIdentifier sprite_identifier;           // 0x00
+    RCT12EntityIdentifier EntityIdentifier;            // 0x00
     uint8_t type;                                      // 0x01
     uint16_t next_in_quadrant;                         // 0x02
     uint16_t next;                                     // 0x04
     uint16_t previous;                                 // 0x06
     RCT12EntityLinkListOffset linked_list_type_offset; // 0x08
-    uint8_t sprite_height_negative;                    // 0x09
-    uint16_t sprite_index;                             // 0x0A
+    uint8_t SpriteHeightNegative;                      // 0x09
+    uint16_t EntityIndex;                              // 0x0A
     uint16_t flags;                                    // 0x0C
     int16_t x;                                         // 0x0E
     int16_t y;                                         // 0x10
     int16_t z;                                         // 0x12
-    uint8_t sprite_width;                              // 0x14
-    uint8_t sprite_height_positive;                    // 0x15
-    int16_t sprite_left;                               // 0x16
-    int16_t sprite_top;                                // 0x18
-    int16_t sprite_right;                              // 0x1A
-    int16_t sprite_bottom;                             // 0x1C
-    uint8_t sprite_direction;                          // 0x1E
+    uint8_t SpriteWidth;                               // 0x14
+    uint8_t SpriteHeightPositive;                      // 0x15
+    int16_t SpriteLeft;                                // 0x16
+    int16_t SpriteTop;                                 // 0x18
+    int16_t SpriteRight;                               // 0x1A
+    int16_t SpriteBottom;                              // 0x1C
+    uint8_t EntityDirection;                           // 0x1E
 };
-assert_struct_size(RCT12SpriteBase, 0x1F);
+assert_struct_size(RCT12EntityBase, 0x1F);
 
-struct RCT12SpriteBalloon : RCT12SpriteBase
+struct RCT12EntityBalloon : RCT12EntityBase
 {
     uint8_t pad_1F[0x24 - 0x1F];
     uint16_t popped;      // 0x24
@@ -684,9 +684,9 @@ struct RCT12SpriteBalloon : RCT12SpriteBase
     uint8_t pad_28[4];
     uint8_t colour; // 0x2C
 };
-assert_struct_size(RCT12SpriteBalloon, 0x2D);
+assert_struct_size(RCT12EntityBalloon, 0x2D);
 
-struct RCT12SpriteDuck : RCT12SpriteBase
+struct RCT12EntityDuck : RCT12EntityBase
 {
     uint8_t pad_1F[0x26 - 0x1F];
     uint16_t frame; // 0x26
@@ -696,23 +696,23 @@ struct RCT12SpriteDuck : RCT12SpriteBase
     uint8_t pad_34[0x14];
     uint8_t state; // 0x48
 };
-assert_struct_size(RCT12SpriteDuck, 0x49);
+assert_struct_size(RCT12EntityDuck, 0x49);
 
-struct RCT12SpriteLitter : RCT12SpriteBase
+struct RCT12EntityLitter : RCT12EntityBase
 {
     uint8_t pad_1F[0x24 - 0x1F];
     uint32_t creationTick; // 0x24
 };
-assert_struct_size(RCT12SpriteLitter, 0x28);
+assert_struct_size(RCT12EntityLitter, 0x28);
 
-struct RCT12SpriteParticle : RCT12SpriteBase
+struct RCT12EntityParticle : RCT12EntityBase
 {
     uint8_t pad_1F[0x26 - 0x1F];
     uint16_t frame; // 0x26
 };
-assert_struct_size(RCT12SpriteParticle, 0x28);
+assert_struct_size(RCT12EntityParticle, 0x28);
 
-struct RCT12SpriteJumpingFountain : RCT12SpriteBase
+struct RCT12EntityJumpingFountain : RCT12EntityBase
 {
     uint8_t pad_1F[0x26 - 0x1F];
     uint8_t num_ticks_alive; // 0x26
@@ -724,9 +724,9 @@ struct RCT12SpriteJumpingFountain : RCT12SpriteBase
     uint8_t pad_34[0x46 - 0x34];
     uint16_t iteration; // 0x46
 };
-assert_struct_size(RCT12SpriteJumpingFountain, 0x48);
+assert_struct_size(RCT12EntityJumpingFountain, 0x48);
 
-struct RCT12SpriteMoneyEffect : RCT12SpriteBase
+struct RCT12EntityMoneyEffect : RCT12EntityBase
 {
     uint8_t pad_1F[0x24 - 0x1F];
     uint16_t move_delay;   // 0x24
@@ -737,40 +737,40 @@ struct RCT12SpriteMoneyEffect : RCT12SpriteBase
     int16_t offset_x; // 0x44
     uint16_t wiggle;  // 0x46
 };
-assert_struct_size(RCT12SpriteMoneyEffect, 0x48);
+assert_struct_size(RCT12EntityMoneyEffect, 0x48);
 
-struct RCT12SpriteCrashedVehicleParticle : RCT12SpriteBase
+struct RCT12EntityCrashedVehicleParticle : RCT12EntityBase
 {
     uint8_t pad_1F[0x24 - 0x1F];
     uint16_t time_to_live; // 0x24
     uint16_t frame;        // 0x26
     uint8_t pad_28[0x2C - 0x28];
-    uint8_t colour[2];            // 0x2C
-    uint16_t crashed_sprite_base; // 0x2E
-    int16_t velocity_x;           // 0x30
-    int16_t velocity_y;           // 0x32
-    int16_t velocity_z;           // 0x34
+    uint8_t colour[2];          // 0x2C
+    uint16_t CrashedEntityBase; // 0x2E
+    int16_t velocity_x;         // 0x30
+    int16_t velocity_y;         // 0x32
+    int16_t velocity_z;         // 0x34
     uint8_t pad_36[0x38 - 0x36];
     int32_t acceleration_x; // 0x38
     int32_t acceleration_y; // 0x3C
     int32_t acceleration_z; // 0x40
 };
-assert_struct_size(RCT12SpriteCrashedVehicleParticle, 0x44);
+assert_struct_size(RCT12EntityCrashedVehicleParticle, 0x44);
 
-struct RCT12SpriteCrashSplash : RCT12SpriteBase
+struct RCT12EntityCrashSplash : RCT12EntityBase
 {
     uint8_t pad_1F[0x26 - 0x1F];
     uint16_t frame; // 0x26
 };
-assert_struct_size(RCT12SpriteCrashSplash, 0x28);
+assert_struct_size(RCT12EntityCrashSplash, 0x28);
 
-struct RCT12SpriteSteamParticle : RCT12SpriteBase
+struct RCT12EntitySteamParticle : RCT12EntityBase
 {
     uint8_t pad_1F[0x24 - 0x1F];
     uint16_t time_to_move; // 0x24
     uint16_t frame;        // 0x26
 };
-assert_struct_size(RCT12SpriteSteamParticle, 0x28);
+assert_struct_size(RCT12EntitySteamParticle, 0x28);
 
 struct RCT12PeepThought
 {

--- a/src/openrct2/rct2/RCT2.h
+++ b/src/openrct2/rct2/RCT2.h
@@ -423,7 +423,7 @@ namespace RCT2
     };
     assert_struct_size(ScoresEntry, 0x02B0);
 
-    struct Vehicle : RCT12SpriteBase
+    struct Vehicle : RCT12EntityBase
     {
         uint8_t Pitch;         // 0x1F
         uint8_t bank_rotation; // 0x20
@@ -548,7 +548,7 @@ namespace RCT2
     };
     assert_struct_size(Vehicle, 0xDA);
 
-    struct Peep : RCT12SpriteBase
+    struct Peep : RCT12EntityBase
     {
         uint8_t pad_1F[0x22 - 0x1F];
         StringId name_string_idx; // 0x22
@@ -722,18 +722,18 @@ namespace RCT2
         uint8_t pad_00[0x100];
 
     public:
-        RCT12SpriteBase unknown;
+        RCT12EntityBase unknown;
         Vehicle vehicle;
         Peep peep;
-        RCT12SpriteLitter litter;
-        RCT12SpriteBalloon balloon;
-        RCT12SpriteDuck duck;
-        RCT12SpriteJumpingFountain jumping_fountain;
-        RCT12SpriteMoneyEffect money_effect;
-        RCT12SpriteCrashedVehicleParticle crashed_vehicle_particle;
-        RCT12SpriteCrashSplash crash_splash;
-        RCT12SpriteSteamParticle steam_particle;
-        RCT12SpriteParticle misc_particle;
+        RCT12EntityLitter litter;
+        RCT12EntityBalloon balloon;
+        RCT12EntityDuck duck;
+        RCT12EntityJumpingFountain jumping_fountain;
+        RCT12EntityMoneyEffect money_effect;
+        RCT12EntityCrashedVehicleParticle crashed_vehicle_particle;
+        RCT12EntityCrashSplash crash_splash;
+        RCT12EntitySteamParticle steam_particle;
+        RCT12EntityParticle misc_particle;
     };
     assert_struct_size(Entity, 0x100);
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1238,7 +1238,7 @@ namespace RCT2
             for (int32_t i = 0; i < GetMaxEntities(); i++)
             {
                 const auto& sprite = _s6.sprites[i];
-                if (sprite.unknown.sprite_identifier == RCT12SpriteIdentifier::Peep)
+                if (sprite.unknown.EntityIdentifier == RCT12EntityIdentifier::Peep)
                 {
                     if (sprite.peep.current_ride == static_cast<RCT12RideId>(rideIndex.ToUnderlying())
                         && (static_cast<PeepState>(sprite.peep.state) == PeepState::OnRide
@@ -1677,7 +1677,7 @@ namespace RCT2
             return (_s6.header.classic_flag == 0xf) ? Limits::MaxEntitiesRCTCExtended : Limits::MaxEntities;
         }
 
-        template<typename OpenRCT2_T> void ImportEntity(const RCT12SpriteBase& src);
+        template<typename OpenRCT2_T> void ImportEntity(const RCT12EntityBase& src);
 
         void ImportEntityPeep(::Peep* dst, const Peep* src)
         {
@@ -1747,15 +1747,15 @@ namespace RCT2
             dst->WalkingFrameNum = src->no_action_frame_num;
         }
 
-        constexpr EntityType GetEntityTypeFromRCT2Sprite(const RCT12SpriteBase* src)
+        constexpr EntityType GetEntityTypeFromRCT2Sprite(const RCT12EntityBase* src)
         {
             EntityType output = EntityType::Null;
-            switch (src->sprite_identifier)
+            switch (src->EntityIdentifier)
             {
-                case RCT12SpriteIdentifier::Vehicle:
+                case RCT12EntityIdentifier::Vehicle:
                     output = EntityType::Vehicle;
                     break;
-                case RCT12SpriteIdentifier::Peep:
+                case RCT12EntityIdentifier::Peep:
                     if (RCT12PeepType(static_cast<const Peep*>(src)->peep_type) == RCT12PeepType::Guest)
                     {
                         output = EntityType::Guest;
@@ -1765,7 +1765,7 @@ namespace RCT2
                         output = EntityType::Staff;
                     }
                     break;
-                case RCT12SpriteIdentifier::Misc:
+                case RCT12EntityIdentifier::Misc:
 
                     switch (RCT12MiscEntityType(src->type))
                     {
@@ -1801,7 +1801,7 @@ namespace RCT2
                             break;
                     }
                     break;
-                case RCT12SpriteIdentifier::Litter:
+                case RCT12EntityIdentifier::Litter:
                     output = EntityType::Litter;
                     break;
                 default:
@@ -1810,21 +1810,21 @@ namespace RCT2
             return output;
         }
 
-        void ImportEntityCommonProperties(EntityBase* dst, const RCT12SpriteBase* src)
+        void ImportEntityCommonProperties(EntityBase* dst, const RCT12EntityBase* src)
         {
             dst->Type = GetEntityTypeFromRCT2Sprite(src);
-            dst->sprite_height_negative = src->sprite_height_negative;
-            dst->sprite_index = EntityId::FromUnderlying(src->sprite_index);
+            dst->sprite_height_negative = src->SpriteHeightNegative;
+            dst->sprite_index = EntityId::FromUnderlying(src->EntityIndex);
             dst->x = src->x;
             dst->y = src->y;
             dst->z = src->z;
-            dst->sprite_width = src->sprite_width;
-            dst->sprite_height_positive = src->sprite_height_positive;
-            dst->SpriteRect = ScreenRect(src->sprite_left, src->sprite_top, src->sprite_right, src->sprite_bottom);
-            dst->sprite_direction = src->sprite_direction;
+            dst->sprite_width = src->SpriteWidth;
+            dst->sprite_height_positive = src->SpriteHeightPositive;
+            dst->SpriteRect = ScreenRect(src->SpriteLeft, src->SpriteTop, src->SpriteRight, src->SpriteBottom);
+            dst->sprite_direction = src->EntityDirection;
         }
 
-        void ImportEntity(const RCT12SpriteBase& src);
+        void ImportEntity(const RCT12EntityBase& src);
 
         std::string GetUserString(StringId stringId)
         {
@@ -1936,9 +1936,9 @@ namespace RCT2
         }
     };
 
-    template<> void S6Importer::ImportEntity<::Vehicle>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::Vehicle>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::Vehicle>(EntityId::FromUnderlying(baseSrc.sprite_index));
+        auto dst = CreateEntityAt<::Vehicle>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const RCT2::Vehicle*>(&baseSrc);
         const auto& ride = _s6.rides[src->ride];
 
@@ -2042,7 +2042,7 @@ namespace RCT2
         dst->ride_subtype = RCTEntryIndexToOpenRCT2EntryIndex(src->ride_subtype);
         dst->seat_rotation = src->seat_rotation;
         dst->target_seat_rotation = src->target_seat_rotation;
-        dst->IsCrashedVehicle = src->flags & RCT12_SPRITE_FLAGS_IS_CRASHED_VEHICLE_SPRITE;
+        dst->IsCrashedVehicle = src->flags & RCT12_ENTITY_FLAGS_IS_CRASHED_VEHICLE_ENTITY;
     }
 
     static uint32_t AdjustScenarioToCurrentTicks(const S6Data& s6, uint32_t tick)
@@ -2054,9 +2054,9 @@ namespace RCT2
         return s6.game_ticks_1 - ticksElapsed;
     }
 
-    template<> void S6Importer::ImportEntity<::Guest>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::Guest>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::Guest>(EntityId::FromUnderlying(baseSrc.sprite_index));
+        auto dst = CreateEntityAt<::Guest>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const Peep*>(&baseSrc);
         ImportEntityPeep(dst, src);
 
@@ -2128,9 +2128,9 @@ namespace RCT2
         dst->FavouriteRideRating = src->favourite_ride_rating;
     }
 
-    template<> void S6Importer::ImportEntity<::Staff>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::Staff>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::Staff>(EntityId::FromUnderlying(baseSrc.sprite_index));
+        auto dst = CreateEntityAt<::Staff>(EntityId::FromUnderlying(baseSrc.EntityIndex));
         auto src = static_cast<const Peep*>(&baseSrc);
         ImportEntityPeep(dst, src);
 
@@ -2148,19 +2148,19 @@ namespace RCT2
         ImportStaffPatrolArea(dst, src->staff_id);
     }
 
-    template<> void S6Importer::ImportEntity<::SteamParticle>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::SteamParticle>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::SteamParticle>(EntityId::FromUnderlying(baseSrc.sprite_index));
-        auto src = static_cast<const RCT12SpriteSteamParticle*>(&baseSrc);
+        auto dst = CreateEntityAt<::SteamParticle>(EntityId::FromUnderlying(baseSrc.EntityIndex));
+        auto src = static_cast<const RCT12EntitySteamParticle*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
         dst->time_to_move = src->time_to_move;
         dst->frame = src->frame;
     }
 
-    template<> void S6Importer::ImportEntity<::MoneyEffect>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::MoneyEffect>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::MoneyEffect>(EntityId::FromUnderlying(baseSrc.sprite_index));
-        auto src = static_cast<const RCT12SpriteMoneyEffect*>(&baseSrc);
+        auto dst = CreateEntityAt<::MoneyEffect>(EntityId::FromUnderlying(baseSrc.EntityIndex));
+        auto src = static_cast<const RCT12EntityMoneyEffect*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
         dst->MoveDelay = src->move_delay;
         dst->NumMovements = src->num_movements;
@@ -2170,17 +2170,17 @@ namespace RCT2
         dst->Wiggle = src->wiggle;
     }
 
-    template<> void S6Importer::ImportEntity<::VehicleCrashParticle>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::VehicleCrashParticle>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::VehicleCrashParticle>(EntityId::FromUnderlying(baseSrc.sprite_index));
-        auto src = static_cast<const RCT12SpriteCrashedVehicleParticle*>(&baseSrc);
+        auto dst = CreateEntityAt<::VehicleCrashParticle>(EntityId::FromUnderlying(baseSrc.EntityIndex));
+        auto src = static_cast<const RCT12EntityCrashedVehicleParticle*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
         dst->frame = src->frame;
         dst->time_to_live = src->time_to_live;
         dst->frame = src->frame;
         dst->colour[0] = src->colour[0];
         dst->colour[1] = src->colour[1];
-        dst->crashed_sprite_base = src->crashed_sprite_base;
+        dst->crashed_sprite_base = src->CrashedEntityBase;
         dst->velocity_x = src->velocity_x;
         dst->velocity_y = src->velocity_y;
         dst->velocity_z = src->velocity_z;
@@ -2189,34 +2189,34 @@ namespace RCT2
         dst->acceleration_z = src->acceleration_z;
     }
 
-    template<> void S6Importer::ImportEntity<::ExplosionCloud>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::ExplosionCloud>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::ExplosionCloud>(EntityId::FromUnderlying(baseSrc.sprite_index));
-        auto src = static_cast<const RCT12SpriteParticle*>(&baseSrc);
+        auto dst = CreateEntityAt<::ExplosionCloud>(EntityId::FromUnderlying(baseSrc.EntityIndex));
+        auto src = static_cast<const RCT12EntityParticle*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
         dst->frame = src->frame;
     }
 
-    template<> void S6Importer::ImportEntity<::ExplosionFlare>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::ExplosionFlare>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::ExplosionFlare>(EntityId::FromUnderlying(baseSrc.sprite_index));
-        auto src = static_cast<const RCT12SpriteParticle*>(&baseSrc);
+        auto dst = CreateEntityAt<::ExplosionFlare>(EntityId::FromUnderlying(baseSrc.EntityIndex));
+        auto src = static_cast<const RCT12EntityParticle*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
         dst->frame = src->frame;
     }
 
-    template<> void S6Importer::ImportEntity<::CrashSplashParticle>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::CrashSplashParticle>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::CrashSplashParticle>(EntityId::FromUnderlying(baseSrc.sprite_index));
-        auto src = static_cast<const RCT12SpriteParticle*>(&baseSrc);
+        auto dst = CreateEntityAt<::CrashSplashParticle>(EntityId::FromUnderlying(baseSrc.EntityIndex));
+        auto src = static_cast<const RCT12EntityParticle*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
         dst->frame = src->frame;
     }
 
-    template<> void S6Importer::ImportEntity<::JumpingFountain>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::JumpingFountain>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::JumpingFountain>(EntityId::FromUnderlying(baseSrc.sprite_index));
-        auto src = static_cast<const RCT12SpriteJumpingFountain*>(&baseSrc);
+        auto dst = CreateEntityAt<::JumpingFountain>(EntityId::FromUnderlying(baseSrc.EntityIndex));
+        auto src = static_cast<const RCT12EntityJumpingFountain*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
         dst->NumTicksAlive = src->num_ticks_alive;
         dst->frame = src->frame;
@@ -2229,10 +2229,10 @@ namespace RCT2
             : ::JumpingFountainType::Water;
     }
 
-    template<> void S6Importer::ImportEntity<::Balloon>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::Balloon>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::Balloon>(EntityId::FromUnderlying(baseSrc.sprite_index));
-        auto src = static_cast<const RCT12SpriteBalloon*>(&baseSrc);
+        auto dst = CreateEntityAt<::Balloon>(EntityId::FromUnderlying(baseSrc.EntityIndex));
+        auto src = static_cast<const RCT12EntityBalloon*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
         dst->popped = src->popped;
         dst->time_to_move = src->time_to_move;
@@ -2240,10 +2240,10 @@ namespace RCT2
         dst->colour = src->colour;
     }
 
-    template<> void S6Importer::ImportEntity<::Duck>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::Duck>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::Duck>(EntityId::FromUnderlying(baseSrc.sprite_index));
-        auto src = static_cast<const RCT12SpriteDuck*>(&baseSrc);
+        auto dst = CreateEntityAt<::Duck>(EntityId::FromUnderlying(baseSrc.EntityIndex));
+        auto src = static_cast<const RCT12EntityDuck*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
         dst->frame = src->frame;
         dst->target_x = src->target_x;
@@ -2251,16 +2251,16 @@ namespace RCT2
         dst->state = static_cast<::Duck::DuckState>(src->state);
     }
 
-    template<> void S6Importer::ImportEntity<::Litter>(const RCT12SpriteBase& baseSrc)
+    template<> void S6Importer::ImportEntity<::Litter>(const RCT12EntityBase& baseSrc)
     {
-        auto dst = CreateEntityAt<::Litter>(EntityId::FromUnderlying(baseSrc.sprite_index));
-        auto src = static_cast<const RCT12SpriteLitter*>(&baseSrc);
+        auto dst = CreateEntityAt<::Litter>(EntityId::FromUnderlying(baseSrc.EntityIndex));
+        auto src = static_cast<const RCT12EntityLitter*>(&baseSrc);
         ImportEntityCommonProperties(dst, src);
         dst->SubType = ::Litter::Type(src->type);
         dst->creationTick = AdjustScenarioToCurrentTicks(_s6, src->creationTick);
     }
 
-    void S6Importer::ImportEntity(const RCT12SpriteBase& src)
+    void S6Importer::ImportEntity(const RCT12EntityBase& src)
     {
         switch (GetEntityTypeFromRCT2Sprite(&src))
         {


### PR DESCRIPTION
Replaces ‘sprite’ with ‘entity’ where appropriate. I left left/top/bottom/right as ‘sprite’, since those seemed to refer to actual graphic sprites.