### PR TITLE
ObjectEntry Cleanup. FootpathItem, SceneryGroup, Water, LargeScenery

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -46,7 +46,6 @@
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Banner.h>
 #include <openrct2/world/Footpath.h>
-#include <openrct2/world/LargeScenery.h>
 #include <openrct2/world/Map.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -466,7 +466,7 @@ public:
                 }
                 else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_PATH_ITEM)
                 { // path bit
-                    gCurrentToolId = static_cast<Tool>(GetFootpathItemEntry(tabSelectedScenery.EntryIndex)->tool_id);
+                    gCurrentToolId = static_cast<Tool>(OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(tabSelectedScenery.EntryIndex)->tool_id);
                 }
                 else
                 { // small scenery
@@ -877,7 +877,7 @@ public:
         // path bits
         for (ObjectEntryIndex sceneryId = 0; sceneryId < MAX_PATH_ADDITION_OBJECTS; sceneryId++)
         {
-            const auto* sceneryEntry = GetFootpathItemEntry(sceneryId);
+            const auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(sceneryId);
             if (sceneryEntry != nullptr)
             {
                 InitSceneryEntry({ SCENERY_TYPE_PATH_ITEM, sceneryId }, sceneryEntry->scenery_tab_id);
@@ -1312,7 +1312,7 @@ private:
                 }
                 case SCENERY_TYPE_PATH_ITEM:
                 {
-                    auto* sceneryEntry = GetFootpathItemEntry(selectedScenery.EntryIndex);
+                    auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(selectedScenery.EntryIndex);
                     if (sceneryEntry != nullptr)
                     {
                         price = sceneryEntry->price;
@@ -1430,7 +1430,7 @@ private:
         }
         else if (scenerySelection.SceneryType == SCENERY_TYPE_PATH_ITEM)
         {
-            auto* pathBitEntry = GetFootpathItemEntry(scenerySelection.EntryIndex);
+            auto* pathBitEntry = OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(scenerySelection.EntryIndex);
             auto imageId = ImageId(pathBitEntry->image);
             GfxDrawSprite(&dpi, imageId, { 11, 16 });
         }

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -32,7 +32,6 @@
 #include <openrct2/object/SmallSceneryEntry.h>
 #include <openrct2/object/WallSceneryEntry.h>
 #include <openrct2/sprites.h>
-#include <openrct2/world/LargeScenery.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>
 

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -457,7 +457,8 @@ public:
                 }
                 else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_LARGE)
                 {
-                    gCurrentToolId = static_cast<Tool>(GetLargeSceneryEntry(tabSelectedScenery.EntryIndex)->tool_id);
+                    gCurrentToolId = static_cast<Tool>(
+                        OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(tabSelectedScenery.EntryIndex)->tool_id);
                 }
                 else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_WALL)
                 {
@@ -633,7 +634,7 @@ public:
             }
             else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_LARGE)
             {
-                auto* sceneryEntry = GetLargeSceneryEntry(tabSelectedScenery.EntryIndex);
+                auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(tabSelectedScenery.EntryIndex);
 
                 if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR
                     && !(sceneryEntry->flags & LARGE_SCENERY_FLAG_HIDE_PRIMARY_REMAP_BUTTON))
@@ -848,7 +849,7 @@ public:
         // large scenery
         for (ObjectEntryIndex sceneryId = 0; sceneryId < MAX_LARGE_SCENERY_OBJECTS; sceneryId++)
         {
-            const auto* sceneryEntry = GetLargeSceneryEntry(sceneryId);
+            const auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(sceneryId);
             if (sceneryEntry != nullptr)
             {
                 InitSceneryEntry({ SCENERY_TYPE_LARGE, sceneryId }, sceneryEntry->scenery_tab_id);
@@ -1333,7 +1334,7 @@ private:
                 }
                 case SCENERY_TYPE_LARGE:
                 {
-                    auto* sceneryEntry = GetLargeSceneryEntry(selectedScenery.EntryIndex);
+                    auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(selectedScenery.EntryIndex);
                     if (sceneryEntry != nullptr)
                     {
                         price = sceneryEntry->price;
@@ -1383,7 +1384,7 @@ private:
         }
         else if (scenerySelection.SceneryType == SCENERY_TYPE_LARGE)
         {
-            auto sceneryEntry = GetLargeSceneryEntry(scenerySelection.EntryIndex);
+            auto sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(scenerySelection.EntryIndex);
             auto imageId = ImageId(sceneryEntry->image + gWindowSceneryRotation);
             if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR)
                 imageId = imageId.WithPrimary(gWindowSceneryPrimaryColour);

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -146,7 +146,7 @@ private:
 
         const SceneryGroupEntry* GetSceneryGroupEntry() const
         {
-            return ::GetSceneryGroupEntry(SceneryGroupIndex);
+            return OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(SceneryGroupIndex);
         }
     };
 
@@ -466,7 +466,8 @@ public:
                 }
                 else if (tabSelectedScenery.SceneryType == SCENERY_TYPE_PATH_ITEM)
                 { // path bit
-                    gCurrentToolId = static_cast<Tool>(OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(tabSelectedScenery.EntryIndex)->tool_id);
+                    gCurrentToolId = static_cast<Tool>(
+                        OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(tabSelectedScenery.EntryIndex)->tool_id);
                 }
                 else
                 { // small scenery
@@ -812,7 +813,7 @@ public:
 
         for (ObjectEntryIndex scenerySetIndex = 0; scenerySetIndex < MaxTabs - 1; scenerySetIndex++)
         {
-            const auto* sceneryGroupEntry = GetSceneryGroupEntry(scenerySetIndex);
+            const auto* sceneryGroupEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(scenerySetIndex);
             if (sceneryGroupEntry != nullptr && SceneryGroupIsInvented(scenerySetIndex))
             {
                 SceneryTabInfo tabInfo;

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -263,7 +263,7 @@ public:
         }
         else
         {
-            auto* sceneryEntry = GetLargeSceneryEntry(_sceneryEntry);
+            auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(_sceneryEntry);
 
             main_colour_btn->type = WindowWidgetType::Empty;
             text_colour_btn->type = WindowWidgetType::Empty;

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -24,7 +24,6 @@
 #include <openrct2/object/WallSceneryEntry.h>
 #include <openrct2/sprites.h>
 #include <openrct2/world/Banner.h>
-#include <openrct2/world/LargeScenery.h>
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/Wall.h>
 

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -36,7 +36,6 @@
 #include <openrct2/windows/TileInspectorGlobals.h>
 #include <openrct2/world/Banner.h>
 #include <openrct2/world/Footpath.h>
-#include <openrct2/world/LargeScenery.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/Surface.h>

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -25,6 +25,7 @@
 #include <openrct2/object/FootpathRailingsObject.h>
 #include <openrct2/object/FootpathSurfaceObject.h>
 #include <openrct2/object/LargeSceneryEntry.h>
+#include <openrct2/object/ObjectEntryManager.h>
 #include <openrct2/object/SmallSceneryEntry.h>
 #include <openrct2/object/TerrainEdgeObject.h>
 #include <openrct2/object/TerrainSurfaceObject.h>
@@ -1461,7 +1462,7 @@ public:
                         { colours[1] });
 
                     // Banner info
-                    auto* largeSceneryEntry = GetLargeSceneryEntry(largeSceneryType);
+                    auto* largeSceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(largeSceneryType);
                     if (largeSceneryEntry != nullptr && largeSceneryEntry->scrolling_mode != SCROLLING_MODE_NONE)
                     {
                         auto banner = sceneryElement->GetBanner();

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1146,8 +1146,7 @@ public:
                     // Path addition
                     if (tileElement->AsPath()->HasAddition())
                     {
-                        const auto pathAdditionType = tileElement->AsPath()->GetAdditionEntryIndex();
-                        const auto* pathBitEntry = GetFootpathItemEntry(pathAdditionType);
+                        const auto pathBitEntry = tileElement->AsPath()->GetAdditionEntry();
                         StringId additionNameId = pathBitEntry != nullptr ? pathBitEntry->name
                                                                           : static_cast<StringId>(STR_UNKNOWN_OBJECT_TYPE);
                         auto ft = Formatter();

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -54,6 +54,7 @@
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/network/network.h>
 #include <openrct2/object/BannerSceneryEntry.h>
+#include <openrct2/object/FootpathItemEntry.h>
 #include <openrct2/object/LargeSceneryEntry.h>
 #include <openrct2/object/ObjectEntryManager.h>
 #include <openrct2/object/SmallSceneryEntry.h>
@@ -1598,7 +1599,7 @@ private:
             case ViewportInteractionItem::FootpathItem:
             {
                 auto entryIndex = info.Element->AsPath()->GetAdditionEntryIndex();
-                auto* pathBitEntry = GetFootpathItemEntry(entryIndex);
+                auto* pathBitEntry = OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(entryIndex);
                 if (pathBitEntry != nullptr)
                 {
                     WindowScenerySetSelectedItem(

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -1066,7 +1066,7 @@ private:
                     return;
                 }
 
-                auto* sceneryEntry = GetLargeSceneryEntry(selection.EntryIndex);
+                auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(selection.EntryIndex);
                 gMapSelectionTiles.clear();
 
                 for (auto* tile = sceneryEntry->tiles; tile->x_offset != static_cast<int16_t>(static_cast<uint16_t>(0xFFFF));
@@ -1572,7 +1572,7 @@ private:
             case ViewportInteractionItem::LargeScenery:
             {
                 auto entryIndex = info.Element->AsLargeScenery()->GetEntryIndex();
-                auto* sceneryEntry = GetLargeSceneryEntry(entryIndex);
+                auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(entryIndex);
                 if (sceneryEntry != nullptr)
                 {
                     WindowScenerySetSelectedItem(
@@ -2021,7 +2021,7 @@ private:
         uint16_t maxPossibleHeight = ZoomLevel::max().ApplyTo(
             std::numeric_limits<decltype(TileElement::BaseHeight)>::max() - 32);
 
-        auto* sceneryEntry = GetLargeSceneryEntry(sceneryIndex);
+        auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(sceneryIndex);
         if (sceneryEntry)
         {
             int16_t maxClearZ = 0;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -65,7 +65,6 @@
 #include <openrct2/util/Math.hpp>
 #include <openrct2/windows/Intent.h>
 #include <openrct2/world/Footpath.h>
-#include <openrct2/world/LargeScenery.h>
 #include <openrct2/world/Park.h>
 #include <openrct2/world/Scenery.h>
 #include <openrct2/world/Surface.h>

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -28,7 +28,6 @@
 #include "scenario/Scenario.h"
 #include "windows/Intent.h"
 #include "world/Footpath.h"
-#include "world/LargeScenery.h"
 #include "world/Scenery.h"
 
 #include <iterator>

--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -40,6 +40,7 @@
 #include "management/Research.h"
 #include "network/network.h"
 #include "object/Object.h"
+#include "object/ObjectEntryManager.h"
 #include "object/ObjectList.h"
 #include "object/WaterEntry.h"
 #include "platform/Platform.h"
@@ -148,7 +149,7 @@ enum
  */
 void UpdatePaletteEffects()
 {
-    auto water_type = static_cast<WaterObjectEntry*>(ObjectEntryGetChunk(ObjectType::Water, 0));
+    auto water_type = OpenRCT2::ObjectManager::GetObjectEntry<WaterObjectEntry>(0);
 
     if (gClimateLightningFlash == 1)
     {

--- a/src/openrct2/actions/ClearAction.cpp
+++ b/src/openrct2/actions/ClearAction.cpp
@@ -14,7 +14,6 @@
 #include "../drawing/Drawing.h"
 #include "../localisation/StringIds.h"
 #include "../management/Finance.h"
-#include "../world/LargeScenery.h"
 #include "../world/Location.hpp"
 #include "../world/Map.h"
 #include "FootpathRemoveAction.h"

--- a/src/openrct2/actions/FootpathAdditionPlaceAction.cpp
+++ b/src/openrct2/actions/FootpathAdditionPlaceAction.cpp
@@ -16,6 +16,7 @@
 #include "../localisation/StringIds.h"
 #include "../management/Finance.h"
 #include "../object/FootpathItemEntry.h"
+#include "../object/ObjectEntryManager.h"
 #include "../world/Footpath.h"
 #include "../world/Location.hpp"
 #include "../world/Park.h"
@@ -94,7 +95,7 @@ GameActions::Result FootpathAdditionPlaceAction::Query() const
 
     if (_pathItemType != 0)
     {
-        auto* pathBitEntry = GetFootpathItemEntry(_pathItemType - 1);
+        auto* pathBitEntry = OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(_pathItemType - 1);
         if (pathBitEntry == nullptr)
         {
             return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_NONE);
@@ -164,7 +165,7 @@ GameActions::Result FootpathAdditionPlaceAction::Execute() const
 
     if (_pathItemType != 0)
     {
-        auto* pathBitEntry = GetFootpathItemEntry(_pathItemType - 1);
+        auto* pathBitEntry = OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(_pathItemType - 1);
         if (pathBitEntry == nullptr)
         {
             return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_NONE);
@@ -192,7 +193,7 @@ GameActions::Result FootpathAdditionPlaceAction::Execute() const
     pathElement->SetIsBroken(false);
     if (_pathItemType != 0)
     {
-        auto* pathBitEntry = GetFootpathItemEntry(_pathItemType - 1);
+        auto* pathBitEntry = OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(_pathItemType - 1);
         if (pathBitEntry != nullptr && pathBitEntry->flags & PATH_BIT_FLAG_IS_BIN)
         {
             pathElement->SetAdditionStatus(255);

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -12,6 +12,7 @@
 #include "../OpenRCT2.h"
 #include "../management/Finance.h"
 #include "../object/LargeSceneryEntry.h"
+#include "../object/ObjectEntryManager.h"
 #include "../object/ObjectLimits.h"
 #include "../ride/Ride.h"
 #include "../ride/RideConstruction.h"
@@ -81,7 +82,7 @@ GameActions::Result LargeSceneryPlaceAction::Query() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_POSITION_THIS_HERE, STR_NONE);
     }
 
-    auto* sceneryEntry = GetLargeSceneryEntry(_sceneryType);
+    auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(_sceneryType);
     if (sceneryEntry == nullptr)
     {
         LOG_ERROR("Invalid game command for scenery placement, sceneryType = %u", _sceneryType);
@@ -193,7 +194,7 @@ GameActions::Result LargeSceneryPlaceAction::Execute() const
 
     money32 supportsCost = 0;
 
-    auto* sceneryEntry = GetLargeSceneryEntry(_sceneryType);
+    auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(_sceneryType);
     if (sceneryEntry == nullptr)
     {
         LOG_ERROR("Invalid game command for scenery placement, sceneryType = %u", _sceneryType);

--- a/src/openrct2/actions/LargeSceneryPlaceAction.cpp
+++ b/src/openrct2/actions/LargeSceneryPlaceAction.cpp
@@ -18,7 +18,6 @@
 #include "../ride/RideConstruction.h"
 #include "../world/Banner.h"
 #include "../world/ConstructionClearance.h"
-#include "../world/LargeScenery.h"
 #include "../world/MapAnimation.h"
 #include "../world/Surface.h"
 

--- a/src/openrct2/actions/WallPlaceAction.cpp
+++ b/src/openrct2/actions/WallPlaceAction.cpp
@@ -19,7 +19,6 @@
 #include "../ride/TrackDesign.h"
 #include "../world/Banner.h"
 #include "../world/ConstructionClearance.h"
-#include "../world/LargeScenery.h"
 #include "../world/MapAnimation.h"
 #include "../world/Surface.h"
 #include "../world/Wall.h"

--- a/src/openrct2/actions/WallSetColourAction.cpp
+++ b/src/openrct2/actions/WallSetColourAction.cpp
@@ -15,7 +15,6 @@
 #include "../ride/Track.h"
 #include "../ride/TrackData.h"
 #include "../world/Banner.h"
-#include "../world/LargeScenery.h"
 #include "../world/MapAnimation.h"
 #include "../world/Scenery.h"
 #include "../world/Surface.h"

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -16,6 +16,7 @@
 #include "../config/Config.h"
 #include "../core/Guard.hpp"
 #include "../object/Object.h"
+#include "../object/ObjectEntryManager.h"
 #include "../object/WaterEntry.h"
 #include "../platform/Platform.h"
 #include "../sprites.h"
@@ -622,7 +623,7 @@ void LoadPalette()
         return;
     }
 
-    auto water_type = static_cast<WaterObjectEntry*>(ObjectEntryGetChunk(ObjectType::Water, 0));
+    auto water_type = OpenRCT2::ObjectManager::GetObjectEntry<WaterObjectEntry>(0);
 
     uint32_t palette = 0x5FC;
 

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -49,7 +49,6 @@
 #include "../windows/Intent.h"
 #include "../world/Climate.h"
 #include "../world/Footpath.h"
-#include "../world/LargeScenery.h"
 #include "../world/Location.hpp"
 #include "../world/Map.h"
 #include "../world/Park.h"

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -48,7 +48,6 @@
 #include "../world/ConstructionClearance.h"
 #include "../world/Entrance.h"
 #include "../world/Footpath.h"
-#include "../world/LargeScenery.h"
 #include "../world/Map.h"
 #include "../world/Park.h"
 #include "../world/Scenery.h"

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -24,6 +24,7 @@
 #include "../management/Finance.h"
 #include "../network/network.h"
 #include "../object/FootpathItemEntry.h"
+#include "../object/ObjectEntryManager.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
 #include "../object/SceneryGroupEntry.h"
@@ -1032,7 +1033,7 @@ uint32_t StaffGetAvailableEntertainerCostumes()
     {
         if (SceneryGroupIsInvented(i))
         {
-            const auto sgEntry = GetSceneryGroupEntry(i);
+            const auto sgEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(i);
             entertainerCostumes |= sgEntry->entertainer_costumes;
         }
     }

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -318,6 +318,7 @@
     <ClInclude Include="object\ObjectManager.h" />
     <ClInclude Include="object\ObjectRepository.h" />
     <ClInclude Include="object\ObjectType.h" />
+    <ClInclude Include="object\ObjectTypes.h" />
     <ClInclude Include="object\ResourceTable.h" />
     <ClInclude Include="object\RideObject.h" />
     <ClInclude Include="object\SceneryGroupEntry.h" />

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -21,6 +21,7 @@
 #include "../localisation/Formatter.h"
 #include "../localisation/Localisation.h"
 #include "../localisation/StringIds.h"
+#include "../object/ObjectEntryManager.h"
 #include "../object/ObjectList.h"
 #include "../object/RideObject.h"
 #include "../object/SceneryGroupEntry.h"
@@ -268,7 +269,7 @@ void ResearchFinishItem(const ResearchItem& researchItem)
     else
     {
         // Scenery
-        SceneryGroupEntry* sceneryGroupEntry = GetSceneryGroupEntry(researchItem.entryIndex);
+        const auto* sceneryGroupEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(researchItem.entryIndex);
         if (sceneryGroupEntry != nullptr)
         {
             SceneryGroupSetInvented(researchItem.entryIndex);
@@ -465,7 +466,7 @@ void ResearchPopulateListRandom()
     // Scenery
     for (uint32_t i = 0; i < MAX_SCENERY_GROUP_OBJECTS; i++)
     {
-        SceneryGroupEntry* sceneryGroupEntry = GetSceneryGroupEntry(i);
+        const auto* sceneryGroupEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(i);
         if (sceneryGroupEntry == nullptr)
         {
             continue;
@@ -581,7 +582,7 @@ void ScenerySetNotInvented(const ScenerySelection& sceneryItem)
 
 bool SceneryGroupIsInvented(int32_t sgIndex)
 {
-    const auto sgEntry = GetSceneryGroupEntry(sgIndex);
+    const auto sgEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(sgIndex);
     if (sgEntry == nullptr || sgEntry->SceneryEntries.empty())
     {
         return false;
@@ -606,7 +607,7 @@ bool SceneryGroupIsInvented(int32_t sgIndex)
 
 void SceneryGroupSetInvented(int32_t sgIndex)
 {
-    const auto sgEntry = GetSceneryGroupEntry(sgIndex);
+    const auto sgEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(sgIndex);
     if (sgEntry != nullptr)
     {
         for (const auto& entry : sgEntry->SceneryEntries)
@@ -620,7 +621,7 @@ void SetAllSceneryGroupsNotInvented()
 {
     for (int32_t i = 0; i < MAX_SCENERY_GROUP_OBJECTS; ++i)
     {
-        SceneryGroupEntry* scenery_set = GetSceneryGroupEntry(i);
+        const auto* scenery_set = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(i);
         if (scenery_set == nullptr)
         {
             continue;
@@ -686,7 +687,7 @@ StringId ResearchItem::GetName() const
         return rideEntry->naming.Name;
     }
 
-    SceneryGroupEntry* sceneryEntry = GetSceneryGroupEntry(entryIndex);
+    const auto* sceneryEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(entryIndex);
     if (sceneryEntry == nullptr)
     {
         return STR_EMPTY;
@@ -722,7 +723,7 @@ static void ResearchRemoveNullItems(std::vector<ResearchItem>& items)
         }
         else
         {
-            return GetSceneryGroupEntry(researchItem.entryIndex) == nullptr;
+            return OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(researchItem.entryIndex) == nullptr;
         }
     });
     items.erase(it, std::end(items));
@@ -747,7 +748,7 @@ static void ResearchMarkItemAsResearched(const ResearchItem& item)
     }
     else if (item.type == Research::EntryType::Scenery)
     {
-        const auto sgEntry = GetSceneryGroupEntry(item.entryIndex);
+        const auto sgEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(item.entryIndex);
         if (sgEntry != nullptr)
         {
             for (const auto& sceneryEntry : sgEntry->SceneryEntries)
@@ -793,7 +794,7 @@ static void ResearchAddAllMissingItems(bool isResearched)
 
     for (ObjectEntryIndex i = 0; i < MAX_SCENERY_GROUP_OBJECTS; i++)
     {
-        const auto* groupEntry = GetSceneryGroupEntry(i);
+        const auto* groupEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(i);
         if (groupEntry != nullptr)
         {
             ResearchInsertSceneryGroupEntry(i, isResearched);

--- a/src/openrct2/object/FootpathItemEntry.h
+++ b/src/openrct2/object/FootpathItemEntry.h
@@ -36,6 +36,8 @@ enum
 
 struct PathBitEntry
 {
+    static constexpr auto kObjectType = ObjectType::PathBits;
+
     StringId name;
     uint32_t image;
     uint16_t flags;

--- a/src/openrct2/object/LargeSceneryEntry.h
+++ b/src/openrct2/object/LargeSceneryEntry.h
@@ -61,6 +61,8 @@ enum LARGE_SCENERY_TEXT_FLAGS
 
 struct LargeSceneryEntry
 {
+    static constexpr auto kObjectType = ObjectType::LargeScenery;
+
     StringId name;
     uint32_t image;
     CursorID tool_id;

--- a/src/openrct2/object/SceneryGroupEntry.h
+++ b/src/openrct2/object/SceneryGroupEntry.h
@@ -17,6 +17,8 @@
 
 struct SceneryGroupEntry
 {
+    static constexpr auto kObjectType = ObjectType::SceneryGroup;
+
     StringId name;
     uint32_t image;
     std::vector<ScenerySelection> SceneryEntries;

--- a/src/openrct2/object/WaterEntry.h
+++ b/src/openrct2/object/WaterEntry.h
@@ -18,6 +18,8 @@ enum
 
 struct WaterObjectEntry
 {
+    static constexpr auto kObjectType = ObjectType::Water;
+
     StringId string_idx;      // 0x00
     uint32_t image_id;        // 0x02
     uint32_t palette_index_1; // 0x06

--- a/src/openrct2/object/WaterEntry.h
+++ b/src/openrct2/object/WaterEntry.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "ObjectTypes.h"
 
 enum
 {

--- a/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.LargeScenery.cpp
@@ -23,7 +23,6 @@
 #include "../../ride/TrackDesign.h"
 #include "../../util/Util.h"
 #include "../../world/Banner.h"
-#include "../../world/LargeScenery.h"
 #include "../../world/Map.h"
 #include "../../world/Scenery.h"
 #include "../../world/TileInspector.h"

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -61,7 +61,6 @@
 #include "../world/Climate.h"
 #include "../world/Entrance.h"
 #include "../world/Footpath.h"
-#include "../world/LargeScenery.h"
 #include "../world/MapAnimation.h"
 #include "../world/Park.h"
 #include "../world/Scenery.h"

--- a/src/openrct2/rct12/RCT12.cpp
+++ b/src/openrct2/rct12/RCT12.cpp
@@ -19,7 +19,6 @@
 #include "../scenario/Scenario.h"
 #include "../world/Banner.h"
 #include "../world/Footpath.h"
-#include "../world/LargeScenery.h"
 #include "../world/SmallScenery.h"
 #include "../world/Surface.h"
 #include "../world/TileElement.h"

--- a/src/openrct2/ride/TrackDesignSave.cpp
+++ b/src/openrct2/ride/TrackDesignSave.cpp
@@ -24,7 +24,6 @@
 #include "../util/Util.h"
 #include "../windows/Intent.h"
 #include "../world/Footpath.h"
-#include "../world/LargeScenery.h"
 #include "../world/Scenery.h"
 #include "../world/Wall.h"
 #include "RideData.h"

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -36,6 +36,7 @@
 #include "../management/Research.h"
 #include "../network/network.h"
 #include "../object/Object.h"
+#include "../object/ObjectEntryManager.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
 #include "../object/WaterEntry.h"
@@ -335,7 +336,7 @@ static void ScenarioWeekUpdate()
     RideCheckAllReachable();
     RideUpdateFavouritedStat();
 
-    auto water_type = static_cast<WaterObjectEntry*>(ObjectEntryGetChunk(ObjectType::Water, 0));
+    auto water_type = OpenRCT2::ObjectManager::GetObjectEntry<WaterObjectEntry>(0);
 
     if (month <= MONTH_APRIL && water_type != nullptr && water_type->flags & WATER_FLAGS_ALLOW_DUCKS)
     {

--- a/src/openrct2/world/Footpath.cpp
+++ b/src/openrct2/world/Footpath.cpp
@@ -22,9 +22,11 @@
 #include "../localisation/Localisation.h"
 #include "../management/Finance.h"
 #include "../network/network.h"
+#include "../object/FootpathItemEntry.h"
 #include "../object/FootpathObject.h"
 #include "../object/FootpathRailingsObject.h"
 #include "../object/FootpathSurfaceObject.h"
+#include "../object/ObjectEntryManager.h"
 #include "../object/ObjectList.h"
 #include "../object/ObjectManager.h"
 #include "../paint/VirtualFloor.h"
@@ -1617,11 +1619,11 @@ ObjectEntryIndex PathElement::GetAdditionEntryIndex() const
     return GetAddition() - 1;
 }
 
-PathBitEntry* PathElement::GetAdditionEntry() const
+const PathBitEntry* PathElement::GetAdditionEntry() const
 {
     if (!HasAddition())
         return nullptr;
-    return GetFootpathItemEntry(GetAdditionEntryIndex());
+    return OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(GetAdditionEntryIndex());
 }
 
 void PathElement::SetAddition(uint8_t newAddition)

--- a/src/openrct2/world/LargeScenery.cpp
+++ b/src/openrct2/world/LargeScenery.cpp
@@ -12,6 +12,7 @@
 #include "../Context.h"
 #include "../common.h"
 #include "../object/LargeSceneryObject.h"
+#include "../object/ObjectEntryManager.h"
 #include "../object/ObjectManager.h"
 #include "../world/Banner.h"
 #include "TileElement.h"
@@ -86,9 +87,9 @@ ObjectEntryIndex LargeSceneryElement::GetEntryIndex() const
     return EntryIndex;
 }
 
-LargeSceneryEntry* LargeSceneryElement::GetEntry() const
+const LargeSceneryEntry* LargeSceneryElement::GetEntry() const
 {
-    return GetLargeSceneryEntry(GetEntryIndex());
+    return OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(GetEntryIndex());
 }
 
 const LargeSceneryObject* LargeSceneryElement::GetObject() const
@@ -109,16 +110,4 @@ void LargeSceneryElement::SetEntryIndex(ObjectEntryIndex newIndex)
 void LargeSceneryElement::SetSequenceIndex(uint8_t sequence)
 {
     SequenceIndex = sequence;
-}
-
-LargeSceneryEntry* GetLargeSceneryEntry(ObjectEntryIndex entryIndex)
-{
-    LargeSceneryEntry* result = nullptr;
-    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    auto obj = objMgr.GetLoadedObject(ObjectType::LargeScenery, entryIndex);
-    if (obj != nullptr)
-    {
-        result = static_cast<LargeSceneryEntry*>(obj->GetLegacyData());
-    }
-    return result;
 }

--- a/src/openrct2/world/LargeScenery.h
+++ b/src/openrct2/world/LargeScenery.h
@@ -9,12 +9,6 @@
 
 #pragma once
 
-#include "../common.h"
-#include "Map.h"
-#include "TileElement.h"
-
-LargeSceneryEntry* GetLargeSceneryEntry(ObjectEntryIndex entryIndex);
-
 enum
 {
     LARGE_SCENERY_ELEMENT_FLAGS2_ACCOUNTED = 1 << 0,

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -44,7 +44,6 @@
 #include "Banner.h"
 #include "Climate.h"
 #include "Footpath.h"
-#include "LargeScenery.h"
 #include "MapAnimation.h"
 #include "Park.h"
 #include "Scenery.h"

--- a/src/openrct2/world/MapAnimation.cpp
+++ b/src/openrct2/world/MapAnimation.cpp
@@ -25,7 +25,6 @@
 #include "../world/Wall.h"
 #include "Banner.h"
 #include "Footpath.h"
-#include "LargeScenery.h"
 #include "Map.h"
 #include "Scenery.h"
 

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -363,7 +363,7 @@ static bool IsSceneryEntryValid(const ScenerySelection& item)
         case SCENERY_TYPE_WALL:
             return OpenRCT2::ObjectManager::GetObjectEntry<WallSceneryEntry>(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_LARGE:
-            return GetLargeSceneryEntry(item.EntryIndex) != nullptr;
+            return OpenRCT2::ObjectManager::GetObjectEntry<LargeSceneryEntry>(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_BANNER:
             return OpenRCT2::ObjectManager::GetObjectEntry<BannerSceneryEntry>(item.EntryIndex) != nullptr;
         default:

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -301,18 +301,6 @@ void SceneryRemoveGhostToolPlacement()
     }
 }
 
-PathBitEntry* GetFootpathItemEntry(ObjectEntryIndex entryIndex)
-{
-    PathBitEntry* result = nullptr;
-    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    auto obj = objMgr.GetLoadedObject(ObjectType::PathBits, entryIndex);
-    if (obj != nullptr)
-    {
-        result = static_cast<PathBitEntry*>(obj->GetLegacyData());
-    }
-    return result;
-}
-
 SceneryGroupEntry* GetSceneryGroupEntry(ObjectEntryIndex entryIndex)
 {
     SceneryGroupEntry* result = nullptr;
@@ -383,7 +371,7 @@ static bool IsSceneryEntryValid(const ScenerySelection& item)
         case SCENERY_TYPE_SMALL:
             return OpenRCT2::ObjectManager::GetObjectEntry<SmallSceneryEntry>(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_PATH_ITEM:
-            return GetFootpathItemEntry(item.EntryIndex) != nullptr;
+            return OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_WALL:
             return OpenRCT2::ObjectManager::GetObjectEntry<WallSceneryEntry>(item.EntryIndex) != nullptr;
         case SCENERY_TYPE_LARGE:

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -301,18 +301,6 @@ void SceneryRemoveGhostToolPlacement()
     }
 }
 
-SceneryGroupEntry* GetSceneryGroupEntry(ObjectEntryIndex entryIndex)
-{
-    SceneryGroupEntry* result = nullptr;
-    auto& objMgr = OpenRCT2::GetContext()->GetObjectManager();
-    auto obj = objMgr.GetLoadedObject(ObjectType::SceneryGroup, entryIndex);
-    if (obj != nullptr)
-    {
-        result = static_cast<SceneryGroupEntry*>(obj->GetLegacyData());
-    }
-    return result;
-}
-
 int32_t WallEntryGetDoorSound(const WallSceneryEntry* wallEntry)
 {
     return (wallEntry->flags2 & WALL_SCENERY_2_DOOR_SOUND_MASK) >> WALL_SCENERY_2_DOOR_SOUND_SHIFT;
@@ -404,7 +392,7 @@ static std::vector<ScenerySelection> GetAllMiscScenery()
     std::vector<ScenerySelection> nonMiscScenery;
     for (ObjectEntryIndex i = 0; i < MAX_SCENERY_GROUP_OBJECTS; i++)
     {
-        const auto* sgEntry = GetSceneryGroupEntry(i);
+        const auto* sgEntry = OpenRCT2::ObjectManager::GetObjectEntry<SceneryGroupEntry>(i);
         if (sgEntry != nullptr)
         {
             nonMiscScenery.insert(nonMiscScenery.end(), sgEntry->SceneryEntries.begin(), sgEntry->SceneryEntries.end());

--- a/src/openrct2/world/Scenery.cpp
+++ b/src/openrct2/world/Scenery.cpp
@@ -35,7 +35,6 @@
 #include "../scenario/Scenario.h"
 #include "Climate.h"
 #include "Footpath.h"
-#include "LargeScenery.h"
 #include "Map.h"
 #include "Park.h"
 #include "Wall.h"

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -75,10 +75,8 @@ void ScenerySetDefaultPlacementConfiguration();
 void SceneryRemoveGhostToolPlacement();
 
 struct SceneryGroupEntry;
-struct PathBitEntry;
 struct WallSceneryEntry;
 
-PathBitEntry* GetFootpathItemEntry(ObjectEntryIndex entryIndex);
 SceneryGroupEntry* GetSceneryGroupEntry(ObjectEntryIndex entryIndex);
 
 int32_t WallEntryGetDoorSound(const WallSceneryEntry* wallEntry);

--- a/src/openrct2/world/Scenery.h
+++ b/src/openrct2/world/Scenery.h
@@ -74,10 +74,7 @@ void SceneryUpdateTile(const CoordsXY& sceneryPos);
 void ScenerySetDefaultPlacementConfiguration();
 void SceneryRemoveGhostToolPlacement();
 
-struct SceneryGroupEntry;
 struct WallSceneryEntry;
-
-SceneryGroupEntry* GetSceneryGroupEntry(ObjectEntryIndex entryIndex);
 
 int32_t WallEntryGetDoorSound(const WallSceneryEntry* wallEntry);
 

--- a/src/openrct2/world/TileElement.cpp
+++ b/src/openrct2/world/TileElement.cpp
@@ -16,7 +16,6 @@
 #include "../object/WallSceneryEntry.h"
 #include "../ride/Track.h"
 #include "Banner.h"
-#include "LargeScenery.h"
 #include "Location.hpp"
 #include "Scenery.h"
 

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -306,7 +306,7 @@ public:
     bool HasAddition() const;
     uint8_t GetAddition() const;
     ObjectEntryIndex GetAdditionEntryIndex() const;
-    PathBitEntry* GetAdditionEntry() const;
+    const PathBitEntry* GetAdditionEntry() const;
     void SetAddition(uint8_t newAddition);
 
     bool AdditionIsGhost() const;

--- a/src/openrct2/world/TileElement.h
+++ b/src/openrct2/world/TileElement.h
@@ -475,7 +475,7 @@ private:
 public:
     ObjectEntryIndex GetEntryIndex() const;
     void SetEntryIndex(ObjectEntryIndex newIndex);
-    LargeSceneryEntry* GetEntry() const;
+    const LargeSceneryEntry* GetEntry() const;
     const LargeSceneryObject* GetObject() const;
 
     uint8_t GetSequenceIndex() const;

--- a/src/openrct2/world/TileInspector.cpp
+++ b/src/openrct2/world/TileInspector.cpp
@@ -25,7 +25,6 @@
 #include "../windows/TileInspectorGlobals.h"
 #include "Banner.h"
 #include "Footpath.h"
-#include "LargeScenery.h"
 #include "Location.hpp"
 #include "Map.h"
 #include "Park.h"

--- a/src/openrct2/world/Wall.cpp
+++ b/src/openrct2/world/Wall.cpp
@@ -21,7 +21,6 @@
 #include "../ride/Track.h"
 #include "../ride/TrackData.h"
 #include "Banner.h"
-#include "LargeScenery.h"
 #include "Map.h"
 #include "MapAnimation.h"
 #include "Park.h"


### PR DESCRIPTION
Moving the above to use the new getter for object entries. Also ensures that only a const pointer is used for entries.