### PR TITLE
Fix #19652: remove_unused_objects removes scenery groups

### DIFF
--- a/src/openrct2/EditorObjectSelectionSession.cpp
+++ b/src/openrct2/EditorObjectSelectionSession.cpp
@@ -679,6 +679,10 @@ int32_t EditorRemoveUnusedObjects()
                 if (objectType == ObjectType::ParkEntrance || objectType == ObjectType::Water)
                     continue;
 
+                // It’s hard to determine exactly if a scenery group is used, so do not remove these automatically.
+                if (objectType == ObjectType::SceneryGroup)
+                    continue;
+
                 _numSelectedObjectsForType[EnumValue(objectType)]--;
                 _objectSelectionFlags[i] &= ~ObjectSelectionFlags::Selected;
                 numUnselectedObjects++;


### PR DESCRIPTION
No changelog entry needed as the bug was introduced after the release of v0.4.3.