### PR TITLE
Change lift speed range of Classic Wooden RC

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Improved: [#19044] Added special thanks to RMC and Wiegand to the About page.
 - Change: [#19018] Renamed actions to fit the naming scheme.
 - Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
+- Change: [#19233] Reduce lift speed minimum and maximum values for “Classic Wooden Coaster”.
 - Fix: [#474] Mini golf window shows more players than there actually are (original bug).
 - Fix: [#18467] “Selected only” Object Selection filter is active in Track Designs Manager, and cannot be toggled.
 - Fix: [#18905] Ride Construction window theme is not applied correctly.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "3"
+#define NETWORK_STREAM_VERSION "4"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/coaster/meta/ClassicWoodenRollerCoaster.h
+++ b/src/openrct2/ride/coaster/meta/ClassicWoodenRollerCoaster.h
@@ -36,7 +36,7 @@ constexpr const RideTypeDescriptor ClassicWoodenRollerCoasterRTD =
    SET_FIELD(AvailableBreakdowns, (1 << BREAKDOWN_SAFETY_CUT_OUT) | (1 << BREAKDOWN_RESTRAINTS_STUCK_CLOSED) | (1 << BREAKDOWN_RESTRAINTS_STUCK_OPEN) | (1 << BREAKDOWN_VEHICLE_MALFUNCTION) | (1 << BREAKDOWN_BRAKES_FAILURE)),
    SET_FIELD(Heights, { 41, 24, 8, 11, }),
    SET_FIELD(MaxMass, 19),
-   SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::LiftWood, 5, 7 }),
+   SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::LiftWood, 3, 5 }),
    SET_FIELD(RatingsCalculationFunction, RideRatingsCalculateClassicWoodenRollerCoaster),
    SET_FIELD(RatingsMultipliers, { 52, 33, 4 }),
    SET_FIELD(UpkeepCosts, { 40, 20, 80, 10, 3, 10 }),


### PR DESCRIPTION
As this ride is meant to reflect both old-school wooden roller coasters, as well as RCT1’s wooden RC, it makes no sense the lift can be set to speeds up to 11 km/h. Limit this to 4-8 km/h.