### PR TITLE
Add command to combine CSG1i and CSG1

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#18732] [Plugin] API to get the guests thoughts.
 - Feature: [#18744] Cheat to allow using a regular path as a queue path.
 - Feature: [#19023] Add Canadian French translation.
+- Feature: [#19378] Add command to combine CSG1i.DAT and CSG1.DAT.
 - Feature: [objects#226] Port RCT1 Corkscrew Coaster train.
 - Feature: [objects#229] Port RCT1 go karts with helmets.
 - Improved: [#11473] Hot reload for plug-ins now works on macOS.

--- a/src/openrct2/cmdline/SpriteCommands.cpp
+++ b/src/openrct2/cmdline/SpriteCommands.cpp
@@ -36,6 +36,7 @@ const CommandLineCommand CommandLine::SpriteCommands[]
     // Main commands
     DefineCommand("append",       "<spritefile> <input> [x_offset y_offset]", SpriteOptions, HandleSprite),
     DefineCommand("build",        "<spritefile> <json path> [silent]",        SpriteOptions, HandleSprite),
+    DefineCommand("combine",      "<index file> <image file> <output>",       SpriteOptions, HandleSprite),
     DefineCommand("create",       "<spritefile>",                             SpriteOptions, HandleSprite),
     DefineCommand("details",      "<spritefile> [idx]",                       SpriteOptions, HandleSprite),
     DefineCommand("export",       "<spritefile> <idx> <output>",              SpriteOptions, HandleSprite),


### PR DESCRIPTION
This command allows one to combine the CSG1i.DAT and CSG1.DAT files into a G1-compatible sprite file, so that it can be read and manipulated by any tool that can handle RCT2’s or OpenRCT2’s sprite files.