### PR TITLE
Fix #19243: .park scenarios don't complete properly

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -41,6 +41,7 @@
 - Fix: [#19112] Text boxes not updated with empty strings in Track List, Server List, and Start Server windows.
 - Fix: [#19114] [Plugin] GameActionResult does not comply to API specification.
 - Fix: [#19136] SV6 saves with experimental RCT1 paths not imported correctly.
+- Fix: [#19243] .park scenarios don't complete properly
 - Fix: [#19250] MusicObjects do not free their preview images.
 - Fix: [#19292] Overflow in totalRideValue.
 - Fix: [#19339] Incorrect import of crashed particles from SV4.

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -437,12 +437,12 @@ public:
 
         ScenarioIndexEntry* scenario = GetByFilename(scenarioFileName);
 
-        // Check if this is an RCTC scenario that corresponds to a known RCT1/2 scenario or vice versa, see #12626
         if (scenario == nullptr)
         {
             const std::string scenarioBaseName = Path::GetFileNameWithoutExtension(scenarioFileName);
             const std::string scenarioExtension = Path::GetExtension(scenarioFileName);
 
+            // Check if this is an RCTC scenario that corresponds to a known RCT1/2 scenario or vice versa, see #12626
             if (String::Equals(scenarioExtension, ".sea", true))
             {
                 // Get scenario using RCT2 style name of RCTC scenario
@@ -452,6 +452,11 @@ public:
             {
                 // Get scenario using RCTC style name of RCT2 scenario
                 scenario = GetByFilename((scenarioBaseName + ".sea").c_str());
+            }
+            // gScenarioFileName .Park scenarios is the full file path instead of just <scenarioName.park>, so need to convert
+            else if (String::Equals(scenarioExtension, ".park", true))
+            {
+                scenario = GetByFilename((scenarioBaseName + ".park").c_str());
             }
         }
 


### PR DESCRIPTION
Fix https://github.com/OpenRCT2/OpenRCT2/issues/19243

When playing a .sc4 or .sc6 scenario, gScenarioFileName is stored as <scenarioname.fileextension>. When playing a .park scenario, gScenarioFileName is <C:\\Full\\File\\Path\\scenarioname.park>. This is causing an error when checking if high score should be written for a completed .park scenario.

This fix adds a check in ScenarioRepositoryTryRecordHighscore() for this.