### PR TITLE
Avoid triggering an assert when saving the park

### DIFF
--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1193,7 +1193,12 @@ namespace OpenRCT2
                     // Ride ID
                     cs.ReadWrite(rideId);
 
-                    auto& ride = *RideAllocateAtIndex(rideId);
+                    auto& ride = [&]() -> Ride& {
+                        if (cs.GetMode() == OrcaStream::Mode::WRITING)
+                            return *GetRide(rideId);
+                        else
+                            return *RideAllocateAtIndex(rideId);
+                    }();
 
                     // Status
                     cs.ReadWrite(ride.type);


### PR DESCRIPTION
The function RideAllocateAtIndex was previously called GetOrAllocateRideAt, it shouldn't use this function to get a ride when saving.