### PR TITLE
Fix blank row getting added at exactly 19 scenery groups

### DIFF
--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1223,7 +1223,7 @@ private:
 
     int32_t GetTabRowCount()
     {
-        int32_t tabEntries = static_cast<int32_t>(_tabEntries.size());
+        int32_t tabEntries = static_cast<int32_t>(_tabEntries.size() - 1);
         return std::max<int32_t>((tabEntries + MaxTabsPerRow - 1) / MaxTabsPerRow, 0);
     }
 


### PR DESCRIPTION
After the "all scenery" tab was added, the scenery window would show a blank row if you had exactly 19 scenery groups selected (or 38, or 57, etc.). This happened because the "all scenery" tab is in the tab list, but shouldn't be counted when calculating tab wrapping (it's the 20th tab).

This change fixes the issue by simply subtracting one from the tab count, to ignore the "all scenery" tab.

![image](https://user-images.githubusercontent.com/5436387/221435718-ab48cf82-fd40-4061-af1f-847a3113c58f.png)
