### PR TITLE
Fix #19517: Crash when peeps try to exit or enter a hacked ride

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -55,6 +55,7 @@
 - Fix: [#19380] Startup crash when no sequences are installed and random sequences are enabled.
 - Fix: [#19391] String corruption caused by an improper buffer handling in ‘GfxWrapString’.
 - Fix: [#19475] Cannot increase loan when more than £1000 in debt.
+- Fix: [#19517] Crash when peeps try to exit or enter hacked rides that have no waypoints specified.
 
 0.4.3 (2022-12-14)
 ------------------------------------------------------------------------

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -3626,10 +3626,13 @@ void Guest::UpdateRideLeaveEntranceWaypoints(const Ride& ride)
     const auto& rtd = ride.GetRideTypeDescriptor();
     CoordsXY waypoint = rtd.GetGuestWaypointLocation(*vehicle, ride, CurrentRideStation);
 
-    const auto waypointIndex = Var37 / 4;
-    Guard::Assert(carEntry->peep_loading_waypoints.size() >= static_cast<size_t>(waypointIndex));
-    waypoint.x += carEntry->peep_loading_waypoints[waypointIndex][0].x;
-    waypoint.y += carEntry->peep_loading_waypoints[waypointIndex][0].y;
+    const auto waypointIndex = Var37 / 4U;
+    if (waypointIndex < carEntry->peep_loading_waypoints.size())
+    {
+        Guard::Assert(carEntry->peep_loading_waypoints.size() >= static_cast<size_t>(waypointIndex));
+        waypoint.x += carEntry->peep_loading_waypoints[waypointIndex][0].x;
+        waypoint.y += carEntry->peep_loading_waypoints[waypointIndex][0].y;
+    }
 
     SetDestination(waypoint);
     RideSubState = PeepRideSubState::ApproachVehicleWaypoints;
@@ -4265,19 +4268,26 @@ void Guest::UpdateRideLeaveVehicle()
         return;
 
     Var37 = ((exitLocation.direction | GetWaypointedSeatLocation(*ride, carEntry, station_direction) * 4) * 4) | 1;
-    Guard::Assert(carEntry->peep_loading_waypoints.size() >= static_cast<size_t>(Var37 / 4));
+
     CoordsXYZ exitWaypointLoc = waypointLoc;
 
-    exitWaypointLoc.x += carEntry->peep_loading_waypoints[Var37 / 4][2].x;
-    exitWaypointLoc.y += carEntry->peep_loading_waypoints[Var37 / 4][2].y;
+    const auto waypointIndex = Var37 / 4U;
+    if (waypointIndex < carEntry->peep_loading_waypoints.size())
+    {
+        exitWaypointLoc.x += carEntry->peep_loading_waypoints[waypointIndex][2].x;
+        exitWaypointLoc.y += carEntry->peep_loading_waypoints[waypointIndex][2].y;
+    }
 
     if (ride->type == RIDE_TYPE_MOTION_SIMULATOR)
         exitWaypointLoc.z += 15;
 
     MoveTo(exitWaypointLoc);
 
-    waypointLoc.x += carEntry->peep_loading_waypoints[Var37 / 4][1].x;
-    waypointLoc.y += carEntry->peep_loading_waypoints[Var37 / 4][1].y;
+    if (waypointIndex < carEntry->peep_loading_waypoints.size())
+    {
+        waypointLoc.x += carEntry->peep_loading_waypoints[waypointIndex][1].x;
+        waypointLoc.y += carEntry->peep_loading_waypoints[waypointIndex][1].y;
+    }
 
     SetDestination(waypointLoc, 2);
     RideSubState = PeepRideSubState::ApproachExitWaypoints;
@@ -4429,9 +4439,13 @@ void Guest::UpdateRideApproachVehicleWaypoints()
     }
 
     const auto& vehicle_type = rideEntry->Cars[vehicle->vehicle_type];
-    Guard::Assert(waypoint < 3);
-    targetLoc.x += vehicle_type.peep_loading_waypoints[Var37 / 4][waypoint].x;
-    targetLoc.y += vehicle_type.peep_loading_waypoints[Var37 / 4][waypoint].y;
+    const auto waypointIndex = Var37 / 4U;
+    if (waypointIndex < vehicle_type.peep_loading_waypoints.size())
+    {
+        Guard::Assert(waypoint < 3);
+        targetLoc.x += vehicle_type.peep_loading_waypoints[waypointIndex][waypoint].x;
+        targetLoc.y += vehicle_type.peep_loading_waypoints[waypointIndex][waypoint].y;
+    }
 
     SetDestination(targetLoc);
 }


### PR DESCRIPTION
![openrct2_2023-02-28_18-26-3794f2b4c6989864bd7](https://user-images.githubusercontent.com/5415177/221917807-2b8216e0-0d7b-4879-bc75-3ffc69550200.png)

Peeps trying to get on or off this ride triggers the assert, such a ride doesn't really contain waypoints where the peeps should move to when entering it which are just offsets added to the station, this PR simply checks if waypoints exist and only then adds the specified offsets, there should be no side effects as the typical ride either operates in a mode where they don't need waypoints or the ride typically specifies them, this is a rather special case but its still functional with the changes, peeps get on the ride take a seat and then walk off to the exit station so I'm quite confident this won't suddenly break other things, I mean it currently crashes so thats not really better.

Closes #19517