### PR TITLE
Fix water tile in Six Flags Holland (and merge with Infernal Views fix)

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -65,7 +65,7 @@
 - Fix: [#19493] SV4 saves not importing the correct vehicle colours.
 - Fix: [#19517] Crash when peeps try to exit or enter hacked rides that have no waypoints specified.
 - Fix: [#19524] Staff counter shows incorrect values if there are more than 32767 staff members.
-- Fix: [#19641] Missing water tile in Infernal Views' river.
+- Fix: [#19641] Missing water tile in Infernal Views' and Six Flags Holland's river.
 
 0.4.3 (2022-12-14)
 ------------------------------------------------------------------------

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -506,8 +506,8 @@ namespace RCT2
             park.Name = GetUserString(_s6.ParkName);
 
             FixLandOwnership();
+            FixWater();
             FixAyersRockScenario();
-            FixInfernalViewsScenario();
 
             ResearchDetermineFirstOfType();
             UpdateConsolidatedPatrolAreas();
@@ -642,6 +642,30 @@ namespace RCT2
             }
         }
 
+        void FixWater() const
+        {
+            if (!_isScenario)
+            {
+                return;
+            }
+            if (String::Equals(_s6.ScenarioFilename, "Infernal Views.SC6", true)
+                || String::Equals(_s6.ScenarioFilename, "infernal views.sea", true))
+            {
+                auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ 45, 62 }.ToCoordsXY());
+
+                surfaceElement->SetWaterHeight(96);
+            }
+            else if (
+                String::Equals(_s6.ScenarioFilename, "Six Flags Holland.SC6")
+                || String::Equals(_s6.ScenarioFilename, "six flags holland.sea", true))
+
+            {
+                auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ 126, 73 }.ToCoordsXY());
+
+                surfaceElement->SetWaterHeight(96);
+            }
+        }
+
         void FixAyersRockScenario() const
         {
             if (!_isScenario || !String::Equals(_s6.ScenarioFilename, "Australasia - Ayers Rock.SC6"))
@@ -694,16 +718,6 @@ namespace RCT2
                     trackElement->SetTrackType(TrackElemType::FlatCovered);
                 } while (!(tileElement++)->IsLastForTile());
             }
-        }
-
-        void FixInfernalViewsScenario() const
-        {
-            if (!_isScenario || !String::Equals(_s6.ScenarioFilename, "Infernal Views.SC6"))
-                return;
-
-            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ 45, 62 }.ToCoordsXY());
-
-            surfaceElement->SetWaterHeight(96);
         }
 
         void ImportRides()


### PR DESCRIPTION
Create similar fix for the missing water tile in Six Flags Holland.
![hollandbefore](https://user-images.githubusercontent.com/108596959/225131498-05b44847-e265-412f-89b4-f480cfde2118.PNG)
![hollandafter](https://user-images.githubusercontent.com/108596959/225131505-52592e87-599f-4137-9063-9df62a0e7fad.PNG)
