### PR TITLE
Fix #14635: Show more scenery tab groups in rows

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -102,6 +102,7 @@ The following people are not part of the development team, but have been contrib
 * Karst van Galen Last (AuraSpecs) - Ride paint (bounding boxes, extra track pieces), soundtrack, sound effects, misc.
 * (8street) - Misc.
 * Umar Ahmed (umar-ahmed) - MacOS file watcher
+* Andrew Arnold (fidwell) - Added window support for more scenery groups.
 
 ## Bug fixes
 * (KirilAngelov)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Improved: [#19253] Queue junctions drawn properly when using regular paths as queue.
 - Improved: [#19067] New Ride window now allows filtering similarly to Object Selection.
 - Improved: [#19272] Scenery window now allows filtering similarly to Object Selection.
+- Improved: [#14635] Scenery window now shows up to 255 scenery groups.
 - Change: [#19018] Renamed actions to fit the naming scheme.
 - Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
 - Change: [#19233] Reduce lift speed minimum and maximum values for “Classic Wooden Coaster”.


### PR DESCRIPTION
Fixes #14635. This PR does not include the horizontal offsets discussed in the issue. I figured it might be better to keep this PR smaller.