### PR TITLE
Part of #19608: improve error reporting of zip command failure

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -213,7 +213,7 @@ The following people are not part of the development team, but have been contrib
 * Ernest Elgin (eaeiv)
 * Ernest Wong (ErnWong)
 * Joel H. (HtotheTML)
-
+* John Mulcahy (jayjay300)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/src/openrct2/core/Zip.cpp
+++ b/src/openrct2/core/Zip.cpp
@@ -181,7 +181,7 @@ public:
         if (res == -1)
         {
             zip_source_free(source);
-            throw std::runtime_error("Unable to set file contents.");
+            throw std::runtime_error(std::string(zip_strerror(_zip)));
         }
     }
 


### PR DESCRIPTION
Error is actually returned as a string on the original archive object, so can just be passed to runtime_error as before but providing more information on root cause of failure.