### PR TITLE
Remove Windows Vista from systems claimed as supported

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -29,6 +29,7 @@
 - Change: [#19018] Renamed actions to fit the naming scheme.
 - Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
 - Change: [#19233] Reduce lift speed minimum and maximum values for “Classic Wooden Coaster”.
+- Removed: [#19520] Support for Windows Vista systems.
 - Fix: [#474] Mini golf window shows more players than there actually are (original bug).
 - Fix: [#7210] Land tile smoothing occurs with edge tiles (original bug).
 - Fix: [#17996] Finances window not cleared when starting some .park scenarios.

--- a/distribution/readme.txt
+++ b/distribution/readme.txt
@@ -66,7 +66,7 @@ following information in your bug report:
 
 3.0) Supported platforms
 ---- -------------------
-OpenRCT2 is currently supported on Windows Vista and above, many distributions of
+OpenRCT2 is currently supported on Windows 7 and above, many distributions of
 Linux, macOS 10.13 or higher, Android, FreeBSD and OpenBSD. OpenRCT2 will only work on
 little-endian architectures.
 Further instructions can be found on GitHub.

--- a/distribution/windows/install.nsi
+++ b/distribution/windows/install.nsi
@@ -18,7 +18,7 @@
     InstallDir "$PROGRAMFILES64\OpenRCT2\"
 !endif
 
-!define SUPPORTED_OS        "Windows Vista, 7, 8.1 and 10"
+!define SUPPORTED_OS        "Windows 7 and later"
 
 ; Define root variable relative to installer
 !define PATH_ROOT "..\..\"


### PR DESCRIPTION
It was reported OpenRCT2 stopped working on Vista with 0.4.2 release due to `CoGetApartmentType` and `TryAcquireSRWLockExclusive` symbols linked in statically.

This commit simply removes references to Vista as a supported system.