### PR TITLE
Allow shops and stalls to set their own clearances

### DIFF
--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2689,6 +2689,10 @@ private:
 
         const auto& ted = GetTrackElementDescriptor(trackType);
         const auto* trackBlock = ted.Block;
+        const auto* rideEntry = currentRide->GetRideEntry();
+        auto clearanceHeight = (rideEntry != nullptr) ? rideEntry->Clearance
+                                                      : currentRide->GetRideTypeDescriptor().Heights.ClearanceHeight;
+
         while (trackBlock->index != 255)
         {
             auto quarterTile = trackBlock->var_08.Rotate(trackDirection);
@@ -2696,8 +2700,7 @@ private:
             CoordsXY coords = originCoords + offsets.Rotate(trackDirection);
 
             int32_t baseZ = originZ + trackBlock->z;
-            int32_t clearanceZ = trackBlock->var_07 + currentRide->GetRideTypeDescriptor().Heights.ClearanceHeight + baseZ
-                + (4 * COORDS_Z_STEP);
+            int32_t clearanceZ = trackBlock->var_07 + clearanceHeight + baseZ + (4 * COORDS_Z_STEP);
 
             auto centreTileCoords = TileCoordsXY{ coords };
             auto eastTileCoords = centreTileCoords + TileDirectionDelta[TILE_ELEMENT_DIRECTION_EAST];

--- a/src/openrct2/actions/TrackPlaceAction.cpp
+++ b/src/openrct2/actions/TrackPlaceAction.cpp
@@ -209,6 +209,7 @@ GameActions::Result TrackPlaceAction::Query() const
 
     // If that is not the case, then perform the remaining checks
     trackBlock = ted.Block;
+    auto clearanceHeight = rideEntry->Clearance;
 
     money32 costs = 0;
     money64 supportCosts = 0;
@@ -227,14 +228,13 @@ GameActions::Result TrackPlaceAction::Query() const
         int32_t baseZ = Floor2(mapLoc.z, COORDS_Z_STEP);
 
         int32_t clearanceZ = trackBlock->var_07;
-        if (trackBlock->flags & RCT_PREVIEW_TRACK_FLAG_IS_VERTICAL
-            && ride->GetRideTypeDescriptor().Heights.ClearanceHeight > 24)
+        if (trackBlock->flags & RCT_PREVIEW_TRACK_FLAG_IS_VERTICAL && clearanceHeight > 24)
         {
             clearanceZ += 24;
         }
         else
         {
-            clearanceZ += ride->GetRideTypeDescriptor().Heights.ClearanceHeight;
+            clearanceZ += clearanceHeight;
         }
 
         clearanceZ = Floor2(clearanceZ, COORDS_Z_STEP) + baseZ;
@@ -441,6 +441,7 @@ GameActions::Result TrackPlaceAction::Execute() const
     money32 costs = 0;
     money64 supportCosts = 0;
     const PreviewTrack* trackBlock = ted.Block;
+    auto clearanceHeight = rideEntry->Clearance;
     CoordsXYZ originLocation = CoordsXYZ{ _origin.x, _origin.y, _origin.z }
         + CoordsXYZ{ CoordsXY{ trackBlock->x, trackBlock->y }.Rotate(_origin.direction), trackBlock->z };
     for (int32_t blockIndex = 0; trackBlock->index != 0xFF; trackBlock++, blockIndex++)
@@ -452,14 +453,13 @@ GameActions::Result TrackPlaceAction::Execute() const
 
         int32_t baseZ = Floor2(mapLoc.z, COORDS_Z_STEP);
         int32_t clearanceZ = trackBlock->var_07;
-        if (trackBlock->flags & RCT_PREVIEW_TRACK_FLAG_IS_VERTICAL
-            && ride->GetRideTypeDescriptor().Heights.ClearanceHeight > 24)
+        if (trackBlock->flags & RCT_PREVIEW_TRACK_FLAG_IS_VERTICAL && clearanceHeight > 24)
         {
             clearanceZ += 24;
         }
         else
         {
-            clearanceZ += ride->GetRideTypeDescriptor().Heights.ClearanceHeight;
+            clearanceZ += clearanceHeight;
         }
 
         clearanceZ = Floor2(clearanceZ, COORDS_Z_STEP) + baseZ;

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -196,6 +196,7 @@ void RideObject::ReadLegacy(IReadObjectContext* context, IStream* stream)
         context->LogError(ObjectError::InvalidProperty, "Nausea multiplier too high.");
     }
     RideObjectUpdateRideType(_legacyType);
+    _legacyType.Clearance = GetDefaultClearance();
 }
 
 void RideObject::Load()
@@ -471,6 +472,7 @@ void RideObject::ReadJson(IReadObjectContext* context, json_t& root)
         }
 
         _legacyType.max_height = Json::GetNumber<uint8_t>(properties["maxHeight"]);
+        _legacyType.Clearance = Json::GetNumber<uint8_t>(properties["clearance"], GetDefaultClearance());
 
         // This needs to be set for both shops/facilities _and_ regular rides.
         for (auto& item : _legacyType.shop_item)
@@ -1015,4 +1017,11 @@ void RideObject::ReadLegacySpriteGroups(CarEntry* vehicle, uint16_t spriteGroups
     {
         vehicle->SpriteGroups[EnumValue(SpriteGroupType::CurvedLiftHill)].spritePrecision = baseSpritePrecision;
     }
+}
+
+uint8_t RideObject::GetDefaultClearance() const
+{
+    auto rideType = _legacyType.GetFirstNonNullRideType();
+    const auto& rtd = GetRideTypeDescriptor(rideType);
+    return rtd.Heights.ClearanceHeight;
 }

--- a/src/openrct2/object/RideObject.h
+++ b/src/openrct2/object/RideObject.h
@@ -64,4 +64,5 @@ private:
     static colour_t ParseColour(const std::string& s);
 
     void ReadLegacySpriteGroups(CarEntry* vehicle, uint16_t spriteGroups);
+    uint8_t GetDefaultClearance() const;
 };

--- a/src/openrct2/ride/RideData.h
+++ b/src/openrct2/ride/RideData.h
@@ -40,6 +40,14 @@ enum class ResearchCategory : uint8_t;
 
 using ride_ratings_calculation = void (*)(Ride& ride, RideRatingUpdateState& state);
 
+constexpr const uint8_t DefaultFoodStallHeight = 8 * COORDS_Z_STEP;
+constexpr const uint8_t DefaultDrinksStallHeight = 8 * COORDS_Z_STEP;
+constexpr const uint8_t DefaultShopHeight = 8 * COORDS_Z_STEP;
+constexpr const uint8_t DefaultToiletHeight = 4 * COORDS_Z_STEP;
+constexpr const uint8_t DefaultInformationKioskHeight = 6 * COORDS_Z_STEP;
+constexpr const uint8_t DefaultFirstAidHeight = 6 * COORDS_Z_STEP;
+constexpr const uint8_t DefaultCashMachineHeight = 8 * COORDS_Z_STEP;
+
 struct RideComponentName
 {
     StringId singular;

--- a/src/openrct2/ride/RideEntry.h
+++ b/src/openrct2/ride/RideEntry.h
@@ -73,6 +73,7 @@ struct RideObjectEntry
     ShopItem shop_item[RCT2::ObjectLimits::MaxShopItemsPerRideEntry];
     StringId capacity;
     void* obj;
+    uint8_t Clearance;
 
     const CarEntry* GetCar(size_t id) const
     {

--- a/src/openrct2/ride/shops/Facility.cpp
+++ b/src/openrct2/ride/shops/Facility.cpp
@@ -35,7 +35,8 @@ static void PaintFacility(
     auto lengthX = (direction & 1) == 0 ? 28 : 2;
     auto lengthY = (direction & 1) == 0 ? 2 : 28;
     CoordsXYZ offset(0, 0, height);
-    BoundBoxXYZ bb = { { direction == 3 ? 28 : 2, direction == 0 ? 28 : 2, height }, { lengthX, lengthY, 29 } };
+    BoundBoxXYZ bb = { { direction == 3 ? 28 : 2, direction == 0 ? 28 : 2, height },
+                       { lengthX, lengthY, trackElement.GetClearanceZ() - trackElement.GetBaseZ() - 3 } };
 
     auto imageTemplate = session.TrackColours[SCHEME_TRACK];
     auto imageIndex = firstCarEntry->base_image_id + ((direction + 2) & 3);

--- a/src/openrct2/ride/shops/Shop.cpp
+++ b/src/openrct2/ride/shops/Shop.cpp
@@ -33,7 +33,7 @@ static void PaintShop(
         return;
 
     CoordsXYZ offset(0, 0, height);
-    BoundBoxXYZ bb = { { 2, 2, height }, { 28, 28, 45 } };
+    BoundBoxXYZ bb = { { 2, 2, height }, { 28, 28, trackElement.GetClearanceZ() - trackElement.GetBaseZ() - 3 } };
 
     auto imageFlags = session.TrackColours[SCHEME_TRACK].WithoutSecondary();
     auto imageIndex = firstCarEntry->base_image_id + direction;

--- a/src/openrct2/ride/shops/meta/CashMachine.h
+++ b/src/openrct2/ride/shops/meta/CashMachine.h
@@ -32,7 +32,7 @@ constexpr const RideTypeDescriptor CashMachineRTD =
     SET_FIELD(NameConvention, { RideComponentType::Car, RideComponentType::Building, RideComponentType::Station }),
     SET_FIELD(EnumName, nameof(RIDE_TYPE_CASH_MACHINE)),
     SET_FIELD(AvailableBreakdowns, 0),
-    SET_FIELD(Heights, { 12, 64, 0, 0, }),
+    SET_FIELD(Heights, { 12, DefaultCashMachineHeight, 0, 0, }),
     SET_FIELD(MaxMass, 255),
     SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::Null, 5, 5 }),
     SET_FIELD(RatingsCalculationFunction, RideRatingsCalculateCashMachine),

--- a/src/openrct2/ride/shops/meta/DrinkStall.h
+++ b/src/openrct2/ride/shops/meta/DrinkStall.h
@@ -33,7 +33,7 @@ constexpr const RideTypeDescriptor DrinkStallRTD =
     SET_FIELD(NameConvention, { RideComponentType::Car, RideComponentType::Building, RideComponentType::Station }),
     SET_FIELD(EnumName, nameof(RIDE_TYPE_DRINK_STALL)),
     SET_FIELD(AvailableBreakdowns, 0),
-    SET_FIELD(Heights, { 12, 64, 0, 0, }),
+    SET_FIELD(Heights, { 12, DefaultDrinksStallHeight, 0, 0, }),
     SET_FIELD(MaxMass, 255),
     SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::Null, 5, 5 }),
     SET_FIELD(RatingsCalculationFunction, RideRatingsCalculateDrinkStall),

--- a/src/openrct2/ride/shops/meta/FirstAid.h
+++ b/src/openrct2/ride/shops/meta/FirstAid.h
@@ -33,7 +33,7 @@ constexpr const RideTypeDescriptor FirstAidRTD =
     SET_FIELD(NameConvention, { RideComponentType::Car, RideComponentType::Building, RideComponentType::Station }),
     SET_FIELD(EnumName, nameof(RIDE_TYPE_FIRST_AID)),
     SET_FIELD(AvailableBreakdowns, 0),
-    SET_FIELD(Heights, { 12, 48, 0, 0, }),
+    SET_FIELD(Heights, { 12, DefaultFirstAidHeight, 0, 0, }),
     SET_FIELD(MaxMass, 255),
     SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::Null, 5, 5 }),
     SET_FIELD(RatingsCalculationFunction, RideRatingsCalculateFirstAid),

--- a/src/openrct2/ride/shops/meta/FoodStall.h
+++ b/src/openrct2/ride/shops/meta/FoodStall.h
@@ -33,7 +33,7 @@ constexpr const RideTypeDescriptor FoodStallRTD =
     SET_FIELD(NameConvention, { RideComponentType::Car, RideComponentType::Building, RideComponentType::Station }),
     SET_FIELD(EnumName, nameof(RIDE_TYPE_FOOD_STALL)),
     SET_FIELD(AvailableBreakdowns, 0),
-    SET_FIELD(Heights, { 12, 64, 0, 0, }),
+    SET_FIELD(Heights, { 12, DefaultFoodStallHeight, 0, 0, }),
     SET_FIELD(MaxMass, 255),
     SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::Null, 5, 5 }),
     SET_FIELD(RatingsCalculationFunction, RideRatingsCalculateFoodStall),

--- a/src/openrct2/ride/shops/meta/InformationKiosk.h
+++ b/src/openrct2/ride/shops/meta/InformationKiosk.h
@@ -33,7 +33,7 @@ constexpr const RideTypeDescriptor InformationKioskRTD =
     SET_FIELD(NameConvention, { RideComponentType::Car, RideComponentType::Building, RideComponentType::Station }),
     SET_FIELD(EnumName, nameof(RIDE_TYPE_INFORMATION_KIOSK)),
     SET_FIELD(AvailableBreakdowns, 0),
-    SET_FIELD(Heights, { 12, 48, 0, 0, }),
+    SET_FIELD(Heights, { 12, DefaultInformationKioskHeight, 0, 0, }),
     SET_FIELD(MaxMass, 255),
     SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::Null, 5, 5 }),
     SET_FIELD(RatingsCalculationFunction, RideRatingsCalculateInformationKiosk),

--- a/src/openrct2/ride/shops/meta/Shop.h
+++ b/src/openrct2/ride/shops/meta/Shop.h
@@ -33,7 +33,7 @@ constexpr const RideTypeDescriptor ShopRTD =
     SET_FIELD(NameConvention, { RideComponentType::Car, RideComponentType::Building, RideComponentType::Station }),
     SET_FIELD(EnumName, nameof(RIDE_TYPE_SHOP)),
     SET_FIELD(AvailableBreakdowns, 0),
-    SET_FIELD(Heights, { 12, 64, 0, 0, }),
+    SET_FIELD(Heights, { 12, DefaultShopHeight, 0, 0, }),
     SET_FIELD(MaxMass, 255),
     SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::Null, 5, 5 }),
     SET_FIELD(RatingsCalculationFunction, RideRatingsCalculateShop),

--- a/src/openrct2/ride/shops/meta/Toilets.h
+++ b/src/openrct2/ride/shops/meta/Toilets.h
@@ -33,7 +33,7 @@ constexpr const RideTypeDescriptor ToiletsRTD =
     SET_FIELD(NameConvention, { RideComponentType::Car, RideComponentType::Building, RideComponentType::Station }),
     SET_FIELD(EnumName, nameof(RIDE_TYPE_TOILETS)),
     SET_FIELD(AvailableBreakdowns, 0),
-    SET_FIELD(Heights, { 12, 32, 0, 0, }),
+    SET_FIELD(Heights, { 12, DefaultToiletHeight, 0, 0, }),
     SET_FIELD(MaxMass, 255),
     SET_FIELD(LiftData, { OpenRCT2::Audio::SoundId::Null, 5, 5 }),
     SET_FIELD(RatingsCalculationFunction, RideRatingsCalculateToilets),


### PR DESCRIPTION
Another branch I started quite some time ago. I ran into bounding box issues at the time, but since I now understand these much better, I was able to resolve them.

RCT2 uses a default height for everything, e.g. 6m for all food and drink stalls, no matter the actual height. This branch allows shops to specify their own clearance height. So the burger bar is now 3m tall, the drinks stall is 4.5m, etcetera. The bounding box now also depends on this clearance height, so placing a base block above the burger bar no longer causes the burger bar to glitch through it.

If desired, I can add some screenshots later (not near my development PC at this moment).