### PR TITLE
Install OpenMusic by default in Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ option(PORTABLE "Create a portable build (-rpath=$ORIGIN)" OFF)
 option(APPIMAGE "Create an appimage build (-rpath=$ORIGIN/../lib)" OFF)
 option(DOWNLOAD_TITLE_SEQUENCES "Download title sequences during installation." ON)
 option(DOWNLOAD_OBJECTS "Download objects during installation." ON)
+option(DOWNLOAD_OPENSFX "Download OpenSoundEffects during installation." OFF)
+option(DOWNLOAD_OPENMSX "Download OpenMusic during installation." OFF)
 CMAKE_DEPENDENT_OPTION(DOWNLOAD_REPLAYS "Download replays during installation." ON
     "WITH_TESTS" OFF)
 CMAKE_DEPENDENT_OPTION(MACOS_USE_DEPENDENCIES "Use OpenRCT2 dependencies instead of system libraries" ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,11 @@ if (MACOS_USE_DEPENDENCIES)
     endif ()
 endif ()
 
+# If OS is Linux, import OpenSoundEffects and OpenMusic
+if(UNIX AND NOT APPLE)
+    set(DOWNLOAD_OPENMSX ON)
+endif()
+
 # LIST of supported flags, use SET_CHECK_CXX_FLAGS() to apply to target.
 # Use ADD_CHECK_CXX_COMPILER_FLAG() to add to list.
 set(SUPPORTED_CHECK_CXX_COMPILER_FLAGS "")


### PR DESCRIPTION
In order to load parks using certain music files, such as the dodgems theme, the Linux build must include OpenMusic by default.  
  
Note that this isn't a long-term fix, and follow-up work to the [download.cmake](https://github.com/OpenRCT2/OpenRCT2/blob/develop/cmake/download.cmake) file to allow both OpenMusic and OpenSoundEffects to be imported at the same time. The `download_openrct2_zip` function expects each downloaded zip file to be in its own unique directory, while OpenMusic and OpenSoundEffects are both imported into the `install/usr/share/openrct2/` directory

See https://github.com/OpenRCT2/OpenRCT2/issues/19160 for additional info