### PR TITLE
Refactor and clean up date handling

### DIFF
--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -18,8 +18,9 @@ namespace Graph
 {
     static void DrawMonths(DrawPixelInfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
-        int32_t currentMonth = gDate.GetMonth();
-        int32_t currentDay = gDate.GetMonthTicks();
+        auto& date = GetDate();
+        int32_t currentMonth = date.GetMonth();
+        int32_t currentDay = date.GetMonthTicks();
         int32_t yearOver32 = (currentMonth * 4) + (currentDay >> 14) - 31;
         auto screenCoords = origCoords;
         for (int32_t i = count - 1; i >= 0; i--)
@@ -153,13 +154,12 @@ namespace Graph
 {
     static void DrawMonths(DrawPixelInfo* dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
-        int32_t i, yearOver32, currentMonth, currentDay;
-
-        currentMonth = gDate.GetMonth();
-        currentDay = gDate.GetMonthTicks();
-        yearOver32 = (currentMonth * 4) + (currentDay >> 14) - 31;
+        auto& date = GetDate();
+        int32_t currentMonth = date.GetMonth();
+        int32_t currentDay = date.GetMonthTicks();
+        int32_t yearOver32 = (currentMonth * 4) + (currentDay >> 14) - 31;
         auto screenCoords = origCoords;
-        for (i = count - 1; i >= 0; i--)
+        for (int32_t i = count - 1; i >= 0; i--)
         {
             if (history[i] != MONEY64_UNDEFINED && yearOver32 % 4 == 0)
             {

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -9,6 +9,7 @@
 
 #include <openrct2-ui/interface/Graph.h>
 #include <openrct2/Context.h>
+#include <openrct2/Date.h>
 #include <openrct2/localisation/Date.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Localisation.h>
@@ -17,8 +18,8 @@ namespace Graph
 {
     static void DrawMonths(DrawPixelInfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
-        int32_t currentMonth = DateGetMonth(gDateMonthsElapsed);
-        int32_t currentDay = gDateMonthTicks;
+        int32_t currentMonth = gDate.GetMonth();
+        int32_t currentDay = gDate.GetMonthTicks();
         int32_t yearOver32 = (currentMonth * 4) + (currentDay >> 14) - 31;
         auto screenCoords = origCoords;
         for (int32_t i = count - 1; i >= 0; i--)
@@ -154,8 +155,8 @@ namespace Graph
     {
         int32_t i, yearOver32, currentMonth, currentDay;
 
-        currentMonth = DateGetMonth(gDateMonthsElapsed);
-        currentDay = gDateMonthTicks;
+        currentMonth = gDate.GetMonth();
+        currentDay = gDate.GetMonthTicks();
         yearOver32 = (currentMonth * 4) + (currentDay >> 14) - 31;
         auto screenCoords = origCoords;
         for (i = count - 1; i >= 0; i--)

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -747,14 +747,14 @@ private:
                 break;
             case WIDX_DATE_SET:
             {
-                auto setDateAction = ParkSetDateAction(_yearSpinnerValue, _monthSpinnerValue, _daySpinnerValue);
+                auto setDateAction = ParkSetDateAction(_yearSpinnerValue - 1, _monthSpinnerValue - 1, _daySpinnerValue - 1);
                 GameActions::Execute(&setDateAction);
                 WindowInvalidateByClass(WindowClass::BottomToolbar);
                 break;
             }
             case WIDX_DATE_RESET:
             {
-                auto setDateAction = ParkSetDateAction(1, 1, 1);
+                auto setDateAction = ParkSetDateAction(0, 0, 0);
                 GameActions::Execute(&setDateAction);
                 WindowInvalidateByClass(WindowClass::BottomToolbar);
                 InvalidateWidget(WIDX_YEAR_BOX);

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -31,6 +31,8 @@
 constexpr auto CHEATS_MONEY_DEFAULT = 10000.00_GBP;
 constexpr auto CHEATS_MONEY_INCREMENT_DIV = 5000.00_GBP;
 
+using OpenRCT2::Date;
+
 // clang-format off
 enum
 {
@@ -724,25 +726,29 @@ private:
             case WIDX_MONTH_UP:
                 _monthSpinnerValue++;
                 _monthSpinnerValue = std::clamp(_monthSpinnerValue, 1, static_cast<int32_t>(MONTH_COUNT));
-                _daySpinnerValue = std::clamp(_daySpinnerValue, 1, static_cast<int32_t>(days_in_month[_monthSpinnerValue - 1]));
+                _daySpinnerValue = std::clamp(
+                    _daySpinnerValue, 1, static_cast<int32_t>(Date::GetDaysInMonth(_monthSpinnerValue - 1)));
                 InvalidateWidget(WIDX_MONTH_BOX);
                 InvalidateWidget(WIDX_DAY_BOX);
                 break;
             case WIDX_MONTH_DOWN:
                 _monthSpinnerValue--;
                 _monthSpinnerValue = std::clamp(_monthSpinnerValue, 1, static_cast<int32_t>(MONTH_COUNT));
-                _daySpinnerValue = std::clamp(_daySpinnerValue, 1, static_cast<int32_t>(days_in_month[_monthSpinnerValue - 1]));
+                _daySpinnerValue = std::clamp(
+                    _daySpinnerValue, 1, static_cast<int32_t>(Date::GetDaysInMonth(_monthSpinnerValue - 1)));
                 InvalidateWidget(WIDX_MONTH_BOX);
                 InvalidateWidget(WIDX_DAY_BOX);
                 break;
             case WIDX_DAY_UP:
                 _daySpinnerValue++;
-                _daySpinnerValue = std::clamp(_daySpinnerValue, 1, static_cast<int32_t>(days_in_month[_monthSpinnerValue - 1]));
+                _daySpinnerValue = std::clamp(
+                    _daySpinnerValue, 1, static_cast<int32_t>(Date::GetDaysInMonth(_monthSpinnerValue - 1)));
                 InvalidateWidget(WIDX_DAY_BOX);
                 break;
             case WIDX_DAY_DOWN:
                 _daySpinnerValue--;
-                _daySpinnerValue = std::clamp(_daySpinnerValue, 1, static_cast<int32_t>(days_in_month[_monthSpinnerValue - 1]));
+                _daySpinnerValue = std::clamp(
+                    _daySpinnerValue, 1, static_cast<int32_t>(Date::GetDaysInMonth(_monthSpinnerValue - 1)));
                 InvalidateWidget(WIDX_DAY_BOX);
                 break;
             case WIDX_DATE_SET:

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -224,13 +224,13 @@ static_assert(std::size(_windowFinancesPageHoldDownWidgets) == WINDOW_FINANCES_P
 class FinancesWindow final : public Window
 {
 private:
-    int32_t _lastPaintedMonth;
+    uint32_t _lastPaintedMonth;
 
 public:
     void OnOpen() override
     {
         SetPage(WINDOW_FINANCES_PAGE_SUMMARY);
-        _lastPaintedMonth = std::numeric_limits<int32_t>::max();
+        _lastPaintedMonth = std::numeric_limits<uint32_t>::max();
         ResearchUpdateUncompletedTypes();
     }
 
@@ -381,7 +381,7 @@ public:
         }
 
         // Expenditure / Income values for each month
-        uint16_t currentMonthYear = static_cast<uint16_t>(gDateMonthsElapsed);
+        auto currentMonthYear = gDate.GetMonthsElapsed();
         for (int32_t i = SummaryMaxAvailableMonth(); i >= 0; i--)
         {
             screenCoords.y = 0;
@@ -522,7 +522,7 @@ public:
         ft.Add<money64>(gBankLoan);
 
         // Keep up with new months being added in the first two years.
-        if (gDateMonthsElapsed != _lastPaintedMonth)
+        if (gDate.GetMonthsElapsed() != _lastPaintedMonth)
             InitialiseScrollPosition(WIDX_SUMMARY_SCROLL, 0);
     }
 
@@ -593,7 +593,7 @@ public:
 
     uint16_t SummaryMaxAvailableMonth()
     {
-        return std::min<uint16_t>(gDateMonthsElapsed, EXPENDITURE_TABLE_MONTH_COUNT - 1);
+        return std::min<uint16_t>(gDate.GetMonthsElapsed(), EXPENDITURE_TABLE_MONTH_COUNT - 1);
     }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -381,7 +381,7 @@ public:
         }
 
         // Expenditure / Income values for each month
-        auto currentMonthYear = gDate.GetMonthsElapsed();
+        auto currentMonthYear = GetDate().GetMonthsElapsed();
         for (int32_t i = SummaryMaxAvailableMonth(); i >= 0; i--)
         {
             screenCoords.y = 0;
@@ -522,7 +522,7 @@ public:
         ft.Add<money64>(gBankLoan);
 
         // Keep up with new months being added in the first two years.
-        if (gDate.GetMonthsElapsed() != _lastPaintedMonth)
+        if (GetDate().GetMonthsElapsed() != _lastPaintedMonth)
             InitialiseScrollPosition(WIDX_SUMMARY_SCROLL, 0);
     }
 
@@ -593,7 +593,7 @@ public:
 
     uint16_t SummaryMaxAvailableMonth()
     {
-        return std::min<uint16_t>(gDate.GetMonthsElapsed(), EXPENDITURE_TABLE_MONTH_COUNT - 1);
+        return std::min<uint16_t>(GetDate().GetMonthsElapsed(), EXPENDITURE_TABLE_MONTH_COUNT - 1);
     }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -190,7 +190,6 @@ static void WindowGameBottomToolbarMouseup(WindowBase* w, WidgetIndex widgetInde
 
 static OpenRCT2String WindowGameBottomToolbarTooltip(WindowBase* w, const WidgetIndex widgetIndex, const StringId fallback)
 {
-    int32_t month, day;
     auto ft = Formatter();
 
     switch (widgetIndex)
@@ -201,13 +200,6 @@ static OpenRCT2String WindowGameBottomToolbarTooltip(WindowBase* w, const Widget
             break;
         case WIDX_PARK_RATING:
             ft.Add<int16_t>(gParkRating);
-            break;
-        case WIDX_DATE:
-            month = DateGetMonth(gDateMonthsElapsed);
-            day = ((gDateMonthTicks * days_in_month[month]) >> 16) & 0xFF;
-
-            ft.Add<StringId>(DateDayNames[day]);
-            ft.Add<StringId>(DateGameMonthNames[month]);
             break;
     }
     return { fallback, ft };
@@ -496,9 +488,9 @@ static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase
                                         window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].top + w->windowPos.y + 2 };
 
     // Date
-    int32_t year = DateGetYear(gDateMonthsElapsed) + 1;
-    int32_t month = DateGetMonth(gDateMonthsElapsed);
-    int32_t day = ((gDateMonthTicks * days_in_month[month]) >> 16) & 0xFF;
+    int32_t year = gDate.GetYear() + 1;
+    int32_t month = gDate.GetMonth();
+    int32_t day = gDate.GetDay();
 
     colour_t colour
         = (gHoverWidget.window_classification == WindowClass::BottomToolbar && gHoverWidget.widget_index == WIDX_DATE

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -488,9 +488,10 @@ static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase
                                         window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].top + w->windowPos.y + 2 };
 
     // Date
-    int32_t year = gDate.GetYear() + 1;
-    int32_t month = gDate.GetMonth();
-    int32_t day = gDate.GetDay();
+    auto& date = GetDate();
+    int32_t year = date.GetYear() + 1;
+    int32_t month = date.GetMonth();
+    int32_t day = date.GetDay();
 
     colour_t colour
         = (gHoverWidget.window_classification == WindowClass::BottomToolbar && gHoverWidget.widget_index == WIDX_DATE

--- a/src/openrct2/Date.cpp
+++ b/src/openrct2/Date.cpp
@@ -9,8 +9,10 @@
 
 #include "localisation/Date.h"
 
+#include "Context.h"
 #include "Date.h"
 #include "Game.h"
+#include "GameState.h"
 #include "core/Guard.hpp"
 
 #include <algorithm>
@@ -23,11 +25,10 @@ constexpr int32_t MASK_FORTNIGHT_TICKS = 0x7FFF;
 constexpr int32_t MASK_MONTH_TICKS = 0xFFFF;
 
 // rct2: 0x00993988
-const int16_t days_in_month[MONTH_COUNT] = {
+static const int16_t days_in_month[MONTH_COUNT] = {
     31, 30, 31, 30, 31, 31, 30, 31,
 };
 
-Date gDate;
 RealWorldTime gRealTimeOfDay;
 
 Date::Date(uint32_t monthsElapsed, uint16_t monthTicks)
@@ -144,16 +145,6 @@ int32_t DateGetTotalMonths(int32_t month, int32_t year)
     return (year - 1) * MONTH_COUNT + month;
 }
 
-/**
- *
- *  rct2: 0x006C4494
- */
-void DateReset()
-{
-    gDate = OpenRCT2::Date();
-    gCurrentRealTimeTicks = 0;
-}
-
 void DateUpdateRealTimeOfDay()
 {
     time_t timestamp = time(nullptr);
@@ -162,4 +153,9 @@ void DateUpdateRealTimeOfDay()
     gRealTimeOfDay.second = now->tm_sec;
     gRealTimeOfDay.minute = now->tm_min;
     gRealTimeOfDay.hour = now->tm_hour;
+}
+
+Date& GetDate()
+{
+    return OpenRCT2::GetContext()->GetGameState()->GetDate();
 }

--- a/src/openrct2/Date.cpp
+++ b/src/openrct2/Date.cpp
@@ -10,6 +10,7 @@
 #include "localisation/Date.h"
 
 #include "Date.h"
+#include "Game.h"
 #include "core/Guard.hpp"
 
 #include <algorithm>
@@ -21,6 +22,14 @@ constexpr int32_t MASK_WEEK_TICKS = 0x3FFF;
 constexpr int32_t MASK_FORTNIGHT_TICKS = 0x7FFF;
 constexpr int32_t MASK_MONTH_TICKS = 0xFFFF;
 
+// rct2: 0x00993988
+const int16_t days_in_month[MONTH_COUNT] = {
+    31, 30, 31, 30, 31, 31, 30, 31,
+};
+
+Date gDate;
+RealWorldTime gRealTimeOfDay;
+
 Date::Date(uint32_t monthsElapsed, uint16_t monthTicks)
     : _monthTicks(monthTicks)
     , _monthsElapsed(monthsElapsed)
@@ -29,17 +38,17 @@ Date::Date(uint32_t monthsElapsed, uint16_t monthTicks)
 
 Date Date::FromYMD(int32_t year, int32_t month, int32_t day)
 {
-    // Year, months
-    Guard::ArgumentInRange(month, 0, MONTH_COUNT - 1);
-    int32_t monthsElapsed = (year * MONTH_COUNT) + month;
+    year = std::clamp(year, 0, MAX_YEAR - 1);
+    month = std::clamp(month, 0, static_cast<int>(MONTH_COUNT) - 1);
+    auto daysInMonth = days_in_month[month];
+    day = std::clamp(day, 0, daysInMonth - 1);
 
+    int32_t monthsElapsed = (year * MONTH_COUNT) + month;
     // Day
     int32_t monthTicks = 0;
     if (day != 0)
     {
-        auto daysInMonth = GetDaysInMonth(month);
-        day = std::clamp(day, 0, daysInMonth - 1);
-        monthTicks = (day << 16) / daysInMonth;
+        monthTicks = ((day << 16) / daysInMonth) + MONTH_TICKS_INCREMENT;
     }
 
     return Date(monthsElapsed, monthTicks);
@@ -118,4 +127,39 @@ int32_t Date::GetDaysInMonth(int32_t month)
     Guard::ArgumentInRange(month, 0, MONTH_COUNT - 1);
 
     return days_in_month[month];
+}
+
+int32_t DateGetMonth(int32_t months)
+{
+    return months % MONTH_COUNT;
+}
+
+int32_t DateGetYear(int32_t months)
+{
+    return months / MONTH_COUNT;
+}
+
+int32_t DateGetTotalMonths(int32_t month, int32_t year)
+{
+    return (year - 1) * MONTH_COUNT + month;
+}
+
+/**
+ *
+ *  rct2: 0x006C4494
+ */
+void DateReset()
+{
+    gDate = OpenRCT2::Date();
+    gCurrentRealTimeTicks = 0;
+}
+
+void DateUpdateRealTimeOfDay()
+{
+    time_t timestamp = time(nullptr);
+    struct tm* now = localtime(&timestamp);
+
+    gRealTimeOfDay.second = now->tm_sec;
+    gRealTimeOfDay.minute = now->tm_min;
+    gRealTimeOfDay.hour = now->tm_hour;
 }

--- a/src/openrct2/Date.h
+++ b/src/openrct2/Date.h
@@ -11,6 +11,31 @@
 
 #include "common.h"
 
+constexpr int32_t MAX_YEAR = 8192;
+constexpr int32_t TICKS_PER_MONTH = 0x10000;
+
+enum
+{
+    MONTH_MARCH,
+    MONTH_APRIL,
+    MONTH_MAY,
+    MONTH_JUNE,
+    MONTH_JULY,
+    MONTH_AUGUST,
+    MONTH_SEPTEMBER,
+    MONTH_OCTOBER,
+
+    MONTH_COUNT
+};
+
+enum
+{
+    DATE_FORMAT_DAY_MONTH_YEAR,
+    DATE_FORMAT_MONTH_DAY_YEAR,
+    DATE_FORMAT_YEAR_MONTH_DAY,
+    DATE_FORMAT_YEAR_DAY_MONTH
+};
+
 namespace OpenRCT2
 {
     /**
@@ -44,3 +69,28 @@ namespace OpenRCT2
         static int32_t GetDaysInMonth(int32_t month);
     };
 } // namespace OpenRCT2
+
+struct RealWorldDate
+{
+    uint8_t day;
+    uint8_t month;
+    int16_t year;
+    uint8_t day_of_week;
+};
+
+struct RealWorldTime
+{
+    uint8_t second;
+    uint8_t minute;
+    uint8_t hour;
+};
+
+extern const int16_t days_in_month[MONTH_COUNT];
+extern OpenRCT2::Date gDate;
+extern RealWorldTime gRealTimeOfDay;
+
+int32_t DateGetMonth(int32_t months);
+int32_t DateGetYear(int32_t months);
+int32_t DateGetTotalMonths(int32_t month, int32_t year);
+void DateReset();
+void DateUpdateRealTimeOfDay();

--- a/src/openrct2/Date.h
+++ b/src/openrct2/Date.h
@@ -85,12 +85,10 @@ struct RealWorldTime
     uint8_t hour;
 };
 
-extern const int16_t days_in_month[MONTH_COUNT];
-extern OpenRCT2::Date gDate;
+OpenRCT2::Date& GetDate();
 extern RealWorldTime gRealTimeOfDay;
 
 int32_t DateGetMonth(int32_t months);
 int32_t DateGetYear(int32_t months);
 int32_t DateGetTotalMonths(int32_t month, int32_t year);
-void DateReset();
 void DateUpdateRealTimeOfDay();

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -71,7 +71,7 @@ void GameState::InitAll(const TileCoordsXY& mapSize)
     RideInitAll();
     ResetAllEntities();
     UpdateConsolidatedPatrolAreas();
-    DateReset();
+    ResetDate();
     ClimateReset(ClimateType::CoolAndWet);
     News::InitQueue();
 
@@ -314,8 +314,7 @@ void GameState::UpdateLogic(LogicTimings* timings)
     auto day = _date.GetDay();
 #endif
 
-    gDate.Update();
-    _date = gDate;
+    _date.Update();
     report_time(LogicTimePart::Date);
 
     ScenarioUpdate();
@@ -408,4 +407,19 @@ void GameState::CreateStateSnapshot()
     auto& snapshot = snapshots->CreateSnapshot();
     snapshots->Capture(snapshot);
     snapshots->LinkSnapshot(snapshot, gCurrentTicks, ScenarioRandState().s0);
+}
+
+void GameState::SetDate(Date newDate)
+{
+    _date = newDate;
+}
+
+/**
+ *
+ *  rct2: 0x006C4494
+ */
+void GameState::ResetDate()
+{
+    _date = OpenRCT2::Date();
+    gCurrentRealTimeTicks = 0;
 }

--- a/src/openrct2/GameState.cpp
+++ b/src/openrct2/GameState.cpp
@@ -11,6 +11,7 @@
 
 #include "./peep/GuestPathfinding.h"
 #include "Context.h"
+#include "Date.h"
 #include "Editor.h"
 #include "Game.h"
 #include "GameState.h"
@@ -313,8 +314,8 @@ void GameState::UpdateLogic(LogicTimings* timings)
     auto day = _date.GetDay();
 #endif
 
-    DateUpdate();
-    _date = Date(static_cast<uint32_t>(gDateMonthsElapsed), gDateMonthTicks);
+    gDate.Update();
+    _date = gDate;
     report_time(LogicTimePart::Date);
 
     ScenarioUpdate();

--- a/src/openrct2/GameState.h
+++ b/src/openrct2/GameState.h
@@ -86,6 +86,8 @@ namespace OpenRCT2
         void InitAll(const TileCoordsXY& mapSize);
         void Tick();
         void UpdateLogic(LogicTimings* timings = nullptr);
+        void SetDate(Date newDate);
+        void ResetDate();
 
     private:
         void CreateStateSnapshot();

--- a/src/openrct2/actions/ParkSetDateAction.cpp
+++ b/src/openrct2/actions/ParkSetDateAction.cpp
@@ -10,6 +10,7 @@
 #include "ParkSetDateAction.h"
 
 #include "../Context.h"
+#include "../GameState.h"
 #include "../core/MemoryStream.h"
 #include "../localisation/StringIds.h"
 #include "../management/Finance.h"
@@ -54,6 +55,6 @@ GameActions::Result ParkSetDateAction::Query() const
 
 GameActions::Result ParkSetDateAction::Execute() const
 {
-    gDate = OpenRCT2::Date::FromYMD(_year, _month, _day);
+    OpenRCT2::GetContext()->GetGameState()->SetDate(OpenRCT2::Date::FromYMD(_year, _month, _day));
     return GameActions::Result();
 }

--- a/src/openrct2/actions/ParkSetDateAction.cpp
+++ b/src/openrct2/actions/ParkSetDateAction.cpp
@@ -44,7 +44,7 @@ void ParkSetDateAction::Serialise(DataSerialiser& stream)
 
 GameActions::Result ParkSetDateAction::Query() const
 {
-    if (_year <= 0 || _year > MAX_YEAR || _month <= 0 || _month > MONTH_COUNT || _day <= 0 || _day > 31)
+    if (_year < 0 || _year >= MAX_YEAR || _month < 0 || _month >= MONTH_COUNT || _day < 0 || _day >= 31)
     {
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_NONE, STR_NONE);
     }
@@ -54,6 +54,6 @@ GameActions::Result ParkSetDateAction::Query() const
 
 GameActions::Result ParkSetDateAction::Execute() const
 {
-    DateSet(_year, _month, _day);
+    gDate = OpenRCT2::Date::FromYMD(_year, _month, _day);
     return GameActions::Result();
 }

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -286,7 +286,7 @@ GameActions::Result RideCreateAction::Execute() const
     ride->num_riders = 0;
     ride->slide_in_use = 0;
     ride->maze_tiles = 0;
-    ride->build_date = gDateMonthsElapsed;
+    ride->build_date = gDate.GetMonthsElapsed();
     ride->music_tune_id = TUNE_ID_NULL;
 
     ride->breakdown_reason = 255;

--- a/src/openrct2/actions/RideCreateAction.cpp
+++ b/src/openrct2/actions/RideCreateAction.cpp
@@ -286,7 +286,7 @@ GameActions::Result RideCreateAction::Execute() const
     ride->num_riders = 0;
     ride->slide_in_use = 0;
     ride->maze_tiles = 0;
-    ride->build_date = gDate.GetMonthsElapsed();
+    ride->build_date = GetDate().GetMonthsElapsed();
     ride->music_tune_id = TUNE_ID_NULL;
 
     ride->breakdown_reason = 255;

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -190,7 +190,7 @@ GameActions::Result StaffHireNewAction::QueryExecute(bool execute) const
         }
 
         // Staff uses this
-        newPeep->As<Staff>()->SetHireDate(gDateMonthsElapsed);
+        newPeep->As<Staff>()->SetHireDate(gDate.GetMonthsElapsed());
         newPeep->PathfindGoal.x = 0xFF;
         newPeep->PathfindGoal.y = 0xFF;
         newPeep->PathfindGoal.z = 0xFF;

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -190,7 +190,7 @@ GameActions::Result StaffHireNewAction::QueryExecute(bool execute) const
         }
 
         // Staff uses this
-        newPeep->As<Staff>()->SetHireDate(gDate.GetMonthsElapsed());
+        newPeep->As<Staff>()->SetHireDate(GetDate().GetMonthsElapsed());
         newPeep->PathfindGoal.x = 0xFF;
         newPeep->PathfindGoal.y = 0xFF;
         newPeep->PathfindGoal.z = 0xFF;

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -171,7 +171,7 @@ void Duck::UpdateSwim()
     }
     else
     {
-        int32_t currentMonth = gDate.GetMonth();
+        int32_t currentMonth = GetDate().GetMonth();
         if (currentMonth >= MONTH_SEPTEMBER && (randomNumber >> 16) < 218)
         {
             state = DuckState::FlyAway;

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -171,7 +171,7 @@ void Duck::UpdateSwim()
     }
     else
     {
-        int32_t currentMonth = DateGetMonth(gDateMonthsElapsed);
+        int32_t currentMonth = gDate.GetMonth();
         if (currentMonth >= MONTH_SEPTEMBER && (randomNumber >> 16) < 218)
         {
             state = DuckState::FlyAway;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -265,7 +265,7 @@ void Staff::ResetStats()
 {
     for (auto peep : EntityList<Staff>())
     {
-        peep->SetHireDate(gDateMonthsElapsed);
+        peep->SetHireDate(gDate.GetMonthsElapsed());
         peep->StaffLawnsMown = 0;
         peep->StaffRidesFixed = 0;
         peep->StaffGardensWatered = 0;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -265,7 +265,7 @@ void Staff::ResetStats()
 {
     for (auto peep : EntityList<Staff>())
     {
-        peep->SetHireDate(gDate.GetMonthsElapsed());
+        peep->SetHireDate(GetDate().GetMonthsElapsed());
         peep->StaffLawnsMown = 0;
         peep->StaffRidesFixed = 0;
         peep->StaffGardensWatered = 0;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -10,6 +10,7 @@
 #include "InteractiveConsole.h"
 
 #include "../Context.h"
+#include "../Date.h"
 #include "../EditorObjectSelectionSession.h"
 #include "../Game.h"
 #include "../OpenRCT2.h"
@@ -18,6 +19,7 @@
 #include "../Version.h"
 #include "../actions/CheatSetAction.h"
 #include "../actions/ClimateSetAction.h"
+#include "../actions/ParkSetDateAction.h"
 #include "../actions/ParkSetParameterAction.h"
 #include "../actions/RideFreezeRatingAction.h"
 #include "../actions/RideSetPriceAction.h"
@@ -1452,7 +1454,7 @@ static int32_t ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& cons
     // YYYY (no month provided, preserve existing month)
     if (argv.size() == 1)
     {
-        month = gDateMonthsElapsed % MONTH_COUNT + 1;
+        month = gDate.GetMonth() + 1;
     }
 
     // YYYY MM or YYYY MM DD (month provided)
@@ -1469,8 +1471,7 @@ static int32_t ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& cons
     // YYYY OR YYYY MM (no day provided, preserve existing day)
     if (argv.size() <= 2)
     {
-        day = std::clamp(
-            gDateMonthTicks / (TICKS_PER_MONTH / days_in_month[month - 1]) + 1, 1, static_cast<int>(days_in_month[month - 1]));
+        day = std::clamp(gDate.GetDay() + 1, 1, static_cast<int>(days_in_month[month - 1]));
     }
 
     // YYYY MM DD (year, month, and day provided)
@@ -1483,7 +1484,8 @@ static int32_t ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& cons
         }
     }
 
-    DateSet(year, month, day);
+    auto setDateAction = ParkSetDateAction(year - 1, month - 1, day - 1);
+    GameActions::Execute(&setDateAction);
     WindowInvalidateByClass(WindowClass::BottomToolbar);
 
     return 1;

--- a/src/openrct2/interface/InteractiveConsole.cpp
+++ b/src/openrct2/interface/InteractiveConsole.cpp
@@ -78,6 +78,7 @@
 #endif
 
 using arguments_t = std::vector<std::string>;
+using OpenRCT2::Date;
 
 static constexpr const char* ClimateNames[] = {
     "cool_and_wet",
@@ -1454,7 +1455,7 @@ static int32_t ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& cons
     // YYYY (no month provided, preserve existing month)
     if (argv.size() == 1)
     {
-        month = gDate.GetMonth() + 1;
+        month = GetDate().GetMonth() + 1;
     }
 
     // YYYY MM or YYYY MM DD (month provided)
@@ -1471,14 +1472,14 @@ static int32_t ConsoleCommandForceDate([[maybe_unused]] InteractiveConsole& cons
     // YYYY OR YYYY MM (no day provided, preserve existing day)
     if (argv.size() <= 2)
     {
-        day = std::clamp(gDate.GetDay() + 1, 1, static_cast<int>(days_in_month[month - 1]));
+        day = std::clamp(GetDate().GetDay() + 1, 1, static_cast<int>(Date::GetDaysInMonth(month - 1)));
     }
 
     // YYYY MM DD (year, month, and day provided)
     if (argv.size() == 3)
     {
         day = atoi(argv[2].c_str());
-        if (day < 1 || day > days_in_month[month - 1])
+        if (day < 1 || day > Date::GetDaysInMonth(month - 1))
         {
             return -1;
         }

--- a/src/openrct2/localisation/Date.h
+++ b/src/openrct2/localisation/Date.h
@@ -9,57 +9,12 @@
 
 #pragma once
 
+#include "../Date.h"
 #include "../common.h"
 
-constexpr int32_t MAX_YEAR = 8192;
-constexpr int32_t TICKS_PER_MONTH = 0x10000;
-
-enum
-{
-    MONTH_MARCH,
-    MONTH_APRIL,
-    MONTH_MAY,
-    MONTH_JUNE,
-    MONTH_JULY,
-    MONTH_AUGUST,
-    MONTH_SEPTEMBER,
-    MONTH_OCTOBER,
-
-    MONTH_COUNT
-};
-
-enum
-{
-    DATE_FORMAT_DAY_MONTH_YEAR,
-    DATE_FORMAT_MONTH_DAY_YEAR,
-    DATE_FORMAT_YEAR_MONTH_DAY,
-    DATE_FORMAT_YEAR_DAY_MONTH
-};
-
-struct RealWorldTime
-{
-    uint8_t second;
-    uint8_t minute;
-    uint8_t hour;
-};
-
-extern const int16_t days_in_month[MONTH_COUNT];
 extern const StringId DateFormatStringIDs[];
 extern const StringId DateFormatStringFormatIds[];
 
-extern uint16_t gDateMonthTicks;
-extern int32_t gDateMonthsElapsed;
-
-extern RealWorldTime gRealTimeOfDay;
-
-int32_t DateGetMonth(int32_t months);
-int32_t DateGetYear(int32_t months);
-int32_t DateGetTotalMonths(int32_t month, int32_t year);
-void DateReset();
-void DateUpdate();
-void DateSet(int32_t year, int32_t month, int32_t day);
-void DateUpdateRealTimeOfDay();
-bool DateIsDayStart(int32_t monthTicks);
-bool DateIsWeekStart(int32_t monthTicks);
-bool DateIsFortnightStart(int32_t monthTicks);
-bool DateIsMonthStart(int32_t monthTicks);
+extern const StringId DateDayNames[31];
+extern const StringId DateGameMonthNames[MONTH_COUNT];
+extern const StringId DateGameShortMonthNames[MONTH_COUNT];

--- a/src/openrct2/localisation/Localisation.cpp
+++ b/src/openrct2/localisation/Localisation.cpp
@@ -263,62 +263,6 @@ const StringId PeepThoughts[] = {
     STR_PEEP_THOUGHT_TYPE_EXCITED_DEPRECATED,
     STR_PEEP_THOUGHT_TYPE_HERE_WE_ARE,
 };
-
-const StringId DateDayNames[] = {
-    STR_DATE_DAY_1,
-    STR_DATE_DAY_2,
-    STR_DATE_DAY_3,
-    STR_DATE_DAY_4,
-    STR_DATE_DAY_5,
-    STR_DATE_DAY_6,
-    STR_DATE_DAY_7,
-    STR_DATE_DAY_8,
-    STR_DATE_DAY_9,
-    STR_DATE_DAY_10,
-    STR_DATE_DAY_11,
-    STR_DATE_DAY_12,
-    STR_DATE_DAY_13,
-    STR_DATE_DAY_14,
-    STR_DATE_DAY_15,
-    STR_DATE_DAY_16,
-    STR_DATE_DAY_17,
-    STR_DATE_DAY_18,
-    STR_DATE_DAY_19,
-    STR_DATE_DAY_20,
-    STR_DATE_DAY_21,
-    STR_DATE_DAY_22,
-    STR_DATE_DAY_23,
-    STR_DATE_DAY_24,
-    STR_DATE_DAY_25,
-    STR_DATE_DAY_26,
-    STR_DATE_DAY_27,
-    STR_DATE_DAY_28,
-    STR_DATE_DAY_29,
-    STR_DATE_DAY_30,
-    STR_DATE_DAY_31,
-};
-
-const StringId DateGameMonthNames[MONTH_COUNT] = {
-    STR_MONTH_MARCH,
-    STR_MONTH_APRIL,
-    STR_MONTH_MAY,
-    STR_MONTH_JUNE,
-    STR_MONTH_JULY,
-    STR_MONTH_AUGUST,
-    STR_MONTH_SEPTEMBER,
-    STR_MONTH_OCTOBER,
-};
-
-const StringId DateGameShortMonthNames[MONTH_COUNT] = {
-    STR_MONTH_SHORT_MAR,
-    STR_MONTH_SHORT_APR,
-    STR_MONTH_SHORT_MAY,
-    STR_MONTH_SHORT_JUN,
-    STR_MONTH_SHORT_JUL,
-    STR_MONTH_SHORT_AUG,
-    STR_MONTH_SHORT_SEP,
-    STR_MONTH_SHORT_OCT,
-};
 // clang-format on
 
 std::string FormatStringID(StringId format, const void* args)

--- a/src/openrct2/localisation/Localisation.h
+++ b/src/openrct2/localisation/Localisation.h
@@ -63,6 +63,3 @@ extern const StringId ResearchFundingLevelNames[4];
 extern const StringId MarketingCampaignNames[ADVERTISING_CAMPAIGN_COUNT][3];
 extern const StringId RideInspectionIntervalNames[];
 extern const StringId PeepThoughts[174];
-extern const StringId DateDayNames[31];
-extern const StringId DateGameMonthNames[MONTH_COUNT];
-extern const StringId DateGameShortMonthNames[MONTH_COUNT];

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -320,7 +320,7 @@ money64 FinanceGetCurrentCash()
 void FinanceShiftExpenditureTable()
 {
     // If EXPENDITURE_TABLE_MONTH_COUNT months have passed then is full, sum the oldest month
-    if (gDate.GetMonthsElapsed() >= EXPENDITURE_TABLE_MONTH_COUNT)
+    if (GetDate().GetMonthsElapsed() >= EXPENDITURE_TABLE_MONTH_COUNT)
     {
         money64 sum = 0;
         for (uint32_t i = 0; i < static_cast<int32_t>(ExpenditureType::Count); i++)
@@ -363,7 +363,7 @@ void FinanceResetCashToInitial()
 money64 FinanceGetLastMonthShopProfit()
 {
     money64 profit = 0;
-    if (gDate.GetMonthsElapsed() != 0)
+    if (GetDate().GetMonthsElapsed() != 0)
     {
         const auto* lastMonthExpenditure = gExpenditureTable[1];
 

--- a/src/openrct2/management/Finance.cpp
+++ b/src/openrct2/management/Finance.cpp
@@ -320,7 +320,7 @@ money64 FinanceGetCurrentCash()
 void FinanceShiftExpenditureTable()
 {
     // If EXPENDITURE_TABLE_MONTH_COUNT months have passed then is full, sum the oldest month
-    if (gDateMonthsElapsed >= EXPENDITURE_TABLE_MONTH_COUNT)
+    if (gDate.GetMonthsElapsed() >= EXPENDITURE_TABLE_MONTH_COUNT)
     {
         money64 sum = 0;
         for (uint32_t i = 0; i < static_cast<int32_t>(ExpenditureType::Count); i++)
@@ -363,7 +363,7 @@ void FinanceResetCashToInitial()
 money64 FinanceGetLastMonthShopProfit()
 {
     money64 profit = 0;
-    if (gDateMonthsElapsed != 0)
+    if (gDate.GetMonthsElapsed() != 0)
     {
         const auto* lastMonthExpenditure = gExpenditureTable[1];
 

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -328,8 +328,8 @@ News::Item* News::AddItemToQueue(News::ItemType type, const utf8* text, uint32_t
     newsItem->Flags = 0;
     newsItem->Assoc = assoc; // Make optional for Award, Money, Graph and Null
     newsItem->Ticks = 0;
-    newsItem->MonthYear = static_cast<uint16_t>(gDateMonthsElapsed);
-    newsItem->Day = ((days_in_month[DateGetMonth(newsItem->MonthYear)] * gDateMonthTicks) >> 16) + 1;
+    newsItem->MonthYear = static_cast<uint16_t>(gDate.GetMonthsElapsed());
+    newsItem->Day = gDate.GetDay() + 1;
     newsItem->Text = text;
 
     return newsItem;

--- a/src/openrct2/management/NewsItem.cpp
+++ b/src/openrct2/management/NewsItem.cpp
@@ -323,13 +323,14 @@ News::Item* News::AddItemToQueue(ItemType type, StringId string_id, EntityId ass
 
 News::Item* News::AddItemToQueue(News::ItemType type, const utf8* text, uint32_t assoc)
 {
+    auto& date = GetDate();
     News::Item* newsItem = gNewsItems.FirstOpenOrNewSlot();
     newsItem->Type = type;
     newsItem->Flags = 0;
     newsItem->Assoc = assoc; // Make optional for Award, Money, Graph and Null
     newsItem->Ticks = 0;
-    newsItem->MonthYear = static_cast<uint16_t>(gDate.GetMonthsElapsed());
-    newsItem->Day = gDate.GetDay() + 1;
+    newsItem->MonthYear = static_cast<uint16_t>(date.GetMonthsElapsed());
+    newsItem->Day = date.GetDay() + 1;
     newsItem->Text = text;
 
     return newsItem;

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -9,6 +9,7 @@
 
 #include "Research.h"
 
+#include "../Date.h"
 #include "../Game.h"
 #include "../OpenRCT2.h"
 #include "../actions/ParkSetResearchFundingAction.h"
@@ -112,11 +113,11 @@ static void ResearchCalculateExpectedDate()
         progressRemaining -= gResearchProgress;
         int32_t daysRemaining = (progressRemaining / _researchRate[gResearchFundingLevel]) * 128;
 
-        int32_t expectedDay = gDateMonthTicks + (daysRemaining & 0xFFFF);
+        int32_t expectedDay = gDate.GetMonthTicks() + (daysRemaining & 0xFFFF);
         int32_t dayQuotient = expectedDay / 0x10000;
         int32_t dayRemainder = expectedDay % 0x10000;
 
-        int32_t expectedMonth = DateGetMonth(gDateMonthsElapsed + dayQuotient + (daysRemaining >> 16));
+        int32_t expectedMonth = DateGetMonth(gDate.GetMonthsElapsed() + dayQuotient + (daysRemaining >> 16));
         expectedDay = (dayRemainder * days_in_month[expectedMonth]) >> 16;
 
         gResearchExpectedDay = expectedDay;

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -109,16 +109,18 @@ static void ResearchCalculateExpectedDate()
     }
     else
     {
+        auto& date = GetDate();
+
         int32_t progressRemaining = gResearchProgressStage == RESEARCH_STAGE_COMPLETING_DESIGN ? 0x10000 : 0x20000;
         progressRemaining -= gResearchProgress;
         int32_t daysRemaining = (progressRemaining / _researchRate[gResearchFundingLevel]) * 128;
 
-        int32_t expectedDay = gDate.GetMonthTicks() + (daysRemaining & 0xFFFF);
+        int32_t expectedDay = date.GetMonthTicks() + (daysRemaining & 0xFFFF);
         int32_t dayQuotient = expectedDay / 0x10000;
         int32_t dayRemainder = expectedDay % 0x10000;
 
-        int32_t expectedMonth = DateGetMonth(gDate.GetMonthsElapsed() + dayQuotient + (daysRemaining >> 16));
-        expectedDay = (dayRemainder * days_in_month[expectedMonth]) >> 16;
+        int32_t expectedMonth = DateGetMonth(date.GetMonthsElapsed() + dayQuotient + (daysRemaining >> 16));
+        expectedDay = (dayRemainder * Date::GetDaysInMonth(expectedMonth)) >> 16;
 
         gResearchExpectedDay = expectedDay;
         gResearchExpectedMonth = expectedMonth;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "0"
+#define NETWORK_STREAM_VERSION "1"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -297,9 +297,10 @@ private:
             { "players", numPlayers },
         };
 
+        auto& date = GetDate();
         json_t mapSize = { { "x", gMapSize.x - 2 }, { "y", gMapSize.y - 2 } };
         json_t gameInfo = {
-            { "mapSize", mapSize },         { "day", gDate.GetMonthTicks() }, { "month", gDate.GetMonthsElapsed() },
+            { "mapSize", mapSize },         { "day", date.GetMonthTicks() }, { "month", date.GetMonthsElapsed() },
             { "guests", gNumGuestsInPark }, { "parkValue", gParkValue },
         };
         if (!(gParkFlags & PARK_FLAGS_NO_MONEY))

--- a/src/openrct2/network/NetworkServerAdvertiser.cpp
+++ b/src/openrct2/network/NetworkServerAdvertiser.cpp
@@ -299,7 +299,7 @@ private:
 
         json_t mapSize = { { "x", gMapSize.x - 2 }, { "y", gMapSize.y - 2 } };
         json_t gameInfo = {
-            { "mapSize", mapSize },         { "day", gDateMonthTicks },  { "month", gDateMonthsElapsed },
+            { "mapSize", mapSize },         { "day", gDate.GetMonthTicks() }, { "month", gDate.GetMonthsElapsed() },
             { "guests", gNumGuestsInPark }, { "parkValue", gParkValue },
         };
         if (!(gParkFlags & PARK_FLAGS_NO_MONEY))

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -479,8 +479,19 @@ namespace OpenRCT2
                     cs.Write(isPaused);
                 }
                 cs.ReadWrite(gCurrentTicks);
-                cs.ReadWrite(gDateMonthTicks);
-                cs.ReadWrite(gDateMonthsElapsed);
+                if (cs.GetMode() == OrcaStream::Mode::READING)
+                {
+                    uint16_t monthTicks;
+                    uint32_t monthsElapsed;
+                    cs.ReadWrite(monthTicks);
+                    cs.ReadWrite(monthsElapsed);
+                    gDate = Date(monthsElapsed, monthTicks);
+                }
+                else
+                {
+                    cs.Write(gDate.GetMonthTicks());
+                    cs.Write(gDate.GetMonthsElapsed());
+                }
 
                 if (cs.GetMode() == OrcaStream::Mode::READING)
                 {

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -485,12 +485,13 @@ namespace OpenRCT2
                     uint32_t monthsElapsed;
                     cs.ReadWrite(monthTicks);
                     cs.ReadWrite(monthsElapsed);
-                    gDate = Date(monthsElapsed, monthTicks);
+                    GetContext()->GetGameState()->SetDate(Date(monthsElapsed, monthTicks));
                 }
                 else
                 {
-                    cs.Write(gDate.GetMonthTicks());
-                    cs.Write(gDate.GetMonthsElapsed());
+                    auto& date = GetDate();
+                    cs.Write(date.GetMonthTicks());
+                    cs.Write(date.GetMonthsElapsed());
                 }
 
                 if (cs.GetMode() == OrcaStream::Mode::READING)

--- a/src/openrct2/platform/Platform.Linux.cpp
+++ b/src/openrct2/platform/Platform.Linux.cpp
@@ -28,6 +28,7 @@
 #        include <fontconfig/fontconfig.h>
 #    endif // NO_TTF
 
+#    include "../Date.h"
 #    include "../OpenRCT2.h"
 #    include "../core/Path.hpp"
 #    include "../localisation/Language.h"

--- a/src/openrct2/platform/Platform.Posix.cpp
+++ b/src/openrct2/platform/Platform.Posix.cpp
@@ -11,10 +11,10 @@
 
 #    include "Platform.h"
 
+#    include "../Date.h"
 #    include "../core/Memory.hpp"
 #    include "../core/Path.hpp"
 #    include "../core/String.hpp"
-#    include "../localisation/Date.h"
 #    include "../util/Util.h"
 
 #    include <cerrno>

--- a/src/openrct2/platform/Platform.Win32.cpp
+++ b/src/openrct2/platform/Platform.Win32.cpp
@@ -21,6 +21,7 @@
 #    include <shlobj.h>
 #    undef GetEnvironmentVariable
 
+#    include "../Date.h"
 #    include "../OpenRCT2.h"
 #    include "../common.h"
 #    include "../core/Path.hpp"

--- a/src/openrct2/platform/Platform.h
+++ b/src/openrct2/platform/Platform.h
@@ -40,13 +40,7 @@ enum class SPECIAL_FOLDER
     RCT2_DISCORD,
 };
 
-struct RealWorldDate
-{
-    uint8_t day;
-    uint8_t month;
-    int16_t year;
-    uint8_t day_of_week;
-};
+struct RealWorldDate;
 struct RealWorldTime;
 
 namespace Platform

--- a/src/openrct2/platform/Platform.macOS.mm
+++ b/src/openrct2/platform/Platform.macOS.mm
@@ -9,11 +9,13 @@
 
 #if defined(__APPLE__) && defined(__MACH__)
 
+#    include "Platform.h"
+
+#    include "../Date.h"
 #    include "../OpenRCT2.h"
 #    include "../core/Path.hpp"
 #    include "../core/String.hpp"
 #    include "../localisation/Language.h"
-#    include "Platform.h"
 
 // undefine `interface` and `abstract`, because it's causing conflicts with Objective-C's keywords
 #    undef interface

--- a/src/openrct2/platform/Shared.cpp
+++ b/src/openrct2/platform/Shared.cpp
@@ -7,6 +7,7 @@
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
 
+#include "../Date.h"
 #include "../common.h"
 
 #ifdef _WIN32

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2121,7 +2121,7 @@ namespace RCT1
             // Date and srand
             gCurrentTicks = _s4.Ticks;
             ScenarioRandSeed(_s4.RandomA, _s4.RandomB);
-            gDate = Date(_s4.Month, _s4.Day);
+            GetContext()->GetGameState()->SetDate(Date(_s4.Month, _s4.Day));
 
             // Park rating
             gParkRating = _s4.ParkRating;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2121,8 +2121,7 @@ namespace RCT1
             // Date and srand
             gCurrentTicks = _s4.Ticks;
             ScenarioRandSeed(_s4.RandomA, _s4.RandomB);
-            gDateMonthsElapsed = static_cast<int32_t>(_s4.Month);
-            gDateMonthTicks = _s4.Day;
+            gDate = Date(_s4.Month, _s4.Day);
 
             // Park rating
             gParkRating = _s4.ParkRating;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -249,7 +249,7 @@ namespace RCT2
                 gScenarioDetails = loadMaybeUTF8(_s6.ScenarioDescription);
             }
 
-            gDate = OpenRCT2::Date(_s6.ElapsedMonths, _s6.CurrentDay);
+            OpenRCT2::GetContext()->GetGameState()->SetDate(OpenRCT2::Date(_s6.ElapsedMonths, _s6.CurrentDay));
             gCurrentTicks = _s6.GameTicks1;
 
             ScenarioRandSeed(_s6.ScenarioSrand0, _s6.ScenarioSrand1);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -249,8 +249,7 @@ namespace RCT2
                 gScenarioDetails = loadMaybeUTF8(_s6.ScenarioDescription);
             }
 
-            gDateMonthsElapsed = static_cast<int32_t>(_s6.ElapsedMonths);
-            gDateMonthTicks = _s6.CurrentDay;
+            gDate = OpenRCT2::Date(_s6.ElapsedMonths, _s6.CurrentDay);
             gCurrentTicks = _s6.GameTicks1;
 
             ScenarioRandSeed(_s6.ScenarioSrand0, _s6.ScenarioSrand1);

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -307,7 +307,7 @@ size_t Ride::GetNumPrices() const
 
 int32_t Ride::GetAge() const
 {
-    return gDate.GetMonthsElapsed() - build_date;
+    return GetDate().GetMonthsElapsed() - build_date;
 }
 
 int32_t Ride::GetTotalQueueLength() const
@@ -953,7 +953,7 @@ void ResetAllRideBuildDates()
 {
     for (auto& ride : GetRideManager())
     {
-        ride.build_date -= gDate.GetMonthsElapsed();
+        ride.build_date -= GetDate().GetMonthsElapsed();
     }
 }
 
@@ -5162,7 +5162,7 @@ void Ride::Delete()
 void Ride::Renew()
 {
     // Set build date to current date (so the ride is brand new)
-    build_date = gDate.GetMonthsElapsed();
+    build_date = GetDate().GetMonthsElapsed();
     reliability = RIDE_INITIAL_RELIABILITY;
 }
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -307,7 +307,7 @@ size_t Ride::GetNumPrices() const
 
 int32_t Ride::GetAge() const
 {
-    return gDateMonthsElapsed - build_date;
+    return gDate.GetMonthsElapsed() - build_date;
 }
 
 int32_t Ride::GetTotalQueueLength() const
@@ -953,7 +953,7 @@ void ResetAllRideBuildDates()
 {
     for (auto& ride : GetRideManager())
     {
-        ride.build_date -= gDateMonthsElapsed;
+        ride.build_date -= gDate.GetMonthsElapsed();
     }
 }
 
@@ -5162,7 +5162,7 @@ void Ride::Delete()
 void Ride::Renew()
 {
     // Set build date to current date (so the ride is brand new)
-    build_date = gDateMonthsElapsed;
+    build_date = gDate.GetMonthsElapsed();
     reliability = RIDE_INITIAL_RELIABILITY;
 }
 

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -11,6 +11,7 @@
 
 #include "../Cheats.h"
 #include "../Context.h"
+#include "../Date.h"
 #include "../FileClassifier.h"
 #include "../Game.h"
 #include "../GameState.h"
@@ -326,7 +327,7 @@ static void ScenarioDayUpdate()
 
 static void ScenarioWeekUpdate()
 {
-    int32_t month = DateGetMonth(gDateMonthsElapsed);
+    int32_t month = gDate.GetMonth();
 
     FinancePayWages();
     FinancePayResearch();
@@ -369,7 +370,7 @@ static void ScenarioUpdateDayNightCycle()
 
     if (gScreenFlags == SCREEN_FLAGS_PLAYING && gConfigGeneral.DayNightCycle)
     {
-        float monthFraction = gDateMonthTicks / static_cast<float>(TICKS_PER_MONTH);
+        float monthFraction = gDate.GetMonthTicks() / static_cast<float>(TICKS_PER_MONTH);
         if (monthFraction < (1 / 8.0f))
         {
             gDayNightCycle = 0.0f;
@@ -409,19 +410,19 @@ void ScenarioUpdate()
 
     if (gScreenFlags == SCREEN_FLAGS_PLAYING)
     {
-        if (DateIsDayStart(gDateMonthTicks))
+        if (gDate.IsDayStart())
         {
             ScenarioDayUpdate();
         }
-        if (DateIsWeekStart(gDateMonthTicks))
+        if (gDate.IsWeekStart())
         {
             ScenarioWeekUpdate();
         }
-        if (DateIsFortnightStart(gDateMonthTicks))
+        if (gDate.IsFortnightStart())
         {
             ScenarioFortnightUpdate();
         }
-        if (DateIsMonthStart(gDateMonthTicks))
+        if (gDate.IsMonthStart())
         {
             ScenarioMonthUpdate();
         }
@@ -617,7 +618,7 @@ ResultWithMessage ScenarioPrepareForSave()
 ObjectiveStatus Objective::CheckGuestsBy() const
 {
     auto parkRating = gParkRating;
-    auto currentMonthYear = gDateMonthsElapsed;
+    int32_t currentMonthYear = gDate.GetMonthsElapsed();
 
     if (currentMonthYear == MONTH_COUNT * Year || AllowEarlyCompletion())
     {
@@ -637,7 +638,7 @@ ObjectiveStatus Objective::CheckGuestsBy() const
 
 ObjectiveStatus Objective::CheckParkValueBy() const
 {
-    int32_t currentMonthYear = gDateMonthsElapsed;
+    int32_t currentMonthYear = gDate.GetMonthsElapsed();
     money64 objectiveParkValue = Currency;
     money64 parkValue = gParkValue;
 
@@ -695,7 +696,7 @@ ObjectiveStatus Objective::Check10RollerCoasters() const
  */
 ObjectiveStatus Objective::CheckGuestsAndRating() const
 {
-    if (gParkRating < 700 && gDateMonthsElapsed >= 1)
+    if (gParkRating < 700 && gDate.GetMonthsElapsed() >= 1)
     {
         gScenarioParkRatingWarningDays++;
         if (gScenarioParkRatingWarningDays == 1)

--- a/src/openrct2/scenario/Scenario.cpp
+++ b/src/openrct2/scenario/Scenario.cpp
@@ -159,7 +159,7 @@ void ScenarioReset()
     FinanceResetHistory();
     AwardReset();
     ResetAllRideBuildDates();
-    DateReset();
+    GetContext()->GetGameState()->ResetDate();
     Duck::RemoveAll();
     ParkCalculateSize();
     MapCountRemainingLandRights();
@@ -327,7 +327,7 @@ static void ScenarioDayUpdate()
 
 static void ScenarioWeekUpdate()
 {
-    int32_t month = gDate.GetMonth();
+    int32_t month = GetDate().GetMonth();
 
     FinancePayWages();
     FinancePayResearch();
@@ -370,7 +370,7 @@ static void ScenarioUpdateDayNightCycle()
 
     if (gScreenFlags == SCREEN_FLAGS_PLAYING && gConfigGeneral.DayNightCycle)
     {
-        float monthFraction = gDate.GetMonthTicks() / static_cast<float>(TICKS_PER_MONTH);
+        float monthFraction = GetDate().GetMonthTicks() / static_cast<float>(TICKS_PER_MONTH);
         if (monthFraction < (1 / 8.0f))
         {
             gDayNightCycle = 0.0f;
@@ -410,19 +410,20 @@ void ScenarioUpdate()
 
     if (gScreenFlags == SCREEN_FLAGS_PLAYING)
     {
-        if (gDate.IsDayStart())
+        auto& date = GetDate();
+        if (date.IsDayStart())
         {
             ScenarioDayUpdate();
         }
-        if (gDate.IsWeekStart())
+        if (date.IsWeekStart())
         {
             ScenarioWeekUpdate();
         }
-        if (gDate.IsFortnightStart())
+        if (date.IsFortnightStart())
         {
             ScenarioFortnightUpdate();
         }
-        if (gDate.IsMonthStart())
+        if (date.IsMonthStart())
         {
             ScenarioMonthUpdate();
         }
@@ -618,7 +619,7 @@ ResultWithMessage ScenarioPrepareForSave()
 ObjectiveStatus Objective::CheckGuestsBy() const
 {
     auto parkRating = gParkRating;
-    int32_t currentMonthYear = gDate.GetMonthsElapsed();
+    int32_t currentMonthYear = GetDate().GetMonthsElapsed();
 
     if (currentMonthYear == MONTH_COUNT * Year || AllowEarlyCompletion())
     {
@@ -638,7 +639,7 @@ ObjectiveStatus Objective::CheckGuestsBy() const
 
 ObjectiveStatus Objective::CheckParkValueBy() const
 {
-    int32_t currentMonthYear = gDate.GetMonthsElapsed();
+    int32_t currentMonthYear = GetDate().GetMonthsElapsed();
     money64 objectiveParkValue = Currency;
     money64 parkValue = gParkValue;
 
@@ -696,7 +697,7 @@ ObjectiveStatus Objective::Check10RollerCoasters() const
  */
 ObjectiveStatus Objective::CheckGuestsAndRating() const
 {
-    if (gParkRating < 700 && gDate.GetMonthsElapsed() >= 1)
+    if (gParkRating < 700 && GetDate().GetMonthsElapsed() >= 1)
     {
         gScenarioParkRatingWarningDays++;
         if (gScenarioParkRatingWarningDays == 1)

--- a/src/openrct2/scripting/bindings/world/ScDate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScDate.hpp
@@ -46,7 +46,7 @@ namespace OpenRCT2::Scripting
         void monthsElapsed_set(int32_t value)
         {
             ThrowIfGameStateNotMutable();
-            gDate = Date(value, gDate.GetMonthTicks());
+            GetContext()->GetGameState()->SetDate(Date(value, GetDate().GetMonthTicks()));
         }
 
         uint32_t monthProgress_get() const
@@ -58,7 +58,7 @@ namespace OpenRCT2::Scripting
         void monthProgress_set(int32_t value)
         {
             ThrowIfGameStateNotMutable();
-            gDate = Date(gDate.GetMonthsElapsed(), value);
+            GetContext()->GetGameState()->SetDate(Date(GetDate().GetMonthsElapsed(), value));
         }
 
         uint32_t yearsElapsed_get() const

--- a/src/openrct2/scripting/bindings/world/ScDate.hpp
+++ b/src/openrct2/scripting/bindings/world/ScDate.hpp
@@ -46,7 +46,7 @@ namespace OpenRCT2::Scripting
         void monthsElapsed_set(int32_t value)
         {
             ThrowIfGameStateNotMutable();
-            gDateMonthsElapsed = static_cast<int32_t>(value);
+            gDate = Date(value, gDate.GetMonthTicks());
         }
 
         uint32_t monthProgress_get() const
@@ -58,13 +58,13 @@ namespace OpenRCT2::Scripting
         void monthProgress_set(int32_t value)
         {
             ThrowIfGameStateNotMutable();
-            gDateMonthTicks = value;
+            gDate = Date(gDate.GetMonthsElapsed(), value);
         }
 
         uint32_t yearsElapsed_get() const
         {
             const auto& date = GetDate();
-            return date.GetMonthsElapsed() / 8;
+            return date.GetYear();
         }
 
         uint32_t ticksElapsed_get() const

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -91,7 +91,7 @@ int32_t ClimateCelsiusToFahrenheit(int32_t celsius)
 void ClimateReset(ClimateType climate)
 {
     auto weather = WeatherType::PartiallyCloudy;
-    int32_t month = gDate.GetMonth();
+    int32_t month = GetDate().GetMonth();
     const WeatherTransition* transition = &ClimateTransitions[static_cast<uint8_t>(climate)][month];
     const WeatherState* weatherState = &ClimateWeatherData[EnumValue(weather)];
 
@@ -197,7 +197,7 @@ void ClimateUpdate()
 
 void ClimateForceWeather(WeatherType weather)
 {
-    int32_t month = gDate.GetMonth();
+    int32_t month = GetDate().GetMonth();
     const WeatherTransition* transition = &ClimateTransitions[static_cast<uint8_t>(gClimate)][month];
     const auto weatherState = &ClimateWeatherData[EnumValue(weather)];
 
@@ -295,7 +295,7 @@ static int8_t ClimateStepWeatherLevel(int8_t currentWeatherLevel, int8_t nextWea
  */
 static void ClimateDetermineFutureWeather(int32_t randomDistribution)
 {
-    int32_t month = gDate.GetMonth();
+    int32_t month = GetDate().GetMonth();
 
     // Generate a random variable with values 0 up to DistributionSize-1 and chose weather from the distribution table
     // accordingly

--- a/src/openrct2/world/Climate.cpp
+++ b/src/openrct2/world/Climate.cpp
@@ -91,7 +91,7 @@ int32_t ClimateCelsiusToFahrenheit(int32_t celsius)
 void ClimateReset(ClimateType climate)
 {
     auto weather = WeatherType::PartiallyCloudy;
-    int32_t month = DateGetMonth(gDateMonthsElapsed);
+    int32_t month = gDate.GetMonth();
     const WeatherTransition* transition = &ClimateTransitions[static_cast<uint8_t>(climate)][month];
     const WeatherState* weatherState = &ClimateWeatherData[EnumValue(weather)];
 
@@ -197,7 +197,7 @@ void ClimateUpdate()
 
 void ClimateForceWeather(WeatherType weather)
 {
-    int32_t month = DateGetMonth(gDateMonthsElapsed);
+    int32_t month = gDate.GetMonth();
     const WeatherTransition* transition = &ClimateTransitions[static_cast<uint8_t>(gClimate)][month];
     const auto weatherState = &ClimateWeatherData[EnumValue(weather)];
 
@@ -295,7 +295,7 @@ static int8_t ClimateStepWeatherLevel(int8_t currentWeatherLevel, int8_t nextWea
  */
 static void ClimateDetermineFutureWeather(int32_t randomDistribution)
 {
-    int32_t month = DateGetMonth(gDateMonthsElapsed);
+    int32_t month = gDate.GetMonth();
 
     // Generate a random variable with values 0 up to DistributionSize-1 and chose weather from the distribution table
     // accordingly

--- a/test/tests/MultiLaunch.cpp
+++ b/test/tests/MultiLaunch.cpp
@@ -48,8 +48,11 @@ TEST(MultiLaunchTest, all)
         ASSERT_EQ(RideGetCount(), 134);
         auto gs = context->GetGameState();
         ASSERT_NE(gs, nullptr);
+
         auto& date = gs->GetDate();
-        ASSERT_EQ(date.GetMonthTicks(), 0);
+        // NOTE: This value is saved in the SV6 file, after the import this will be the current state.
+        // In case the save file gets replaced this needs to be adjusted.
+        ASSERT_EQ(date.GetMonthTicks(), 0x1e98);
 
         for (int j = 0; j < updatesToTest; j++)
         {


### PR DESCRIPTION
Probably best if reviewed by both @ZehMatt and @IntelOrca .

This cleans up some aspects of dates:
- Moves all the functions that are not localisation-related from `Localisation.Date` to `Date`
- Moves some date-related localisation stuff _to_ `Localisation.Date`
- Use 0-index year, month and day in Game Action (needs network version bump!)
- Use `Date` type for `gDate` instead of two separate variables
- Clean up duplicate date functions
- Makes the `date` command in the legacy console network-safe