### PR TITLE
Fix #17996 - Finances window not cleared when starting some .park scenarios

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
 - Change: [#19233] Reduce lift speed minimum and maximum values for “Classic Wooden Coaster”.
 - Fix: [#474] Mini golf window shows more players than there actually are (original bug).
+- Fix: [#17996] Finances window not cleared when starting some .park scenarios
 - Fix: [#18260] Crash opening parks that have multiple tiles referencing the same banner entry.
 - Fix: [#18467] “Selected only” Object Selection filter is active in Track Designs Manager, and cannot be toggled.
 - Fix: [#18905] Ride Construction window theme is not applied correctly.

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -196,6 +196,14 @@ void FinanceResetHistory()
         gWeeklyProfitHistory[i] = MONEY64_UNDEFINED;
         gParkValueHistory[i] = MONEY64_UNDEFINED;
     }
+
+    for (uint32_t i = 0; i < EXPENDITURE_TABLE_MONTH_COUNT; ++i)
+    {
+        for (uint32_t j = 0; j < static_cast<int32_t>(ExpenditureType::Count); ++j)
+        {
+            gExpenditureTable[i][j] = 0;
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
Fix https://github.com/OpenRCT2/OpenRCT2/issues/17996

Scenarios created in .park retain their finance graphs, so a new scenario game started from a .park scenario may already show financial activity from the start. Slightly annoying if you're trying to avoid it while making a scenario.

Clearing gExpenditureTable on scenario load is sufficient to fix this. This does not impact saved games loaded from .sv6 or .park, only new scenario games. Alternatively, the reset to gExpenditureTable could be done on converting to scenario, but doing it on scenario load will fix it for all .park scenarios created while this issue was present.