### PR TITLE
Improve performance for the compressing/decompressing functions

### DIFF
--- a/src/openrct2/util/Util.cpp
+++ b/src/openrct2/util/Util.cpp
@@ -372,10 +372,12 @@ bool UtilGzipCompress(FILE* source, FILE* dest)
     std::vector<uint8_t> in(InflateDeflateBufferSize);
     std::vector<uint8_t> out(InflateDeflateBufferSize);
 
-    const int windowBits = 15;
-    const int gzipEncoding = 16;
+    constexpr int windowBits = 15;
+    constexpr int gzipEncoding = 16;
+    constexpr int memoryUsageLevel = 8;
+
     if (const auto ret = deflateInit2(
-            &strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, windowBits | gzipEncoding, 8, Z_DEFAULT_STRATEGY);
+            &strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, windowBits | gzipEncoding, memoryUsageLevel, Z_DEFAULT_STRATEGY);
         ret != Z_OK)
     {
         LOG_ERROR("Failed to initialise stream");
@@ -430,7 +432,13 @@ std::vector<uint8_t> Gzip(const void* data, const size_t dataLen)
     strm.zfree = Z_NULL;
     strm.opaque = Z_NULL;
 
-    if (const auto ret = deflateInit2(&strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 | 16, 8, Z_DEFAULT_STRATEGY); ret != Z_OK)
+    constexpr int windowBits = 15;
+    constexpr int gzipEncoding = 16;
+    constexpr int memoryUsageLevel = 8;
+
+    if (const auto ret = deflateInit2(
+            &strm, Z_DEFAULT_COMPRESSION, Z_DEFLATED, windowBits | gzipEncoding, memoryUsageLevel, Z_DEFAULT_STRATEGY);
+        ret != Z_OK)
     {
         throw std::runtime_error("deflateInit2 failed with error " + std::to_string(ret));
     }
@@ -483,7 +491,10 @@ std::vector<uint8_t> Ungzip(const void* data, const size_t dataLen)
     strm.zfree = Z_NULL;
     strm.opaque = Z_NULL;
 
-    if (const auto ret = inflateInit2(&strm, 15 | 16); ret != Z_OK)
+    constexpr int windowBits = 15;
+    constexpr int gzipEncoding = 16;
+
+    if (const auto ret = inflateInit2(&strm, windowBits | gzipEncoding); ret != Z_OK)
     {
         throw std::runtime_error("inflateInit2 failed with error " + std::to_string(ret));
     }


### PR DESCRIPTION
From 
![image](https://user-images.githubusercontent.com/5415177/222018836-fd6cb0fd-fcaa-4e54-a0b1-f76a4ed1cce7.png) 3.23 seconds
down to
![image](https://user-images.githubusercontent.com/5415177/222018795-ee23dbc0-c166-4c5c-a3d8-c32944918e8d.png) 2.68 seconds.

Loading a 100 MiB save file, unfortunately I can't upload such huge files here and because its already compressed I can't make it smaller.
