### PR TITLE
Cleanup changelog inconsistencies

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,7 +5,7 @@
 - Feature: [#18732] [Plugin] API to get the guests thoughts.
 - Feature: [#18744] Cheat to allow using a regular path as a queue path.
 - Feature: [#19023] Add Canadian French translation.
-- Feature: [#19341] Add "All Scenery" tab to scenery window.
+- Feature: [#19341] Add “All Scenery” tab to scenery window.
 - Feature: [#19378] Add command to combine CSG1i.DAT and CSG1.DAT.
 - Feature: [objects#226] Port RCT1 Corkscrew Coaster train.
 - Feature: [objects#229] Port RCT1 go karts with helmets.
@@ -24,14 +24,14 @@
 - Improved: [#19253] Queue junctions drawn properly when using regular paths as queue.
 - Improved: [#19067] New Ride window now allows filtering similarly to Object Selection.
 - Improved: [#19272] Scenery window now allows filtering similarly to Object Selection.
-- Improved: [#19463] Added W and Y with circumflex to sprite font (for Welsh).
 - Improved: [#19447] The control key now enables word jumping in text input fields.
+- Improved: [#19463] Added ‘W’ and ‘Y’ with circumflex to sprite font (for Welsh).
 - Change: [#19018] Renamed actions to fit the naming scheme.
 - Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
 - Change: [#19233] Reduce lift speed minimum and maximum values for “Classic Wooden Coaster”.
 - Fix: [#474] Mini golf window shows more players than there actually are (original bug).
 - Fix: [#7210] Land tile smoothing occurs with edge tiles (original bug).
-- Fix: [#17996] Finances window not cleared when starting some .park scenarios
+- Fix: [#17996] Finances window not cleared when starting some .park scenarios.
 - Fix: [#18260] Crash opening parks that have multiple tiles referencing the same banner entry.
 - Fix: [#18467] “Selected only” Object Selection filter is active in Track Designs Manager, and cannot be toggled.
 - Fix: [#18905] Ride Construction window theme is not applied correctly.
@@ -43,15 +43,15 @@
 - Fix: [#19091] [Plugin] Remote plugins in multiplayer servers do not unload properly.
 - Fix: [#19112] Clearing the last character in the Object Selection filter does not properly reset it.
 - Fix: [#19112] Text boxes not updated with empty strings in Track List, Server List, and Start Server windows.
-- Fix: [#19114] [Plugin] GameActionResult does not comply to API specification.
+- Fix: [#19114] [Plugin] ‘GameActionResult’ does not comply to API specification.
 - Fix: [#19136] SV6 saves with experimental RCT1 paths not imported correctly.
-- Fix: [#19243] .park scenarios don't complete properly
+- Fix: [#19243] .park scenarios don’t complete properly.
 - Fix: [#19250] MusicObjects do not free their preview images.
-- Fix: [#19292] Overflow in totalRideValue.
+- Fix: [#19292] Overflow in ‘totalRideValue’.
 - Fix: [#19339] Incorrect import of crashed particles from SV4.
-- Fix: [#19379] "No platforms" station style shows platforms on the Junior Roller Coaster.
+- Fix: [#19379] “No platforms” station style shows platforms on the Junior Roller Coaster.
 - Fix: [#19380] Startup crash when no sequences are installed and random sequences are enabled.
-- Fix: [#19391] String corruption caused by an improper buffer handling in GfxWrapString.
+- Fix: [#19391] String corruption caused by an improper buffer handling in ‘GfxWrapString’.
 
 0.4.3 (2022-12-14)
 ------------------------------------------------------------------------
@@ -179,7 +179,7 @@
 - Fix: [#17571] All researched tracked rides show up as new vehicles in .park scenarios.
 - Fix: [#17600] Notifications are not properly cleared when loading a park.
 - Fix: [#17605] Crash when opening parks which have had objects removed externally.
-- Fix: [#17639, 17735] When building upside down, the special elements list contains many items twice (original bug).
+- Fix: [#17639, #17735] When building upside down, the special elements list contains many items twice (original bug).
 - Fix: [#17664] Unable to save after an extended period of time due to inactive ride music data leaking.
 - Fix: [#17703] (undefined string) when building on invalid height.
 - Fix: [#17776] “Other Parks” tab uses separate lists for SC4/SC6 and .park scenarios.


### PR DESCRIPTION
- Add missing full stops
- Use proper quotes, and add them where applicable
- Sort the list
- Add missing # before issue number