### PR TITLE
Fix import of ride value

### DIFF
--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "8"
+#define NETWORK_STREAM_VERSION "9"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1411,7 +1411,27 @@ namespace OpenRCT2
                     {
                         uint16_t tempRideValue{};
                         cs.ReadWrite(tempRideValue);
-                        ride.value = ToMoney64(tempRideValue);
+                        if (tempRideValue == 0xFFFFU)
+                        {
+                            ride.value = RIDE_VALUE_UNDEFINED;
+                        }
+                        else
+                        {
+                            ride.value = ToMoney64(tempRideValue);
+                        }
+                    }
+                    else if (version == 19)
+                    {
+                        money64 tempRideValue{};
+                        cs.ReadWrite(tempRideValue);
+                        if (tempRideValue == 0xFFFFU)
+                        {
+                            ride.value = RIDE_VALUE_UNDEFINED;
+                        }
+                        else
+                        {
+                            ride.value = tempRideValue;
+                        }
                     }
                     else
                     {

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -9,7 +9,7 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 19;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 20;
 
     // The minimum version that is forwards compatible with the current version.
     constexpr uint32_t PARK_FILE_MIN_VERSION = 19;


### PR DESCRIPTION
Fixes mistake from #19469 

The ride value undefined constant was changed causing all imports of the undefined value to be incorrect. We can fix the broken imports but can't fix the users of the broken value (gParkValue and its history)