### PR TITLE
Clean up calls to PaintAddImageAsChildRotated()

### DIFF
--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -309,7 +309,7 @@ PaintStruct* PaintAddImageAsChild(
 
 PaintStruct* PaintAddImageAsChildRotated(
     PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
-    const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset);
+    const BoundBoxXYZ& boundBox);
 
 PaintStruct* PaintAddImageAsParentRotated(
     PaintSession& session, const uint8_t direction, const ImageId imageId, const CoordsXYZ& offset,

--- a/src/openrct2/paint/PaintHelpers.cpp
+++ b/src/openrct2/paint/PaintHelpers.cpp
@@ -26,16 +26,17 @@ PaintStruct* PaintAddImageAsParentRotated(
 
 PaintStruct* PaintAddImageAsChildRotated(
     PaintSession& session, const uint8_t direction, const ImageId image_id, const CoordsXYZ& offset,
-    const CoordsXYZ& boundBoxSize, const CoordsXYZ& boundBoxOffset)
+    const BoundBoxXYZ& boundBox)
 {
     if (direction & 1)
     {
         return PaintAddImageAsChild(
             session, image_id, { offset.y, offset.x, offset.z },
-            { { boundBoxOffset.y, boundBoxOffset.x, boundBoxOffset.z }, { boundBoxSize.y, boundBoxSize.x, boundBoxSize.z } });
+            { { boundBox.offset.y, boundBox.offset.x, boundBox.offset.z },
+              { boundBox.length.y, boundBox.length.x, boundBox.length.z } });
     }
 
-    return PaintAddImageAsChild(session, image_id, offset, { boundBoxOffset, boundBoxSize });
+    return PaintAddImageAsChild(session, image_id, offset, boundBox);
 }
 
 void PaintUtilPushTunnelRotated(PaintSession& session, uint8_t direction, uint16_t height, uint8_t type)

--- a/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
+++ b/src/openrct2/ride/coaster/AirPoweredVerticalCoaster.cpp
@@ -214,7 +214,7 @@ static void AirPoweredVerticalRCTrackStation(
         { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
-        { 32, 20, 1 }, { 0, 6, height });
+        { { 0, 6, height }, { 32, 20, 1 } });
 
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
 
@@ -660,7 +660,7 @@ static void AirPoweredVerticalRCTrackVerticalSlopeUp(
             PaintAddImageAsParentRotated(
                 session, direction, supportsImageId, { 0, 0, height }, { { 0, 6, height }, { 20, 32, bbHeight } });
             PaintAddImageAsChildRotated(
-                session, direction, trackImageId, { 0, 0, height }, { 20, 32, bbHeight }, { 0, 6, height });
+                session, direction, trackImageId, { 0, 0, height }, { { 0, 6, height }, { 20, 32, bbHeight } });
 
             WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
 
@@ -679,7 +679,7 @@ static void AirPoweredVerticalRCTrackVerticalSlopeUp(
                 PaintAddImageAsParentRotated(
                     session, direction, supportsImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
                 PaintAddImageAsChildRotated(
-                    session, direction, trackImageId, { 0, 0, height }, { 32, 20, bbHeight }, { 0, 6, height });
+                    session, direction, trackImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
             }
             else
             {
@@ -687,7 +687,7 @@ static void AirPoweredVerticalRCTrackVerticalSlopeUp(
                 PaintAddImageAsParentRotated(
                     session, direction, supportsImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
                 PaintAddImageAsChildRotated(
-                    session, direction, trackImageId, { 0, 0, height }, { 32, 20, bbHeight }, { 0, 6, height });
+                    session, direction, trackImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
             }
 
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -707,7 +707,7 @@ static void AirPoweredVerticalRCTrackVerticalSlopeUp(
                 PaintAddImageAsParentRotated(
                     session, direction, supportsImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
                 PaintAddImageAsChildRotated(
-                    session, direction, trackImageId, { 0, 0, height }, { 32, 20, bbHeight }, { 0, 6, height });
+                    session, direction, trackImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
             }
             else
             {
@@ -715,7 +715,7 @@ static void AirPoweredVerticalRCTrackVerticalSlopeUp(
                 PaintAddImageAsParentRotated(
                     session, direction, trackImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
                 PaintAddImageAsChildRotated(
-                    session, direction, supportsImageId, { 0, 0, height }, { 32, 20, bbHeight }, { 0, 6, height });
+                    session, direction, supportsImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
             }
 
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -736,7 +736,7 @@ static void AirPoweredVerticalRCTrackVerticalSlopeUp(
                 }
                 PaintAddImageAsParent(session, floorImageId, { 0, 0, height }, { { 3, 3, height }, { 26, 26, 126 } });
                 PaintAddImageAsChildRotated(
-                    session, direction, supportsImageId, { 0, 0, height }, { 26, 26, 126 }, { 3, 3, height });
+                    session, direction, supportsImageId, { 0, 0, height }, { { 3, 3, height }, { 26, 26, 126 } });
             }
             else
             {
@@ -752,14 +752,14 @@ static void AirPoweredVerticalRCTrackVerticalSlopeUp(
                 PaintAddImageAsParentRotated(
                     session, direction, supportsImageId, { 0, 0, height }, { { 0, 6, height + 128 }, { 5, 20, 79 } });
                 PaintAddImageAsChildRotated(
-                    session, direction, trackImageId, { 0, 0, height }, { 5, 20, 79 }, { 0, 6, height + 128 });
+                    session, direction, trackImageId, { 0, 0, height }, { { 0, 6, height + 128 }, { 5, 20, 79 } });
             }
             else
             {
                 PaintAddImageAsParentRotated(
                     session, direction, trackImageId, { 0, 0, height }, { { 27, 6, height }, { 1, 20, 126 } });
                 PaintAddImageAsChildRotated(
-                    session, direction, supportsImageId, { 0, 0, height }, { 1, 20, 126 }, { 27, 6, height });
+                    session, direction, supportsImageId, { 0, 0, height }, { { 27, 6, height }, { 1, 20, 126 } });
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
 
@@ -849,13 +849,15 @@ static void AirPoweredVerticalRCTrackVerticalTop(
             {
                 PaintAddImageAsParentRotated(
                     session, direction, imageIdS, { 0, 0, height }, { { 0, 6, height }, { 32, 20, 15 } });
-                PaintAddImageAsChildRotated(session, direction, imageIdT, { 0, 0, height }, { 31, 20, 15 }, { 1, 6, height });
+                PaintAddImageAsChildRotated(
+                    session, direction, imageIdT, { 0, 0, height }, { { 1, 6, height }, { 31, 20, 15 } });
             }
             else
             {
                 PaintAddImageAsParentRotated(
                     session, direction, imageIdS, { 0, 0, height }, { { 24, 6, height }, { 5, 20, 1 } });
-                PaintAddImageAsChildRotated(session, direction, imageIdT, { 0, 0, height }, { 5, 20, 1 }, { 24, 6, height });
+                PaintAddImageAsChildRotated(
+                    session, direction, imageIdT, { 0, 0, height }, { { 24, 6, height }, { 5, 20, 1 } });
             }
             break;
         case 1:
@@ -893,13 +895,15 @@ static void AirPoweredVerticalRCTrackVerticalTop(
             {
                 PaintAddImageAsParentRotated(
                     session, direction, imageIdS, { 0, 0, height }, { { 24, 6, height }, { 5, 20, 1 } });
-                PaintAddImageAsChildRotated(session, direction, imageIdT, { 0, 0, height }, { 5, 20, 1 }, { 24, 6, height });
+                PaintAddImageAsChildRotated(
+                    session, direction, imageIdT, { 0, 0, height }, { { 24, 6, height }, { 5, 20, 1 } });
             }
             else
             {
                 PaintAddImageAsParentRotated(
                     session, direction, imageIdS, { 0, 0, height }, { { 0, 6, height }, { 32, 20, 15 } });
-                PaintAddImageAsChildRotated(session, direction, imageIdT, { 0, 0, height }, { 32, 20, 15 }, { 0, 6, height });
+                PaintAddImageAsChildRotated(
+                    session, direction, imageIdT, { 0, 0, height }, { { 0, 6, height }, { 32, 20, 15 } });
             }
             break;
     }

--- a/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
+++ b/src/openrct2/ride/coaster/CompactInvertedCoaster.cpp
@@ -92,7 +92,7 @@ static void CompactInvertedRCTrackStation(
         { { 0, 6, height + 29 }, { 32, 20, 3 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 29 },
-        { 32, 20, 3 }, { 0, 6, height + 29 });
+        { { 0, 6, height + 29 }, { 32, 20, 3 } });
     TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
     TrackPaintUtilDrawStationInverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);

--- a/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/FlyingRollerCoaster.cpp
@@ -158,7 +158,7 @@ static void FlyingRCTrackStation(
             { { 0, 6, height + 24 }, { 32, 20, 3 } });
         PaintAddImageAsChildRotated(
             session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 24 },
-            { 32, 20, 1 }, { 0, 6, height + 24 });
+            { { 0, 6, height + 24 }, { 32, 20, 1 } });
         TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
         TrackPaintUtilDrawStationInverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
     }

--- a/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
+++ b/src/openrct2/ride/coaster/HeartlineTwisterCoaster.cpp
@@ -841,13 +841,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21308), { 0, 0, height + 16 },
-                        { 32, 20, 2 }, { 0, 6, height + 16 });
+                        { { 0, 6, height + 16 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21318), { 0, 0, height + 8 },
                         { { 0, 27, height + 8 }, { 32, 1, 34 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height + 16 },
-                        { 32, 1, 34 }, { 0, 27, height + 16 });
+                        { { 0, 27, height + 16 }, { 32, 1, 34 } });
                     WoodenASupportsPaintSetup(session, 6, 5, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -856,13 +856,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21309), { 0, 0, height + 16 },
-                        { 32, 20, 2 }, { 0, 6, height + 16 });
+                        { { 0, 6, height + 16 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21319), { 0, 0, height + 8 },
                         { { 0, 27, height + 8 }, { 32, 1, 34 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height + 16 },
-                        { 32, 1, 34 }, { 0, 27, height + 16 });
+                        { { 0, 27, height + 16 }, { 32, 1, 34 } });
                     WoodenASupportsPaintSetup(session, 7, 6, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -871,13 +871,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21306), { 0, 0, height + 16 },
-                        { 32, 20, 2 }, { 0, 6, height + 16 });
+                        { { 0, 6, height + 16 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21320), { 0, 0, height + 8 },
                         { { 0, 27, height + 8 }, { 32, 1, 34 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height + 16 },
-                        { 32, 1, 34 }, { 0, 27, height + 16 });
+                        { { 0, 27, height + 16 }, { 32, 1, 34 } });
                     WoodenASupportsPaintSetup(session, 6, 7, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -886,13 +886,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferUp(
                         { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21307), { 0, 0, height + 16 },
-                        { 32, 20, 2 }, { 0, 6, height + 16 });
+                        { { 0, 6, height + 16 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21321), { 0, 0, height + 8 },
                         { { 0, 27, height + 8 }, { 32, 1, 34 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height + 16 },
-                        { 32, 1, 34 }, { 0, 27, height + 16 });
+                        { { 0, 27, height + 16 }, { 32, 1, 34 } });
                     WoodenASupportsPaintSetup(session, 7, 8, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -1055,13 +1055,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21308), { 0, 0, height + 16 },
-                        { 32, 20, 2 }, { 0, 6, height + 16 });
+                        { { 0, 6, height + 16 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21318), { 0, 0, height + 8 },
                         { { 0, 27, height + 8 }, { 32, 1, 34 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21312), { 0, 0, height + 16 },
-                        { 32, 1, 34 }, { 0, 27, height + 16 });
+                        { { 0, 27, height + 16 }, { 32, 1, 34 } });
                     WoodenASupportsPaintSetup(session, 6, 5, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -1070,13 +1070,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21309), { 0, 0, height + 16 },
-                        { 32, 20, 2 }, { 0, 6, height + 16 });
+                        { { 0, 6, height + 16 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21319), { 0, 0, height + 8 },
                         { { 0, 27, height + 8 }, { 32, 1, 34 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21313), { 0, 0, height + 16 },
-                        { 32, 1, 34 }, { 0, 27, height + 16 });
+                        { { 0, 27, height + 16 }, { 32, 1, 34 } });
                     WoodenASupportsPaintSetup(session, 7, 6, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -1085,13 +1085,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21306), { 0, 0, height + 16 },
-                        { 32, 20, 2 }, { 0, 6, height + 16 });
+                        { { 0, 6, height + 16 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21320), { 0, 0, height + 8 },
                         { { 0, 27, height + 8 }, { 32, 1, 34 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21310), { 0, 0, height + 16 },
-                        { 32, 1, 34 }, { 0, 27, height + 16 });
+                        { { 0, 27, height + 16 }, { 32, 1, 34 } });
                     WoodenASupportsPaintSetup(session, 6, 7, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -1100,13 +1100,13 @@ static void HeartlineTwisterRCTrackHeartlineTransferDown(
                         { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21307), { 0, 0, height + 16 },
-                        { 32, 20, 2 }, { 0, 6, height + 16 });
+                        { { 0, 6, height + 16 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21321), { 0, 0, height + 8 },
                         { { 0, 27, height + 8 }, { 32, 1, 34 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(21311), { 0, 0, height + 16 },
-                        { 32, 1, 34 }, { 0, 27, height + 16 });
+                        { { 0, 27, height + 16 }, { 32, 1, 34 } });
                     WoodenASupportsPaintSetup(session, 7, 8, height + 8, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }

--- a/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedHairpinCoaster.cpp
@@ -100,7 +100,7 @@ static void InvertedHairpinRCTrackStation(
         { { 0, 6, height + 24 }, { 32, 20, 3 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 24 },
-        { 32, 20, 1 }, { 0, 6, height + 24 });
+        { { 0, 6, height + 24 }, { 32, 20, 1 } });
     TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
     TrackPaintUtilDrawStationInverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedImpulseCoaster.cpp
@@ -71,7 +71,7 @@ static void InvertedImpulseRCTrackStation(
         { { 0, 6, height + 29 }, { 32, 20, 3 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 29 },
-        { 32, 20, 3 }, { 0, 6, height + 29 });
+        { { 0, 6, height + 29 }, { 32, 20, 3 } });
     TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
     TrackPaintUtilDrawStationInverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);

--- a/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/InvertedRollerCoaster.cpp
@@ -91,7 +91,7 @@ static void InvertedRCTrackStation(
         { { 0, 6, height + 29 }, { 32, 20, 3 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 29 },
-        { 32, 20, 3 }, { 0, 6, height + 29 });
+        { { 0, 6, height + 29 }, { 32, 20, 3 } });
     TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 3);
     TrackPaintUtilDrawStationInverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);

--- a/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LayDownRollerCoaster.cpp
@@ -158,7 +158,7 @@ static void LayDownRCTrackStation(
             { { 0, 6, height + 24 }, { 32, 20, 3 } });
         PaintAddImageAsChildRotated(
             session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 24 },
-            { 32, 20, 1 }, { 0, 6, height + 24 });
+            { { 0, 6, height + 24 }, { 32, 20, 1 } });
         TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 11);
         TrackPaintUtilDrawStationInverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
         PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);

--- a/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
@@ -2238,7 +2238,7 @@ static void LoopingRCTrackLeftVerticalLoop(
                         session, METAL_SUPPORTS_THICK_CENTRED, 1, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15364), { 16, 0, height },
-                        { 3, 16, 119 }, { 16, 0, height });
+                        { { 16, 0, height }, { 3, 16, 119 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2248,7 +2248,7 @@ static void LoopingRCTrackLeftVerticalLoop(
                         session, METAL_SUPPORTS_THICK_ALT_CENTRED, 0, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15366), { 12, 0, height },
-                        { 3, 16, 119 }, { 12, 0, height });
+                        { { 12, 0, height }, { 3, 16, 119 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2258,7 +2258,7 @@ static void LoopingRCTrackLeftVerticalLoop(
                         session, METAL_SUPPORTS_THICK, 2, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15365), { 10, 16, height },
-                        { 4, 16, 119 }, { 10, 16, height });
+                        { { 10, 16, height }, { 4, 16, 119 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2268,7 +2268,7 @@ static void LoopingRCTrackLeftVerticalLoop(
                         session, METAL_SUPPORTS_THICK_ALT, 3, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15367), { 16, 16, height },
-                        { 2, 16, 119 }, { 16, 16, height });
+                        { { 16, 16, height }, { 2, 16, 119 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -2352,7 +2352,7 @@ static void LoopingRCTrackLeftVerticalLoop(
                         session, METAL_SUPPORTS_THICK, 2, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15365), { 10, 16, height },
-                        { 4, 16, 119 }, { 10, 16, height });
+                        { { 10, 16, height }, { 4, 16, 119 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2362,7 +2362,7 @@ static void LoopingRCTrackLeftVerticalLoop(
                         session, METAL_SUPPORTS_THICK_ALT, 3, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15367), { 16, 16, height },
-                        { 2, 16, 119 }, { 16, 16, height });
+                        { { 16, 16, height }, { 2, 16, 119 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2372,7 +2372,7 @@ static void LoopingRCTrackLeftVerticalLoop(
                         session, METAL_SUPPORTS_THICK_CENTRED, 1, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15364), { 16, 0, height },
-                        { 3, 16, 119 }, { 16, 0, height });
+                        { { 16, 0, height }, { 3, 16, 119 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2382,7 +2382,7 @@ static void LoopingRCTrackLeftVerticalLoop(
                         session, METAL_SUPPORTS_THICK_ALT_CENTRED, 0, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15366), { 12, 0, height },
-                        { 3, 16, 119 }, { 12, 0, height });
+                        { { 12, 0, height }, { 3, 16, 119 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -2535,7 +2535,7 @@ static void LoopingRCTrackRightVerticalLoop(
                         session, METAL_SUPPORTS_THICK, 3, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15384), { 16, 16, height },
-                        { 2, 16, 119 }, { 16, 16, height });
+                        { { 16, 16, height }, { 2, 16, 119 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2545,7 +2545,7 @@ static void LoopingRCTrackRightVerticalLoop(
                         session, METAL_SUPPORTS_THICK_ALT, 1, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15386), { 10, 16, height },
-                        { 4, 16, 119 }, { 10, 16, height });
+                        { { 10, 16, height }, { 4, 16, 119 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2555,7 +2555,7 @@ static void LoopingRCTrackRightVerticalLoop(
                         session, METAL_SUPPORTS_THICK_CENTRED, 0, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15385), { 12, 0, height },
-                        { 3, 16, 119 }, { 12, 0, height });
+                        { { 12, 0, height }, { 3, 16, 119 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2565,7 +2565,7 @@ static void LoopingRCTrackRightVerticalLoop(
                         session, METAL_SUPPORTS_THICK_ALT_CENTRED, 2, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15387), { 16, 0, height },
-                        { 2, 16, 119 }, { 16, 0, height });
+                        { { 16, 0, height }, { 2, 16, 119 } });
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 168, 0x20);
@@ -2639,7 +2639,7 @@ static void LoopingRCTrackRightVerticalLoop(
                         session, METAL_SUPPORTS_THICK_CENTRED, 0, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15385), { 12, 0, height },
-                        { 3, 16, 119 }, { 12, 0, height });
+                        { { 12, 0, height }, { 3, 16, 119 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2649,7 +2649,7 @@ static void LoopingRCTrackRightVerticalLoop(
                         session, METAL_SUPPORTS_THICK_ALT_CENTRED, 2, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15387), { 16, 0, height },
-                        { 2, 16, 119 }, { 16, 0, height });
+                        { { 16, 0, height }, { 2, 16, 119 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2659,7 +2659,7 @@ static void LoopingRCTrackRightVerticalLoop(
                         session, METAL_SUPPORTS_THICK, 3, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15384), { 16, 16, height },
-                        { 2, 16, 119 }, { 16, 16, height });
+                        { { 16, 16, height }, { 2, 16, 119 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2669,7 +2669,7 @@ static void LoopingRCTrackRightVerticalLoop(
                         session, METAL_SUPPORTS_THICK_ALT, 1, 0, height - 8, session.TrackColours[SCHEME_TRACK]);
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15386), { 10, 16, height },
-                        { 4, 16, 119 }, { 10, 16, height });
+                        { { 10, 16, height }, { 4, 16, 119 } });
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 168, 0x20);

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -110,13 +110,13 @@ static void MineTrainRCTrackStation(
         bool isClosed = trackElement.IsBrakeClosed();
         PaintAddImageAsChildRotated(
             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_MineTrainBlockBrakeImages[direction][isClosed]),
-            { 0, 0, height }, { 32, 20, 1 }, { 0, 0, height });
+            { 0, 0, height }, { { 0, 0, height }, { 32, 20, 1 } });
     }
     else
     {
         PaintAddImageAsChildRotated(
             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
-            { 32, 20, 1 }, { 0, 0, height });
+            { { 0, 0, height }, { 32, 20, 1 } });
     }
     TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 3);
     TrackPaintUtilDrawStation(session, ride, direction, height, trackElement);

--- a/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
+++ b/src/openrct2/ride/coaster/MiniSuspendedCoaster.cpp
@@ -103,7 +103,7 @@ static void MiniSuspendedRCTrackStation(
         { 32, 20, 1 });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 24 },
-        { 32, 20, 1 }, { 0, 2, height });
+        { { 0, 2, height }, { 32, 20, 1 } });
     TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 3);
     TrackPaintUtilDrawStationInverted(session, ride, direction, height, trackElement, STATION_VARIANT_1);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverseFreefallCoaster.cpp
@@ -284,7 +284,7 @@ static void PaintReverseFreefallRCSlope(
                 PaintAddImageAsParentRotated(
                     session, direction, supportsImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
                 PaintAddImageAsChildRotated(
-                    session, direction, trackImageId, { 0, 0, height }, { 32, 20, bbHeight }, { 0, 6, height });
+                    session, direction, trackImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
 
                 int32_t tunnelOffset = tunnelOffsets03[trackSequence];
                 if (direction & 1)
@@ -302,7 +302,7 @@ static void PaintReverseFreefallRCSlope(
                 PaintAddImageAsParentRotated(
                     session, direction, trackImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
                 PaintAddImageAsChildRotated(
-                    session, direction, supportsImageId, { 0, 0, height }, { 32, 20, bbHeight }, { 0, 6, height });
+                    session, direction, supportsImageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, bbHeight } });
             }
 
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -323,8 +323,8 @@ static void PaintReverseFreefallRCSlope(
                 }
                 PaintAddImageAsParent(session, floorImageId, { 0, 0, height }, { 26, 26, 126 }, { 3, 3, height });
                 PaintAddImageAsChildRotated(
-                    session, direction, supportsImageId, { 0, 0, height }, { isDirection03 ? 26 : 18, 26, 126 },
-                    { isDirection03 ? 3 : 11, 3, height });
+                    session, direction, supportsImageId, { 0, 0, height },
+                    { { isDirection03 ? 3 : 11, 3, height }, { isDirection03 ? 26 : 18, 26, 126 } });
             }
             else
             {
@@ -341,14 +341,14 @@ static void PaintReverseFreefallRCSlope(
                 PaintAddImageAsParentRotated(
                     session, direction, supportsImageId, { 0, 0, height }, { { 0, 6, height + 128 }, { 5, 20, 79 } });
                 PaintAddImageAsChildRotated(
-                    session, direction, trackImageId, { 0, 0, height }, { 5, 20, 79 }, { 0, 6, height + 128 });
+                    session, direction, trackImageId, { 0, 0, height }, { { 0, 6, height + 128 }, { 5, 20, 79 } });
             }
             else
             {
                 PaintAddImageAsParentRotated(
                     session, direction, trackImageId, { 0, 0, height }, { { 27, 6, height }, { 1, 20, 126 } });
                 PaintAddImageAsChildRotated(
-                    session, direction, supportsImageId, { 0, 0, height }, { 1, 20, 126 }, { 27, 6, height });
+                    session, direction, supportsImageId, { 0, 0, height }, { { 27, 6, height }, { 1, 20, 126 } });
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);

--- a/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/ReverserRollerCoaster.cpp
@@ -111,7 +111,7 @@ static void ReverserRCTrackStation(
         { { 0, 2, height }, { 32, 27, 2 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 0, height },
-        { 32, 27, 2 }, { 0, 2, height });
+        { { 0, 2, height }, { 32, 27, 2 } });
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     TrackPaintUtilDrawStation2(session, ride, direction, height, trackElement, 9, 11);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/Steeplechase.cpp
+++ b/src/openrct2/ride/coaster/Steeplechase.cpp
@@ -83,7 +83,7 @@ static void SteeplechaseTrackStation(
         { { 0, 2, height }, { 32, 28, 3 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 6, height },
-        { 32, 20, 3 }, { 0, 0, height });
+        { { 0, 0, height }, { 32, 20, 3 } });
     TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 3);
     TrackPaintUtilDrawStation(session, ride, direction, height, trackElement);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
+++ b/src/openrct2/ride/coaster/SuspendedSwingingCoaster.cpp
@@ -91,7 +91,7 @@ static void SuspendedSwingingRCTrackStation(
         { { 0, 6, height + 29 }, { 32, 20, 3 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 29 },
-        { 32, 20, 3 }, { 0, 6, height + 29 });
+        { { 0, 6, height + 29 }, { 32, 20, 3 } });
     TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 0);
     TrackPaintUtilDrawStationInverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);

--- a/src/openrct2/ride/coaster/WildMouse.cpp
+++ b/src/openrct2/ride/coaster/WildMouse.cpp
@@ -209,13 +209,13 @@ static void WildMouseTrackStation(
         PaintAddImageAsChildRotated(
             session, direction,
             session.TrackColours[SCHEME_TRACK].WithIndex(_wild_mouse_block_brakes_image_ids[direction][isClosed]),
-            { 0, 0, height }, { 32, 20, 2 }, { 0, 0, height });
+            { 0, 0, height }, { { 0, 0, height }, { 32, 20, 2 } });
     }
     else
     {
         PaintAddImageAsChildRotated(
             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_wild_mouse_brakes_image_ids[direction]),
-            { 0, 0, height }, { 32, 20, 2 }, { 0, 0, height });
+            { 0, 0, height }, { { 0, 0, height }, { 32, 20, 2 } });
     }
     TrackPaintUtilDrawStationMetalSupports(session, direction, height, session.TrackColours[SCHEME_SUPPORTS]);
     TrackPaintUtilDrawStation(session, ride, direction, height, trackElement);

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.cpp
@@ -2297,8 +2297,8 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23781), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24647), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24647), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2306,14 +2306,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23786), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24652), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24652), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23812), { 0, 0, height },
                         { { 0, 2, height + 67 }, { 32, 27, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24678), { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24678), { 0, 0, height },
+                        { { 0, 2, height + 67 }, { 32, 27, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2321,8 +2321,8 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23791), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24657), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24657), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2330,8 +2330,8 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23796), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24662), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24662), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2355,8 +2355,8 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23782), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24648), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24648), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2364,14 +2364,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23787), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24653), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24653), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23813), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24679), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24679), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2379,8 +2379,8 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23792), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24658), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24658), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2388,14 +2388,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23797), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24663), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24663), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23819), { 0, 0, height },
                         { { 0, 16, height + 67 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24685), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24685), { 0, 0, height },
+                        { { 0, 16, height + 67 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2413,8 +2413,8 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23783), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24649), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24649), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2422,14 +2422,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23788), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24654), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24654), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23814), { 0, 0, height },
                         { { 16, 16, height + 59 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24680), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 59 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24680), { 0, 0, height },
+                        { { 16, 16, height + 59 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2437,8 +2437,8 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23793), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24659), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24659), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2446,14 +2446,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23798), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24664), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24664), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23820), { 0, 0, height },
                         { { 0, 0, height + 59 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24686), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 59 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24686), { 0, 0, height },
+                        { { 0, 0, height + 59 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2478,8 +2478,8 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23784), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24650), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24650), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2487,14 +2487,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23789), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24655), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24655), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23815), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24681), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24681), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2502,14 +2502,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23794), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24660), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24660), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23817), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24683), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24683), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2517,14 +2517,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23799), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24665), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24665), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23821), { 0, 0, height },
                         { { 16, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24687), { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24687), { 0, 0, height },
+                        { { 16, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2542,8 +2542,8 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23785), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24651), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24651), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2551,14 +2551,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23790), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24656), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24656), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23816), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24682), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24682), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2566,14 +2566,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23795), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24661), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24661), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23818), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24684), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24684), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2581,14 +2581,14 @@ static void WoodenRCTrackLeftQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23800), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24666), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24666), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23822), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24688), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24688), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2623,8 +2623,8 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23761), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24627), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24627), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2632,8 +2632,8 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23766), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24632), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24632), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2641,14 +2641,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23771), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24637), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24637), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23807), { 0, 0, height },
                         { { 0, 2, height + 67 }, { 32, 27, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24673), { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24673), { 0, 0, height },
+                        { { 0, 2, height + 67 }, { 32, 27, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2656,8 +2656,8 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23776), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24642), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24642), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2681,14 +2681,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23762), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24628), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24628), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23801), { 0, 0, height },
                         { { 0, 16, height + 67 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24667), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24667), { 0, 0, height },
+                        { { 0, 16, height + 67 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2696,8 +2696,8 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23767), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24633), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24633), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2705,14 +2705,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23772), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24638), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24638), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23808), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24674), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24674), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2720,8 +2720,8 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23777), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24643), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24643), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2739,14 +2739,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23763), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24629), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24629), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23802), { 0, 0, height },
                         { { 0, 0, height + 59 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24668), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 59 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24668), { 0, 0, height },
+                        { { 0, 0, height + 59 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2754,8 +2754,8 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23768), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24634), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24634), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2763,14 +2763,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23773), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24639), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24639), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23809), { 0, 0, height },
                         { { 16, 16, height + 59 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24675), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 59 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24675), { 0, 0, height },
+                        { { 16, 16, height + 59 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2778,8 +2778,8 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23778), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24644), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24644), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2804,14 +2804,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23764), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24630), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24630), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23803), { 0, 0, height },
                         { { 16, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24669), { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24669), { 0, 0, height },
+                        { { 16, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2819,14 +2819,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23769), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24635), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24635), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23805), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24671), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24671), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2834,14 +2834,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23774), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24640), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24640), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23810), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24676), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24676), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2849,8 +2849,8 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23779), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24645), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24645), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2868,14 +2868,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23765), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24631), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24631), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23804), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24670), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24670), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2883,14 +2883,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23770), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24636), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24636), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23806), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24672), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24672), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2898,14 +2898,14 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23775), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24641), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24641), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23811), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24677), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24677), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -2913,8 +2913,8 @@ static void WoodenRCTrackRightQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23780), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24646), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24646), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -2969,8 +2969,8 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23725), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24591), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24591), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -2978,14 +2978,14 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23729), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24595), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24595), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23741), { 0, 0, height },
                         { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24607), { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24607), { 0, 0, height },
+                        { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -2993,8 +2993,8 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23728), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24594), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24594), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3002,14 +3002,14 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23732), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24598), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24598), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23744), { 0, 0, height },
                         { { 0, 2, height + 27 }, { 32, 27, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24610), { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24610), { 0, 0, height },
+                        { { 0, 2, height + 27 }, { 32, 27, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3028,8 +3028,8 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23726), { 0, 0, height },
                         { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24592), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24592), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 26, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3037,14 +3037,14 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23730), { 0, 0, height },
                         { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24596), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24596), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23742), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 26, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24608), { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24608), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 26, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3052,8 +3052,8 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23727), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24593), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24593), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 26, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3061,14 +3061,14 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23731), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24597), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24597), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23743), { 0, 0, height },
                         { { 0, 6, height + 27 }, { 32, 26, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24609), { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24609), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 26, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3086,8 +3086,8 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23727), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24593), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24593), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 26, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3095,14 +3095,14 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23731), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24597), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24597), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23743), { 0, 0, height },
                         { { 0, 6, height + 27 }, { 32, 26, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24609), { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24609), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 26, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3110,8 +3110,8 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23726), { 0, 0, height },
                         { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24592), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24592), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 26, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3119,14 +3119,14 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23730), { 0, 0, height },
                         { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24596), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24596), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23742), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 26, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24608), { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24608), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 26, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3144,8 +3144,8 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23728), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24594), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24594), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3153,14 +3153,14 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23732), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24598), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24598), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23744), { 0, 0, height },
                         { { 0, 2, height + 27 }, { 32, 27, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24610), { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24610), { 0, 0, height },
+                        { { 0, 2, height + 27 }, { 32, 27, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3168,8 +3168,8 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23725), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24591), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24591), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3177,14 +3177,14 @@ static void WoodenRCTrackSBendLeft(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23729), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24595), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24595), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23741), { 0, 0, height },
                         { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24607), { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24607), { 0, 0, height },
+                        { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3219,14 +3219,14 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23733), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24599), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24599), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23745), { 0, 0, height },
                         { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24611), { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24611), { 0, 0, height },
+                        { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3234,8 +3234,8 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23737), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24603), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24603), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3243,14 +3243,14 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23736), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24602), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24602), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23748), { 0, 0, height },
                         { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24614), { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24614), { 0, 0, height },
+                        { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3258,8 +3258,8 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23740), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24606), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24606), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3278,14 +3278,14 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23734), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24600), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24600), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23746), { 0, 0, height },
                         { { 0, 6, height + 27 }, { 32, 26, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24612), { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24612), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 26, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3293,8 +3293,8 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23738), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24604), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24604), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 26, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3302,14 +3302,14 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23735), { 0, 0, height },
                         { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24601), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24601), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23747), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 26, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24613), { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24613), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 26, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3317,8 +3317,8 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23739), { 0, 0, height },
                         { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24605), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24605), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 26, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3336,14 +3336,14 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23735), { 0, 0, height },
                         { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24601), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24601), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23747), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 26, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24613), { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24613), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 26, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3351,8 +3351,8 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23739), { 0, 0, height },
                         { { 0, 0, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24605), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24605), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 26, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3360,14 +3360,14 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23734), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24600), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24600), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23746), { 0, 0, height },
                         { { 0, 6, height + 27 }, { 32, 26, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24612), { 0, 0, height }, { 32, 26, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24612), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 26, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3375,8 +3375,8 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23738), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24604), { 0, 0, height }, { 32, 26, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24604), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 26, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3394,14 +3394,14 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23736), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24602), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24602), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23748), { 0, 0, height },
                         { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24614), { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24614), { 0, 0, height },
+                        { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3409,8 +3409,8 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23740), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24606), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24606), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -3418,14 +3418,14 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23733), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24599), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24599), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23745), { 0, 0, height },
                         { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24611), { 0, 0, height }, { 32, 25, 0 },
-                        { 0, 3, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24611), { 0, 0, height },
+                        { { 0, 3, height + 27 }, { 32, 25, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -3433,8 +3433,8 @@ static void WoodenRCTrackSBendRight(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23737), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24603), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24603), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -3979,8 +3979,8 @@ static void WoodenRCTrackLeftQuarterTurn3(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23828), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24694), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24694), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -3988,14 +3988,14 @@ static void WoodenRCTrackLeftQuarterTurn3(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23831), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24697), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24697), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23840), { 0, 6, height },
                         { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24706), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24706), { 0, 6, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4003,8 +4003,8 @@ static void WoodenRCTrackLeftQuarterTurn3(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23834), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24700), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24700), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4012,14 +4012,14 @@ static void WoodenRCTrackLeftQuarterTurn3(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23825), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24691), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24691), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23837), { 0, 6, height },
                         { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24703), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24703), { 0, 6, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4041,44 +4041,44 @@ static void WoodenRCTrackLeftQuarterTurn3(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23827), { 16, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24693), { 16, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24693), { 16, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23830), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24696), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24696), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23839), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24705), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24705), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23833), { 0, 16, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24699), { 0, 16, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24699), { 0, 16, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23824), { 16, 16, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24690), { 16, 16, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24690), { 16, 16, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23836), { 16, 16, height },
                         { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24702), { 16, 16, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24702), { 16, 16, height },
+                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -4093,8 +4093,8 @@ static void WoodenRCTrackLeftQuarterTurn3(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23826), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24692), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24692), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4102,14 +4102,14 @@ static void WoodenRCTrackLeftQuarterTurn3(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23829), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24695), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24695), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23838), { 6, 0, height },
                         { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24704), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24704), { 6, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4117,8 +4117,8 @@ static void WoodenRCTrackLeftQuarterTurn3(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23832), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24698), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24698), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4126,14 +4126,14 @@ static void WoodenRCTrackLeftQuarterTurn3(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23823), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24689), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24689), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23835), { 6, 0, height },
                         { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24701), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24701), { 6, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4179,8 +4179,8 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_5),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24712), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24712), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4189,15 +4189,15 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_8),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24715), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24715), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_17),
                         { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24724), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24724), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4206,8 +4206,8 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_11),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24718), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24718), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4216,15 +4216,15 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_2),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24709), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24709), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_14),
                         { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24721), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24721), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4247,8 +4247,8 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_4),
                         { 0, 0, height }, { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24711), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24711), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4256,15 +4256,15 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_7),
                         { 0, 0, height }, { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24714), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24714), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_16),
                         { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24723), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24723), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4272,8 +4272,8 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_10),
                         { 0, 0, height }, { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24717), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24717), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4281,15 +4281,15 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_1),
                         { 0, 0, height }, { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24708), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24708), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_13),
                         { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24720), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24720), { 0, 0, height },
+                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -4305,8 +4305,8 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_3),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24710), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24710), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4315,15 +4315,15 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_6),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24713), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24713), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_15),
                         { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24722), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24722), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4332,8 +4332,8 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_9),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24716), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24716), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4342,15 +4342,15 @@ static void WoodenRCTrackLeftQuarterTurn3Bank(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_0),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24707), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24707), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_12),
                         { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24719), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24719), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4395,8 +4395,8 @@ static void WoodenRCTrackLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23906), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24772), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24772), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4404,14 +4404,14 @@ static void WoodenRCTrackLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23908), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24774), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24774), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23919), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24785), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24785), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4419,8 +4419,8 @@ static void WoodenRCTrackLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23910), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24776), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24776), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4428,14 +4428,14 @@ static void WoodenRCTrackLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23904), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24770), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24770), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23917), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24783), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24783), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4462,8 +4462,8 @@ static void WoodenRCTrackLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23905), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24771), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24771), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4471,14 +4471,14 @@ static void WoodenRCTrackLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23907), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24773), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24773), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23918), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24784), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24784), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4486,14 +4486,14 @@ static void WoodenRCTrackLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23909), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24775), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24775), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23920), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24786), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24786), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4501,14 +4501,14 @@ static void WoodenRCTrackLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23903), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24769), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24769), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23916), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24782), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24782), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4543,14 +4543,14 @@ static void WoodenRCTrackRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23895), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24761), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24761), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23911), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24777), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24777), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4558,8 +4558,8 @@ static void WoodenRCTrackRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23897), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24763), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24763), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4567,14 +4567,14 @@ static void WoodenRCTrackRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23899), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24765), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24765), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23914), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24780), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24780), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4582,8 +4582,8 @@ static void WoodenRCTrackRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23901), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24767), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24767), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4610,14 +4610,14 @@ static void WoodenRCTrackRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23896), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24762), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24762), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23912), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24778), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24778), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4625,14 +4625,14 @@ static void WoodenRCTrackRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23898), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24764), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24764), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23913), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24779), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24779), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4640,14 +4640,14 @@ static void WoodenRCTrackRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23900), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24766), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24766), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23915), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24781), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24781), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4655,8 +4655,8 @@ static void WoodenRCTrackRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23902), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24768), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24768), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4712,8 +4712,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24748), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24748), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4722,15 +4722,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24751), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24751), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53),
                         { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24760), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24760), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4739,8 +4739,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24754), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24754), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4749,15 +4749,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24745), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24745), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50),
                         { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24757), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24757), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4799,8 +4799,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40),
                         { 0, 0, height }, { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24747), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24747), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -4808,15 +4808,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43),
                         { 0, 0, height }, { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24750), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24750), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52),
                         { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24759), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24759), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -4824,8 +4824,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46),
                         { 0, 0, height }, { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24753), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24753), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -4833,15 +4833,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37),
                         { 0, 0, height }, { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24744), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24744), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49),
                         { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24756), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24756), { 0, 0, height },
+                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -4857,8 +4857,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24746), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24746), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4867,15 +4867,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24749), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24749), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51),
                         { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24758), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24758), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4884,8 +4884,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24752), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24752), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4894,15 +4894,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36),
                         { 0, 0, height }, { { 6, 0, height + 8 }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24743), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24743), { 0, 0, height },
+                        { { 6, 0, height + 8 }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48),
                         { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24755), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24755), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -4931,15 +4931,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_38),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24745), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24745), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_50),
                         { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24757), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24757), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -4948,8 +4948,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_41),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24748), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24748), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -4958,15 +4958,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_44),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24751), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24751), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_53),
                         { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24760), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24760), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -4975,8 +4975,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_47),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24754), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24754), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5023,15 +5023,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_37),
                         { 0, 0, height }, { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24744), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24744), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_49),
                         { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24756), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24756), { 0, 0, height },
+                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5039,8 +5039,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_40),
                         { 0, 0, height }, { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24747), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24747), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5048,15 +5048,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_43),
                         { 0, 0, height }, { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24750), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24750), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_52),
                         { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24759), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24759), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5064,8 +5064,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_46),
                         { 0, 0, height }, { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24753), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24753), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -5081,15 +5081,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_36),
                         { 0, 0, height }, { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24743), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24743), { 0, 0, height },
+                        { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_48),
                         { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24755), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24755), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5098,8 +5098,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_39),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24746), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24746), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5108,15 +5108,15 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_42),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24749), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24749), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_51),
                         { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24758), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24758), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5125,8 +5125,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_45),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24752), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24752), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5161,15 +5161,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24725), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24725), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30),
                         { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24737), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24737), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5178,8 +5178,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24728), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24728), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5188,15 +5188,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24731), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24731), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33),
                         { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24740), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24740), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5205,8 +5205,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24734), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24734), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5248,15 +5248,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_19),
                         { 0, 0, height }, { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24726), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24726), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31),
                         { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24738), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24738), { 0, 0, height },
+                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5264,8 +5264,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22),
                         { 0, 0, height }, { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24729), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24729), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5273,15 +5273,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25),
                         { 0, 0, height }, { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24732), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24732), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34),
                         { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24741), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24741), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -5289,8 +5289,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28),
                         { 0, 0, height }, { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24735), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24735), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -5306,15 +5306,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20),
                         { 0, 0, height }, { { 6, 0, height + 8 }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24727), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24727), { 0, 0, height },
+                        { { 6, 0, height + 8 }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32),
                         { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24739), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24739), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5323,8 +5323,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24730), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24730), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5333,15 +5333,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24733), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24733), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35),
                         { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24742), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24742), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5350,8 +5350,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24736), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24736), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5380,8 +5380,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_21),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24728), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24728), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5390,15 +5390,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_24),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24731), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24731), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_33),
                         { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24740), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24740), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5407,8 +5407,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_27),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24734), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24734), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5417,15 +5417,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_18),
                         { 0, 0, height }, { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24725), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24725), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_30),
                         { 0, 0, height }, { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24737), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24737), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5472,8 +5472,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_22),
                         { 0, 0, height }, { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24729), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24729), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -5481,15 +5481,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_25),
                         { 0, 0, height }, { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24732), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24732), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_34),
                         { 0, 0, height }, { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24741), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24741), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -5497,23 +5497,23 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_28),
                         { 0, 0, height }, { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24735), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24735), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23860), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24726), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24726), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_31),
                         { 0, 0, height }, { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24738), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24738), { 0, 0, height },
+                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -5529,8 +5529,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_23),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24730), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24730), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5539,15 +5539,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_26),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24733), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24733), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_35),
                         { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24742), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24742), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5556,8 +5556,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_29),
                         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24736), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24736), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5566,15 +5566,15 @@ static void WoodenRCTrackRightHalfBankedHelixUpSmall(
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_20),
                         { 0, 0, height }, { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24727), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24727), { 0, 0, height },
+                        { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction,
                         WoodenRCGetTrackColour<isClassic>(session).WithIndex(SPR_WOODEN_RC_SMALL_RIGHT_BANKED_TURN_32),
                         { 0, 0, height }, { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24739), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24739), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5639,8 +5639,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23704), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24570), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24570), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5648,14 +5648,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23709), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24575), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24575), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23724), { 0, 0, height },
                         { { 0, 2, height + 27 }, { 32, 27, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24590), { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24590), { 0, 0, height },
+                        { { 0, 2, height + 27 }, { 32, 27, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5663,8 +5663,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23714), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24580), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24580), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5672,14 +5672,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23699), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24565), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24565), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23719), { 0, 0, height },
                         { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24585), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24585), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5707,8 +5707,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23703), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24569), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24569), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5716,14 +5716,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23708), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24574), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24574), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23723), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24589), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24589), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5731,8 +5731,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23713), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24579), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24579), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5740,14 +5740,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23698), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24564), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24564), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23718), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24584), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24584), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5765,8 +5765,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23702), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24568), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24568), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5774,14 +5774,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23707), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24573), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24573), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23722), { 0, 0, height },
                         { { 16, 16, height + 29 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24588), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 29 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24588), { 0, 0, height },
+                        { { 16, 16, height + 29 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5789,8 +5789,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23712), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24578), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24578), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5798,14 +5798,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23697), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24563), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24563), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23717), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24583), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24583), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5828,8 +5828,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23701), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24567), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24567), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5837,14 +5837,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23706), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24572), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24572), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23721), { 0, 0, height },
                         { { 0, 0, height + 33 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24587), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 33 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24587), { 0, 0, height },
+                        { { 0, 0, height + 33 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5852,8 +5852,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23711), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24577), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24577), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5861,14 +5861,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23696), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24562), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24562), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23716), { 0, 0, height },
                         { { 16, 0, height + 27 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24582), { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24582), { 0, 0, height },
+                        { { 16, 0, height + 27 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5886,8 +5886,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23700), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24566), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24566), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5895,14 +5895,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23705), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24571), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24571), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23720), { 0, 0, height },
                         { { 2, 0, height + 33 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24586), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 33 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24586), { 0, 0, height },
+                        { { 2, 0, height + 33 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5910,8 +5910,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23710), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24576), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24576), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5919,14 +5919,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23695), { 0, 0, height },
                         { { 6, 0, height + 8 }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24561), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24561), { 0, 0, height },
+                        { { 6, 0, height + 8 }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23715), { 0, 0, height },
                         { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24581), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24581), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -5954,14 +5954,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23699), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24565), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24565), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23719), { 0, 0, height },
                         { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24585), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24585), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -5969,8 +5969,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23704), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24570), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24570), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -5978,14 +5978,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23709), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24575), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24575), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23724), { 0, 0, height },
                         { { 2, 0, height + 27 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24590), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24590), { 0, 0, height },
+                        { { 2, 0, height + 27 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -5993,8 +5993,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23714), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24580), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24580), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6027,14 +6027,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23698), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24564), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24564), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23718), { 0, 0, height },
                         { { 16, 0, height + 27 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24584), { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24584), { 0, 0, height },
+                        { { 16, 0, height + 27 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6042,8 +6042,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23703), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24569), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24569), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6051,14 +6051,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23708), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24574), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24574), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23723), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24589), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24589), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6066,8 +6066,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23713), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24579), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24579), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6085,14 +6085,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23697), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24563), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24563), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23717), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24583), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24583), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6100,8 +6100,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23702), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24568), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24568), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6109,14 +6109,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23707), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24573), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24573), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23722), { 0, 0, height },
                         { { 16, 16, height + 29 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24588), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 29 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24588), { 0, 0, height },
+                        { { 16, 16, height + 29 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6124,8 +6124,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23712), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24578), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24578), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6148,14 +6148,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23696), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24562), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24562), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23716), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24582), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24582), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6163,8 +6163,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23701), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24567), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24567), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6172,14 +6172,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23706), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24572), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24572), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23721), { 0, 0, height },
                         { { 0, 0, height + 33 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24587), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 33 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24587), { 0, 0, height },
+                        { { 0, 0, height + 33 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6187,8 +6187,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23711), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24577), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24577), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6206,14 +6206,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23695), { 0, 0, height },
                         { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24561), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24561), { 0, 0, height },
+                        { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23715), { 0, 0, height },
                         { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24581), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24581), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6221,8 +6221,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23700), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24566), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24566), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6230,14 +6230,14 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23705), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24571), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24571), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23720), { 0, 0, height },
                         { { 0, 2, height + 33 }, { 32, 27, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24586), { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 33 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24586), { 0, 0, height },
+                        { { 0, 2, height + 33 }, { 32, 27, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6245,8 +6245,8 @@ static void WoodenRCTrackLeftHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23710), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24576), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24576), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6280,14 +6280,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23665), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24531), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24531), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23685), { 0, 0, height },
                         { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24551), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24551), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6295,8 +6295,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23670), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24536), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24536), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6304,14 +6304,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23675), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24541), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24541), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23690), { 0, 0, height },
                         { { 0, 2, height + 27 }, { 32, 27, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24556), { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24556), { 0, 0, height },
+                        { { 0, 2, height + 27 }, { 32, 27, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6319,8 +6319,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23680), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24546), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24546), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6348,14 +6348,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23666), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24532), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24532), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23686), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24552), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24552), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6363,8 +6363,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23671), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24537), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24537), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6372,14 +6372,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23676), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24542), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24542), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23691), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24557), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24557), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6387,8 +6387,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23681), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24547), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24547), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6406,14 +6406,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23667), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24533), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24533), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23687), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24553), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24553), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6421,8 +6421,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23672), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24538), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24538), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6430,14 +6430,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23677), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24543), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24543), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23692), { 0, 0, height },
                         { { 16, 16, height + 29 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24558), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 29 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24558), { 0, 0, height },
+                        { { 16, 16, height + 29 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6445,8 +6445,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23682), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24548), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24548), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6469,14 +6469,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23668), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24534), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24534), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23688), { 0, 0, height },
                         { { 16, 0, height + 27 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24554), { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24554), { 0, 0, height },
+                        { { 16, 0, height + 27 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6484,8 +6484,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23673), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24539), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24539), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6493,14 +6493,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23678), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24544), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24544), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23693), { 0, 0, height },
                         { { 0, 0, height + 33 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24559), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 33 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24559), { 0, 0, height },
+                        { { 0, 0, height + 33 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6508,8 +6508,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23683), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24549), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24549), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6525,16 +6525,16 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                 case 0:
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23669), { 0, 0, height },
-                        { 20, 32, 2 }, { 6, 0, height + 8 });
+                        { { 6, 0, height + 8 }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24535), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height + 8 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24535), { 0, 0, height },
+                        { { 6, 0, height + 8 }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23689), { 0, 0, height },
                         { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24555), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24555), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6542,8 +6542,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23674), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24540), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24540), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6551,14 +6551,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23679), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24545), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24545), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23694), { 0, 0, height },
                         { { 2, 0, height + 33 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24560), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 33 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24560), { 0, 0, height },
+                        { { 2, 0, height + 33 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6566,8 +6566,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23684), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24550), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24550), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6595,8 +6595,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23670), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24536), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24536), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6604,14 +6604,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23675), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24541), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24541), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23690), { 0, 0, height },
                         { { 2, 0, height + 27 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24556), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24556), { 0, 0, height },
+                        { { 2, 0, height + 27 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6619,8 +6619,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23680), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24546), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24546), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6628,14 +6628,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23665), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24531), { 0, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24531), { 0, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23685), { 0, 0, height },
                         { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24551), { 0, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24551), { 0, 0, height },
+                        { { 6, 0, height + 27 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6668,8 +6668,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23671), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24537), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24537), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6677,14 +6677,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23676), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24542), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24542), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23691), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24557), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24557), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6692,8 +6692,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23681), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24547), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24547), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6701,14 +6701,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23666), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24532), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24532), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23686), { 0, 0, height },
                         { { 16, 0, height + 27 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24552), { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24552), { 0, 0, height },
+                        { { 16, 0, height + 27 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6726,8 +6726,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23672), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24538), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24538), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6735,14 +6735,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23677), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24543), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24543), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23692), { 0, 0, height },
                         { { 16, 16, height + 29 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24558), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 29 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24558), { 0, 0, height },
+                        { { 16, 16, height + 29 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6750,8 +6750,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23682), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24548), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24548), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6759,14 +6759,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23667), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24533), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24533), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23687), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24553), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24553), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6789,8 +6789,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23673), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24539), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24539), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6798,14 +6798,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23678), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24544), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24544), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23693), { 0, 0, height },
                         { { 0, 0, height + 33 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24559), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 33 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24559), { 0, 0, height },
+                        { { 0, 0, height + 33 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6813,8 +6813,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23683), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24549), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24549), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6822,14 +6822,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23668), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24534), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24534), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23688), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24554), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24554), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6847,8 +6847,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23674), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24540), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24540), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -6856,14 +6856,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23679), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24545), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24545), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23694), { 0, 0, height },
                         { { 0, 2, height + 33 }, { 32, 27, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24560), { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 33 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24560), { 0, 0, height },
+                        { { 0, 2, height + 33 }, { 32, 27, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -6871,8 +6871,8 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23684), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24550), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24550), { 0, 0, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -6880,14 +6880,14 @@ static void WoodenRCTrackRightHalfBankedHelixUpLarge(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23669), { 0, 0, height },
                         { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24535), { 0, 0, height }, { 32, 20, 2 },
-                        { 0, 6, height + 8 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24535), { 0, 0, height },
+                        { { 0, 6, height + 8 }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23689), { 0, 0, height },
                         { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24555), { 0, 0, height }, { 32, 20, 0 },
-                        { 0, 6, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24555), { 0, 0, height },
+                        { { 0, 6, height + 27 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -6949,56 +6949,56 @@ static void WoodenRCTrackLeftQuarterTurn160DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24209), { 0, 0, height },
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25075), { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25075), { 0, 0, height },
+                { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24217), { 0, 0, height },
                 { { 2, 2, height + 99 }, { 28, 28, 1 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25083), { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25083), { 0, 0, height },
+                { { 2, 2, height + 99 }, { 28, 28, 1 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24210), { 0, 0, height },
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25076), { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25076), { 0, 0, height },
+                { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24218), { 0, 0, height },
                 { { 2, 2, height + 99 }, { 28, 28, 1 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25084), { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25084), { 0, 0, height },
+                { { 2, 2, height + 99 }, { 28, 28, 1 } });
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24211), { 0, 0, height },
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25077), { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25077), { 0, 0, height },
+                { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24219), { 0, 0, height },
                 { { 2, 2, height + 99 }, { 28, 28, 1 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25085), { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25085), { 0, 0, height },
+                { { 2, 2, height + 99 }, { 28, 28, 1 } });
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24212), { 0, 0, height },
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25078), { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25078), { 0, 0, height },
+                { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24220), { 0, 0, height },
                 { { 2, 2, height + 99 }, { 28, 28, 1 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25086), { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25086), { 0, 0, height },
+                { { 2, 2, height + 99 }, { 28, 28, 1 } });
             break;
     }
     TrackPaintUtilLeftQuarterTurn1TileTunnel(session, direction, height, -8, TUNNEL_SQUARE_7, +56, TUNNEL_SQUARE_8);
@@ -7019,56 +7019,56 @@ static void WoodenRCTrackRightQuarterTurn160DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24213), { 0, 0, height },
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25079), { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25079), { 0, 0, height },
+                { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24221), { 0, 0, height },
                 { { 2, 2, height + 99 }, { 28, 28, 1 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25087), { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25087), { 0, 0, height },
+                { { 2, 2, height + 99 }, { 28, 28, 1 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24214), { 0, 0, height },
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25080), { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25080), { 0, 0, height },
+                { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24222), { 0, 0, height },
                 { { 2, 2, height + 99 }, { 28, 28, 1 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25088), { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25088), { 0, 0, height },
+                { { 2, 2, height + 99 }, { 28, 28, 1 } });
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24215), { 0, 0, height },
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25081), { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25081), { 0, 0, height },
+                { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24223), { 0, 0, height },
                 { { 2, 2, height + 99 }, { 28, 28, 1 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25089), { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25089), { 0, 0, height },
+                { { 2, 2, height + 99 }, { 28, 28, 1 } });
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24216), { 0, 0, height },
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25082), { 0, 0, height }, { 28, 28, 3 },
-                { 2, 2, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25082), { 0, 0, height },
+                { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24224), { 0, 0, height },
                 { { 2, 2, height + 99 }, { 28, 28, 1 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25090), { 0, 0, height }, { 28, 28, 1 },
-                { 2, 2, height + 99 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25090), { 0, 0, height },
+                { { 2, 2, height + 99 }, { 28, 28, 1 } });
             break;
     }
     TrackPaintUtilRightQuarterTurn1TileTunnel(session, direction, height, -8, TUNNEL_SQUARE_7, +56, TUNNEL_SQUARE_8);
@@ -7128,8 +7128,8 @@ static void WoodenRCTrack25DegUpLeftBanked(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24249), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25115), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25115), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -7137,14 +7137,14 @@ static void WoodenRCTrack25DegUpLeftBanked(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24250), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25116), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25116), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24257), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25123), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25123), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -7152,14 +7152,14 @@ static void WoodenRCTrack25DegUpLeftBanked(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24251), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25117), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25117), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24258), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25124), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25124), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -7167,8 +7167,8 @@ static void WoodenRCTrack25DegUpLeftBanked(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24252), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25118), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25118), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -7197,8 +7197,8 @@ static void WoodenRCTrack25DegUpRightBanked(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24253), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25119), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25119), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -7206,14 +7206,14 @@ static void WoodenRCTrack25DegUpRightBanked(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24254), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25120), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25120), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24259), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25125), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25125), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -7221,14 +7221,14 @@ static void WoodenRCTrack25DegUpRightBanked(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24255), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25121), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25121), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24260), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25126), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25126), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -7236,8 +7236,8 @@ static void WoodenRCTrack25DegUpRightBanked(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24256), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25122), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25122), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -7266,32 +7266,32 @@ static void WoodenRCTrackOnRidePhoto(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23753), { 0, 2, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(24619), { 0, 2, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(24619), { 0, 2, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23754), { 0, 2, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(24620), { 0, 2, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(24620), { 0, 2, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23753), { 0, 2, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(24619), { 0, 2, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(24619), { 0, 2, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23754), { 0, 2, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(24620), { 0, 2, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(24620), { 0, 2, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             break;
     }
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7339,96 +7339,96 @@ static void WoodenRCTrackWaterSplash(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23989), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24855), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24855), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23997), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24863), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23993), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24859), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24859), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23990), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24856), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24856), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23998), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24864), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23994), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24860), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24860), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23987), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24853), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24853), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23995), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24861), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23991), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24857), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24857), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23988), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24854), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24854), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23996), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24862), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23992), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24858), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24858), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7444,96 +7444,96 @@ static void WoodenRCTrackWaterSplash(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23977), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24843), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24843), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23985), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24851), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23981), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24847), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24847), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23978), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24844), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24844), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23986), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24852), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23982), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24848), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24848), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23975), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24841), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24841), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23983), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24849), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23979), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24845), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24845), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23976), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24842), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24842), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23984), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24850), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23980), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24846), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24846), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7549,24 +7549,24 @@ static void WoodenRCTrackWaterSplash(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23999), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24865), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24865), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24003), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24869), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24001), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24867), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24867), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 1:
                 case 3:
@@ -7574,24 +7574,24 @@ static void WoodenRCTrackWaterSplash(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24000), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24866), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24866), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24004), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24870), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24002), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24868), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24868), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7606,96 +7606,96 @@ static void WoodenRCTrackWaterSplash(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23975), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24841), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24841), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23983), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24849), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23979), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24845), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24845), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23976), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24842), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24842), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23984), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24850), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23980), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24846), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24846), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23977), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24843), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24843), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23985), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24851), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23981), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24847), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24847), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23978), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24844), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24844), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23986), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24852), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23982), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24848), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24848), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7710,96 +7710,96 @@ static void WoodenRCTrackWaterSplash(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23987), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24853), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24853), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23995), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24861), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23991), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24857), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24857), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23988), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24854), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24854), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23996), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24862), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23992), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24858), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24858), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23989), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24855), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24855), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23997), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24863), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23993), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24859), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24859), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23990), { 0, 0, height },
                         { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24856), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24856), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterMask, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterMask, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, waterOverlay, { 0, 0, height + 16 }, { 32, 25, 2 }, { 0, 3, height + 16 });
+                        session, direction, waterOverlay, { 0, 0, height + 16 }, { { 0, 3, height + 16 }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(23998), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(24864), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23994), { 0, 0, height },
-                        { 32, 25, 2 }, { 0, 3, height });
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24860), { 0, 0, height }, { 32, 25, 2 },
-                        { 0, 3, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24860), { 0, 0, height },
+                        { { 0, 3, height }, { 32, 25, 2 } });
                     break;
             }
             WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
@@ -7826,8 +7826,8 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24137), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25003), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25003), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7835,14 +7835,14 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24141), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25007), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25007), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24153), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25019), { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25019), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -7850,8 +7850,8 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24145), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25011), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25011), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7859,14 +7859,14 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24149), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25015), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25015), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24157), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25023), { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25023), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -7885,8 +7885,8 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24138), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25004), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25004), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7894,14 +7894,14 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24142), { 0, 0, height },
                         { { 0, 0, height }, { 34, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25008), { 0, 0, height }, { 34, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25008), { 0, 0, height },
+                        { { 0, 0, height }, { 34, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24154), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25020), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25020), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -7909,8 +7909,8 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24146), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25012), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25012), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7918,14 +7918,14 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24150), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25016), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25016), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24158), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25024), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25024), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -7940,8 +7940,8 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24139), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25005), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25005), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -7949,14 +7949,14 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24143), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25009), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25009), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24155), { 0, 0, height },
                         { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25021), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25021), { 0, 0, height },
+                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -7964,8 +7964,8 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24147), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25013), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25013), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -7973,14 +7973,14 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24151), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25017), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25017), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24159), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25025), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25025), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8014,44 +8014,44 @@ static void WoodenRCTrackLeftEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24140), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25006), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25006), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24144), { 0, 0, height },
                         { { 0, 16, height }, { 16, 18, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25010), { 0, 0, height }, { 16, 18, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25010), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 18, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24156), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25022), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25022), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24148), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25014), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25014), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24152), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25018), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25018), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24160), { 0, 0, height },
                         { { 16, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25026), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25026), { 0, 0, height },
+                        { { 16, 0, height + 27 }, { 16, 16, 0 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8076,14 +8076,14 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24113), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24979), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24979), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24129), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24995), { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24995), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8091,8 +8091,8 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24117), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24983), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24983), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8100,14 +8100,14 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24121), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24987), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24987), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24133), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24999), { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24999), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8115,8 +8115,8 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24125), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24991), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24991), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8135,14 +8135,14 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24114), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24980), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24980), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24130), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24996), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24996), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8150,8 +8150,8 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24118), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24984), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24984), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8159,14 +8159,14 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24122), { 0, 0, height },
                         { { 0, 0, height }, { 34, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24988), { 0, 0, height }, { 34, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24988), { 0, 0, height },
+                        { { 0, 0, height }, { 34, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24134), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25000), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25000), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8174,8 +8174,8 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24126), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24992), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24992), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8190,14 +8190,14 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24115), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24981), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24981), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24131), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24997), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24997), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8205,8 +8205,8 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24119), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24985), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24985), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8214,14 +8214,14 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24123), { 0, 0, height },
                         { { 4, 4, height }, { 28, 28, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24989), { 0, 0, height }, { 28, 28, 2 },
-                        { 4, 4, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24989), { 0, 0, height },
+                        { { 4, 4, height }, { 28, 28, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24135), { 0, 0, height },
                         { { 4, 4, height + 27 }, { 28, 28, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25001), { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25001), { 0, 0, height },
+                        { { 4, 4, height + 27 }, { 28, 28, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8229,8 +8229,8 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24127), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24993), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24993), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8264,44 +8264,44 @@ static void WoodenRCTrackRightEighthToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24116), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24982), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24982), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24132), { 0, 0, height },
                         { { 16, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24998), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24998), { 0, 0, height },
+                        { { 16, 0, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24120), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24986), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24986), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24124), { 0, 0, height },
                         { { 0, 16, height }, { 16, 18, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24990), { 0, 0, height }, { 16, 18, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24990), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 18, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24136), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25002), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25002), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24128), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24994), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24994), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8346,8 +8346,8 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24185), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25051), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25051), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8355,14 +8355,14 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24189), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25055), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25055), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24201), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25067), { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25067), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8370,8 +8370,8 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24193), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25059), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25059), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8379,14 +8379,14 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24197), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25063), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25063), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24205), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25071), { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25071), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8405,8 +8405,8 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24186), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25052), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25052), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8414,14 +8414,14 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24190), { 0, 0, height },
                         { { 0, 0, height }, { 34, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25056), { 0, 0, height }, { 34, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25056), { 0, 0, height },
+                        { { 0, 0, height }, { 34, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24202), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25068), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25068), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8429,8 +8429,8 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24194), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25060), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25060), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8438,14 +8438,14 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24198), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25064), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25064), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24206), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25072), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25072), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8460,8 +8460,8 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24187), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25053), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25053), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8469,14 +8469,14 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24191), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25057), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25057), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24203), { 0, 0, height },
                         { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25069), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25069), { 0, 0, height },
+                        { { 16, 16, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8484,8 +8484,8 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24195), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25061), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25061), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8493,14 +8493,14 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24199), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25065), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25065), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24207), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25073), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25073), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8534,44 +8534,44 @@ static void WoodenRCTrackLeftEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24188), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25054), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25054), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24192), { 0, 0, height },
                         { { 0, 16, height }, { 16, 18, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25058), { 0, 0, height }, { 16, 18, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25058), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 18, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24204), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25070), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25070), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24196), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25062), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25062), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24200), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25066), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25066), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24208), { 0, 0, height },
                         { { 16, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25074), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25074), { 0, 0, height },
+                        { { 16, 0, height + 27 }, { 16, 16, 0 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8596,14 +8596,14 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24161), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25027), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25027), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24177), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25043), { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25043), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8611,8 +8611,8 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24165), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25031), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25031), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8620,14 +8620,14 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24169), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25035), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25035), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24181), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25047), { 0, 0, height }, { 32, 32, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25047), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8635,8 +8635,8 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24173), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25039), { 0, 0, height }, { 32, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25039), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8655,14 +8655,14 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24162), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25028), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25028), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24178), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25044), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25044), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8670,8 +8670,8 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24166), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25032), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25032), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8679,14 +8679,14 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24170), { 0, 0, height },
                         { { 0, 0, height }, { 34, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25036), { 0, 0, height }, { 34, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25036), { 0, 0, height },
+                        { { 0, 0, height }, { 34, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24182), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25048), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25048), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8694,8 +8694,8 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24174), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25040), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25040), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8710,14 +8710,14 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24163), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25029), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25029), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24179), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25045), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25045), { 0, 0, height },
+                        { { 0, 0, height + 27 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -8725,8 +8725,8 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24167), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25033), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25033), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -8734,14 +8734,14 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24171), { 0, 0, height },
                         { { 4, 4, height }, { 28, 28, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25037), { 0, 0, height }, { 28, 28, 2 },
-                        { 4, 4, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25037), { 0, 0, height },
+                        { { 4, 4, height }, { 28, 28, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24183), { 0, 0, height },
                         { { 4, 4, height + 27 }, { 28, 28, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25049), { 0, 0, height }, { 28, 28, 0 },
-                        { 4, 4, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25049), { 0, 0, height },
+                        { { 4, 4, height + 27 }, { 28, 28, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -8749,8 +8749,8 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24175), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25041), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25041), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -8784,44 +8784,44 @@ static void WoodenRCTrackRightEighthBankToDiag(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24164), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25030), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25030), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24180), { 0, 0, height },
                         { { 16, 0, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25046), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 0, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25046), { 0, 0, height },
+                        { { 16, 0, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24168), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25034), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25034), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24172), { 0, 0, height },
                         { { 0, 16, height }, { 16, 18, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25038), { 0, 0, height }, { 16, 18, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25038), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 18, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24184), { 0, 0, height },
                         { { 0, 16, height + 27 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25050), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 16, height + 27 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25050), { 0, 0, height },
+                        { { 0, 16, height + 27 }, { 16, 16, 0 } });
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24176), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25042), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25042), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -8869,7 +8869,7 @@ static void WoodenRCTrackDiagFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24916), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -8883,7 +8883,7 @@ static void WoodenRCTrackDiagFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24874), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -8901,13 +8901,13 @@ static void WoodenRCTrackDiagFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24913), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24051),
                             { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24917), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 27 });
+                            { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -8931,13 +8931,13 @@ static void WoodenRCTrackDiagFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24871), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24009),
                             { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24875), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 27 });
+                            { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -8971,13 +8971,13 @@ static void WoodenRCTrackDiagFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24915), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24052),
                             { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24918), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 27 });
+                            { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -9001,13 +9001,13 @@ static void WoodenRCTrackDiagFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24873), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24010),
                             { -16, -16, height }, { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24876), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 27 });
+                            { { -16, -16, height + 27 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -9029,7 +9029,7 @@ static void WoodenRCTrackDiagFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24914), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9043,7 +9043,7 @@ static void WoodenRCTrackDiagFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24872), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9072,7 +9072,7 @@ static void WoodenRCTrackDiag25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24934), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9086,7 +9086,7 @@ static void WoodenRCTrackDiag25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24892), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9104,13 +9104,13 @@ static void WoodenRCTrackDiag25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24931), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24069),
                             { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24935), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -9134,13 +9134,13 @@ static void WoodenRCTrackDiag25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24889), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24027),
                             { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24893), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -9174,13 +9174,13 @@ static void WoodenRCTrackDiag25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24933), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24070),
                             { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24936), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -9204,13 +9204,13 @@ static void WoodenRCTrackDiag25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24891), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24028),
                             { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24894), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -9232,7 +9232,7 @@ static void WoodenRCTrackDiag25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24932), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9246,7 +9246,7 @@ static void WoodenRCTrackDiag25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24890), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9273,7 +9273,7 @@ static void WoodenRCTrackDiag60DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24910), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9288,13 +9288,13 @@ static void WoodenRCTrackDiag60DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24907), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24045), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24911), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 91 });
+                        { { -16, -16, height + 91 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -9325,13 +9325,13 @@ static void WoodenRCTrackDiag60DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24909), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24046), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24912), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 91 });
+                        { { -16, -16, height + 91 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -9350,7 +9350,7 @@ static void WoodenRCTrackDiag60DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24908), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9378,7 +9378,7 @@ static void WoodenRCTrackDiagFlatTo25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24922), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9392,7 +9392,7 @@ static void WoodenRCTrackDiagFlatTo25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24880), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9410,13 +9410,13 @@ static void WoodenRCTrackDiagFlatTo25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24919), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24057),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24923), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -9440,13 +9440,13 @@ static void WoodenRCTrackDiagFlatTo25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24877), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24015),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24881), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -9480,13 +9480,13 @@ static void WoodenRCTrackDiagFlatTo25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24921), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24058),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24924), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -9510,13 +9510,13 @@ static void WoodenRCTrackDiagFlatTo25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24879), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24016),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24882), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -9538,7 +9538,7 @@ static void WoodenRCTrackDiagFlatTo25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24920), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9552,7 +9552,7 @@ static void WoodenRCTrackDiagFlatTo25DegUp(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24878), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9579,7 +9579,7 @@ static void WoodenRCTrackDiag25DegUpTo60DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24898), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9594,13 +9594,13 @@ static void WoodenRCTrackDiag25DegUpTo60DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24895), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24033), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24899), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -9631,13 +9631,13 @@ static void WoodenRCTrackDiag25DegUpTo60DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24897), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24034), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24900), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -9656,7 +9656,7 @@ static void WoodenRCTrackDiag25DegUpTo60DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24896), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9682,7 +9682,7 @@ static void WoodenRCTrackDiag60DegUpTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24904), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9697,13 +9697,13 @@ static void WoodenRCTrackDiag60DegUpTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24901), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24039), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24905), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -9734,13 +9734,13 @@ static void WoodenRCTrackDiag60DegUpTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24903), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24040), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24906), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -9759,7 +9759,7 @@ static void WoodenRCTrackDiag60DegUpTo25DegUp(
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24902), { -16, -16, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -9787,7 +9787,7 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24928), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9801,7 +9801,7 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24886), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9819,13 +9819,13 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24925), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24063),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24929), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -9849,13 +9849,13 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24883), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24021),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24887), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -9889,13 +9889,13 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24927), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24064),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24930), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -9919,13 +9919,13 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24885), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24022),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24888), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -9947,7 +9947,7 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24926), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9961,7 +9961,7 @@ static void WoodenRCTrackDiag25DegUpToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24884), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -9990,7 +9990,7 @@ static void WoodenRCTrackDiag25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24932), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10004,7 +10004,7 @@ static void WoodenRCTrackDiag25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24890), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10022,13 +10022,13 @@ static void WoodenRCTrackDiag25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24933), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24070),
                             { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24936), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -10052,13 +10052,13 @@ static void WoodenRCTrackDiag25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24891), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24028),
                             { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24894), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -10092,13 +10092,13 @@ static void WoodenRCTrackDiag25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24931), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24069),
                             { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24935), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -10122,13 +10122,13 @@ static void WoodenRCTrackDiag25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24889), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24027),
                             { -16, -16, height }, { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24893), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 43 });
+                            { { -16, -16, height + 43 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -10150,7 +10150,7 @@ static void WoodenRCTrackDiag25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24934), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10164,7 +10164,7 @@ static void WoodenRCTrackDiag25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24892), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10191,7 +10191,7 @@ static void WoodenRCTrackDiag60DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24908), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10206,13 +10206,13 @@ static void WoodenRCTrackDiag60DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24909), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24046), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24912), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 91 });
+                        { { -16, -16, height + 91 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -10243,13 +10243,13 @@ static void WoodenRCTrackDiag60DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24907), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24045), { -16, -16, height },
                         { { -16, -16, height + 91 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24911), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 91 });
+                        { { -16, -16, height + 91 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -10268,7 +10268,7 @@ static void WoodenRCTrackDiag60DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24910), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10296,7 +10296,7 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24926), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10310,7 +10310,7 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24884), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10326,13 +10326,13 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24927), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24064),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24930), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -10356,13 +10356,13 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24885), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24022),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24888), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -10394,13 +10394,13 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24925), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24063),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24929), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -10424,13 +10424,13 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24883), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24021),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24887), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -10450,7 +10450,7 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24928), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10464,7 +10464,7 @@ static void WoodenRCTrackDiagFlatTo25DegDown(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24886), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10492,7 +10492,7 @@ static void WoodenRCTrackDiag25DegDownTo60DegDown(
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24902), { -16, -16, height },
-                        { 16, 16, 2 }, { 0, 0, height });
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10507,13 +10507,13 @@ static void WoodenRCTrackDiag25DegDownTo60DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24903), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24040), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24906), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -10544,13 +10544,13 @@ static void WoodenRCTrackDiag25DegDownTo60DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24901), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24039), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24905), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -10569,7 +10569,7 @@ static void WoodenRCTrackDiag25DegDownTo60DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24904), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10595,7 +10595,7 @@ static void WoodenRCTrackDiag60DegDownTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24896), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10610,13 +10610,13 @@ static void WoodenRCTrackDiag60DegDownTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24897), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24034), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24900), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -10647,13 +10647,13 @@ static void WoodenRCTrackDiag60DegDownTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24895), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24033), { -16, -16, height },
                         { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24899), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 59 });
+                        { { -16, -16, height + 59 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -10672,7 +10672,7 @@ static void WoodenRCTrackDiag60DegDownTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24898), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10700,7 +10700,7 @@ static void WoodenRCTrackDiag25DegDownToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24920), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10714,7 +10714,7 @@ static void WoodenRCTrackDiag25DegDownToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24878), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10732,13 +10732,13 @@ static void WoodenRCTrackDiag25DegDownToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24921), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24058),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24924), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -10762,13 +10762,13 @@ static void WoodenRCTrackDiag25DegDownToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24879), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24016),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24882), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
@@ -10802,13 +10802,13 @@ static void WoodenRCTrackDiag25DegDownToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24919), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24057),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24923), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -10832,13 +10832,13 @@ static void WoodenRCTrackDiag25DegDownToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24877), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsParentRotated(
                             session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24015),
                             { -16, -16, height }, { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24881), { -16, -16, height },
-                            { 32, 32, 0 }, { -16, -16, height + 35 });
+                            { { -16, -16, height + 35 }, { 32, 32, 0 } });
                         WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
@@ -10860,7 +10860,7 @@ static void WoodenRCTrackDiag25DegDownToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24922), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10874,7 +10874,7 @@ static void WoodenRCTrackDiag25DegDownToFlat(
                             { -16, -16, height }, { { -16, -16, height }, { 32, 32, 2 } });
                         PaintAddImageAsChildRotated(
                             session, direction, WoodenRCGetRailsColour(session).WithIndex(24880), { -16, -16, height },
-                            { 32, 32, 2 }, { -16, -16, height });
+                            { { -16, -16, height }, { 32, 32, 2 } });
                         break;
                 }
             }
@@ -10901,7 +10901,7 @@ static void WoodenRCTrackDiagFlatToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24946), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -10916,13 +10916,13 @@ static void WoodenRCTrackDiagFlatToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24943), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24081), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24947), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -10953,13 +10953,13 @@ static void WoodenRCTrackDiagFlatToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24945), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24082), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24948), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -10978,7 +10978,7 @@ static void WoodenRCTrackDiagFlatToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24944), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11004,7 +11004,7 @@ static void WoodenRCTrackDiagFlatToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24952), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11019,13 +11019,13 @@ static void WoodenRCTrackDiagFlatToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24949), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24087), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24953), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11056,13 +11056,13 @@ static void WoodenRCTrackDiagFlatToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24951), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24088), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24954), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11081,7 +11081,7 @@ static void WoodenRCTrackDiagFlatToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24950), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11107,7 +11107,7 @@ static void WoodenRCTrackDiagLeftBankToFlat(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24950), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11122,13 +11122,13 @@ static void WoodenRCTrackDiagLeftBankToFlat(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24951), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24088), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24954), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11159,13 +11159,13 @@ static void WoodenRCTrackDiagLeftBankToFlat(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24949), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24087), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24953), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11184,7 +11184,7 @@ static void WoodenRCTrackDiagLeftBankToFlat(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24952), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11210,7 +11210,7 @@ static void WoodenRCTrackDiagRightBankToFlat(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24944), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11225,13 +11225,13 @@ static void WoodenRCTrackDiagRightBankToFlat(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24945), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24082), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24948), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11262,13 +11262,13 @@ static void WoodenRCTrackDiagRightBankToFlat(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24943), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24081), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24947), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11287,7 +11287,7 @@ static void WoodenRCTrackDiagRightBankToFlat(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24946), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11313,7 +11313,7 @@ static void WoodenRCTrackDiagLeftBankTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24970), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11328,13 +11328,13 @@ static void WoodenRCTrackDiagLeftBankTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24967), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24105), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24971), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11365,13 +11365,13 @@ static void WoodenRCTrackDiagLeftBankTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24969), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24106), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24972), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11390,7 +11390,7 @@ static void WoodenRCTrackDiagLeftBankTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24968), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11416,7 +11416,7 @@ static void WoodenRCTrackDiagRightBankTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24976), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11431,13 +11431,13 @@ static void WoodenRCTrackDiagRightBankTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24973), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24111), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24977), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11468,13 +11468,13 @@ static void WoodenRCTrackDiagRightBankTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24975), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24112), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24978), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11493,7 +11493,7 @@ static void WoodenRCTrackDiagRightBankTo25DegUp(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24974), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11519,7 +11519,7 @@ static void WoodenRCTrackDiag25DegUpToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24958), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11534,13 +11534,13 @@ static void WoodenRCTrackDiag25DegUpToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24955), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24093), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24959), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11571,13 +11571,13 @@ static void WoodenRCTrackDiag25DegUpToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24957), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24094), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24960), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11596,7 +11596,7 @@ static void WoodenRCTrackDiag25DegUpToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24956), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11622,7 +11622,7 @@ static void WoodenRCTrackDiag25DegUpToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24964), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11637,13 +11637,13 @@ static void WoodenRCTrackDiag25DegUpToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24961), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24099), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24965), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11674,13 +11674,13 @@ static void WoodenRCTrackDiag25DegUpToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24963), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24100), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24966), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11699,7 +11699,7 @@ static void WoodenRCTrackDiag25DegUpToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24962), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11725,7 +11725,7 @@ static void WoodenRCTrackDiagLeftBankTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24962), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             break;
@@ -11738,13 +11738,13 @@ static void WoodenRCTrackDiagLeftBankTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24963), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24100), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24966), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11773,13 +11773,13 @@ static void WoodenRCTrackDiagLeftBankTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24961), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24099), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24965), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11796,7 +11796,7 @@ static void WoodenRCTrackDiagLeftBankTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24964), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             break;
@@ -11823,7 +11823,7 @@ static void WoodenRCTrackDiagRightBankTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24956), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             break;
@@ -11836,13 +11836,13 @@ static void WoodenRCTrackDiagRightBankTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24957), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24094), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24960), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11871,13 +11871,13 @@ static void WoodenRCTrackDiagRightBankTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24955), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24093), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24959), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenBSupportsPaintSetup(session, 2, 0, height + 16, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11894,7 +11894,7 @@ static void WoodenRCTrackDiagRightBankTo25DegDown(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24958), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             break;
@@ -11921,7 +11921,7 @@ static void WoodenRCTrackDiag25DegDownToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24974), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -11936,13 +11936,13 @@ static void WoodenRCTrackDiag25DegDownToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24975), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24112), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24978), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -11973,13 +11973,13 @@ static void WoodenRCTrackDiag25DegDownToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24973), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24111), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24977), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -11998,7 +11998,7 @@ static void WoodenRCTrackDiag25DegDownToLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24976), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12024,7 +12024,7 @@ static void WoodenRCTrackDiag25DegDownToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24968), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12039,13 +12039,13 @@ static void WoodenRCTrackDiag25DegDownToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24969), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24106), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24972), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12076,13 +12076,13 @@ static void WoodenRCTrackDiag25DegDownToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24967), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24105), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24971), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 35 });
+                        { { -16, -16, height + 35 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12101,7 +12101,7 @@ static void WoodenRCTrackDiag25DegDownToRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24970), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12127,7 +12127,7 @@ static void WoodenRCTrackDiagLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24940), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12142,13 +12142,13 @@ static void WoodenRCTrackDiagLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24937), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24075), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24941), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12179,13 +12179,13 @@ static void WoodenRCTrackDiagLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24939), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24076), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24942), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12204,7 +12204,7 @@ static void WoodenRCTrackDiagLeftBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24938), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12230,7 +12230,7 @@ static void WoodenRCTrackDiagRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24938), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12245,13 +12245,13 @@ static void WoodenRCTrackDiagRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24939), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24076), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24942), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12282,13 +12282,13 @@ static void WoodenRCTrackDiagRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24937), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24075), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24941), { -16, -16, height },
-                        { 32, 32, 0 }, { -16, -16, height + 27 });
+                        { { -16, -16, height + 27 }, { 32, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12307,7 +12307,7 @@ static void WoodenRCTrackDiagRightBank(
                         { { -16, -16, height }, { 32, 32, 2 } });
                     PaintAddImageAsChildRotated(
                         session, direction, WoodenRCGetRailsColour(session).WithIndex(24940), { -16, -16, height },
-                        { 32, 32, 2 }, { -16, -16, height });
+                        { { -16, -16, height }, { 32, 32, 2 } });
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -12332,8 +12332,8 @@ static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23958), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24824), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24824), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12341,14 +12341,14 @@ static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23960), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24826), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24826), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23971), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24837), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24837), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12356,8 +12356,8 @@ static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23962), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24828), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24828), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12365,14 +12365,14 @@ static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23956), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24822), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24822), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23969), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24835), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24835), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12399,8 +12399,8 @@ static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23957), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24823), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24823), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12408,14 +12408,14 @@ static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23959), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24825), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24825), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23970), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24836), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24836), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12423,14 +12423,14 @@ static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23961), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24827), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24827), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23972), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24838), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24838), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12438,14 +12438,14 @@ static void WoodenRCTrackLeftBankToLeftQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23955), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24821), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24821), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23968), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24834), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24834), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12480,14 +12480,14 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23947), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24813), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24813), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23963), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24829), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24829), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12495,8 +12495,8 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23949), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24815), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24815), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12504,14 +12504,14 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23951), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24817), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24817), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23966), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24832), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24832), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12519,8 +12519,8 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23953), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24819), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24819), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12547,14 +12547,14 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23948), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24814), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24814), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23964), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24830), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24830), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12562,14 +12562,14 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23950), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24816), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24816), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23965), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24831), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24831), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12577,14 +12577,14 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23952), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24818), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24818), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23967), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24833), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24833), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12592,8 +12592,8 @@ static void WoodenRCTrackRightBankToRightQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23954), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24820), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24820), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12628,14 +12628,14 @@ static void WoodenRCTrackLeftQuarterTurn325DegDownToLeftBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23950), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24816), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24816), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23965), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24831), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24831), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12643,14 +12643,14 @@ static void WoodenRCTrackLeftQuarterTurn325DegDownToLeftBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23952), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24818), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24818), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23967), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24833), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24833), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12658,8 +12658,8 @@ static void WoodenRCTrackLeftQuarterTurn325DegDownToLeftBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23954), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24820), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24820), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12667,14 +12667,14 @@ static void WoodenRCTrackLeftQuarterTurn325DegDownToLeftBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23948), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24814), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24814), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23964), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24830), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24830), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12701,8 +12701,8 @@ static void WoodenRCTrackLeftQuarterTurn325DegDownToLeftBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23949), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24815), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24815), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12710,14 +12710,14 @@ static void WoodenRCTrackLeftQuarterTurn325DegDownToLeftBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23951), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24817), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24817), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23966), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24832), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24832), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12725,8 +12725,8 @@ static void WoodenRCTrackLeftQuarterTurn325DegDownToLeftBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23953), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24819), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24819), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12734,14 +12734,14 @@ static void WoodenRCTrackLeftQuarterTurn325DegDownToLeftBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23947), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24813), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24813), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23963), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24829), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24829), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12776,14 +12776,14 @@ static void WoodenRCTrackRightQuarterTurn325DegDownToRightBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23955), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24821), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24821), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23968), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24834), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24834), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12791,8 +12791,8 @@ static void WoodenRCTrackRightQuarterTurn325DegDownToRightBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23957), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24823), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24823), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12800,14 +12800,14 @@ static void WoodenRCTrackRightQuarterTurn325DegDownToRightBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23959), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24825), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24825), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23970), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24836), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24836), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12815,14 +12815,14 @@ static void WoodenRCTrackRightQuarterTurn325DegDownToRightBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23961), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24827), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24827), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23972), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24838), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24838), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12849,14 +12849,14 @@ static void WoodenRCTrackRightQuarterTurn325DegDownToRightBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23956), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24822), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24822), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23969), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24835), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24835), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12864,8 +12864,8 @@ static void WoodenRCTrackRightQuarterTurn325DegDownToRightBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23958), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24824), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24824), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12873,14 +12873,14 @@ static void WoodenRCTrackRightQuarterTurn325DegDownToRightBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23960), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24826), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24826), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23971), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24837), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24837), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12888,8 +12888,8 @@ static void WoodenRCTrackRightQuarterTurn325DegDownToRightBank(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23962), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24828), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24828), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -12940,8 +12940,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23932), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24798), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24798), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -12949,14 +12949,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23934), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24800), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24800), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23945), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24811), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24811), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -12964,8 +12964,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23936), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24802), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24802), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -12973,14 +12973,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23930), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24796), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24796), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23943), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24809), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24809), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13007,8 +13007,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23931), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24797), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24797), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13016,14 +13016,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23933), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24799), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24799), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23944), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24810), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24810), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13031,14 +13031,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23935), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24801), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24801), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23946), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24812), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24812), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13046,14 +13046,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23929), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24795), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24795), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23942), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24808), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24808), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13088,14 +13088,14 @@ static void WoodenRCTrackRightBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23921), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24787), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24787), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23937), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24803), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24803), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13103,8 +13103,8 @@ static void WoodenRCTrackRightBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23923), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24789), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24789), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13112,14 +13112,14 @@ static void WoodenRCTrackRightBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23925), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24791), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24791), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23940), { 0, 6, height },
                         { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24806), { 0, 6, height }, { 32, 20, 0 },
-                        { 0, 6, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24806), { 0, 6, height },
+                        { { 0, 6, height + 67 }, { 32, 20, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13127,8 +13127,8 @@ static void WoodenRCTrackRightBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23927), { 0, 6, height },
                         { { 0, 6, height }, { 32, 20, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24793), { 0, 6, height }, { 32, 20, 2 },
-                        { 0, 6, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24793), { 0, 6, height },
+                        { { 0, 6, height }, { 32, 20, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13155,14 +13155,14 @@ static void WoodenRCTrackRightBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23922), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24788), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24788), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23938), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24804), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24804), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13170,14 +13170,14 @@ static void WoodenRCTrackRightBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23924), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24790), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24790), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23939), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24805), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24805), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13185,14 +13185,14 @@ static void WoodenRCTrackRightBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23926), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24792), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24792), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23941), { 6, 0, height },
                         { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24807), { 6, 0, height }, { 20, 32, 0 },
-                        { 6, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24807), { 6, 0, height },
+                        { { 6, 0, height + 67 }, { 20, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13200,8 +13200,8 @@ static void WoodenRCTrackRightBankedQuarterTurn325DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(23928), { 6, 0, height },
                         { { 6, 0, height }, { 20, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24794), { 6, 0, height }, { 20, 32, 2 },
-                        { 6, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(24794), { 6, 0, height },
+                        { { 6, 0, height }, { 20, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13258,8 +13258,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24321), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25187), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25187), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13267,14 +13267,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24326), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25192), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25192), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24352), { 0, 0, height },
                         { { 0, 2, height + 67 }, { 32, 27, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25218), { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25218), { 0, 0, height },
+                        { { 0, 2, height + 67 }, { 32, 27, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13282,8 +13282,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24331), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25197), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25197), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13291,8 +13291,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24336), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25202), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25202), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13316,8 +13316,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24322), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25188), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25188), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13325,14 +13325,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24327), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25193), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25193), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24353), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25219), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25219), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13340,8 +13340,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24332), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25198), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25198), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13349,14 +13349,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24337), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25203), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25203), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24359), { 0, 0, height },
                         { { 0, 16, height + 67 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25225), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25225), { 0, 0, height },
+                        { { 0, 16, height + 67 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13374,8 +13374,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24323), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25189), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25189), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13383,14 +13383,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24328), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25194), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25194), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24354), { 0, 0, height },
                         { { 16, 16, height + 59 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25220), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 59 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25220), { 0, 0, height },
+                        { { 16, 16, height + 59 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13398,8 +13398,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24333), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25199), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25199), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13407,14 +13407,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24338), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25204), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25204), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24360), { 0, 0, height },
                         { { 0, 0, height + 59 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25226), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 59 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25226), { 0, 0, height },
+                        { { 0, 0, height + 59 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13439,8 +13439,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24324), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25190), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25190), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13448,14 +13448,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24329), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25195), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25195), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24355), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25221), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25221), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13463,14 +13463,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24334), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25200), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25200), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24357), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25223), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25223), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13478,14 +13478,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24339), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25205), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25205), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24361), { 0, 0, height },
                         { { 16, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25227), { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25227), { 0, 0, height },
+                        { { 16, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13503,8 +13503,8 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24325), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25191), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25191), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13512,14 +13512,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24330), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25196), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25196), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24356), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25222), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25222), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13527,14 +13527,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24335), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25201), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25201), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24358), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25224), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25224), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13542,14 +13542,14 @@ static void WoodenRCTrackLeftBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24340), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25206), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25206), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24362), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25228), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25228), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13584,8 +13584,8 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24301), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25167), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25167), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13593,8 +13593,8 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24306), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25172), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25172), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13602,14 +13602,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24311), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25177), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25177), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24347), { 0, 0, height },
                         { { 0, 2, height + 67 }, { 32, 27, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25213), { 0, 0, height }, { 32, 27, 0 },
-                        { 0, 2, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25213), { 0, 0, height },
+                        { { 0, 2, height + 67 }, { 32, 27, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13617,8 +13617,8 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24316), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25182), { 0, 0, height }, { 32, 27, 2 },
-                        { 0, 2, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25182), { 0, 0, height },
+                        { { 0, 2, height }, { 32, 27, 2 } });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13642,14 +13642,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24302), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25168), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25168), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24341), { 0, 0, height },
                         { { 0, 16, height + 67 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25207), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 16, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25207), { 0, 0, height },
+                        { { 0, 16, height + 67 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13657,8 +13657,8 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24307), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25173), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25173), { 0, 0, height },
+                        { { 0, 16, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13666,14 +13666,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24312), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25178), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25178), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24348), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 32, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25214), { 0, 0, height }, { 32, 16, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25214), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 32, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13681,8 +13681,8 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24317), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25183), { 0, 0, height }, { 32, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25183), { 0, 0, height },
+                        { { 0, 0, height }, { 32, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13700,14 +13700,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24303), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25169), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25169), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24342), { 0, 0, height },
                         { { 0, 0, height + 59 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25208), { 0, 0, height }, { 16, 16, 0 },
-                        { 0, 0, height + 59 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25208), { 0, 0, height },
+                        { { 0, 0, height + 59 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13715,8 +13715,8 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24308), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25174), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25174), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13724,14 +13724,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24313), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25179), { 0, 0, height }, { 16, 16, 2 },
-                        { 16, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25179), { 0, 0, height },
+                        { { 16, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24349), { 0, 0, height },
                         { { 16, 16, height + 59 }, { 16, 16, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25215), { 0, 0, height }, { 16, 16, 0 },
-                        { 16, 16, height + 59 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25215), { 0, 0, height },
+                        { { 16, 16, height + 59 }, { 16, 16, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13739,8 +13739,8 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24318), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25184), { 0, 0, height }, { 16, 16, 2 },
-                        { 0, 16, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25184), { 0, 0, height },
+                        { { 0, 16, height }, { 16, 16, 2 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13765,14 +13765,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24304), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25170), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25170), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24343), { 0, 0, height },
                         { { 16, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25209), { 0, 0, height }, { 16, 32, 0 },
-                        { 16, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25209), { 0, 0, height },
+                        { { 16, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 4, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13780,14 +13780,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24309), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25175), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25175), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24345), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25211), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25211), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 5, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13795,14 +13795,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24314), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25180), { 0, 0, height }, { 16, 32, 2 },
-                        { 0, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25180), { 0, 0, height },
+                        { { 0, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24350), { 0, 0, height },
                         { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25216), { 0, 0, height }, { 16, 32, 0 },
-                        { 0, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25216), { 0, 0, height },
+                        { { 0, 0, height + 67 }, { 16, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 2, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13810,8 +13810,8 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24319), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25185), { 0, 0, height }, { 16, 32, 2 },
-                        { 16, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25185), { 0, 0, height },
+                        { { 16, 0, height }, { 16, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13829,14 +13829,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24305), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25171), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25171), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24344), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25210), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25210), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
@@ -13844,14 +13844,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24310), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25176), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25176), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24346), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25212), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25212), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
@@ -13859,14 +13859,14 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24315), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25181), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25181), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsParentRotated(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24351), { 0, 0, height },
                         { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25217), { 0, 0, height }, { 27, 32, 0 },
-                        { 2, 0, height + 67 });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25217), { 0, 0, height },
+                        { { 2, 0, height + 67 }, { 27, 32, 0 } });
                     WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
@@ -13874,8 +13874,8 @@ static void WoodenRCTrackRightBankedQuarterTurn525DegUp(
                         session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24320), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 2 } });
                     PaintAddImageAsChildRotated(
-                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25186), { 0, 0, height }, { 27, 32, 2 },
-                        { 2, 0, height });
+                        session, direction, WoodenRCGetRailsColour(session).WithIndex(25186), { 0, 0, height },
+                        { { 2, 0, height }, { 27, 32, 2 } });
                     WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
@@ -13929,8 +13929,8 @@ static void WoodenRCTrack25DegUpToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24261), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25127), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25127), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -13938,8 +13938,8 @@ static void WoodenRCTrack25DegUpToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24262), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25128), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25128), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -13947,8 +13947,8 @@ static void WoodenRCTrack25DegUpToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24263), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25129), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25129), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -13956,8 +13956,8 @@ static void WoodenRCTrack25DegUpToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24264), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25130), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25130), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -13986,8 +13986,8 @@ static void WoodenRCTrack25DegUpToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24265), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25131), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25131), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -13995,8 +13995,8 @@ static void WoodenRCTrack25DegUpToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24266), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25132), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25132), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14004,8 +14004,8 @@ static void WoodenRCTrack25DegUpToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24267), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25133), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25133), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14013,8 +14013,8 @@ static void WoodenRCTrack25DegUpToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24268), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25134), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25134), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -14043,8 +14043,8 @@ static void WoodenRCTrackLeftBanked25DegUpTo25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24269), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25135), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25135), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -14052,8 +14052,8 @@ static void WoodenRCTrackLeftBanked25DegUpTo25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24270), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25136), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25136), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14061,8 +14061,8 @@ static void WoodenRCTrackLeftBanked25DegUpTo25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24271), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25137), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25137), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14070,8 +14070,8 @@ static void WoodenRCTrackLeftBanked25DegUpTo25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24272), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25138), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25138), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -14100,8 +14100,8 @@ static void WoodenRCTrackRightBanked25DegUpTo25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24273), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25139), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25139), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -14109,8 +14109,8 @@ static void WoodenRCTrackRightBanked25DegUpTo25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24274), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25140), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25140), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14118,8 +14118,8 @@ static void WoodenRCTrackRightBanked25DegUpTo25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24275), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25141), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25141), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14127,8 +14127,8 @@ static void WoodenRCTrackRightBanked25DegUpTo25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24276), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25142), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25142), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -14195,8 +14195,8 @@ static void WoodenRCTrackLeftBankedFlatToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24277), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25143), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25143), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -14204,14 +14204,14 @@ static void WoodenRCTrackLeftBankedFlatToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24278), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25144), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25144), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24293), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25159), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25159), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14219,14 +14219,14 @@ static void WoodenRCTrackLeftBankedFlatToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24279), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25145), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25145), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24294), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25160), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25160), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14234,8 +14234,8 @@ static void WoodenRCTrackLeftBankedFlatToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24280), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25146), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25146), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -14264,8 +14264,8 @@ static void WoodenRCTrackRightBankedFlatToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24281), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25147), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25147), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -14273,14 +14273,14 @@ static void WoodenRCTrackRightBankedFlatToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24282), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25148), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25148), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24295), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25161), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25161), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14288,14 +14288,14 @@ static void WoodenRCTrackRightBankedFlatToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24283), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25149), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25149), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24296), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25162), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25162), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14303,8 +14303,8 @@ static void WoodenRCTrackRightBankedFlatToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24284), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25150), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25150), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -14333,8 +14333,8 @@ static void WoodenRCTrackLeftBanked25DegUpToLeftBankedFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24285), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25151), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25151), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -14342,14 +14342,14 @@ static void WoodenRCTrackLeftBanked25DegUpToLeftBankedFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24286), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25152), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25152), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24297), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25163), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25163), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14357,14 +14357,14 @@ static void WoodenRCTrackLeftBanked25DegUpToLeftBankedFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24287), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25153), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25153), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24298), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25164), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25164), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14372,8 +14372,8 @@ static void WoodenRCTrackLeftBanked25DegUpToLeftBankedFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24288), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25154), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25154), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -14402,8 +14402,8 @@ static void WoodenRCTrackRightBanked25DegUpToRightBankedFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24289), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25155), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25155), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -14411,14 +14411,14 @@ static void WoodenRCTrackRightBanked25DegUpToRightBankedFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24290), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25156), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25156), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24299), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25165), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25165), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14426,14 +14426,14 @@ static void WoodenRCTrackRightBanked25DegUpToRightBankedFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24291), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25157), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25157), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24300), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25166), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25166), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14441,8 +14441,8 @@ static void WoodenRCTrackRightBanked25DegUpToRightBankedFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24292), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25158), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25158), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -14511,8 +14511,8 @@ static void WoodenRCTrackFlatToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24225), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25091), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25091), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -14520,14 +14520,14 @@ static void WoodenRCTrackFlatToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24226), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25092), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25092), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24241), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25107), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25107), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14535,14 +14535,14 @@ static void WoodenRCTrackFlatToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24227), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25093), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25093), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24242), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25108), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25108), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14550,8 +14550,8 @@ static void WoodenRCTrackFlatToLeftBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24228), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25094), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25094), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -14580,8 +14580,8 @@ static void WoodenRCTrackFlatToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24229), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25095), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25095), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -14589,14 +14589,14 @@ static void WoodenRCTrackFlatToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24230), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25096), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25096), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24243), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25109), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25109), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 1, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14604,14 +14604,14 @@ static void WoodenRCTrackFlatToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24231), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25097), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25097), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24244), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25110), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25110), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 0, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14619,8 +14619,8 @@ static void WoodenRCTrackFlatToRightBanked25DegUp(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24232), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25098), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25098), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -14649,8 +14649,8 @@ static void WoodenRCTrackLeftBanked25DegUpToFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24233), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25099), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25099), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -14658,14 +14658,14 @@ static void WoodenRCTrackLeftBanked25DegUpToFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24234), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25100), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25100), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24245), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25111), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25111), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14673,14 +14673,14 @@ static void WoodenRCTrackLeftBanked25DegUpToFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24235), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25101), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25101), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24246), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25112), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25112), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14688,8 +14688,8 @@ static void WoodenRCTrackLeftBanked25DegUpToFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24236), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25102), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25102), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
@@ -14718,8 +14718,8 @@ static void WoodenRCTrackRightBanked25DegUpToFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24237), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25103), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25103), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 0, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
@@ -14727,14 +14727,14 @@ static void WoodenRCTrackRightBanked25DegUpToFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24238), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25104), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25104), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24247), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25113), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25113), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 1, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
@@ -14742,14 +14742,14 @@ static void WoodenRCTrackRightBanked25DegUpToFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24239), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25105), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25105), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsParentRotated(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24248), { 0, 0, height },
                 { { 0, 26, height + 5 }, { 32, 1, 9 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25114), { 0, 0, height }, { 32, 1, 9 },
-                { 0, 26, height + 5 });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25114), { 0, 0, height },
+                { { 0, 26, height + 5 }, { 32, 1, 9 } });
             WoodenASupportsPaintSetup(session, 0, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
@@ -14757,8 +14757,8 @@ static void WoodenRCTrackRightBanked25DegUpToFlat(
                 session, direction, WoodenRCGetTrackColour<isClassic>(session).WithIndex(24240), { 0, 0, height },
                 { { 0, 3, height }, { 32, 25, 2 } });
             PaintAddImageAsChildRotated(
-                session, direction, WoodenRCGetRailsColour(session).WithIndex(25106), { 0, 0, height }, { 32, 25, 2 },
-                { 0, 3, height });
+                session, direction, WoodenRCGetRailsColour(session).WithIndex(25106), { 0, 0, height },
+                { { 0, 3, height }, { 32, 25, 2 } });
             WoodenASupportsPaintSetup(session, 1, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }

--- a/src/openrct2/ride/coaster/WoodenRollerCoaster.h
+++ b/src/openrct2/ride/coaster/WoodenRollerCoaster.h
@@ -51,8 +51,8 @@ PaintStruct* WoodenRCTrackPaint(
           { bound_box_length_x, bound_box_length_y, bound_box_length_z } });
     return PaintAddImageAsChildRotated(
         session, direction, railsImageId, { x_offset, y_offset, z_offset },
-        { bound_box_length_x, bound_box_length_y, bound_box_length_z },
-        { bound_box_offset_x, bound_box_offset_y, bound_box_offset_z });
+        { { bound_box_offset_x, bound_box_offset_y, bound_box_offset_z },
+          { bound_box_length_x, bound_box_length_y, bound_box_length_z } });
 }
 
 template<bool isClassic> void WoodenRCTrackPaintBb(PaintSession& session, const SpriteBoundBox2* bb, int16_t height)

--- a/src/openrct2/ride/coaster/WoodenWildMouse.cpp
+++ b/src/openrct2/ride/coaster/WoodenWildMouse.cpp
@@ -161,7 +161,7 @@ static void WoodenWildMouseTrackStation(
         { { 0, 2, height }, { 32, 28, 1 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(imageIds[direction][0]), { 0, 6, height },
-        { 32, 20, 1 }, { 0, 0, height });
+        { { 0, 0, height }, { 32, 20, 1 } });
     WoodenASupportsPaintSetup(session, direction & 1, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
     TrackPaintUtilDrawStation(session, ride, direction, height, trackElement);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);

--- a/src/openrct2/ride/gentle/GhostTrain.cpp
+++ b/src/openrct2/ride/gentle/GhostTrain.cpp
@@ -384,7 +384,7 @@ static void PaintGhostTrainStation(
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 3 } });
 
     imageId = session.TrackColours[SCHEME_TRACK].WithIndex(GhostTrainTrackPiecesFlat[direction]);
-    PaintAddImageAsChildRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 0, height });
+    PaintAddImageAsChildRotated(session, direction, imageId, { 0, 0, height }, { { 0, 0, height }, { 32, 20, 3 } });
 
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 

--- a/src/openrct2/ride/gentle/MiniHelicopters.cpp
+++ b/src/openrct2/ride/gentle/MiniHelicopters.cpp
@@ -326,7 +326,7 @@ static void PaintMiniHelicoptersTrackSpinningTunnel(
     ImageId underlay = session.TrackColours[SCHEME_TRACK].WithIndex(sprites[direction][1]);
 
     PaintAddImageAsParentRotated(session, direction, underlay, { 0, 6, height - 2 }, { { 0, 6, height }, { 32, 20, 1 } });
-    PaintAddImageAsChildRotated(session, direction, imageId, { 0, 0, height }, { 32, 20, 3 }, { 0, 6, height });
+    PaintAddImageAsChildRotated(session, direction, imageId, { 0, 0, height }, { { 0, 6, height }, { 32, 20, 3 } });
     TrackPaintUtilSpinningTunnelPaint(session, 1, height, direction);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_0);
 

--- a/src/openrct2/ride/transport/MiniatureRailway.cpp
+++ b/src/openrct2/ride/transport/MiniatureRailway.cpp
@@ -648,22 +648,23 @@ static void PaintMiniatureRailwayTrackFlat(
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_flat[direction]);
         if (!paintAsGravel)
         {
-            PaintAddImageAsChildRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 2 }, { 0, 6, height });
+            PaintAddImageAsChildRotated(session, direction, imageId, { 0, 6, height }, { { 0, 6, height }, { 32, 20, 2 } });
         }
         else
         {
             imageIdAlt = MiniatureRailwayTrackToGravel(imageId);
-            PaintAddImageAsChildRotated(session, direction, imageIdAlt, { 0, 6, height }, { 32, 20, 2 }, { 0, 6, height });
+            PaintAddImageAsChildRotated(session, direction, imageIdAlt, { 0, 6, height }, { { 0, 6, height }, { 32, 20, 2 } });
         }
         if (paintGrooved)
         {
             imageIdAlt = MiniatureRailwayTrackToGrooved(imageId);
-            PaintAddImageAsChildRotated(session, direction, imageIdAlt, { 0, 6, height }, { 32, 20, 2 }, { 0, 6, height + 2 });
+            PaintAddImageAsChildRotated(
+                session, direction, imageIdAlt, { 0, 6, height }, { { 0, 6, height + 2 }, { 32, 20, 2 } });
             imageIdAlt = MiniatureRailwayTrackToGroovedIndent(
                 session.PathElementOnSameHeight, direction, session.CurrentRotation);
             PaintAddImageAsChildRotated(
                 session, direction, imageIdAlt.WithTransparency(FilterPaletteID::PaletteDarken2), { 0, 6, height },
-                { 32, 20, 2 }, { 0, 6, height + 2 });
+                { { 0, 6, height + 2 }, { 32, 20, 2 } });
         }
     }
     else
@@ -710,7 +711,7 @@ static void PaintMiniatureRailwayStation(
     PaintAddImageAsParentRotated(session, direction, imageId, { 0, 0, height - 2 }, { { 0, 2, height }, { 32, 28, 2 } });
 
     imageId = session.TrackColours[SCHEME_TRACK].WithIndex(miniature_railway_track_pieces_flat_station[direction]);
-    PaintAddImageAsChildRotated(session, direction, imageId, { 0, 6, height }, { 32, 20, 2 }, { 0, 0, height });
+    PaintAddImageAsChildRotated(session, direction, imageId, { 0, 6, height }, { { 0, 0, height }, { 32, 20, 2 } });
 
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
 
@@ -1141,8 +1142,8 @@ static void PaintMiniatureRailwayTrackSBendLeft(
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
             miniature_railway_track_pieces_s_bend_left[direction & 1][trackSequence]);
         PaintAddImageAsChildRotated(
-            session, direction, imageId, { offset.x, offset.y, height }, { bounds.x, bounds.y, 2 },
-            { offset.x, offset.y, height });
+            session, direction, imageId, { offset.x, offset.y, height },
+            { { offset.x, offset.y, height }, { bounds.x, bounds.y, 2 } });
     }
     if (direction == 0 || direction == 2)
     {
@@ -1249,8 +1250,8 @@ static void PaintMiniatureRailwayTrackSBendRight(
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(
             miniature_railway_track_pieces_s_bend_right[direction & 1][trackSequence]);
         PaintAddImageAsChildRotated(
-            session, direction, imageId, { offset.x, offset.y, height }, { bounds.x, bounds.y, 2 },
-            { offset.x, offset.y, height });
+            session, direction, imageId, { offset.x, offset.y, height },
+            { { offset.x, offset.y, height }, { bounds.x, bounds.y, 2 } });
     }
 
     if (direction == 0 || direction == 2)

--- a/src/openrct2/ride/transport/SuspendedMonorail.cpp
+++ b/src/openrct2/ride/transport/SuspendedMonorail.cpp
@@ -71,7 +71,7 @@ static void SuspendedMonorailTrackStation(
         { { 0, 6, height + 32 }, { 32, 20, 3 } });
     PaintAddImageAsChildRotated(
         session, direction, session.TrackColours[SCHEME_SUPPORTS].WithIndex(imageIds[direction][2]), { 0, 6, height + 32 },
-        { 32, 20, 3 }, { 0, 6, height + 32 });
+        { { 0, 6, height + 32 }, { 32, 20, 3 } });
     TrackPaintUtilDrawStationMetalSupports2(session, direction, height, session.TrackColours[SCHEME_SUPPORTS], 3);
     TrackPaintUtilDrawStationInverted(session, ride, direction, height, trackElement, STATION_VARIANT_TALL);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_INVERTED_9);


### PR DESCRIPTION
This is actually the last of the signature cleanups. There is plenty more to clean up in this area, though, stuff like:
- Replacing duplicate and roll-your-own bound box structure (i.e. other than BoundBoxXYZ)
- Replacing local variables called `boundBoxLengthY` and so on with BoundBoxXYZ structures
- Inlining more of the helper functions (i.e. all of the \*Rotated functions and the overloads)