### PR TITLE
Clean up ride code

### DIFF
--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -163,7 +163,7 @@ public:
         if (mapCoords == _placementLoc)
         {
             TrackDesignPreviewDrawOutlines(
-                tds, _trackDesign.get(), *RideAllocateAtIndex(PreviewRideId), { mapCoords, 0, _currentTrackPieceDirection });
+                tds, _trackDesign.get(), RideGetTemporaryForPreview(), { mapCoords, 0, _currentTrackPieceDirection });
             return;
         }
 
@@ -203,7 +203,7 @@ public:
             WidgetInvalidate(*this, WIDX_PRICE);
         }
 
-        TrackDesignPreviewDrawOutlines(tds, _trackDesign.get(), *RideAllocateAtIndex(PreviewRideId), trackLoc);
+        TrackDesignPreviewDrawOutlines(tds, _trackDesign.get(), RideGetTemporaryForPreview(), trackLoc);
     }
 
     void OnToolDown(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
@@ -425,7 +425,7 @@ private:
 
         return z
             + TrackDesignGetZPlacement(
-                   _trackDesign.get(), *RideAllocateAtIndex(PreviewRideId), { loc, z, _currentTrackPieceDirection });
+                   _trackDesign.get(), RideGetTemporaryForPreview(), { loc, z, _currentTrackPieceDirection });
     }
 
     void DrawMiniPreviewTrack(TrackDesign* td6, int32_t pass, const CoordsXY& origin, CoordsXY min, CoordsXY max)

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -163,7 +163,7 @@ public:
         if (mapCoords == _placementLoc)
         {
             TrackDesignPreviewDrawOutlines(
-                tds, _trackDesign.get(), *GetOrAllocateRide(PreviewRideId), { mapCoords, 0, _currentTrackPieceDirection });
+                tds, _trackDesign.get(), *RideAllocateAtIndex(PreviewRideId), { mapCoords, 0, _currentTrackPieceDirection });
             return;
         }
 
@@ -203,7 +203,7 @@ public:
             WidgetInvalidate(*this, WIDX_PRICE);
         }
 
-        TrackDesignPreviewDrawOutlines(tds, _trackDesign.get(), *GetOrAllocateRide(PreviewRideId), trackLoc);
+        TrackDesignPreviewDrawOutlines(tds, _trackDesign.get(), *RideAllocateAtIndex(PreviewRideId), trackLoc);
     }
 
     void OnToolDown(WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords) override
@@ -425,7 +425,7 @@ private:
 
         return z
             + TrackDesignGetZPlacement(
-                   _trackDesign.get(), *GetOrAllocateRide(PreviewRideId), { loc, z, _currentTrackPieceDirection });
+                   _trackDesign.get(), *RideAllocateAtIndex(PreviewRideId), { loc, z, _currentTrackPieceDirection });
     }
 
     void DrawMiniPreviewTrack(TrackDesign* td6, int32_t pass, const CoordsXY& origin, CoordsXY min, CoordsXY max)

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -122,7 +122,7 @@ GameActions::Result RideCreateAction::Execute() const
     int32_t rideEntryIndex = RideGetEntryIndex(_rideType, _subType);
     auto rideIndex = GetNextFreeRideId();
 
-    auto ride = GetOrAllocateRide(rideIndex);
+    auto ride = RideAllocateAtIndex(rideIndex);
     const auto* rideEntry = GetRideEntryByIndex(rideEntryIndex);
     if (rideEntry == nullptr)
     {

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1193,7 +1193,7 @@ namespace OpenRCT2
                     // Ride ID
                     cs.ReadWrite(rideId);
 
-                    auto& ride = *GetOrAllocateRide(rideId);
+                    auto& ride = *RideAllocateAtIndex(rideId);
 
                     // Status
                     cs.ReadWrite(ride.type);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -775,7 +775,7 @@ namespace RCT1
                 if (_s4.Rides[i].Type != RideType::Null)
                 {
                     const auto rideId = RideId::FromUnderlying(i);
-                    ImportRide(GetOrAllocateRide(rideId), &_s4.Rides[i], rideId);
+                    ImportRide(RideAllocateAtIndex(rideId), &_s4.Rides[i], rideId);
                 }
             }
         }

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -703,7 +703,7 @@ namespace RCT2
                 if (src->Type != RIDE_TYPE_NULL)
                 {
                     const auto rideId = RideId::FromUnderlying(index);
-                    auto dst = GetOrAllocateRide(rideId);
+                    auto dst = RideAllocateAtIndex(rideId);
                     ImportRide(dst, src, rideId);
                 }
             }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -174,6 +174,8 @@ Ride* RideAllocateAtIndex(RideId index)
     _maxRideSize = std::max<size_t>(idx + 1, _maxRideSize);
 
     auto result = &_rides[idx];
+    assert(result->id == RideId::GetNull());
+
     result->id = index;
     return result;
 }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -937,6 +937,7 @@ void RideInitAll()
     std::for_each(std::begin(_rides), std::end(_rides), [](auto& ride) {
         ride.id = RideId::GetNull();
         ride.type = RIDE_TYPE_NULL;
+        ride.custom_name = {};
     });
     _maxRideSize = 0;
 }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -95,10 +95,14 @@ static constexpr const int32_t RideInspectionInterval[] = {
     10, 20, 30, 45, 60, 120, 0, 0,
 };
 
+// Ride storage for all the rides in the park, rides with RideId::Null are considered free.
 static std::array<Ride, OpenRCT2::Limits::MaxRidesInPark> _rides{};
 
 // This is not the real size of rides in use, rather the highest slot used + 1.
 static size_t _maxRideSize = 0;
+
+// A special instance of Ride that is used to draw previews such as the track designs.
+static Ride _previewRide{};
 
 struct StationIndexWithMessage
 {
@@ -172,6 +176,11 @@ Ride* RideAllocateAtIndex(RideId index)
     auto result = &_rides[idx];
     result->id = index;
     return result;
+}
+
+Ride& RideGetTemporaryForPreview()
+{
+    return _previewRide;
 }
 
 void RideDelete(RideId id)

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -129,7 +129,7 @@ size_t RideManager::size() const
     size_t count = 0;
     for (size_t i = 0; i < _maxRideSize; i++)
     {
-        if (_rides[i].type != RIDE_TYPE_NULL)
+        if (!_rides[i].id.IsNull())
         {
             count++;
         }
@@ -156,7 +156,7 @@ RideId GetNextFreeRideId()
 {
     for (RideId::UnderlyingType i = 0; i < _rides.size(); i++)
     {
-        if (_rides[i].type == RIDE_TYPE_NULL)
+        if (_rides[i].id.IsNull())
         {
             return RideId::FromUnderlying(i);
         }
@@ -182,11 +182,13 @@ void RideDelete(RideId id)
     assert(_rides[idx].type != RIDE_TYPE_NULL);
 
     auto& ride = _rides[idx];
+    ride.id = RideId::GetNull();
     ride.type = RIDE_TYPE_NULL;
     ride.custom_name = {};
     ride.measurement = {};
 
-    while (_maxRideSize > 0 && _rides[_maxRideSize - 1].type == RIDE_TYPE_NULL)
+    // Shrink maximum ride size.
+    while (_maxRideSize > 0 && _rides[_maxRideSize - 1].id.IsNull())
     {
         _maxRideSize--;
     }
@@ -198,14 +200,14 @@ Ride* GetRide(RideId index)
     {
         return nullptr;
     }
-    
+
     const auto idx = index.ToUnderlying();
     assert(idx < _rides.size());
     if (idx >= _rides.size())
     {
         return nullptr;
     }
-    
+
     auto& ride = _rides[idx];
     if (ride.type != RIDE_TYPE_NULL)
     {
@@ -923,7 +925,10 @@ bool Ride::SupportsStatus(RideStatus s) const
  */
 void RideInitAll()
 {
-    std::for_each(std::begin(_rides), std::end(_rides), [](auto& ride) { ride.type = RIDE_TYPE_NULL; });
+    std::for_each(std::begin(_rides), std::end(_rides), [](auto& ride) {
+        ride.id = RideId::GetNull();
+        ride.type = RIDE_TYPE_NULL;
+    });
     _maxRideSize = 0;
 }
 

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -996,6 +996,7 @@ struct RideManager
 RideManager GetRideManager();
 RideId GetNextFreeRideId();
 Ride* RideAllocateAtIndex(RideId index);
+Ride& RideGetTemporaryForPreview();
 void RideDelete(RideId id);
 
 const RideObjectEntry* GetRideEntryByIndex(ObjectEntryIndex index);

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -995,7 +995,9 @@ struct RideManager
 
 RideManager GetRideManager();
 RideId GetNextFreeRideId();
-Ride* GetOrAllocateRide(RideId index);
+Ride* RideAllocateAtIndex(RideId index);
+void RideDelete(RideId id);
+
 const RideObjectEntry* GetRideEntryByIndex(ObjectEntryIndex index);
 std::string_view GetRideEntryName(ObjectEntryIndex index);
 

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -338,8 +338,7 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
         }
     }
 
-    TrackDesignPreviewDrawOutlines(
-        tds, this, *RideAllocateAtIndex(PreviewRideId), { 4096, 4096, 0, _currentTrackPieceDirection });
+    TrackDesignPreviewDrawOutlines(tds, this, RideGetTemporaryForPreview(), { 4096, 4096, 0, _currentTrackPieceDirection });
 
     // Resave global vars for scenery reasons.
     tds.Origin = startPos;
@@ -458,8 +457,7 @@ ResultWithMessage TrackDesign::CreateTrackDesignMaze(TrackDesignState& tds, cons
 
     // Save global vars as they are still used by scenery????
     int32_t startZ = tds.Origin.z;
-    TrackDesignPreviewDrawOutlines(
-        tds, this, *RideAllocateAtIndex(PreviewRideId), { 4096, 4096, 0, _currentTrackPieceDirection });
+    TrackDesignPreviewDrawOutlines(tds, this, RideGetTemporaryForPreview(), { 4096, 4096, 0, _currentTrackPieceDirection });
     tds.Origin = { startLoc.x, startLoc.y, startZ };
 
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
@@ -2038,7 +2036,7 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
 
     _currentTrackPieceDirection = 0;
     int32_t z = TrackDesignGetZPlacement(
-        tds, td6, *RideAllocateAtIndex(PreviewRideId), { mapSize.x, mapSize.y, 16, _currentTrackPieceDirection });
+        tds, td6, RideGetTemporaryForPreview(), { mapSize.x, mapSize.y, 16, _currentTrackPieceDirection });
 
     if (tds.HasScenery)
     {

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -339,7 +339,7 @@ ResultWithMessage TrackDesign::CreateTrackDesignTrack(TrackDesignState& tds, con
     }
 
     TrackDesignPreviewDrawOutlines(
-        tds, this, *GetOrAllocateRide(PreviewRideId), { 4096, 4096, 0, _currentTrackPieceDirection });
+        tds, this, *RideAllocateAtIndex(PreviewRideId), { 4096, 4096, 0, _currentTrackPieceDirection });
 
     // Resave global vars for scenery reasons.
     tds.Origin = startPos;
@@ -459,7 +459,7 @@ ResultWithMessage TrackDesign::CreateTrackDesignMaze(TrackDesignState& tds, cons
     // Save global vars as they are still used by scenery????
     int32_t startZ = tds.Origin.z;
     TrackDesignPreviewDrawOutlines(
-        tds, this, *GetOrAllocateRide(PreviewRideId), { 4096, 4096, 0, _currentTrackPieceDirection });
+        tds, this, *RideAllocateAtIndex(PreviewRideId), { 4096, 4096, 0, _currentTrackPieceDirection });
     tds.Origin = { startLoc.x, startLoc.y, startZ };
 
     gMapSelectFlags &= ~MAP_SELECT_FLAG_ENABLE_CONSTRUCT;
@@ -2038,7 +2038,7 @@ static bool TrackDesignPlacePreview(TrackDesignState& tds, TrackDesign* td6, mon
 
     _currentTrackPieceDirection = 0;
     int32_t z = TrackDesignGetZPlacement(
-        tds, td6, *GetOrAllocateRide(PreviewRideId), { mapSize.x, mapSize.y, 16, _currentTrackPieceDirection });
+        tds, td6, *RideAllocateAtIndex(PreviewRideId), { mapSize.x, mapSize.y, 16, _currentTrackPieceDirection });
 
     if (tds.HasScenery)
     {

--- a/src/openrct2/ride/TrackDesign.h
+++ b/src/openrct2/ride/TrackDesign.h
@@ -211,8 +211,6 @@ enum
     MAZE_ELEMENT_TYPE_EXIT = (1 << 7)
 };
 
-static constexpr RideId PreviewRideId = RideId::FromUnderlying(0);
-
 extern bool gTrackDesignSceneryToggle;
 
 extern bool _trackDesignDrawingPreview;


### PR DESCRIPTION
This PR changes a couple of things. 
1. Ride storage is now a an fixed array, instead of fragmenting memory this is one single flat array.
2. Added a new function for deleting Rides, this makes it easier to keep track of what rides are used.
3. Rides will be now considered as free if their id is RideId::Null, RIDE_TYPE_NULL is an odd way to communicate that, RIDE_TYPE_NULL is also used for other things.
4. Renamed GetOrAllocateRide to RideAllocateAtIndex, I've added asserts that ensures the slot is free for debug builds.
5. Fixed iterations of deleted rides, if you had 1000 rides and deleted all of them then it would forever skip empty 1000 rides during iterations, its still possible to have gaps in the iteration but it will now adjust the maximum iteration size when the last ride in the list is deleted.
6. Track previews no longer share the ride slot 0, there is now a dedicated instance for this purpose, now there is no question anymore if the first ride with id 0 will be affected in any way, it was primarily safe due to the ghost flag in the game actions, now it can in theory mutate the ride without consequences.
7. Happens to Close #19451, the issue was due to Rides being stored in a vector, the vector may grow the buffer and all pointers stored in Formatters will be invalid, this is primarily due to the custom_name field in Ride which is std::string and during vector growth the string would be copied, the easiest way to trigger is this to have the guest list open and have guests with custom names and then open the track designs, since they allocate a new ride this will grow the vector in specific conditions, creating new rides and the guest list will also do the trick.

There is still a lot of code that can be cleaned up, most things should be probably be placed in RideManager, currently it acts only as an way to obtain iterators, the RideManager should take care of things like creation, deletion, updating rides, but this is for another PR.