### PR TITLE
Fix #19250: MusicObjects do not free their preview images

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Fix: [#19112] Clearing the last character in the Object Selection filter does not properly reset it.
 - Fix: [#19114] [Plugin] GameActionResult does not comply to API specification.
 - Fix: [#19136] SV6 saves with experimental RCT1 paths not imported correctly.
+- Fix: [#19250] MusicObjects do not free their preview images
 
 0.4.3 (2022-12-14)
 ------------------------------------------------------------------------

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -80,6 +80,13 @@ void MusicObject::Load()
 void MusicObject::Unload()
 {
     LanguageFreeObjectString(NameStringId);
+    if (_hasPreview)
+    {
+        GfxObjectFreeImages(_previewImageId, GetImageTable().GetCount());
+    }
+
+    _hasPreview = false;
+    _previewImageId = 0;
     NameStringId = 0;
 }
 

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -80,10 +80,7 @@ void MusicObject::Load()
 void MusicObject::Unload()
 {
     LanguageFreeObjectString(NameStringId);
-    if (_hasPreview)
-    {
-        GfxObjectFreeImages(_previewImageId, GetImageTable().GetCount());
-    }
+    GfxObjectFreeImages(_previewImageId, GetImageTable().GetCount());
 
     _hasPreview = false;
     _previewImageId = 0;


### PR DESCRIPTION
I can confirm this fixes the assertion failure mentioned here:
- https://github.com/OpenRCT2/OpenRCT2/issues/19250

I'm fairly confident it addresses all of these backtrace.io issues, they all have the same `5 images were not freed` assertion failure. I don't know how/if I can access backtrace.io, so if someone could confirm that would be great.
- https://github.com/OpenRCT2/OpenRCT2/issues/19242
- https://github.com/OpenRCT2/OpenRCT2/issues/19244
- https://github.com/OpenRCT2/OpenRCT2/issues/19248
- https://github.com/OpenRCT2/OpenRCT2/issues/19257
- https://github.com/OpenRCT2/OpenRCT2/issues/19258

It may address these backtrace.io issues as well. They have a similar assertion failure but a different image count:
- https://github.com/OpenRCT2/OpenRCT2/issues/19219
- https://github.com/OpenRCT2/OpenRCT2/issues/19208
- https://github.com/OpenRCT2/OpenRCT2/issues/19188
- https://github.com/OpenRCT2/OpenRCT2/issues/19182