### PR TITLE
Add workflow to manage stale PRs

### DIFF
--- a/.github/workflows/stale-backtrace-issues.yml
+++ b/.github/workflows/stale-backtrace-issues.yml
@@ -1,4 +1,4 @@
-name: 'Manage stale PRs'
+name: 'Manage stale backtrace reports'
 on:
   schedule:
     - cron: '30 1 * * *'
@@ -13,5 +13,5 @@ jobs:
           days-before-issue-close: 1
           only-issue-labels: 'backtrace.io'
           stale-issue-label: 'stale-backtrace'
-          stale-pr-message: 'This issue is stale because it has been open for 60 days with no activity. Remove stale label or comment or this will be closed tomorrow.'
-          close-pr-message: 'This issue was closed because of no activity.'
+          stale-pr-message: 'This issue is stale and will be closed tomorrow if no action is taken. To keep it open, leave a comment or remove the `stale-backtrace` label.'
+          close-pr-message: 'This issue was closed due to inactivity.'

--- a/.github/workflows/stale-backtrace-issues.yml
+++ b/.github/workflows/stale-backtrace-issues.yml
@@ -1,0 +1,17 @@
+name: 'Manage stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 1
+          only-issue-labels: 'backtrace.io'
+          stale-issue-label: 'stale-backtrace'
+          stale-pr-message: 'This issue is stale because it has been open for 60 days with no activity. Remove stale label or comment or this will be closed tomorrow.'
+          close-pr-message: 'This issue was closed because of no activity.'

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -12,5 +12,5 @@ jobs:
           days-before-pr-stale: 14
           days-before-pr-close: 14
           stale-pr-label: 'stale-pr'
-          stale-pr-message: 'This PR is stale because it has been open for 14 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
-          close-pr-message: 'This PR was closed because of no activity.'
+          stale-pr-message: 'This pull request is stale and will be closed in 14 days if no action is taken. To keep it open, leave a comment or remove the `stale-pr` label. If you''re awaiting feedback from a developer, please send us a reminder (either here or on [Discord](https://discord.gg/ZXZd8D8)).'
+          close-pr-message: 'This pull request was closed due to inactivity.'

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,16 @@
+name: 'Manage stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v7
+        with:
+          days-before-pr-stale: 14
+          days-before-pr-close: 14
+          stale-pr-label: 'stale-pr'
+          stale-pr-message: 'This PR is stale because it has been open for 14 days with no activity. Remove stale label or comment or this will be closed in 14 days.'
+          close-pr-message: 'This PR was closed because of no activity.'


### PR DESCRIPTION
The current rules for this setup, it runs every day at 1:30, I just copied the example time.
PRs with 14 days inactivity will get a comment and a stale-pr label, if no one responds or removes the label it will be closed after 14 more days.
Backtrace issues will be marked stale after 60 days with stale-backtrace label, if nothing is done it will be closed after 1 more day.