### PR TITLE
Improve performance of hiring staff and its window

### DIFF
--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -95,7 +95,13 @@ private:
         StringId ActionHire;
     };
 
-    std::vector<EntityId> _staffList;
+    struct StaffEntry
+    {
+        EntityId Id;
+        u8string Name;
+    };
+
+    std::vector<StaffEntry> _staffList;
     bool _quickFireMode{};
     std::optional<size_t> _highlightedIndex{};
     int32_t _selectedTab{};
@@ -341,18 +347,18 @@ public:
     void OnScrollMouseDown(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override
     {
         int32_t i = screenCoords.y / SCROLLABLE_ROW_HEIGHT;
-        for (auto spriteIndex : _staffList)
+        for (const auto& entry : _staffList)
         {
             if (i == 0)
             {
                 if (_quickFireMode)
                 {
-                    auto staffFireAction = StaffFireAction(spriteIndex);
+                    auto staffFireAction = StaffFireAction(entry.Id);
                     GameActions::Execute(&staffFireAction);
                 }
                 else
                 {
-                    auto peep = GetEntity<Staff>(spriteIndex);
+                    auto peep = GetEntity<Staff>(entry.Id);
                     if (peep != nullptr)
                     {
                         auto intent = Intent(WindowClass::Peep);
@@ -381,7 +387,7 @@ public:
 
         auto y = 0;
         size_t i = 0;
-        for (auto spriteIndex : _staffList)
+        for (const auto& entry : _staffList)
         {
             if (y > dpi.y + dpi.height)
             {
@@ -390,7 +396,7 @@ public:
 
             if (y + 11 >= dpi.y)
             {
-                auto peep = GetEntity<Staff>(spriteIndex);
+                const auto* peep = GetEntity<Staff>(entry.Id);
                 if (peep == nullptr)
                 {
                     continue;
@@ -481,17 +487,24 @@ public:
     {
         _staffList.clear();
 
-        for (auto peep : EntityList<Staff>())
+        for (auto* peep : EntityList<Staff>())
         {
             EntitySetFlashing(peep, false);
             if (peep->AssignedStaffType == GetSelectedStaffType())
             {
                 EntitySetFlashing(peep, true);
-                _staffList.push_back(peep->Id);
+
+                StaffEntry entry;
+                entry.Id = peep->Id;
+                entry.Name = peep->GetName();
+
+                _staffList.push_back(std::move(entry));
             }
         }
 
-        std::sort(_staffList.begin(), _staffList.end(), [](const auto a, const auto b) { return PeepCompare(a, b) < 0; });
+        std::sort(_staffList.begin(), _staffList.end(), [](const auto& a, const auto& b) {
+            return StrLogicalCmp(a.Name.c_str(), b.Name.c_str()) < 0;
+        });
     }
 
 private:

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -26,6 +26,8 @@
 #include "../world/Entrance.h"
 #include "../world/Park.h"
 
+#include <set>
+
 /* rct2: 0x009929FC */
 static constexpr const PeepSpriteType spriteTypes[] = {
     PeepSpriteType::Handyman,
@@ -142,25 +144,20 @@ GameActions::Result StaffHireNewAction::QueryExecute(bool execute) const
         newPeep->StaffOrders = _staffOrders;
 
         // We search for the first available Id for a given staff type
-        uint32_t newStaffId = 0;
-        for (;;)
+        std::set<uint32_t> usedStaffIds;
+
+        for (auto searchPeep : EntityList<Staff>())
         {
-            bool found = false;
-            ++newStaffId;
-            for (auto searchPeep : EntityList<Staff>())
-            {
-                if (static_cast<uint8_t>(searchPeep->AssignedStaffType) != _staffType)
-                    continue;
+            if (static_cast<uint8_t>(searchPeep->AssignedStaffType) != _staffType)
+                continue;
 
-                if (searchPeep->PeepId == newStaffId)
-                {
-                    found = true;
-                    break;
-                }
-            }
+            usedStaffIds.insert(searchPeep->PeepId);
+        }
 
-            if (!found)
-                break;
+        uint32_t newStaffId = 1;
+        while (usedStaffIds.find(newStaffId) != usedStaffIds.end())
+        {
+            newStaffId++;
         }
 
         newPeep->PeepId = newStaffId;


### PR DESCRIPTION
When hiring a staff finding a free staff id had the complexity of O(N^2) this PR changes this to O(N*log(N)). Also I improved the staff window a little bit, the sort function generated a name for the staff for each iteration instead it now populates the staff list with the name already generated so when it sorts it just needs to actually sort now and has no hidden side effects.

Test save to compare this: 
[toomanystafftest.zip](https://github.com/OpenRCT2/OpenRCT2/files/10846504/toomanystafftest.zip)
