### PR TITLE
Fix an assertion error in ResearchNextDesign, simplify code

### DIFF
--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -130,7 +130,7 @@ void ResearchUpdate();
 void ResearchResetCurrentItem();
 void ResearchPopulateListRandom();
 
-void ResearchFinishItem(ResearchItem* researchItem);
+void ResearchFinishItem(const ResearchItem& researchItem);
 void ResearchInsert(ResearchItem&& item, bool researched);
 void ResearchRemove(const ResearchItem& researchItem);
 


### PR DESCRIPTION
Loop inside `ResearchNextDesign` first dereferenced the iterator, **then** checked if it's the end. This PR cleans up the code to remove the entire "double loop" logic, and cleans up the rest of `Research.cpp` a little.

No changelog entry since dereferencing the end iterator doesn't crash in Release, this only fixes an assertion in Debug.