### PR TITLE
Fix: Input text floating outside chat window

### DIFF
--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -303,5 +303,5 @@ int32_t ChatStringWrappedGetHeight(u8string_view args, int32_t width)
     int32_t numLines;
     GfxWrapString(FormatStringID(STR_STRING, args), width, FontStyle::Medium, nullptr, &numLines);
     const int32_t lineHeight = FontGetLineHeight(FontStyle::Medium);
-    return lineHeight * numLines;
+    return lineHeight * (numLines + 1);
 }


### PR DESCRIPTION
Introduced in #19391
![beforeafter](https://user-images.githubusercontent.com/2897351/224533527-cf3d5cca-94e4-49d0-8a12-6592af4c9b5b.png)
