### PR TITLE
Widen Vehicle::update_flags to 32 bits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,9 @@ set(OPENMSX_VERSION "1.0.1")
 set(OPENMSX_URL  "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA1 "8ff94490180e2fbfdd13a4130eb300da726ca406")
 
-set(REPLAYS_VERSION "0.0.72")
+set(REPLAYS_VERSION "0.0.73")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "93744627E3F1FE5ED6317D5A292D15B63AA71765")
+set(REPLAYS_SHA1 "5AAFEE5DBEFACA454004742CECCC99E5DD3FD4F7")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -51,8 +51,8 @@
     <OpenSFXSha1>8f04aea33f8034131c3069f6accacce0d94f80c1</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.0.1/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha1>8ff94490180e2fbfdd13a4130eb300da726ca406</OpenMSXSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.72/replays.zip</ReplaysUrl>
-    <ReplaysSha1>93744627E3F1FE5ED6317D5A292D15B63AA71765</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.73/replays.zip</ReplaysUrl>
+    <ReplaysSha1>5AAFEE5DBEFACA454004742CECCC99E5DD3FD4F7</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -455,7 +455,6 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Vehicle, target_seat_rotation);
         COMPARE_FIELD(Vehicle, BoatLocation.x);
         COMPARE_FIELD(Vehicle, BoatLocation.y);
-        COMPARE_FIELD(Vehicle, IsCrashedVehicle);
     }
 
     void CompareSpriteDataLitter(const Litter& spriteBase, const Litter& spriteCmp, GameStateSpriteChange& changeData) const

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -404,7 +404,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(Vehicle, next_vehicle_on_ride);
         COMPARE_FIELD(Vehicle, var_44);
         COMPARE_FIELD(Vehicle, mass);
-        COMPARE_FIELD(Vehicle, update_flags);
+        COMPARE_FIELD(Vehicle, Flags);
         COMPARE_FIELD(Vehicle, SwingSprite);
         COMPARE_FIELD(Vehicle, current_station);
         COMPARE_FIELD(Vehicle, SwingPosition);

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "4"
+#define NETWORK_STREAM_VERSION "5"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1891,11 +1891,11 @@ namespace OpenRCT2
         {
             uint16_t updateFlags = 0;
             cs.ReadWrite(updateFlags);
-            entity.update_flags = updateFlags;
+            entity.Flags = updateFlags;
         }
         else
         {
-            cs.ReadWrite(entity.update_flags);
+            cs.ReadWrite(entity.Flags);
         }
         cs.ReadWrite(entity.SwingSprite);
         cs.ReadWrite(entity.current_station);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1887,7 +1887,16 @@ namespace OpenRCT2
         cs.ReadWrite(entity.next_vehicle_on_ride);
         cs.ReadWrite(entity.var_44);
         cs.ReadWrite(entity.mass);
-        cs.ReadWrite(entity.update_flags);
+        if (cs.GetMode() == OrcaStream::Mode::READING && os.GetHeader().TargetVersion < 18)
+        {
+            uint16_t updateFlags = 0;
+            cs.ReadWrite(updateFlags);
+            entity.update_flags = updateFlags;
+        }
+        else
+        {
+            cs.ReadWrite(entity.update_flags);
+        }
         cs.ReadWrite(entity.SwingSprite);
         cs.ReadWrite(entity.current_station);
         cs.ReadWrite(entity.current_time);

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1949,7 +1949,15 @@ namespace OpenRCT2
         cs.ReadWrite(entity.colours.Tertiary);
         cs.ReadWrite(entity.seat_rotation);
         cs.ReadWrite(entity.target_seat_rotation);
-        cs.ReadWrite(entity.IsCrashedVehicle);
+        if (cs.GetMode() == OrcaStream::Mode::READING && os.GetHeader().TargetVersion < 18)
+        {
+            bool isCrashedVehicle = false;
+            cs.ReadWrite(isCrashedVehicle);
+            if (isCrashedVehicle)
+            {
+                entity.SetUpdateFlag(VEHICLE_UPDATE_FLAG_CRASHED);
+            }
+        }
     }
 
     template<> void ParkFile::ReadWriteEntity(OrcaStream& os, OrcaStream::ChunkStream& cs, Guest& guest)

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -8,10 +8,10 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 17;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 18;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t PARK_FILE_MIN_VERSION = 17;
+    constexpr uint32_t PARK_FILE_MIN_VERSION = 18;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2815,7 +2815,10 @@ namespace RCT1
 
         dst->num_peeps = src->NumPeeps;
         dst->next_free_seat = src->NextFreeSeat;
-        dst->IsCrashedVehicle = src->Flags & RCT12_ENTITY_FLAGS_IS_CRASHED_VEHICLE_ENTITY;
+        if (src->Flags & RCT12_ENTITY_FLAGS_IS_CRASHED_VEHICLE_ENTITY)
+        {
+            dst->SetUpdateFlag(VEHICLE_UPDATE_FLAG_CRASHED);
+        }
     }
 
     template<> void S4Importer::ImportEntity<Guest>(const RCT12EntityBase& srcBase)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2804,7 +2804,7 @@ namespace RCT1
         dst->track_progress = src->TrackProgress;
         dst->vertical_drop_countdown = src->VerticalDropCountdown;
         dst->sub_state = src->SubState;
-        dst->update_flags = src->UpdateFlags;
+        dst->Flags = src->UpdateFlags;
 
         SetVehicleColours(dst, src);
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1995,7 +1995,7 @@ namespace RCT2
         dst->next_vehicle_on_ride = EntityId::FromUnderlying(src->NextVehicleOnRide);
         dst->var_44 = src->Var44;
         dst->mass = src->Mass;
-        dst->update_flags = src->UpdateFlags;
+        dst->Flags = src->UpdateFlags;
         dst->SwingSprite = src->SwingSprite;
         dst->current_station = StationIndex::FromUnderlying(src->CurrentStation);
         dst->current_time = src->CurrentTime;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -2044,7 +2044,10 @@ namespace RCT2
         dst->ride_subtype = RCTEntryIndexToOpenRCT2EntryIndex(src->RideSubtype);
         dst->seat_rotation = src->SeatRotation;
         dst->target_seat_rotation = src->TargetSeatRotation;
-        dst->IsCrashedVehicle = src->Flags & RCT12_ENTITY_FLAGS_IS_CRASHED_VEHICLE_ENTITY;
+        if (src->Flags & RCT12_ENTITY_FLAGS_IS_CRASHED_VEHICLE_ENTITY)
+        {
+            dst->SetUpdateFlag(VEHICLE_UPDATE_FLAG_CRASHED);
+        }
     }
 
     static uint32_t AdjustScenarioToCurrentTicks(const S6Data& s6, uint32_t tick)

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -73,7 +73,7 @@ Vehicle* CableLiftSegmentCreate(
     current->SetTrackType(TrackElemType::CableLiftHill);
     current->SetTrackDirection(current->sprite_direction >> 3);
     current->track_progress = 164;
-    current->update_flags = VEHICLE_UPDATE_FLAG_COLLISION_DISABLED;
+    current->Flags = VEHICLE_UPDATE_FLAG_COLLISION_DISABLED;
     current->SetState(Vehicle::Status::MovingToEndOfStation, 0);
     current->num_peeps = 0;
     current->next_free_seat = 0;

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -78,7 +78,6 @@ Vehicle* CableLiftSegmentCreate(
     current->num_peeps = 0;
     current->next_free_seat = 0;
     current->BoatLocation.SetNull();
-    current->IsCrashedVehicle = false;
     return current;
 }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3167,7 +3167,7 @@ static Vehicle* VehicleCreateCar(
         vehicle->SetTrackType(trackElement->GetTrackType());
         vehicle->track_progress = 0;
         vehicle->SetState(Vehicle::Status::MovingToEndOfStation);
-        vehicle->update_flags = 0;
+        vehicle->Flags = 0;
 
         CoordsXY chosenLoc;
         auto numAttempts = 0;
@@ -3266,7 +3266,7 @@ static Vehicle* VehicleCreateCar(
         {
             vehicle->track_progress = 15;
         }
-        vehicle->update_flags = VEHICLE_UPDATE_FLAG_COLLISION_DISABLED;
+        vehicle->Flags = VEHICLE_UPDATE_FLAG_COLLISION_DISABLED;
         if (carEntry.flags & CAR_ENTRY_FLAG_HAS_INVERTED_SPRITE_SET)
         {
             if (trackElement->IsInverted())

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3281,7 +3281,6 @@ static Vehicle* VehicleCreateCar(
     vehicle->num_peeps = 0;
     vehicle->next_free_seat = 0;
     vehicle->BoatLocation.SetNull();
-    vehicle->IsCrashedVehicle = false;
     return vehicle;
 }
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3231,7 +3231,7 @@ void Vehicle::UpdateDeparting()
         }
         if (curRide->mode == RideMode::Shuttle)
         {
-            update_flags ^= VEHICLE_UPDATE_FLAG_REVERSING_SHUTTLE;
+            Flags ^= VEHICLE_UPDATE_FLAG_REVERSING_SHUTTLE;
             velocity = 0;
 
             // We have turned, so treat it like entering a new tile
@@ -3676,7 +3676,7 @@ void Vehicle::UpdateTravelling()
             }
             if (curRide->mode == RideMode::Shuttle)
             {
-                update_flags ^= VEHICLE_UPDATE_FLAG_REVERSING_SHUTTLE;
+                Flags ^= VEHICLE_UPDATE_FLAG_REVERSING_SHUTTLE;
                 velocity = 0;
             }
             else
@@ -7559,7 +7559,7 @@ bool Vehicle::UpdateTrackMotionForwardsGetNewTrack(uint16_t trackType, const Rid
     }
     if (trackType == TrackElemType::RotationControlToggle)
     {
-        update_flags ^= VEHICLE_UPDATE_FLAG_ROTATION_OFF_WILD_MOUSE;
+        Flags ^= VEHICLE_UPDATE_FLAG_ROTATION_OFF_WILD_MOUSE;
     }
     // Change from original: this used to check if the vehicle allowed doors.
     UpdateSceneryDoorBackwards();
@@ -9370,7 +9370,7 @@ void Vehicle::Serialise(DataSerialiser& stream)
     stream << next_vehicle_on_ride;
     stream << var_44;
     stream << mass;
-    stream << update_flags;
+    stream << Flags;
     stream << SwingSprite;
     stream << current_station;
     stream << SwingPosition;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -3494,7 +3494,7 @@ void Vehicle::UpdateCollisionSetup()
             VehicleCrashParticle::Create(train->colours, trainLoc);
         }
 
-        train->IsCrashedVehicle = true;
+        train->SetUpdateFlag(VEHICLE_UPDATE_FLAG_CRASHED);
         train->animationState = ScenarioRand() & 0xFFFF;
 
         train->animation_frame = ScenarioRand() & 0x7;
@@ -5275,7 +5275,7 @@ void Vehicle::CrashOnLand()
     while (numParticles-- != 0)
         VehicleCrashParticle::Create(colours, curLoc);
 
-    IsCrashedVehicle = true;
+    SetUpdateFlag(VEHICLE_UPDATE_FLAG_CRASHED);
     animation_frame = 0;
     animationState = 0;
     sprite_width = 13;
@@ -5344,7 +5344,7 @@ void Vehicle::CrashOnWater()
     for (int32_t i = 0; i < 10; ++i)
         VehicleCrashParticle::Create(colours, curLoc + CoordsXYZ{ -4, 8, 0 });
 
-    IsCrashedVehicle = true;
+    SetUpdateFlag(VEHICLE_UPDATE_FLAG_CRASHED);
     animation_frame = 0;
     animationState = 0;
     sprite_width = 13;
@@ -9410,5 +9410,4 @@ void Vehicle::Serialise(DataSerialiser& stream)
     stream << seat_rotation;
     stream << target_seat_rotation;
     stream << BoatLocation;
-    stream << IsCrashedVehicle;
 }

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -131,7 +131,7 @@ struct Vehicle : EntityBase
 
     uint16_t var_44;
     uint16_t mass;
-    uint16_t update_flags;
+    uint32_t update_flags;
     uint8_t SwingSprite;
     StationIndex current_station;
     union

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -131,7 +131,7 @@ struct Vehicle : EntityBase
 
     uint16_t var_44;
     uint16_t mass;
-    uint32_t update_flags;
+    uint32_t Flags;
     uint8_t SwingSprite;
     StationIndex current_station;
     union
@@ -257,15 +257,15 @@ struct Vehicle : EntityBase
     }
     bool HasUpdateFlag(uint32_t flag) const
     {
-        return (update_flags & flag) != 0;
+        return (Flags & flag) != 0;
     }
     void ClearUpdateFlag(uint32_t flag)
     {
-        update_flags &= ~flag;
+        Flags &= ~flag;
     }
     void SetUpdateFlag(uint32_t flag)
     {
-        update_flags |= flag;
+        Flags |= flag;
     }
     void ApplyMass(int16_t appliedMass);
     void Serialise(DataSerialiser& stream);

--- a/src/openrct2/ride/Vehicle.h
+++ b/src/openrct2/ride/Vehicle.h
@@ -207,7 +207,6 @@ struct Vehicle : EntityBase
     uint8_t seat_rotation;
     uint8_t target_seat_rotation;
     CoordsXY BoatLocation;
-    bool IsCrashedVehicle;
 
     constexpr bool IsHead() const
     {
@@ -457,6 +456,7 @@ enum : uint32_t
     VEHICLE_UPDATE_FLAG_ROTATION_OFF_WILD_MOUSE = (1 << 13), // After passing a rotation toggle track piece this will enable
     VEHICLE_UPDATE_FLAG_SINGLE_CAR_POSITION = (1 << 14), // OpenRCT2 Flag: Used to override UpdateMotion to move the position of
                                                          // an individual car on a train
+    VEHICLE_UPDATE_FLAG_CRASHED = (1 << 15),
 };
 
 enum

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -3671,7 +3671,7 @@ void Vehicle::Paint(PaintSession& session, int32_t imageDirection) const
 {
     const CarEntry* carEntry;
 
-    if (IsCrashedVehicle)
+    if (HasUpdateFlag(VEHICLE_UPDATE_FLAG_CRASHED))
     {
         PaintAddImageAsParent(
             session, ImageId(SPR_WATER_PARTICLES_DENSE_0 + animation_frame), { 0, 0, z }, { 1, 1, 0 }, { 0, 0, z + 2 });


### PR DESCRIPTION
This PR implements two changes to Vehicle struct. The two commits are structured so they can be reviewed independently. My theory is they should not be squash merged.

commit 1: there is only 1 unused bit in update_flags which is likely to be used up by https://github.com/OpenRCT2/OpenRCT2/pull/19305. This PR widens the field for it and future vehicle features.
commit 2: With a widened update_flags field, there is no reason IsCrashedVehicle has to have 8 bits all to itself. This consolidates the property into the update_flags field.
commit 3: Rename update_flags to Flags

Since both changes affect struct size, they both require replay updates. Having them in the same PR means replays only needs updating once.