### PR TITLE
Fix window scrollbar not able to navigate to the end of large lists

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
 - Change: [#19233] Reduce lift speed minimum and maximum values for “Classic Wooden Coaster”.
 - Fix: [#474] Mini golf window shows more players than there actually are (original bug).
+- Fix: [#592] Window scrollbar not able to navigate to the end of large lists.
 - Fix: [#7210] Land tile smoothing occurs with edge tiles (original bug).
 - Fix: [#17996] Finances window not cleared when starting some .park scenarios.
 - Fix: [#18260] Crash opening parks that have multiple tiles referencing the same banner entry.

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -178,18 +178,18 @@ struct Viewport
  */
 struct ScrollBar
 {
-    uint16_t flags{};          // 0x00
-    uint16_t h_left{};         // 0x02
-    uint16_t h_right{};        // 0x04
-    uint16_t h_thumb_left{};   // 0x06
-    uint16_t h_thumb_right{};  // 0x08
-    uint16_t v_top{};          // 0x0A
-    uint16_t v_bottom{};       // 0x0C
-    uint16_t v_thumb_top{};    // 0x0E
-    uint16_t v_thumb_bottom{}; // 0x10
+    uint16_t flags{};
+    int32_t h_left{};
+    int32_t h_right{};
+    int32_t h_thumb_left{};
+    int32_t h_thumb_right{};
+    int32_t v_top{};
+    int32_t v_bottom{};
+    int32_t v_thumb_top{};
+    int32_t v_thumb_bottom{};
 };
 
-constexpr auto WINDOW_SCROLL_UNDEFINED = std::numeric_limits<uint16_t>::max();
+constexpr auto WINDOW_SCROLL_UNDEFINED = std::numeric_limits<int32_t>::max();
 
 struct Focus
 {


### PR DESCRIPTION
With 9000+ staff you could only scroll to half of the list while the scrollbar would sit at the end, this fixes the issue by using bigger integer types, the issue was actually an overflow.

Closes #592