### PR TITLE
Actually Run All Unit Tests in CMake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
           - platform: x86_64
             distro: focal
             image: openrct2/openrct2-build:8-focal
-            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g1 -gz"
+            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g1 -gz" -DWITH_TESTS=off
           - platform: x86_64
             distro: jammy
             image: openrct2/openrct2-build:8-jammy
@@ -271,7 +271,7 @@ jobs:
           - platform: x86_64
             distro: bullseye
             image: openrct2/openrct2-build:8-bullseye
-            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -fno-var-tracking-assignments"
+            build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -fno-var-tracking-assignments" -DWITH_TESTS=off
           - platform: i686
             distro: focal
             image: openrct2/openrct2-build:8-focal32

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,7 +406,7 @@ endif ()
 # Include tests
 if (WITH_TESTS)
     enable_testing()
-    include("${ROOT_DIR}/test/tests/CMakeLists.txt" NO_POLICY_SCOPE)
+    add_subdirectory("test/tests")
 endif ()
 
 # macOS bundle "install" is handled in src/openrct2-ui/CMakeLists.txt

--- a/test/tests/BitSetTests.cpp
+++ b/test/tests/BitSetTests.cpp
@@ -15,11 +15,7 @@ using namespace OpenRCT2;
 TEST(BitTest, test_index_construction)
 {
     BitSet<64u> bits({ 0u, 2u, 4u, 6u, 8u, 10u });
-#if defined(_M_X64) || defined(_M_ARM64)
-    static_assert(std::is_same_v<decltype(bits)::BlockType, uint64_t>);
-#else
-    static_assert(std::is_same_v<decltype(bits)::BlockType, uint32_t>);
-#endif
+    static_assert(sizeof(decltype(bits)::BlockType) == sizeof(uintptr_t));
     constexpr auto size = sizeof(bits);
     static_assert(size == 8u);
 
@@ -94,7 +90,7 @@ TEST(BitTest, test_big)
     static_assert(size == 32u);
 
     bits.flip();
-#if defined(_M_X64) || defined(_M_ARM64)
+#if defined(_M_X64) || defined(_M_ARM64) || defined(__x86_64__)
     static_assert(std::is_same_v<decltype(bits)::BlockType, uint64_t>);
     static_assert(bits.data().size() == 4);
     ASSERT_EQ(bits.data()[0], ~0uLL);

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -3,6 +3,9 @@ include(GoogleTest)
 
 find_package(GTest REQUIRED)
 
+file(CREATE_LINK "${CMAKE_CURRENT_LIST_DIR}/testdata" "${CMAKE_BINARY_DIR}/testdata" SYMBOLIC)
+install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/openrct2\" \"${CMAKE_BINARY_DIR}/data\")")
+
 set(test_files
    "${CMAKE_CURRENT_SOURCE_DIR}/AssertHelpers.hpp"
    "${CMAKE_CURRENT_SOURCE_DIR}/BitSetTests.cpp"
@@ -34,5 +37,7 @@ set(test_files
 add_executable(OpenRCT2Tests ${test_files})
 target_link_libraries(OpenRCT2Tests GTest::gtest GTest::gtest_main libopenrct2)
 target_include_directories(OpenRCT2Tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
-gtest_discover_tests(OpenRCT2Tests)
+set_target_properties(OpenRCT2Tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+gtest_discover_tests(OpenRCT2Tests WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
 

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -1,198 +1,38 @@
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.20)
+include(GoogleTest)
 
 find_package(GTest REQUIRED)
 
-set(GTEST_LIBRARIES ${GTEST_BOTH_LIBRARIES})
+set(test_files
+   "${CMAKE_CURRENT_SOURCE_DIR}/AssertHelpers.hpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/BitSetTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/CircularBuffer.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/CLITests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/CryptTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/Endianness.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/EnumMapTest.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/FormattingTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/ImageImporterTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/IniReaderTest.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/IniWriterTest.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/LanguagePackTest.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/Localisation.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/MultiLaunch.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/Pathfinding.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/Platform.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/PlayTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/ReplayTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/RideRatings.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/S6ImportExportTests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/SawyerCodingTest.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/TestData.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/TestData.h"
+   "${CMAKE_CURRENT_SOURCE_DIR}/tests.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/TileElements.cpp"
+   "${CMAKE_CURRENT_SOURCE_DIR}/TileElementsView.cpp")
 
-include_directories(SYSTEM ${GTEST_INCLUDE_DIRS})
-include_directories("${ROOT_DIR}/src")
-include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
+add_executable(OpenRCT2Tests ${test_files})
+target_link_libraries(OpenRCT2Tests GTest::gtest GTest::gtest_main libopenrct2)
+target_include_directories(OpenRCT2Tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
+gtest_discover_tests(OpenRCT2Tests)
 
-# Some most common files required in tests
-set(COMMON_TEST_SOURCES
-    "${ROOT_DIR}/src/openrct2/core/Console.cpp"
-    "${ROOT_DIR}/src/openrct2/core/Diagnostics.cpp"
-    "${ROOT_DIR}/src/openrct2/core/Guard.cpp"
-    "${ROOT_DIR}/src/openrct2/core/String.cpp"
-    "${ROOT_DIR}/src/openrct2/Diagnostic.cpp"
-    "${ROOT_DIR}/src/openrct2/localisation/ConversionTables.cpp"
-    "${ROOT_DIR}/src/openrct2/localisation/Convert.cpp"
-    "${ROOT_DIR}/src/openrct2/localisation/FormatCodes.cpp"
-    "${ROOT_DIR}/src/openrct2/localisation/UTF8.cpp"
-    "${ROOT_DIR}/src/openrct2/util/Util.cpp"
-    "${ROOT_DIR}/src/openrct2/Version.cpp"
-    )
-
-# Create a re-usable library to save some compilation time
-add_library(test-common STATIC ${COMMON_TEST_SOURCES})
-set_target_properties(test-common PROPERTIES COMPILE_DEFINITIONS DISABLE_HTTP)
-
-# Setup testdata. It should be fine here, as the only way to reach here is by explicitly requesting tests.
-execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_LIST_DIR}/testdata" "${CMAKE_CURRENT_BINARY_DIR}/testdata")
-install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_DATADIR}/openrct2\" \"${CMAKE_CURRENT_BINARY_DIR}/data\")")
-
-if (NOT MINGW AND NOT MSVC)
-    # For unicode code page conversion (required for ini and string tests)
-    find_package(ICU 59.0 REQUIRED COMPONENTS uc)
-    target_link_libraries(test-common ${ICU_LIBRARIES})
-    target_include_directories(test-common SYSTEM PUBLIC ${ICU_INCLUDE_DIRS})
-endif ()
-
-# Start of our tests
-
-# sawyercoding test
-
-set(SAWYERCODING_TEST_SOURCES
-        "${CMAKE_CURRENT_LIST_DIR}/SawyerCodingTest.cpp"
-        )
-add_executable(test_sawyercoding ${SAWYERCODING_TEST_SOURCES})
-target_link_libraries(test_sawyercoding ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_sawyercoding)
-add_test(NAME sawyercoding COMMAND test_sawyercoding)
-
-# LanguagePack test
-set(LANGUAGEPACK_TEST_SOURCES
-        "${CMAKE_CURRENT_LIST_DIR}/LanguagePackTest.cpp"
-        )
-add_executable(test_languagepack ${LANGUAGEPACK_TEST_SOURCES})
-if (UNIX AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "BSD")
-    # Include libdl for dlopen
-    set(LDL dl)
-endif ()
-target_link_libraries(test_languagepack ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_languagepack)
-add_test(NAME languagepack COMMAND test_languagepack)
-
-# INI test
-set(INI_TEST_SOURCES
-        "${CMAKE_CURRENT_LIST_DIR}/IniWriterTest.cpp"
-        "${CMAKE_CURRENT_LIST_DIR}/IniReaderTest.cpp"
-        )
-add_executable(test_ini ${INI_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_ini)
-target_link_libraries(test_ini ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_ini)
-add_test(NAME ini COMMAND test_ini)
-
-# Platform
-add_executable(test_platform ${CMAKE_CURRENT_LIST_DIR}/Platform.cpp)
-SET_CHECK_CXX_FLAGS(test_platform)
-target_link_libraries(test_platform ${GTEST_LIBRARIES} test-common ${LDL} z libopenrct2)
-target_link_platform_libraries(test_platform)
-add_test(NAME platform COMMAND test_platform)
-
-# String test
-set(STRING_TEST_SOURCES
-        "${CMAKE_CURRENT_LIST_DIR}/StringTest.cpp"
-        )
-add_executable(test_string ${STRING_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_string)
-target_link_libraries(test_string ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_string)
-add_test(NAME string COMMAND test_string)
-
-# Formatting tests
-set(STRING_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/FormattingTests.cpp")
-add_executable(test_formatting ${STRING_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_formatting)
-target_link_libraries(test_formatting ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_formatting)
-add_test(NAME formatting COMMAND test_formatting)
-
-# Localisation test
-set(STRING_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/Localisation.cpp")
-add_executable(test_localisation ${STRING_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_localisation)
-target_link_libraries(test_localisation ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_localisation)
-add_test(NAME localisation COMMAND test_localisation)
-
-if (NOT DISABLE_NETWORK)
-    # Crypt tests
-    add_executable(test_crypt "${CMAKE_CURRENT_LIST_DIR}/CryptTests.cpp"
-                              "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
-    SET_CHECK_CXX_FLAGS(test_crypt)
-    target_link_libraries(test_crypt ${GTEST_LIBRARIES} libopenrct2)
-    target_link_platform_libraries(test_crypt)
-    add_test(NAME Crypt COMMAND test_crypt)
-endif ()
-
-# ImageImporter tests
-add_executable(test_imageimporter "${CMAKE_CURRENT_LIST_DIR}/ImageImporterTests.cpp"
-                                  "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
-SET_CHECK_CXX_FLAGS(test_imageimporter)
-target_link_libraries(test_imageimporter ${GTEST_LIBRARIES} libopenrct2)
-target_link_platform_libraries(test_imageimporter)
-add_test(NAME ImageImporter COMMAND test_imageimporter)
-
-# Ride ratings test
-set(RIDE_RATINGS_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/RideRatings.cpp"
-                              "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
-add_executable(test_ride_ratings ${RIDE_RATINGS_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_ride_ratings)
-target_link_libraries(test_ride_ratings ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_ride_ratings)
-add_test(NAME ride_ratings COMMAND test_ride_ratings)
-
-# Multi-launch test
-set(MULTILAUNCH_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/MultiLaunch.cpp"
-                             "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
-add_executable(test_multilaunch ${MULTILAUNCH_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_multilaunch)
-target_link_libraries(test_multilaunch ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_multilaunch)
-add_test(NAME multilaunch COMMAND test_multilaunch)
-
-# Tile element test
-set(TILE_ELEMENT_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/TileElements.cpp"
-                              "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
-add_executable(test_tile_elements ${TILE_ELEMENT_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_tile_elements)
-target_link_libraries(test_tile_elements ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_tile_elements)
-add_test(NAME tile_elements COMMAND test_tile_elements)
-
-# Replay tests
-set(REPLAY_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/ReplayTests.cpp"
-							  "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
-add_executable(test_replays ${REPLAY_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_replays)
-target_link_libraries(test_replays ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_replays)
-add_test(NAME replay_tests COMMAND test_replays)
-
-# Play tests
-set(PLAY_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/PlayTests.cpp"
-                      "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
-add_executable(test_plays ${PLAY_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_plays)
-target_link_libraries(test_plays ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_plays)
-add_test(NAME play_tests COMMAND test_plays)
-
-# Pathfinding test
-set(PATHFINDING_TEST_SOURCES  "${CMAKE_CURRENT_LIST_DIR}/Pathfinding.cpp"
-                              "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
-add_executable(test_pathfinding ${PATHFINDING_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_pathfinding)
-target_link_libraries(test_pathfinding ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_pathfinding)
-add_test(NAME pathfinding COMMAND test_pathfinding)
-
-# S6 Import/Export test
-set(S6IMPORTEXPORT_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/S6ImportExportTests.cpp"
-                                 "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
-add_executable(test_s6importexporttests ${S6IMPORTEXPORT_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_s6importexporttests)
-target_link_libraries(test_s6importexporttests ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_s6importexporttests)
-add_test(NAME s6importexporttests COMMAND test_s6importexporttests)
-
-# EnumMap Test
-set(ENUMMAP_TEST_SOURCES "${CMAKE_CURRENT_LIST_DIR}/EnumMapTest.cpp.cpp"
-                                 "${CMAKE_CURRENT_LIST_DIR}/TestData.cpp")
-add_executable(test_enummap ${S6IMPORTEXPORT_TEST_SOURCES})
-SET_CHECK_CXX_FLAGS(test_enummap)
-target_link_libraries(test_enummap ${GTEST_LIBRARIES} libopenrct2 ${LDL} z)
-target_link_platform_libraries(test_enummap)
-add_test(NAME enummaptests COMMAND test_enummap)

--- a/test/tests/CMakeLists.txt
+++ b/test/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(OpenRCT2Tests ${test_files})
 target_link_libraries(OpenRCT2Tests GTest::gtest GTest::gtest_main libopenrct2)
 target_include_directories(OpenRCT2Tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 set_target_properties(OpenRCT2Tests PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-gtest_discover_tests(OpenRCT2Tests WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
+gtest_discover_tests(OpenRCT2Tests
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    DISCOVERY_MODE PRE_TEST)
 


### PR DESCRIPTION
Seems the majority of our tests haven't been running for any platform that uses cmake (i.e. non windows). This rewrites the cmake to a more modern style for the tests and adds all the tests.

I had to disable the tests on any platform that didn't have modern cmake installed as I'm using the newer gtest integration.