### PR TITLE
Fix a division by zero in TitleScreen::TitleInitialise if there are no installed sequences

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -38,6 +38,7 @@
 - Fix: [#19136] SV6 saves with experimental RCT1 paths not imported correctly.
 - Fix: [#19250] MusicObjects do not free their preview images
 - Fix: [#19292] Overflow in totalRideValue
+- Fix: [#19380] Startup crash when no sequences are installed and random sequences are enabled.
 
 0.4.3 (2022-12-14)
 ------------------------------------------------------------------------

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -230,59 +230,65 @@ void TitleScreen::TitleInitialise()
     }
     if (gConfigInterface.RandomTitleSequence)
     {
-        bool RCT1Installed = false, RCT1AAInstalled = false, RCT1LLInstalled = false;
-        int RCT1Count = 0;
-        size_t scenarioCount = ScenarioRepositoryGetCount();
-
-        for (size_t s = 0; s < scenarioCount; s++)
+        const size_t total = TitleSequenceManager::GetCount();
+        if (total > 0)
         {
-            if (ScenarioRepositoryGetByIndex(s)->source_game == ScenarioSource::RCT1)
-            {
-                RCT1Count++;
-            }
-            if (ScenarioRepositoryGetByIndex(s)->source_game == ScenarioSource::RCT1_AA)
-            {
-                RCT1AAInstalled = true;
-            }
-            if (ScenarioRepositoryGetByIndex(s)->source_game == ScenarioSource::RCT1_LL)
-            {
-                RCT1LLInstalled = true;
-            }
-        }
+            bool RCT1Installed = false, RCT1AAInstalled = false, RCT1LLInstalled = false;
+            uint32_t RCT1Count = 0;
+            const size_t scenarioCount = ScenarioRepositoryGetCount();
 
-        // Mega Park can show up in the scenario list even if RCT1 has been uninstalled, so it must be greater than 1
-        if (RCT1Count > 1)
-        {
-            RCT1Installed = true;
-        }
+            for (size_t s = 0; s < scenarioCount; s++)
+            {
+                const ScenarioSource sourceGame = ScenarioRepositoryGetByIndex(s)->source_game;
+                switch (sourceGame)
+                {
+                    case ScenarioSource::RCT1:
+                        RCT1Count++;
+                        break;
+                    case ScenarioSource::RCT1_AA:
+                        RCT1AAInstalled = true;
+                        break;
+                    case ScenarioSource::RCT1_LL:
+                        RCT1LLInstalled = true;
+                        break;
+                    default:
+                        break;
+                }
+            }
 
-        int32_t random = 0;
-        bool safeSequence = false;
-        std::string RCT1String = FormatStringID(STR_TITLE_SEQUENCE_RCT1, nullptr);
-        std::string RCT1AAString = FormatStringID(STR_TITLE_SEQUENCE_RCT1_AA, nullptr);
-        std::string RCT1LLString = FormatStringID(STR_TITLE_SEQUENCE_RCT1_AA_LL, nullptr);
+            // Mega Park can show up in the scenario list even if RCT1 has been uninstalled, so it must be greater than 1
+            RCT1Installed = RCT1Count > 1;
 
-        // Ensure the random sequence chosen isn't from RCT1 or expansion if the player doesn't have it installed
-        while (!safeSequence)
-        {
-            size_t total = TitleSequenceManager::GetCount();
-            random = UtilRand() % static_cast<int32_t>(total);
-            const utf8* scName = TitleSequenceManagerGetName(random);
-            safeSequence = true;
-            if (scName == RCT1String)
+            int32_t random = 0;
+            bool safeSequence = false;
+            const std::string RCT1String = FormatStringID(STR_TITLE_SEQUENCE_RCT1, nullptr);
+            const std::string RCT1AAString = FormatStringID(STR_TITLE_SEQUENCE_RCT1_AA, nullptr);
+            const std::string RCT1LLString = FormatStringID(STR_TITLE_SEQUENCE_RCT1_AA_LL, nullptr);
+
+            // Ensure the random sequence chosen isn't from RCT1 or expansion if the player doesn't have it installed
+            while (!safeSequence)
             {
-                safeSequence = RCT1Installed;
+                random = UtilRand() % static_cast<int32_t>(total);
+                const utf8* scName = TitleSequenceManagerGetName(random);
+                if (scName == RCT1String)
+                {
+                    safeSequence = RCT1Installed;
+                }
+                else if (scName == RCT1AAString)
+                {
+                    safeSequence = RCT1AAInstalled;
+                }
+                else if (scName == RCT1LLString)
+                {
+                    safeSequence = RCT1LLInstalled;
+                }
+                else
+                {
+                    safeSequence = true;
+                }
             }
-            if (scName == RCT1AAString)
-            {
-                safeSequence = RCT1AAInstalled;
-            }
-            if (scName == RCT1LLString)
-            {
-                safeSequence = RCT1LLInstalled;
-            }
+            ChangePresetSequence(random);
         }
-        ChangePresetSequence(random);
     }
     size_t seqId = TitleGetConfigSequence();
     if (seqId == SIZE_MAX)


### PR DESCRIPTION
This simple code clarity fix resolves a division-by-zero crash on startup if random sequences are enabled and there are no sequences installed. While I'm not entirely sure how can the user "reach" the state of having no sequences in the first place, the game handles this gracefully with random sequences disables and crashes with them enabled, so it can likely be considered a bug.

All the linked issues have been verified against backtrace.io and are crashing on exactly the same line:
Fixes #17133
Fixes #18484
Fixes #19289
Fixes #19295
Fixes #19317
Fixes #19318
Fixes #19345
Fixes #19346
Fixes #19348
Fixes #19349
Fixes #19350
Fixes #19356
Fixes #19359
Fixes #19362
Fixes #19375