### PR TITLE
Enable Large address awareness for 32-bit builds

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,6 +26,7 @@
 - Improved: [#19272] Scenery window now allows filtering similarly to Object Selection.
 - Improved: [#19447] The control key now enables word jumping in text input fields.
 - Improved: [#19463] Added ‘W’ and ‘Y’ with circumflex to sprite font (for Welsh).
+- Improved: [#19549] Enable large address awareness for 32 bit Windows builds allowing to use 4 GiB of virtual memory.
 - Change: [#19018] Renamed actions to fit the naming scheme.
 - Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
 - Change: [#19233] Reduce lift speed minimum and maximum values for “Classic Wooden Coaster”.

--- a/openrct2.common.props
+++ b/openrct2.common.props
@@ -64,6 +64,7 @@
       <AdditionalOptions>/utf-8 /std:c++17 /permissive- /Zc:externConstexpr</AdditionalOptions>
     </ClCompile>
     <Link>
+      <LargeAddressAware Condition="'$(Platform)'=='Win32'">true</LargeAddressAware>
       <AdditionalDependencies>wininet.lib;imm32.lib;version.lib;winmm.lib;crypt32.lib;wldap32.lib;shlwapi.lib;setupapi.lib;bcrypt.lib;winhttp.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Platform)'=='Win32' or '$(Platform)'=='x64'">fribidi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions>/OPT:NOLBR /ignore:4099 %(AdditionalOptions)</AdditionalOptions>

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -900,7 +900,7 @@ private:
 
     void RestoreScrollPositionForCurrentTab()
     {
-        assert(_currentTab < std::size(_windowNewRideTabScroll));
+        assert(static_cast<size_t>(_currentTab) < std::size(_windowNewRideTabScroll));
         auto& currentTabScroll = _windowNewRideTabScroll[_currentTab];
 
         // Get maximum scroll height


### PR DESCRIPTION
The issues that can be found with "can not rellocate" are typically 32 bit builds and the current 32 bit builds only allow 2 GiB memory usage unless that flag is specifically enabled, the issues: https://github.com/OpenRCT2/OpenRCT2/issues?q=is%3Aissue+is%3Aopen+reallocate

This allows to use the full 4 GiB of memory which should eliminate 99% of the cases where it runs out of memory.