### PR TITLE
Reduce guests walking through trains on level crossing next to station

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.5 (in development)
 ------------------------------------------------------------------------
+- Improved: [#18490] Reduce guests walking through trains on level crossing next to station.
 - Improved: [#19764] Miscellaneous scenery tab now grouped next to the all-scenery tab.
 - Fix: [#19296] Crash due to a race condition for parallel object loading.
 - Fix: [#19756] Crash with title sequences containing no commands.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "1"
+#define NETWORK_STREAM_VERSION "2"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -9238,7 +9238,9 @@ void Vehicle::UpdateCrossings() const
                 xyElement.element = output.begin_element;
             }
 
-            if (xyElement.element->AsTrack()->IsStation())
+            // Ensure trains near a station don't block possible crossings after the stop,
+            // except when they are departing
+            if (xyElement.element->AsTrack()->IsStation() && status != Vehicle::Status::Departing)
             {
                 break;
             }
@@ -9252,7 +9254,8 @@ void Vehicle::UpdateCrossings() const
         return;
     }
 
-    uint8_t freeCount = travellingForwards ? 3 : 1;
+    // Ensure departing trains don't clear blocked crossings behind them that might already be blocked by another incoming train
+    uint8_t freeCount = travellingForwards && status != Vehicle::Status::Departing ? 3 : 1;
     while (freeCount-- > 0)
     {
         auto* pathElement = MapGetPathElementAt(TileCoordsXYZ(CoordsXYZ{ xyElement, xyElement.element->GetBaseZ() }));


### PR DESCRIPTION
See #18490. This doesn't fully resolve all issues (see testing results by @cheweytoo below), but it's a step in the right direction.