### PR TITLE
Ensure the stale action has no defaults

### DIFF
--- a/.github/workflows/stale-backtrace-issues.yml
+++ b/.github/workflows/stale-backtrace-issues.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 1
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
           only-issue-labels: 'backtrace.io'
           stale-issue-label: 'stale-backtrace'
           stale-issue-message: 'This issue is stale and will be closed tomorrow if no action is taken. To keep it open, leave a comment or remove the `stale-backtrace` label.'

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/stale@v7
         with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
           days-before-pr-stale: 14
           days-before-pr-close: 14
           stale-pr-label: 'stale-pr'


### PR DESCRIPTION
Few issues got tagged as Stale because the workflow had the defaults, now its explicit and shouldn't happen anymore.