### PR TITLE
Remove code tag for commit hash in issues for backtrace reports

### DIFF
--- a/.github/workflows/backtrace-commit-fix.yml
+++ b/.github/workflows/backtrace-commit-fix.yml
@@ -1,0 +1,26 @@
+name: 'Backtrace issue commit correction'
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  backtrace_commit_correction:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      ISSUE: ${{ github.event.issue.html_url }}
+    if: |
+      contains(github.event.issue.labels.*.name, 'backtrace.io')
+    steps:
+      - name: Modify issue contents
+        env:
+          BODY: ${{ github.event.issue.body }}
+        id: fix
+        run: |
+          changed_body=$(echo "$BODY" | sed '/<strong>commit<\/strong>/,/<\/li>/ s/\(<code>\)\(.*\)\(<\/code>\)/\2/g')
+          if [[ "$changed_body" == "$BODY" ]]; then
+            echo "Unable to match the Backtrace report format."
+            exit 1
+          fi
+          echo "$changed_body" >> body.txt
+          gh issue edit $ISSUE --body-file body.txt

--- a/.github/workflows/backtrace-commit-fix.yml
+++ b/.github/workflows/backtrace-commit-fix.yml
@@ -17,7 +17,7 @@ jobs:
           BODY: ${{ github.event.issue.body }}
         id: fix
         run: |
-          changed_body=$(echo "$BODY" | sed '/<strong>commit<\/strong>/,/<\/li>/ s/\(<code>\)\(.*\)\(<\/code>\)/\2/g')
+          changed_body=$(echo "$BODY" | sed '/<strong>commit<\/strong>/,/<\/li>/ s/<code>\([0-9a-f]\{7,\}\)<\/code>/\1/')
           if [[ "$changed_body" == "$BODY" ]]; then
             echo "Unable to match the Backtrace report format."
             exit 1


### PR DESCRIPTION
Because backtrace wraps the commit in a code tag it can't be clicked, until they start fixing it this is a quick work-around, its quite annoying that I have to manually navigate to the commit. This job only runs if the issue contains the backtrace.io label.

Here is an corrected example issue: https://github.com/ZehMatt/OpenRCT2/issues/39