### PR TITLE
expose localisation settings to plugin API

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,1 @@
+msbuild openrct2.proj /t:build /p:platform=x64 /p:configuration=release

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -396,6 +396,8 @@ void ScriptEngine::Initialise()
     ScClimate::Register(ctx);
     ScClimateState::Register(ctx);
     ScConfiguration::Register(ctx);
+    ScUserConfiguration::Register(ctx);
+    //ScLocalisation::Register(ctx);
     ScConsole::Register(ctx);
     ScContext::Register(ctx);
     ScDate::Register(ctx);

--- a/src/openrct2/scripting/bindings/configuration/ScLanguage.cpp
+++ b/src/openrct2/scripting/bindings/configuration/ScLanguage.cpp
@@ -1,0 +1,71 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "ScLanguage.hpp"
+#    include "../../../config/Config.h"
+#    include "../../Duktape.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    ScLanguage::ScLanguage()
+    {
+    }
+
+    int32_t ScLanguage::id_get() const
+    {
+        return gConfigGeneral.Language;
+    }
+
+    void ScLanguage::id_set(int32_t value)
+    {
+        if (value >= 0 && value < LANGUAGE_COUNT)
+        {
+            gConfigGeneral.Language = value;
+        }
+    }
+
+    std::string ScLanguage::code_get() const
+    {
+        return LanguagesDescriptors[id_get()].locale;
+    }
+
+    std::string ScLanguage::englishName_get() const
+    {
+        return LanguagesDescriptors[id_get()].english_name;
+    }
+
+    std::string ScLanguage::nativeName_get() const
+    {
+        return LanguagesDescriptors[id_get()].native_name;
+    }
+
+    int32_t ScLanguage::fallback_get() const
+    {
+        return LanguagesDescriptors[id_get()].fallback;
+    }
+
+    bool ScLanguage::isRtl_get() const
+    {
+        return LanguagesDescriptors[id_get()].isRtl;
+    }
+
+    void ScLanguage::Register(duk_context* ctx)
+    {
+        dukglue_register_property(ctx, &ScLanguage::id_get, id_set, "id");
+        dukglue_register_property(ctx, &ScLanguage::code_get, nullptr, "code");
+        dukglue_register_property(ctx, &ScLanguage::englishName_get, nullptr, "englishName");
+        dukglue_register_property(ctx, &ScLanguage::nativeName_get, nullptr, "nativeName");
+        dukglue_register_property(ctx, &ScLanguage::fallback_get, nullptr, "fallback");
+        dukglue_register_property(ctx, &ScLanguage::isRtl_get, nullptr, "isRtl");
+    }
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/configuration/ScLanguage.hpp
+++ b/src/openrct2/scripting/bindings/configuration/ScLanguage.hpp
@@ -1,0 +1,37 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "../../Duktape.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    class ScLanguage
+    {
+    public:
+        ScLanguage();
+
+        int32_t id_get() const;
+        void id_set(int32_t value);
+
+        std::string code_get() const;
+        std::string englishName_get() const;
+        std::string nativeName_get() const;
+        int32_t fallback_get() const;
+        bool isRtl_get() const;
+
+        static void Register(duk_context* ctx);
+    };
+
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/configuration/ScLocalisation.cpp
+++ b/src/openrct2/scripting/bindings/configuration/ScLocalisation.cpp
@@ -1,0 +1,131 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "ScLocalisation.hpp"
+//#    include "ScLanguage.hpp"
+#    include "../../../Context.h"
+#    include "../../../config/Config.h"
+#    include "../../ScriptEngine.h"
+#    include "../../Duktape.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    ScLocalisation::ScLocalisation()
+    {
+    }
+
+/* std::shared_ptr<ScLanguage> language_get()
+    {
+        return std::make_shared<ScLanguage>();
+    }*/
+
+    bool ScLocalisation::showHeightAsUnits_get() const
+    {
+        return gConfigGeneral.ShowHeightAsUnits;
+    }
+
+    void ScLocalisation::showHeightAsUnits_set(bool value)
+    {
+        gConfigGeneral.ShowHeightAsUnits = value;
+    }
+
+    std::string ScLocalisation::measurementFormat_get() const
+    {
+        const MeasurementFormat format = gConfigGeneral.MeasurementFormat;
+        switch (format)
+        {
+            case MeasurementFormat::Imperial:
+                return "imperial";
+            case MeasurementFormat::Metric:
+                return "metric";
+            case MeasurementFormat::SI:
+                return "si";
+            default:
+                return "unknown";
+        }
+    }
+
+    void ScLocalisation::measurementFormat_set(std::string value)
+    {
+        if (value == "imperial")
+            gConfigGeneral.MeasurementFormat = MeasurementFormat::Imperial;
+        else if (value == "metric")
+            gConfigGeneral.MeasurementFormat = MeasurementFormat::Metric;
+        else if (value == "si")
+            gConfigGeneral.MeasurementFormat = MeasurementFormat::SI;
+    }
+
+    std::string ScLocalisation::temperatureFormat_get() const
+    {
+        const TemperatureUnit unit = gConfigGeneral.TemperatureFormat;
+        switch (unit)
+        {
+            case TemperatureUnit::Celsius:
+                return "celsius";
+            case TemperatureUnit::Fahrenheit:
+                return "fahrenheit";
+            default:
+                return "unknown";
+        }
+    }
+
+    void ScLocalisation::temperatureFormat_set(std::string value)
+    {
+        if (value == "fahrenheit")
+            gConfigGeneral.TemperatureFormat = TemperatureUnit::Fahrenheit;
+        else if (value == "celsius")
+            gConfigGeneral.TemperatureFormat = TemperatureUnit::Celsius;
+    }
+
+    std::string ScLocalisation::dateFormat_get() const
+    {
+        int32_t format = gConfigGeneral.DateFormat;
+        switch (format)
+        {
+            case 0:
+                return "DMY";
+            case 1:
+                return "MDY";
+            case 2:
+                return "YMD";
+            case 3:
+                return "YDM";
+            default:
+                return "unknown";
+        }
+    }
+
+    void ScLocalisation::dateFormat_set(std::string value)
+    {
+        if (value == "DMY")
+            gConfigGeneral.DateFormat = 0;
+        else if (value == "MDY")
+            gConfigGeneral.DateFormat = 1;
+        else if (value == "YMD")
+            gConfigGeneral.DateFormat = 2;
+        else if (value == "YDM")
+            gConfigGeneral.DateFormat = 3;
+    }
+
+    void ScLocalisation::Register(duk_context* ctx)
+    {
+        //dukglue_register_property(ctx, &ScLocalisation::language_get, nullptr, "language");
+        dukglue_register_property(
+            ctx, &ScLocalisation::showHeightAsUnits_get, &ScLocalisation::showHeightAsUnits_set, "showHeightAsUnits");
+        dukglue_register_property(
+            ctx, &ScLocalisation::measurementFormat_get, &ScLocalisation::measurementFormat_set, "measurementFormat");
+        dukglue_register_property(
+            ctx, &ScLocalisation::temperatureFormat_get, &ScLocalisation::temperatureFormat_set, "temperatureFormat");
+        dukglue_register_property(ctx, &ScLocalisation::dateFormat_get, &ScLocalisation::dateFormat_set, "dateFormat");
+    }
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/configuration/ScLocalisation.hpp
+++ b/src/openrct2/scripting/bindings/configuration/ScLocalisation.hpp
@@ -1,0 +1,42 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "../../Duktape.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    class ScLocalisation
+    {
+    public:
+        ScLocalisation();
+
+//        DukValue language_get() const;
+
+        bool showHeightAsUnits_get() const;
+        void showHeightAsUnits_set(bool value);
+
+        std::string measurementFormat_get() const;
+        void measurementFormat_set(std::string value);
+
+        std::string temperatureFormat_get() const;
+        void temperatureFormat_set(std::string value);
+
+        std::string dateFormat_get() const;
+        void dateFormat_set(std::string value);
+
+        static void Register(duk_context* ctx);
+    };
+
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/configuration/ScUserConfiguration.hpp
+++ b/src/openrct2/scripting/bindings/configuration/ScUserConfiguration.hpp
@@ -1,0 +1,74 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "../../../Context.h"
+#    include "../../../config/Config.h"
+#    include "../../../localisation/LocalisationService.h"
+#    include "../../Duktape.hpp"
+#    include "../../ScriptEngine.h"
+#    include "../game/ScConfiguration.hpp"
+#    include "ScLocalisation.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    class ScUserConfiguration : public ScConfiguration
+    {
+    public:
+        ScUserConfiguration()
+            : ScConfiguration()
+        {
+        }
+        ScUserConfiguration(ScConfigurationKind kind, const DukValue& backingObject)
+            : ScConfiguration(kind,  backingObject)
+        {
+        }
+
+        static void Register(duk_context* ctx)
+        {
+            dukglue_register_property(ctx, &ScUserConfiguration::localisation_get, nullptr, "localisation");
+            dukglue_register_method(ctx, &ScUserConfiguration::getAll, "getAll");
+            dukglue_register_method(ctx, &ScUserConfiguration::get, "get");
+            dukglue_register_method(ctx, &ScUserConfiguration::set, "set");
+            dukglue_register_method(ctx, &ScUserConfiguration::has, "has");
+        }
+
+    protected:
+        DukValue getAll(const DukValue& dukNamespace) const override
+        {
+            return ScConfiguration::getAll(dukNamespace);
+        }
+        
+        DukValue get(const std::string& key, const DukValue& defaultValue) const override
+        {
+            return ScConfiguration::get(key, defaultValue);
+        }
+
+        void set(const std::string& key, const DukValue& value) const override
+        {
+            ScConfiguration::set(key, value);
+        }
+
+        bool has(const std::string& key) const override
+        {
+            return ScConfiguration::has(key);
+        }
+
+    private:
+        std::shared_ptr<ScLocalisation> localisation_get() const
+        {
+            return std::make_shared<ScLocalisation>();
+        }
+    };
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/game/ScConfiguration.hpp
+++ b/src/openrct2/scripting/bindings/game/ScConfiguration.hpp
@@ -46,6 +46,10 @@ namespace OpenRCT2::Scripting
         {
         }
 
+        virtual ~ScConfiguration()
+        {
+        }
+
         static void Register(duk_context* ctx)
         {
             dukglue_register_method(ctx, &ScConfiguration::getAll, "getAll");
@@ -151,7 +155,8 @@ namespace OpenRCT2::Scripting
             return !key.empty() && key.find('.') == std::string_view::npos;
         }
 
-        DukValue getAll(const DukValue& dukNamespace) const
+    protected:
+        virtual DukValue getAll(const DukValue& dukNamespace) const
         {
             DukValue result;
             auto ctx = GetContext()->GetScriptEngine().GetContext();
@@ -195,19 +200,19 @@ namespace OpenRCT2::Scripting
                         currencyObj.Set("id", currencyId);
                         currencyObj.Set("isoCode", CurrencyDescriptors[currencyId].isoCode);
                         currencyObj.Set("rate", CurrencyDescriptors[currencyId].rate);
-                        currencyObj.Set("affix", toString(CurrencyDescriptors[currencyId].affix_unicode));
+                        // currencyObj.Set("affix", toString(CurrencyDescriptors[currencyId].affix_unicode));
                         currencyObj.Set("symbol", CurrencyDescriptors[currencyId].symbol_unicode);
-                        currencyObj.Set("asciiAffix", toString(CurrencyDescriptors[currencyId].affix_ascii));
+                        // currencyObj.Set("asciiAffix", toString(CurrencyDescriptors[currencyId].affix_ascii));
                         currencyObj.Set("asciiSymbol", CurrencyDescriptors[currencyId].symbol_ascii);
                         currencyObj.Set("stringId", CurrencyDescriptors[currencyId].stringId);
                         DukValue currencyRef = currencyObj.Take();
 
                         // localisation
                         obj.Set("language", languageRef);
-                        obj.Set("measurementFormat", toString(gConfigGeneral.MeasurementFormat));
-                        obj.Set("temperatureFormat", toString(gConfigGeneral.TemperatureFormat));
+                        // obj.Set("measurementFormat", toString(gConfigGeneral.MeasurementFormat));
+                        // obj.Set("temperatureFormat", toString(gConfigGeneral.TemperatureFormat));
                         obj.Set("showHeightAsUnits", gConfigGeneral.ShowHeightAsUnits);
-                        obj.Set("dateFormat", toString(gConfigGeneral.DateFormat));
+                        // obj.Set("dateFormat", toString(gConfigGeneral.DateFormat));
                         obj.Set("currency", currencyRef);
                     }
                     result = obj.Take();
@@ -225,7 +230,7 @@ namespace OpenRCT2::Scripting
             return result;
         }
 
-        DukValue get(const std::string& key, const DukValue& defaultValue) const
+        virtual DukValue get(const std::string& key, const DukValue& defaultValue) const
         {
             auto ctx = GetContext()->GetScriptEngine().GetContext();
             if (_kind == ScConfigurationKind::User)
@@ -270,7 +275,7 @@ namespace OpenRCT2::Scripting
             return defaultValue;
         }
 
-        void set(const std::string& key, const DukValue& value) const
+        virtual void set(const std::string& key, const DukValue& value) const
         {
             auto& scriptEngine = GetContext()->GetScriptEngine();
             auto ctx = scriptEngine.GetContext();
@@ -323,90 +328,10 @@ namespace OpenRCT2::Scripting
             }
         }
 
-        bool has(const std::string& key) const
+        virtual bool has(const std::string& key) const
         {
             auto val = get(key, DukValue());
             return val.type() != DukValue::Type::UNDEFINED;
-        }
-
-        std::string toString(MeasurementFormat format) const
-        {
-            if (format == MeasurementFormat::Imperial)
-                return "imperial";
-            else if (format == MeasurementFormat::SI)
-                return "si";
-            else
-                return "metric";
-        }
-
-        MeasurementFormat toMeasurementFormat(std::string format) const
-        {
-            if (format == "imperial")
-                return MeasurementFormat::Imperial;
-            else if (format == "si")
-                return MeasurementFormat::SI;
-            else
-                return MeasurementFormat::Metric;
-        }
-
-        std::string toString(TemperatureUnit unit) const
-        {
-            if (unit == TemperatureUnit::Fahrenheit)
-                return "fahrenheit";
-            else
-                return "celsius";
-        }
-
-        TemperatureUnit toTemperatureUnit(std::string unit) const
-        {
-            if (unit == "fahrenheit")
-                return TemperatureUnit::Fahrenheit;
-            else
-                return TemperatureUnit::Celsius;
-        }
-
-        std::string toString(int32_t dateFormat) const
-        {
-            switch (dateFormat)
-            {
-                case 0:
-                    return "DMY";
-                case 1:
-                    return "MDY";
-                case 2:
-                    return "YMD";
-                case 3:
-                default:
-                    return "YDM";
-            }
-        }
-
-        int32_t toDateFormat(std::string dateFormat) const
-        {
-            if (dateFormat == "DMY")
-                return 0;
-            else if (dateFormat == "MDY")
-                return 1;
-            else if (dateFormat == "YMD")
-                return 2;
-            else
-                return 3;
-        }
-
-        std::string toString(CurrencyAffix affix) const
-        {
-            if (affix == CurrencyAffix::Prefix)
-                return "prefix";
-            else
-                return "suffix";
-        }
-
-        CurrencyAffix toCurrencyAffix(std::string affix) const
-        {
-            if (affix == "prefix")
-                return CurrencyAffix::Prefix;
-            else
-                return CurrencyAffix::Suffix;
         }
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/game/ScConfiguration.hpp
+++ b/src/openrct2/scripting/bindings/game/ScConfiguration.hpp
@@ -176,6 +176,40 @@ namespace OpenRCT2::Scripting
                         obj.Set("general.language", gConfigGeneral.Language);
                         obj.Set("general.showFps", gConfigGeneral.ShowFPS);
                     }
+                    else if (ns == "localisation")
+                    {
+                        // language
+                        const int32_t languageId = gConfigGeneral.Language;
+                        DukObject languageObj(ctx);
+                        languageObj.Set("id", languageId);
+                        languageObj.Set("code", LanguagesDescriptors[languageId].locale);
+                        languageObj.Set("englishName", LanguagesDescriptors[languageId].english_name);
+                        languageObj.Set("nativeName", LanguagesDescriptors[languageId].native_name);
+                        languageObj.Set("fallback", LanguagesDescriptors[languageId].fallback);
+                        languageObj.Set("isRtl", LanguagesDescriptors[languageId].isRtl);
+                        DukValue languageRef = languageObj.Take();
+
+                        // currency
+                        const int32_t currencyId = static_cast<int32_t>(gConfigGeneral.CurrencyFormat);
+                        DukObject currencyObj(ctx);
+                        currencyObj.Set("id", currencyId);
+                        currencyObj.Set("isoCode", CurrencyDescriptors[currencyId].isoCode);
+                        currencyObj.Set("rate", CurrencyDescriptors[currencyId].rate);
+                        currencyObj.Set("affix", toString(CurrencyDescriptors[currencyId].affix_unicode));
+                        currencyObj.Set("symbol", CurrencyDescriptors[currencyId].symbol_unicode);
+                        currencyObj.Set("asciiAffix", toString(CurrencyDescriptors[currencyId].affix_ascii));
+                        currencyObj.Set("asciiSymbol", CurrencyDescriptors[currencyId].symbol_ascii);
+                        currencyObj.Set("stringId", CurrencyDescriptors[currencyId].stringId);
+                        DukValue currencyRef = currencyObj.Take();
+
+                        // localisation
+                        obj.Set("language", languageRef);
+                        obj.Set("measurementFormat", toString(gConfigGeneral.MeasurementFormat));
+                        obj.Set("temperatureFormat", toString(gConfigGeneral.TemperatureFormat));
+                        obj.Set("showHeightAsUnits", gConfigGeneral.ShowHeightAsUnits);
+                        obj.Set("dateFormat", toString(gConfigGeneral.DateFormat));
+                        obj.Set("currency", currencyRef);
+                    }
                     result = obj.Take();
                 }
                 else
@@ -293,6 +327,86 @@ namespace OpenRCT2::Scripting
         {
             auto val = get(key, DukValue());
             return val.type() != DukValue::Type::UNDEFINED;
+        }
+
+        std::string toString(MeasurementFormat format) const
+        {
+            if (format == MeasurementFormat::Imperial)
+                return "imperial";
+            else if (format == MeasurementFormat::SI)
+                return "si";
+            else
+                return "metric";
+        }
+
+        MeasurementFormat toMeasurementFormat(std::string format) const
+        {
+            if (format == "imperial")
+                return MeasurementFormat::Imperial;
+            else if (format == "si")
+                return MeasurementFormat::SI;
+            else
+                return MeasurementFormat::Metric;
+        }
+
+        std::string toString(TemperatureUnit unit) const
+        {
+            if (unit == TemperatureUnit::Fahrenheit)
+                return "fahrenheit";
+            else
+                return "celsius";
+        }
+
+        TemperatureUnit toTemperatureUnit(std::string unit) const
+        {
+            if (unit == "fahrenheit")
+                return TemperatureUnit::Fahrenheit;
+            else
+                return TemperatureUnit::Celsius;
+        }
+
+        std::string toString(int32_t dateFormat) const
+        {
+            switch (dateFormat)
+            {
+                case 0:
+                    return "DMY";
+                case 1:
+                    return "MDY";
+                case 2:
+                    return "YMD";
+                case 3:
+                default:
+                    return "YDM";
+            }
+        }
+
+        int32_t toDateFormat(std::string dateFormat) const
+        {
+            if (dateFormat == "DMY")
+                return 0;
+            else if (dateFormat == "MDY")
+                return 1;
+            else if (dateFormat == "YMD")
+                return 2;
+            else
+                return 3;
+        }
+
+        std::string toString(CurrencyAffix affix) const
+        {
+            if (affix == CurrencyAffix::Prefix)
+                return "prefix";
+            else
+                return "suffix";
+        }
+
+        CurrencyAffix toCurrencyAffix(std::string affix) const
+        {
+            if (affix == "prefix")
+                return CurrencyAffix::Prefix;
+            else
+                return CurrencyAffix::Suffix;
         }
     };
 } // namespace OpenRCT2::Scripting

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -21,6 +21,7 @@
 #    include "../../HookEngine.h"
 #    include "../../IconNames.hpp"
 #    include "../../ScriptEngine.h"
+#    include "../configuration/ScUserConfiguration.hpp"
 #    include "../game/ScConfiguration.hpp"
 #    include "../game/ScDisposable.hpp"
 #    include "../object/ScObject.hpp"
@@ -50,9 +51,9 @@ namespace OpenRCT2::Scripting
             return OPENRCT2_PLUGIN_API_VERSION;
         }
 
-        std::shared_ptr<ScConfiguration> configuration_get()
+        std::shared_ptr<ScUserConfiguration> configuration_get()
         {
-            return std::make_shared<ScConfiguration>();
+            return std::make_shared<ScUserConfiguration>();
         }
 
         std::shared_ptr<ScConfiguration> sharedStorage_get()


### PR DESCRIPTION
Exposes all localisation settings to the plugin API.
```
context.configuration.getAll("localisation")
{ language:
   { id: 8,
     code: 'en-GB',
     englishName: 'English (UK)',
     nativeName: 'English (UK)',
     fallback: 0,
     isRtl: false },
  measurementFormat: 'metric',
  temperatureFormat: 'celsius',
  showHeightAsUnits: false,
  dateFormat: 'DMY',
  currency:
   { id: 8,
     isoCode: 'SEK',
     rate: 10,
     affix: 'suffix',
     symbol: ' kr',
     asciiAffix: 'suffix',
     asciiSymbol: ' kr',
     stringId: 2342 } }
```

Currently only implements `configuration.getAll`. `configuration.get` and `configuration.set` will be added after the first round of feedback.

Edit: actually, `getAll` does not work with nested objects yet. In general, the way the configuration works right now is not so extendable. Any suggestions?