### PR TITLE
Create spritefile from DAT

### DIFF
--- a/src/openrct2/CommandLineSprite.cpp
+++ b/src/openrct2/CommandLineSprite.cpp
@@ -700,7 +700,7 @@ int32_t CommandLineForSprite(const char** argv, int32_t argc)
             LOG_ERROR("Could not save sprite file, cancelling.");
             return -1;
         }
-        fprintf(stdout, "Extracted %d images from %s to %s\n", spriteFile.Header.num_entries, datName, spriteFilePath);
+        fprintf(stdout, "Extracted images [0..%d] from %s to %s\n", spriteFile.Header.num_entries - 1, datName, spriteFilePath);
         return 1;
     }
 

--- a/src/openrct2/command_line/SpriteCommands.cpp
+++ b/src/openrct2/command_line/SpriteCommands.cpp
@@ -42,6 +42,7 @@ const CommandLineCommand CommandLine::SpriteCommands[]
     DefineCommand("export",       "<spritefile> <idx> <output>",              SpriteOptions, HandleSprite),
     DefineCommand("exportall",    "<spritefile> <output directory>",          SpriteOptions, HandleSprite),
     DefineCommand("exportalldat", "<DAT identifier> <output directory>",      SpriteOptions, HandleSprite),
+    DefineCommand("createfromdat", "<DAT identifier> <spritefile>",            SpriteOptions, HandleSprite),
 
     CommandTableEnd
 };

--- a/src/openrct2/object/ImageTable.cpp
+++ b/src/openrct2/object/ImageTable.cpp
@@ -497,6 +497,7 @@ void ImageTable::Read(IReadObjectContext* context, OpenRCT2::IStream* stream)
         }
 
         _data = std::move(data);
+        dataLength = dataSize;
         _entries.insert(_entries.end(), newEntries.begin(), newEntries.end());
     }
     catch (const std::exception&)
@@ -622,4 +623,14 @@ void ImageTable::AddImage(const G1Element* g1)
         std::copy_n(g1->offset, length, newg1.offset);
     }
     _entries.push_back(std::move(newg1));
+}
+
+uintptr_t ImageTable::CopyDataToVector(std::vector<uint8_t>& data) const
+{
+    data = std::vector<uint8_t>(_data.get(), _data.get() + dataLength);
+    return reinterpret_cast<uintptr_t>(_data.get());
+}
+void ImageTable::CopyEntriesToVector(std::vector<G1Element>& entries) const
+{
+    entries = _entries;
 }

--- a/src/openrct2/object/ImageTable.h
+++ b/src/openrct2/object/ImageTable.h
@@ -28,6 +28,7 @@ class ImageTable
 private:
     std::unique_ptr<uint8_t[]> _data;
     std::vector<G1Element> _entries;
+    size_t dataLength;
 
     /**
      * Container for a G1 image, additional information and RAII. Used by ReadJson
@@ -68,4 +69,6 @@ public:
         return static_cast<uint32_t>(_entries.size());
     }
     void AddImage(const G1Element* g1);
+    uintptr_t CopyDataToVector(std::vector<uint8_t>& data) const;
+    void CopyEntriesToVector(std::vector<G1Element>& entries) const;
 };


### PR DESCRIPTION
I want to convert several DATs into just the spritefiles for parkobj.

Since apparently I could have saved Gymnasiast the trouble of adding a combine sprite command if I made a PR of my own implementation, I've made this a PR.