### PR TITLE
Add flag to mark an object as a compatibility object

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3650,6 +3650,8 @@ STR_6545    :Use RCT1 interest calculation
 STR_6546    :Use the interest calculation algorithm of RollerCoaster Tycoon 1, which used a fixed percentage of approximately 1.33%.
 STR_6547    :All Scenery
 STR_6548    :Show railings at junction
+STR_6549    :Compatibility objects cannot be selected!
+STR_6550    :This entry is included for backwards compatibility with old or damaged objects. It cannot be selected, only deselected.  
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1130,7 +1130,8 @@ private:
             uint8_t selectionFlags = _objectSelectionFlags[i];
             const ObjectRepositoryItem* item = &items[i];
             if (item->Type == GetSelectedObjectType() && !(selectionFlags & ObjectSelectionFlags::Flag6) && FilterSource(item)
-                && FilterString(*item) && FilterChunks(item) && FilterSelected(selectionFlags))
+                && FilterString(*item) && FilterChunks(item) && FilterSelected(selectionFlags)
+                && FilterCompatibilityObject(*item, selectionFlags))
             {
                 auto filter = std::make_unique<RideFilters>();
                 filter->category[0] = 0;
@@ -1187,6 +1188,14 @@ private:
         const auto& widget = widgets[WIDX_PREVIEW];
         auto screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_LIST].right + 4, widget.bottom + 23 };
         auto _width2 = windowPos.x + this->width - screenPos.x - 4;
+
+        if (_loadedObject->IsCompatibilityObject())
+        {
+            screenPos.y += DrawTextWrapped(
+                               *dpi, screenPos, _width2, STR_OBJECT_SELECTION_COMPAT_OBJECT_DESCRIPTION, {},
+                               { COLOUR_BRIGHT_RED })
+                + LIST_ROW_HEIGHT;
+        }
 
         auto description = ObjectGetDescription(_loadedObject.get());
         if (!description.empty())
@@ -1327,6 +1336,12 @@ private:
         return false;
     }
 
+    bool FilterCompatibilityObject(const ObjectRepositoryItem& item, uint8_t objectFlag)
+    {
+        // Only show compat objects if they are not selected already.
+        return !(item.Flags & ObjectItemFlags::IsCompatibilityObject) || (objectFlag & ObjectSelectionFlags::Selected);
+    }
+
     static bool IsFilterInName(const ObjectRepositoryItem& item, std::string_view filter)
     {
         return String::Contains(item.Name, filter, true);
@@ -1436,7 +1451,8 @@ private:
             for (size_t i = 0; i < numObjects; i++)
             {
                 const ObjectRepositoryItem* item = &items[i];
-                if (FilterSource(item) && FilterString(*item) && FilterChunks(item) && FilterSelected(selectionFlags[i]))
+                if (FilterSource(item) && FilterString(*item) && FilterChunks(item) && FilterSelected(selectionFlags[i])
+                    && FilterCompatibilityObject(*item, selectionFlags[i]))
                 {
                     _filter_object_counts[EnumValue(item->Type)]++;
                 }

--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -566,6 +566,11 @@ ResultWithMessage WindowEditorObjectSelectionSelectObject(
         return { true };
     }
 
+    if (item->Flags & ObjectItemFlags::IsCompatibilityObject)
+    {
+        return ObjectSelectionError(isMasterObject, STR_OBJECT_SELECTION_ERR_COMPAT_OBJECT);
+    }
+
     ObjectType objectType = item->Type;
     uint16_t maxObjects = object_entry_group_counts[EnumValue(objectType)];
 

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3947,6 +3947,9 @@ enum : uint16_t
 
     STR_TILE_INSPECTOR_PATH_JUNCTION_RAILINGS = 6548,
 
+    STR_OBJECT_SELECTION_ERR_COMPAT_OBJECT = 6549,
+    STR_OBJECT_SELECTION_COMPAT_OBJECT_DESCRIPTION = 6550,
+
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings
 };

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -198,6 +198,15 @@ void Object::SetAuthors(std::vector<std::string>&& authors)
     _authors = std::move(authors);
 }
 
+bool Object::IsCompatibilityObject() const
+{
+    return _isCompatibilityObject;
+}
+void Object::SetIsCompatibilityObject(const bool on)
+{
+    _isCompatibilityObject = on;
+}
+
 bool RCTObjectEntry::IsEmpty() const
 {
     uint64_t a, b;

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -195,6 +195,7 @@ private:
     std::vector<std::string> _authors;
     ObjectGeneration _generation{};
     bool _usesFallbackImages{};
+    bool _isCompatibilityObject{};
 
 protected:
     StringTable& GetStringTable()
@@ -309,6 +310,9 @@ public:
     {
         _version = version;
     }
+
+    bool IsCompatibilityObject() const;
+    void SetIsCompatibilityObject(const bool on);
 
     const ImageTable& GetImageTable() const
     {

--- a/src/openrct2/object/ObjectFactory.cpp
+++ b/src/openrct2/object/ObjectFactory.cpp
@@ -563,6 +563,7 @@ namespace ObjectFactory
                 }
             }
             result->SetAuthors(std::move(authorVector));
+            result->SetIsCompatibilityObject(Json::GetBoolean(jRoot["isCompatibilityObject"]));
 
             ExtractSourceGames(id, jRoot, *result);
         }

--- a/src/openrct2/object/ObjectRepository.cpp
+++ b/src/openrct2/object/ObjectRepository.cpp
@@ -126,6 +126,8 @@ public:
             item.Name = object->GetName();
             item.Authors = object->GetAuthors();
             item.Sources = object->GetSourceGames();
+            if (object->IsCompatibilityObject())
+                item.Flags |= ObjectItemFlags::IsCompatibilityObject;
             object->SetRepositoryItem(&item);
             return item;
         }
@@ -144,6 +146,7 @@ protected:
 
         ds << item.Sources;
         ds << item.Authors;
+        ds << item.Flags;
 
         switch (item.Type)
         {

--- a/src/openrct2/object/ObjectRepository.h
+++ b/src/openrct2/object/ObjectRepository.h
@@ -34,6 +34,11 @@ namespace OpenRCT2::Localisation
 
 struct DrawPixelInfo;
 
+enum ObjectItemFlags : uint8_t
+{
+    IsCompatibilityObject = 1,
+};
+
 struct ObjectRepositoryItem
 {
     size_t Id;
@@ -46,6 +51,7 @@ struct ObjectRepositoryItem
     ObjectVersion Version;
     std::vector<std::string> Authors;
     std::vector<ObjectSourceGame> Sources;
+    uint8_t Flags{};
     std::shared_ptr<Object> LoadedObject{};
     struct
     {


### PR DESCRIPTION
Closes #18997.

This flag is for objects that are broken/duplicated or otherwise not suitable to offer to the user, but nevertheless **have** to be in the game. Examples are base blocks that do not allow putting supports on top - patching them would mean supports will appear in places where the user didn’t intend them. Having this flag allows us to create a new, fixed object and still have all the parks that relied on the broken behaviour of the old object function correctly.

Objects with this flag cannot be selected, only deselected. Once deselected, they will no longer appear in the list, as to avoid confusing the user with duplicate entries (i.e. the old broken one and the new fixed one).