### PR TITLE
Fix #13130: Android respects device locale

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -9,6 +9,7 @@
 - Improved: [#19764] Miscellaneous scenery tab now grouped next to the all-scenery tab.
 - Improved: [#19830] “Highlight path issues” will now hide wall elements.
 - Fix: [#12598] Number of holes is not set correctly when saving track designs.
+- Fix: [#13130] Android always defaulting to UK locale for language, currency and temperature.
 - Fix: [#18895] Responding mechanic blocked at level crossing.
 - Fix: [#19231] Crash due to null pointer to previously deleted banner in tile copy/paste functionality
 - Fix: [#19296] Crash due to a race condition for parallel object loading.

--- a/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
@@ -61,7 +61,7 @@ public class GameActivity extends SDLActivity {
         }
     }
 
-    public boolean getLocaleMeasurementFormat() {
+    public boolean isImperialLocaleMeasurementFormat() {
         Locale deviceLocale;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             return LocaleData.getMeasurementSystem(ULocale.forLocale(getResources().getConfiguration().getLocales().get(0))) == LocaleData.MeasurementSystem.US;

--- a/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
@@ -1,13 +1,32 @@
 package io.openrct2;
 
+import android.os.Build;
+import android.os.LocaleList;
 import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.core.os.LocaleListCompat;
+
 import org.libsdl.app.SDLActivity;
+
+import java.util.Arrays;
+import java.util.Locale;
 
 public class GameActivity extends SDLActivity {
 
     public float getDefaultScale() {
         return getResources().getDisplayMetrics().density;
+    }
+
+    public String getDefaultLocale() {
+        Locale locale;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            locale = getResources().getConfiguration().getLocales().get(0);
+        } else {
+            locale = getResources().getConfiguration().locale;
+        }
+        return locale.getLanguage() + "-" + locale.getCountry();
     }
 
     @Override

--- a/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
@@ -4,16 +4,10 @@ import android.icu.util.Currency;
 import android.icu.util.LocaleData;
 import android.icu.util.ULocale;
 import android.os.Build;
-import android.os.LocaleList;
 import android.view.View;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
-import androidx.core.os.LocaleListCompat;
 
 import org.libsdl.app.SDLActivity;
 
-import java.util.Arrays;
 import java.util.Locale;
 
 public class GameActivity extends SDLActivity {

--- a/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
+++ b/src/openrct2-android/app/src/main/java/io/openrct2/GameActivity.java
@@ -1,5 +1,8 @@
 package io.openrct2;
 
+import android.icu.util.Currency;
+import android.icu.util.LocaleData;
+import android.icu.util.ULocale;
 import android.os.Build;
 import android.os.LocaleList;
 import android.view.View;
@@ -19,14 +22,63 @@ public class GameActivity extends SDLActivity {
         return getResources().getDisplayMetrics().density;
     }
 
-    public String getDefaultLocale() {
-        Locale locale;
+    public String getDefaultLocale(String[] supportedTags) {
+        Locale deviceLocale;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            locale = getResources().getConfiguration().getLocales().get(0);
+            deviceLocale = getResources().getConfiguration().getLocales().get(0);
         } else {
-            locale = getResources().getConfiguration().locale;
+            deviceLocale = getResources().getConfiguration().locale;
         }
-        return locale.getLanguage() + "-" + locale.getCountry();
+
+        for (String supportedTag : supportedTags) {
+            if (supportedTag.isEmpty()) continue;
+            String[] splits = supportedTag.split("-");
+            String language = splits[0];
+            String country = splits[1];
+            if (deviceLocale.getLanguage().equals(language) && deviceLocale.getCountry().equals(country)) {
+                return supportedTag;
+            }
+        }
+
+        Locale canadaEn = Locale.CANADA;
+        if (canadaEn.getLanguage().equals(deviceLocale.getLanguage()) && canadaEn.getCountry().equals(deviceLocale.getCountry())) {
+            return "en-US";
+        }
+
+        for (String supportedTag : supportedTags) {
+            if (supportedTag.isEmpty()) continue;
+            String[] splits = supportedTag.split("-");
+            String language = splits[0];
+            if (deviceLocale.getLanguage().equals(language)) {
+                return supportedTag;
+            }
+        }
+        return "en-UK";
+    }
+
+    public String getLocaleCurrency() {
+        Locale deviceLocale;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            deviceLocale = getResources().getConfiguration().getLocales().get(0);
+            return Currency.getInstance(deviceLocale).getCurrencyCode();
+        } else {
+            deviceLocale = getResources().getConfiguration().locale;
+            return java.util.Currency.getInstance(deviceLocale).getCurrencyCode();
+        }
+    }
+
+    public boolean getLocaleMeasurementFormat() {
+        Locale deviceLocale;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return LocaleData.getMeasurementSystem(ULocale.forLocale(getResources().getConfiguration().getLocales().get(0))) == LocaleData.MeasurementSystem.US;
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            deviceLocale = getResources().getConfiguration().getLocales().get(0);
+        } else {
+            deviceLocale = getResources().getConfiguration().locale;
+        }
+        String localeCountry = deviceLocale.getCountry();
+        return localeCountry.equals(Locale.US.getCountry()) || localeCountry.equals(new Locale("xx", "LR").getCountry()) || localeCountry.equals(new Locale("xx", "MM").getCountry());
     }
 
     @Override

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -134,9 +134,9 @@ namespace Platform
 
         jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
         jclass activityClass = env->GetObjectClass(activity);
-        jmethodID getLocaleMeasurementFormat = env->GetMethodID(activityClass, "getLocaleMeasurementFormat", "()Z");
+        jmethodID getIsImperialLocaleMeasurementFormat = env->GetMethodID(activityClass, "isImperialLocaleMeasurementFormat", "()Z");
 
-        jboolean isImperial = env->CallBooleanMethod(activity, getLocaleMeasurementFormat);
+        jboolean isImperial = env->CallBooleanMethod(activity, isImperialLocaleMeasurementFormat);
 
         env->DeleteLocalRef(activity);
         env->DeleteLocalRef(activityClass);

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -91,10 +91,7 @@ namespace Platform
         jstring jniString = (jstring)env->CallObjectMethod(activity, getDefaultLocale, jLanguageTags);
 
         const char* jniChars = env->GetStringUTFChars(jniString, nullptr);
-
-        utf8* string = (char*)malloc(strlen(jniChars) + 1);
-        std::memcpy((void*)string, jniChars, strlen(jniChars));
-        string[strlen(jniChars)] = 0x00;
+        std::string defaultLocale = jniChars;
 
         env->ReleaseStringUTFChars(jniString, jniChars);
         for (int32_t i = 0; i < LANGUAGE_COUNT; ++i)
@@ -105,8 +102,6 @@ namespace Platform
         env->DeleteLocalRef(jLanguageTags);
         env->DeleteLocalRef(activity);
         env->DeleteLocalRef(activityClass);
-
-        std::string defaultLocale = string;
 
         return LanguageGetIDFromLocale(defaultLocale.c_str());
     }
@@ -122,16 +117,11 @@ namespace Platform
         jstring jniString = (jstring)env->CallObjectMethod(activity, getDefaultLocale);
 
         const char* jniChars = env->GetStringUTFChars(jniString, nullptr);
-
-        utf8* string = (char*)malloc(strlen(jniChars) + 1);
-        std::memcpy((void*)string, jniChars, strlen(jniChars));
-        string[strlen(jniChars)] = 0x00;
+        std::string localeCurrencyCode = jniChars;
 
         env->ReleaseStringUTFChars(jniString, jniChars);
         env->DeleteLocalRef(activity);
         env->DeleteLocalRef(activityClass);
-
-        std::string localeCurrencyCode = string;
 
         return Platform::GetCurrencyValue(localeCurrencyCode.c_str());
     }

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -134,7 +134,8 @@ namespace Platform
 
         jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
         jclass activityClass = env->GetObjectClass(activity);
-        jmethodID getIsImperialLocaleMeasurementFormat = env->GetMethodID(activityClass, "isImperialLocaleMeasurementFormat", "()Z");
+        jmethodID getIsImperialLocaleMeasurementFormat = env->GetMethodID(
+            activityClass, "isImperialLocaleMeasurementFormat", "()Z");
 
         jboolean isImperial = env->CallBooleanMethod(activity, isImperialLocaleMeasurementFormat);
 

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -90,7 +90,7 @@ namespace Platform
             env->SetObjectArrayElement(jLanguageTags, i, jTag);
         }
 
-        jstring jniString = (jstring)env->CallObjectMethod(activity, getDefaultLocale, jLanguageTags);
+        jstring jniString = static_cast<jstring>(env->CallObjectMethod(activity, getDefaultLocale, jLanguageTags));
 
         const char* jniChars = env->GetStringUTFChars(jniString, nullptr);
         std::string defaultLocale = jniChars;
@@ -116,7 +116,7 @@ namespace Platform
         jclass activityClass = env->GetObjectClass(activity);
         jmethodID getDefaultLocale = env->GetMethodID(activityClass, "getLocaleCurrency", "()Ljava/lang/String;");
 
-        jstring jniString = (jstring)env->CallObjectMethod(activity, getDefaultLocale);
+        jstring jniString = static_cast<jstring>(env->CallObjectMethod(activity, getDefaultLocale));
 
         const char* jniChars = env->GetStringUTFChars(jniString, nullptr);
         std::string localeCurrencyCode = jniChars;
@@ -140,12 +140,7 @@ namespace Platform
 
         env->DeleteLocalRef(activity);
         env->DeleteLocalRef(activityClass);
-        bool result = isImperial == JNI_TRUE;
-        if (result)
-        {
-            return MeasurementFormat::Imperial;
-        }
-        return MeasurementFormat::Metric;
+        return isImperial == JNI_TRUE ? MeasurementFormat::Imperial : MeasurementFormat::Metric;
     }
 
     std::string GetSteamPath()

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -137,7 +137,7 @@ namespace Platform
         jmethodID getIsImperialLocaleMeasurementFormat = env->GetMethodID(
             activityClass, "isImperialLocaleMeasurementFormat", "()Z");
 
-        jboolean isImperial = env->CallBooleanMethod(activity, isImperialLocaleMeasurementFormat);
+        jboolean isImperial = env->CallBooleanMethod(activity, getIsImperialLocaleMeasurementFormat);
 
         env->DeleteLocalRef(activity);
         env->DeleteLocalRef(activityClass);

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -78,9 +78,11 @@ namespace Platform
 
         jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
         jclass activityClass = env->GetObjectClass(activity);
-        jmethodID getDefaultLocale = env->GetMethodID(activityClass, "getDefaultLocale", "([Ljava/lang/String;)Ljava/lang/String;");
+        jmethodID getDefaultLocale = env->GetMethodID(
+            activityClass, "getDefaultLocale", "([Ljava/lang/String;)Ljava/lang/String;");
 
-        jobjectArray jLanguageTags = env->NewObjectArray(LANGUAGE_COUNT, env->FindClass("java/lang/String"), env->NewStringUTF(""));
+        jobjectArray jLanguageTags = env->NewObjectArray(
+            LANGUAGE_COUNT, env->FindClass("java/lang/String"), env->NewStringUTF(""));
 
         for (int32_t i = 1; i < LANGUAGE_COUNT; ++i)
         {
@@ -139,7 +141,8 @@ namespace Platform
         env->DeleteLocalRef(activity);
         env->DeleteLocalRef(activityClass);
         bool result = isImperial == JNI_TRUE;
-        if (result) {
+        if (result)
+        {
             return MeasurementFormat::Imperial;
         }
         return MeasurementFormat::Metric;

--- a/src/openrct2/platform/Platform.Android.cpp
+++ b/src/openrct2/platform/Platform.Android.cpp
@@ -74,7 +74,27 @@ namespace Platform
 
     uint16_t GetLocaleLanguage()
     {
-        return LANGUAGE_ENGLISH_UK;
+        JNIEnv* env = static_cast<JNIEnv*>(SDL_AndroidGetJNIEnv());
+
+        jobject activity = static_cast<jobject>(SDL_AndroidGetActivity());
+        jclass activityClass = env->GetObjectClass(activity);
+        jmethodID getDefaultLocale = env->GetMethodID(activityClass, "getDefaultLocale", "()Ljava/lang/String;");
+
+        jstring jniString = (jstring)env->CallObjectMethod(activity, getDefaultLocale);
+
+        const char* jniChars = env->GetStringUTFChars(jniString, nullptr);
+
+        utf8* string = (char*)malloc(strlen(jniChars) + 1);
+        std::memcpy((void*)string, jniChars, strlen(jniChars));
+        string[strlen(jniChars)] = 0x00;
+
+        env->ReleaseStringUTFChars(jniString, jniChars);
+        env->DeleteLocalRef(activity);
+        env->DeleteLocalRef(activityClass);
+
+        std::string defaultLocale = string;
+
+        return LanguageGetIDFromLocale(defaultLocale.c_str());
     }
 
     CurrencyType GetLocaleCurrency()


### PR DESCRIPTION
Fix #13130: Android always defaulting to UK locale

Default settings will now respect the devices configured locale settings.