### PR TITLE
Fix broken string wrapping and language loading

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -43,6 +43,7 @@
 - Fix: [#19292] Overflow in totalRideValue.
 - Fix: [#19379] "No platforms" station style shows platforms on the Junior Roller Coaster.
 - Fix: [#19380] Startup crash when no sequences are installed and random sequences are enabled.
+- Fix: [#19391] String corruption caused by an improper buffer handling in GfxWrapString.
 
 0.4.3 (2022-12-14)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -37,7 +37,7 @@ private:
 
 public:
     ErrorWindow(std::string text, uint16_t numLines)
-        : _text(text)
+        : _text(std::move(text))
         , _numLines(numLines)
     {
     }
@@ -139,7 +139,7 @@ WindowBase* WindowErrorOpen(std::string_view title, std::string_view message)
     width = std::clamp(width, 64, 196);
 
     int32_t numLines{};
-    GfxWrapString(buffer.data(), width + 1, FontStyle::Medium, &numLines);
+    GfxWrapString(buffer, width + 1, FontStyle::Medium, &buffer, &numLines);
 
     width = width + 3;
     int32_t height = (numLines + 1) * FontGetLineHeight(FontStyle::Medium) + 4;
@@ -155,7 +155,7 @@ WindowBase* WindowErrorOpen(std::string_view title, std::string_view message)
         windowPosition.y = std::min(windowPosition.y - height - 40, maxY);
     }
 
-    auto errorWindow = std::make_unique<ErrorWindow>(buffer, numLines);
+    auto errorWindow = std::make_unique<ErrorWindow>(std::move(buffer), numLines);
     return WindowCreate(
         std::move(errorWindow), WindowClass::Error, windowPosition, width, height,
         WF_STICK_TO_FRONT | WF_TRANSPARENT | WF_RESIZABLE);

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -567,10 +567,10 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, WindowBase* 
         w->colours[2], INSET_RECT_F_30);
 
     // Text
-    const auto* newsItemText = newsItem->Text.c_str();
     auto screenCoords = w->windowPos + ScreenCoordsXY{ middleOutsetWidget->midX(), middleOutsetWidget->top + 11 };
     width = middleOutsetWidget->width() - 62;
-    DrawNewsTicker(dpi, screenCoords, width, COLOUR_BRIGHT_GREEN, STR_BOTTOM_TOOLBAR_NEWS_TEXT, &newsItemText, newsItem->Ticks);
+    DrawNewsTicker(
+        dpi, screenCoords, width, COLOUR_BRIGHT_GREEN, STR_BOTTOM_TOOLBAR_NEWS_TEXT, newsItem->Text, newsItem->Ticks);
 
     screenCoords = w->windowPos
         + ScreenCoordsXY{ window_game_bottom_toolbar_widgets[WIDX_NEWS_SUBJECT].left,

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -339,22 +339,21 @@ static ScreenCoordsXY WindowMultiplayerInformationGetSize()
     // Base dimensions.
     const int32_t width = 450;
     int32_t height = 55;
-    int32_t numLines;
 
     // Server name is displayed word-wrapped, so figure out how high it will be.
     {
-        u8string buffer = NetworkGetServerName();
-        GfxWrapString(buffer.data(), width, FontStyle::Medium, &numLines);
-        height += ++numLines * lineHeight + (LIST_ROW_HEIGHT / 2);
+        int32_t numLines;
+        GfxWrapString(NetworkGetServerName(), width, FontStyle::Medium, nullptr, &numLines);
+        height += (numLines + 1) * lineHeight + (LIST_ROW_HEIGHT / 2);
     }
 
     // Likewise, for the optional server description -- which can be a little longer.
     const auto& descString = NetworkGetServerDescription();
     if (!descString.empty())
     {
-        u8string buffer = descString;
-        GfxWrapString(buffer.data(), width, FontStyle::Medium, &numLines);
-        height += ++numLines * lineHeight + (LIST_ROW_HEIGHT / 2);
+        int32_t numLines;
+        GfxWrapString(descString, width, FontStyle::Medium, nullptr, &numLines);
+        height += (numLines + 1) * lineHeight + (LIST_ROW_HEIGHT / 2);
     }
 
     // Finally, account for provider info, if present.

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -32,7 +32,7 @@ static Widget window_tooltip_widgets[] = {
 class TooltipWindow final : public Window
 {
 private:
-    utf8 _tooltipText[CommonTextBufferSize]{};
+    u8string _tooltipText;
     int16_t _tooltipNumLines = 1;
 
 public:
@@ -100,25 +100,24 @@ public:
         // Text
         left = windowPos.x + ((width + 1) / 2) - 1;
         top = windowPos.y + 1;
-        DrawStringCentredRaw(&dpi, { left, top }, _tooltipNumLines, _tooltipText, FontStyle::Small);
+        DrawStringCentredRaw(&dpi, { left, top }, _tooltipNumLines, _tooltipText.data(), FontStyle::Small);
     }
 
 private:
     // Returns the width of the new tooltip text
     int32_t FormatTextForTooltip(const OpenRCT2String& message)
     {
-        utf8 tempBuffer[CommonTextBufferSize];
-        OpenRCT2::FormatStringLegacy(tempBuffer, sizeof(tempBuffer), message.str, message.args.Data());
+        const u8string tempString = FormatStringID(message.str, message.args.Data());
 
         OpenRCT2String formattedMessage{ STR_STRING_TOOLTIP, Formatter() };
-        formattedMessage.args.Add<const char*>(tempBuffer);
-        OpenRCT2::FormatStringLegacy(_tooltipText, sizeof(_tooltipText), formattedMessage.str, formattedMessage.args.Data());
+        formattedMessage.args.Add<const char*>(tempString.c_str());
+        const u8string tooltipTextUnwrapped = FormatStringID(formattedMessage.str, formattedMessage.args.Data());
 
-        auto textWidth = GfxGetStringWidthNewLined(_tooltipText, FontStyle::Small);
+        auto textWidth = GfxGetStringWidthNewLined(tooltipTextUnwrapped, FontStyle::Small);
         textWidth = std::min(textWidth, 196);
 
         int32_t numLines;
-        textWidth = GfxWrapString(_tooltipText, textWidth + 1, FontStyle::Small, &numLines);
+        textWidth = GfxWrapString(tooltipTextUnwrapped, textWidth + 1, FontStyle::Small, &_tooltipText, &numLines);
         _tooltipNumLines = numLines;
         return textWidth;
     }

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -524,15 +524,16 @@ void GfxDrawString(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8s
 void GfxDrawStringNoFormatting(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint);
 
 void GfxDrawStringLeftCentred(DrawPixelInfo* dpi, StringId format, void* args, colour_t colour, const ScreenCoordsXY& coords);
-void DrawStringCentredRaw(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, char* text, FontStyle fontStyle);
+void DrawStringCentredRaw(
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t numLines, const utf8* text, FontStyle fontStyle);
 void DrawNewsTicker(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, void* args,
+    DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t width, colour_t colour, StringId format, u8string_view args,
     int32_t ticks);
 void GfxDrawStringWithYOffsets(
     DrawPixelInfo* dpi, const utf8* text, int32_t colour, const ScreenCoordsXY& coords, const int8_t* yOffsets,
     bool forceSpriteFont, FontStyle fontStyle);
 
-int32_t GfxWrapString(char* buffer, int32_t width, FontStyle fontStyle, int32_t* num_lines);
+int32_t GfxWrapString(u8string_view text, int32_t width, FontStyle fontStyle, u8string* outWrappedText, int32_t* outNumLines);
 int32_t GfxGetStringWidth(std::string_view text, FontStyle fontStyle);
 int32_t GfxGetStringWidthNewLined(std::string_view text, FontStyle fontStyle);
 int32_t GfxGetStringWidthNoFormatting(std::string_view text, FontStyle fontStyle);

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -22,19 +22,17 @@ static void DrawText(
 class StaticLayout
 {
 private:
-    utf8string Buffer;
+    u8string Buffer;
     TextPaint Paint;
     int32_t LineCount = 0;
     int32_t LineHeight;
     int32_t MaxWidth;
 
 public:
-    StaticLayout(utf8string source, const TextPaint& paint, int32_t width)
+    StaticLayout(u8string_view source, const TextPaint& paint, int32_t width)
+        : Paint(paint)
     {
-        Buffer = source;
-        Paint = paint;
-
-        MaxWidth = GfxWrapString(Buffer, width, paint.FontStyle, &LineCount);
+        MaxWidth = GfxWrapString(source, width, paint.FontStyle, &Buffer, &LineCount);
         LineCount += 1;
         LineHeight = FontGetLineHeight(paint.FontStyle);
     }
@@ -55,7 +53,7 @@ public:
                 lineCoords.x += MaxWidth;
                 break;
         }
-        utf8* buffer = Buffer;
+        const utf8* buffer = Buffer.data();
         for (int32_t line = 0; line < LineCount; ++line)
         {
             DrawText(dpi, lineCoords, tempPaint, buffer);
@@ -175,9 +173,7 @@ int32_t DrawTextWrapped(
 {
     const void* args = ft.Data();
 
-    // TODO: Refactor StaticLayout to take a std::string_view instead. It shouldn't have to write to the buffer.
-    const std::string buffer = FormatStringID(format, args);
-    StaticLayout layout(const_cast<char*>(buffer.c_str()), textPaint, width);
+    StaticLayout layout(FormatStringID(format, args), textPaint, width);
 
     if (textPaint.Alignment == TextAlignment::CENTRE)
     {

--- a/src/openrct2/interface/Chat.h
+++ b/src/openrct2/interface/Chat.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "../common.h"
+#include "../core/String.hpp"
 
 #include <string_view>
 
@@ -42,4 +43,4 @@ void ChatDraw(DrawPixelInfo* dpi, uint8_t chatBackgroundColour);
 void ChatAddHistory(std::string_view s);
 void ChatInput(ChatInput input);
 
-int32_t ChatStringWrappedGetHeight(void* args, int32_t width);
+int32_t ChatStringWrappedGetHeight(u8string_view args, int32_t width);

--- a/src/openrct2/localisation/LanguagePack.cpp
+++ b/src/openrct2/localisation/LanguagePack.cpp
@@ -70,7 +70,7 @@ public:
         Guard::ArgumentNotNull(path);
 
         // Load file directly into memory
-        std::vector<utf8> fileData;
+        u8string fileData;
 
         try
         {


### PR DESCRIPTION
This PR consists of two commits fixing issues found with Address Sanitizer:

1. `LanguagePack::FromFile` using `std::vector` to store the loaded language file made the null terminator inexistant, but the underlying code assumed it exists. Swapping the data type for `std::string` is the easiest way to ensure the null terminator exists.
2. `GfxWrapString` could overwrite the in/out buffer without regard for the buffer size, corrupting it. This caused a consistent assertion (or crash with ASAN) when wrapping a Japanese "Can't start construction..." string, but it is **highly** likely to fix many other places in the code (most notably errors) that may have been subtly broken. Unfortunately, I doubt this fixes any of the [DrawScrollSummarised](https://github.com/OpenRCT2/OpenRCT2/issues?q=is%3Aissue+is%3Aopen+DrawScrollSummarised) issues. I would **love** to be proven wrong on that, as it'll mean closing 50+ tickets!

Closes #19330, Closes #18691, Closes #19151, Closes #18419, Closes #18062, Closes #18820, Closes #18813, Closes #18799, Closes #19384, Closes #19360, Closes #19098, Closes #19325, Closes #19313, Closes #19311, Closes #19302, Closes #19301, Closes #18557, Closes #19238, Closes #18295, Closes #19191, Closes #19173, Closes #18235, Closes #19163, Closes #19144, Closes #19138, Closes #18083, Closes #19121, Closes #18046, Closes #19064, Closes #19063, Closes #19054, Closes #19051, Closes #19029, Closes #19015, Closes #19014, Closes #19013, Closes #19012, Closes #19010, Closes #19009, Closes #19008, Closes #19005, Closes #18999, Closes #18983, Closes #18969, Closes #18950, Closes #18940, Closes #18912, Closes #18891, Closes #17439, Closes #18876, Closes #17152, Closes #17087, Closes #17267, Closes #17177, Closes #18685, Closes #18643, Closes #18633, Closes #18618, Closes #18585, Closes #18534, Closes #19052, Closes #18471, Closes #18451, Closes #18409, Closes #18291, Closes #18240, Closes #18237, Closes #19386