### PR TITLE
Improve ride rating calculation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,9 @@ set(OPENMSX_VERSION "1.1.0")
 set(OPENMSX_URL  "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA1 "8f0cf6b2fd4727e91b0d4062e7f199a43d15e777")
 
-set(REPLAYS_VERSION "0.0.75")
+set(REPLAYS_VERSION "0.0.76")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "D1701450AE0FE84B144236243A925801B67D92ED")
+set(REPLAYS_SHA1 "AE5808DE726D27F5311731677A20C96A8FF9101F")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -30,6 +30,7 @@
 - Improved: [#19463] Added ‘W’ and ‘Y’ with circumflex to sprite font (for Welsh).
 - Improved: [#19549] Enable large address awareness for 32 bit Windows builds allowing to use 4 GiB of virtual memory.
 - Improved: [#19668] Decreased the minimum map size from 13 to 3.
+- Improved: [#19683] The delays for ride ratings to appear has been reduced drastically.
 - Change: [#19018] Renamed actions to fit the naming scheme.
 - Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
 - Change: [#19233] Reduce lift speed minimum and maximum values for “Classic Wooden Coaster”.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -51,8 +51,8 @@
     <OpenSFXSha1>64EF7E0B7785602C91AEC66F005C035B05A2133B</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.1.0/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha1>8f0cf6b2fd4727e91b0d4062e7f199a43d15e777</OpenMSXSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.75/replays.zip</ReplaysUrl>
-    <ReplaysSha1>D1701450AE0FE84B144236243A925801B67D92ED</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.76/replays.zip</ReplaysUrl>
+    <ReplaysSha1>AE5808DE726D27F5311731677A20C96A8FF9101F</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "12"
+#define NETWORK_STREAM_VERSION "13"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -536,7 +536,25 @@ namespace OpenRCT2
                 cs.ReadWrite(gGrassSceneryTileLoopPosition);
                 cs.ReadWrite(gWidePathTileLoopPosition);
 
-                ReadWriteRideRatingCalculationData(cs, gRideRatingUpdateState);
+                auto& rideRatings = RideRatingGetUpdateStates();
+                if (os.GetHeader().TargetVersion >= 21)
+                {
+                    cs.ReadWriteArray(rideRatings, [this, &cs](RideRatingUpdateState& calcData) {
+                        ReadWriteRideRatingCalculationData(cs, calcData);
+                        return true;
+                    });
+                }
+                else
+                {
+                    // Only single state was stored prior to version 20.
+                    if (os.GetMode() == OrcaStream::Mode::READING)
+                    {
+                        // Since we read only one state ensure the rest is reset.
+                        RideRatingResetUpdateStates();
+                    }
+                    auto& rideRatingUpdateState = rideRatings[0];
+                    ReadWriteRideRatingCalculationData(cs, rideRatingUpdateState);
+                }
 
                 if (os.GetHeader().TargetVersion >= 14)
                 {

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -12,7 +12,7 @@ namespace OpenRCT2
     constexpr uint32_t PARK_FILE_CURRENT_VERSION = 21;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t PARK_FILE_MIN_VERSION = 19;
+    constexpr uint32_t PARK_FILE_MIN_VERSION = 21;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -9,7 +9,7 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 20;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 21;
 
     // The minimum version that is forwards compatible with the current version.
     constexpr uint32_t PARK_FILE_MIN_VERSION = 19;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1097,7 +1097,10 @@ namespace RCT2
         void ImportRideRatingsCalcData()
         {
             const auto& src = _s6.RideRatingsCalcData;
-            auto& dst = gRideRatingUpdateState;
+            // S6 has only one state, ensure we reset all states before reading the first one.
+            RideRatingResetUpdateStates();
+            auto& rideRatingStates = RideRatingGetUpdateStates();
+            auto& dst = rideRatingStates[0];
             dst = {};
             dst.Proximity = { src.ProximityX, src.ProximityY, src.ProximityZ };
             dst.ProximityStart = { src.ProximityStartX, src.ProximityStartY, src.ProximityStartZ };

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -77,7 +77,7 @@ struct ShelteredEights
     uint8_t TotalShelteredEighths;
 };
 
-RideRatingUpdateState gRideRatingUpdateState;
+static RideRatingUpdateStates gRideRatingUpdateStates;
 
 static void ride_ratings_update_state(RideRatingUpdateState& state);
 static void ride_ratings_update_state_0(RideRatingUpdateState& state);
@@ -92,6 +92,25 @@ static void RideRatingsCalculateValue(Ride& ride);
 static void ride_ratings_score_close_proximity(RideRatingUpdateState& state, TileElement* inputTileElement);
 
 static void ride_ratings_add(RatingTuple* rating, int32_t excitement, int32_t intensity, int32_t nausea);
+
+RideRatingUpdateStates& RideRatingGetUpdateStates()
+{
+    return gRideRatingUpdateStates;
+}
+
+void RideRatingResetUpdateStates()
+{
+    RideRatingUpdateState nullState{};
+    nullState.State = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
+
+    std::fill(gRideRatingUpdateStates.begin(), gRideRatingUpdateStates.end(), nullState);
+}
+
+RideRatingUpdateState& RideRatingGetUpdateState(size_t index)
+{
+    Guard::IndexInRange(index, gRideRatingUpdateStates);
+    return gRideRatingUpdateStates[index];
+}
 
 /**
  * This is a small hack function to keep calling the ride rating processor until
@@ -126,7 +145,7 @@ void RideRatingsUpdateAll()
 
     // NOTE: With the new save format more than one ride can be updated at once, but this has not yet been implemented.
     // The SV6 format could store only a single state.
-    ride_ratings_update_state(gRideRatingUpdateState);
+    ride_ratings_update_state(gRideRatingUpdateStates[0]);
 }
 
 static void ride_ratings_update_state(RideRatingUpdateState& state)

--- a/src/openrct2/ride/RideRatings.cpp
+++ b/src/openrct2/ride/RideRatings.cpp
@@ -6,6 +6,7 @@
  *
  * OpenRCT2 is licensed under the GNU General Public License version 3.
  *****************************************************************************/
+
 #include "RideRatings.h"
 
 #include "../Cheats.h"
@@ -107,12 +108,6 @@ void RideRatingResetUpdateStates()
     nullState.State = RIDE_RATINGS_STATE_FIND_NEXT_RIDE;
 
     std::fill(gRideRatingUpdateStates.begin(), gRideRatingUpdateStates.end(), nullState);
-}
-
-RideRatingUpdateState& RideRatingGetUpdateState(size_t index)
-{
-    Guard::IndexInRange(index, gRideRatingUpdateStates);
-    return gRideRatingUpdateStates[index];
 }
 
 /**

--- a/src/openrct2/ride/RideRatings.h
+++ b/src/openrct2/ride/RideRatings.h
@@ -54,7 +54,12 @@ struct RideRatingUpdateState
     uint16_t StationFlags;
 };
 
-extern RideRatingUpdateState gRideRatingUpdateState;
+static constexpr size_t RideRatingMaxUpdateStates = 4;
+
+using RideRatingUpdateStates = std::array<RideRatingUpdateState, RideRatingMaxUpdateStates>;
+
+RideRatingUpdateStates& RideRatingGetUpdateStates();
+void RideRatingResetUpdateStates();
 
 void RideRatingsUpdateRide(const Ride& ride);
 void RideRatingsUpdateAll();


### PR DESCRIPTION
A couple of things this PR does:
- Has now 4 states that can be updated rather than a single ride only.
- The previous implementation did not skip shops/facilities and instead spent an entire tick to reset the state machine, now it filters rides beforehand so it wont potentially do one tick nothing but initialize data and discard it the next tick. it also considers some other ride states.
- Updating the ride state now has sub-stepping updates to process more data without rewriting the entire state machine, because there is still a problem with hacked rides we can't allow processing it all at once currently, there seems to be no real performance impact doing it like this, I did a bit of testing and 20 sub steps seem to hardly impact the overall framerate, could probably raise this even further but it now updates all rides in a couple of seconds which seemed good enough to me.

My testing shows that iterating and updating all rides takes only a couple seconds now. This will probably break bpb replay as the calculation goes a lot faster now.