### PR TITLE
Fix #19601: Crash hiring staff with auto placement turned off

### DIFF
--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -552,12 +552,13 @@ private:
                 nullLoc.SetNull();
 
                 PeepPickupAction pickupAction{ PeepPickupType::Pickup, staff->Id, nullLoc, NetworkGetCurrentPlayerId() };
-                pickupAction.SetCallback([&staff](const GameAction* ga, const GameActions::Result* result) {
+                pickupAction.SetCallback([staffId = staff->Id](const GameAction* ga, const GameActions::Result* result) {
                     if (result->Error != GameActions::Status::Ok)
                         return;
 
+                    auto* staff2 = GetEntity<Staff>(staffId);
                     auto intent = Intent(WindowClass::Peep);
-                    intent.PutExtra(INTENT_EXTRA_PEEP, staff);
+                    intent.PutExtra(INTENT_EXTRA_PEEP, staff2);
                     auto* wind = ContextOpenIntent(&intent);
                     if (wind != nullptr)
                     {


### PR DESCRIPTION
The reason is that the staff variable captured is on the stack but the callback is delayed so that memory is garbage by the time it invokes the lambda. Regression from #18956

Closes #19601