### PR TITLE
Fix some issues regarding money64 change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,9 @@ set(OPENMSX_VERSION "1.0.1")
 set(OPENMSX_URL  "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA1 "8ff94490180e2fbfdd13a4130eb300da726ca406")
 
-set(REPLAYS_VERSION "0.0.74")
+set(REPLAYS_VERSION "0.0.75")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "7AB14AB3B991BA4214E53BB0B0838D254C1E7BA6")
+set(REPLAYS_SHA1 "D1701450AE0FE84B144236243A925801B67D92ED")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -51,8 +51,8 @@
     <OpenSFXSha1>8f04aea33f8034131c3069f6accacce0d94f80c1</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.0.1/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha1>8ff94490180e2fbfdd13a4130eb300da726ca406</OpenMSXSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.74/replays.zip</ReplaysUrl>
-    <ReplaysSha1>7AB14AB3B991BA4214E53BB0B0838D254C1E7BA6</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.75/replays.zip</ReplaysUrl>
+    <ReplaysSha1>D1701450AE0FE84B144236243A925801B67D92ED</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -7130,7 +7130,7 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
     peep->PeepId = gNextGuestNumber++;
     peep->Name = nullptr;
 
-    money64 cash = (ScenarioRand() & 0x3) * 100 - 100 + gGuestInitialCash;
+    money64 cash = (static_cast<money64>(ScenarioRand() & 0x3) * 100) - 100 + gGuestInitialCash;
     if (cash < 0)
         cash = 0;
 

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "10"
+#define NETWORK_STREAM_VERSION "11"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 


### PR DESCRIPTION
This previously worked because it overflowed twice, the random multipler may be 0 so it would subtract 100 on an unsigned type which resulted in a large number (0xFFFFFF9C) adding gGuestInitialCash would basically overflow it again but now that its 64 bits wide the last addition wouldn't cause another overflow and rather add to the large value. money64 is signed so we just keep it signed and don't have to rely on the overflow anymore.

Closes #19586