### PR TITLE
Fix #7210: Land tile smoothing occurs with edge tiles

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -25,6 +25,7 @@
 - Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
 - Change: [#19233] Reduce lift speed minimum and maximum values for “Classic Wooden Coaster”.
 - Fix: [#474] Mini golf window shows more players than there actually are (original bug).
+- Fix: [#7210] Land tile smoothing occurs with edge tiles (original bug).
 - Fix: [#17996] Finances window not cleared when starting some .park scenarios
 - Fix: [#18260] Crash opening parks that have multiple tiles referencing the same banner entry.
 - Fix: [#18467] “Selected only” Object Selection filter is active in Track Designs Manager, and cannot be toggled.

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -452,6 +452,10 @@ static void ViewportSurfaceSmoothenEdge(
     if (neighbour.tile_element == nullptr)
         return;
 
+    // The edge row consists of invisible grass tiles. Do not attempt to smooth with them.
+    if (MapIsEdge(self.tile_coords.ToCoordsXY()) || MapIsEdge(neighbour.tile_coords.ToCoordsXY()))
+        return;
+
     uint32_t maskImageBase = 0;
     uint8_t neighbourCorners[2] = { 0 };
     uint8_t ownCorners[2] = { 0 };


### PR DESCRIPTION
The clearout continues.