### PR TITLE
fix #16018: Issue with invisible path types

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -33,6 +33,7 @@
 - Fix: [#474] Mini golf window shows more players than there actually are (original bug).
 - Fix: [#592] Window scrollbar not able to navigate to the end of large lists.
 - Fix: [#7210] Land tile smoothing occurs with edge tiles (original bug).
+- Fix: [#19539] Invisible paths showing grass landtile graphics.
 - Fix: [#17996] Finances window not cleared when starting some .park scenarios.
 - Fix: [#18260] Crash opening parks that have multiple tiles referencing the same banner entry.
 - Fix: [#18467] “Selected only” Object Selection filter is active in Track Designs Manager, and cannot be toggled.

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -1400,9 +1400,9 @@ void PathPaintOnlyAddition(
     uint8_t corners = (((pathElement.GetCorners()) << session.CurrentRotation) & 0xF)
         | (((pathElement.GetCorners()) << session.CurrentRotation) >> 4);
 
-    uint16_t edi = edges | (corners << 4);
+    uint16_t edgesAndCorners = edges | (corners << 4);
 
-    Sub6A3F61(session, pathElement, edi, height, pathPaintInfo, imageTemplate, sceneryImageTemplate, false);
+    Sub6A3F61(session, pathElement, edgesAndCorners, height, pathPaintInfo, imageTemplate, sceneryImageTemplate, false);
 
     height += 32;
     if (pathElement.IsSloped())


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3454156/222614736-14170c82-46ac-4a74-acb7-d40fca1d10dc.png)

This adds what amounts to nullptr checking in the paint code. For an unknown reason, the surface and railings descriptors are corrupted and are nullptr for invisible path and queue imported from sv6 and was drawing garbage sprite IDs.

~~This was only tested on Emerald Pointe because it was the only uploaded save file to have the issue. If other parks have different causes, they will not be fixed.~~ There was a second unrelated bug causing another issue.