### PR TITLE
Fix #19694: Show guest purchases influencing the game state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,9 @@ set(OPENMSX_VERSION "1.1.0")
 set(OPENMSX_URL  "https://github.com/OpenRCT2/OpenMusic/releases/download/v${OPENMSX_VERSION}/openmusic.zip")
 set(OPENMSX_SHA1 "8f0cf6b2fd4727e91b0d4062e7f199a43d15e777")
 
-set(REPLAYS_VERSION "0.0.76")
+set(REPLAYS_VERSION "0.0.77")
 set(REPLAYS_URL  "https://github.com/OpenRCT2/replays/releases/download/v${REPLAYS_VERSION}/replays.zip")
-set(REPLAYS_SHA1 "AE5808DE726D27F5311731677A20C96A8FF9101F")
+set(REPLAYS_SHA1 "65CA6D830789C074F575F15E3F9E2C28691C24F8")
 
 option(FORCE32 "Force 32-bit build. It will add `-m32` to compiler flags.")
 option(WITH_TESTS "Build tests")

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -31,6 +31,7 @@
 - Improved: [#19549] Enable large address awareness for 32 bit Windows builds allowing to use 4 GiB of virtual memory.
 - Improved: [#19668] Decreased the minimum map size from 13 to 3.
 - Improved: [#19683] The delays for ride ratings to appear has been reduced drastically.
+- Improved: [#19697] “Show guest purchases” will now work in multiplayer.
 - Change: [#19018] Renamed actions to fit the naming scheme.
 - Change: [#19091] [Plugin] Add game action information to callback arguments of custom actions.
 - Change: [#19233] Reduce lift speed minimum and maximum values for “Classic Wooden Coaster”.

--- a/openrct2.proj
+++ b/openrct2.proj
@@ -51,8 +51,8 @@
     <OpenSFXSha1>64EF7E0B7785602C91AEC66F005C035B05A2133B</OpenSFXSha1>
     <OpenMSXUrl>https://github.com/OpenRCT2/OpenMusic/releases/download/v1.1.0/openmusic.zip</OpenMSXUrl>
     <OpenMSXSha1>8f0cf6b2fd4727e91b0d4062e7f199a43d15e777</OpenMSXSha1>
-    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.76/replays.zip</ReplaysUrl>
-    <ReplaysSha1>AE5808DE726D27F5311731677A20C96A8FF9101F</ReplaysSha1>
+    <ReplaysUrl>https://github.com/OpenRCT2/replays/releases/download/v0.0.77/replays.zip</ReplaysUrl>
+    <ReplaysSha1>65CA6D830789C074F575F15E3F9E2C28691C24F8</ReplaysSha1>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -468,7 +468,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(MoneyEffect, frame);
         COMPARE_FIELD(MoneyEffect, MoveDelay);
         COMPARE_FIELD(MoneyEffect, NumMovements);
-        COMPARE_FIELD(MoneyEffect, Vertical);
+        COMPARE_FIELD(MoneyEffect, GuestPurchase);
         COMPARE_FIELD(MoneyEffect, Value);
         COMPARE_FIELD(MoneyEffect, OffsetX);
         COMPARE_FIELD(MoneyEffect, Wiggle);

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2300,15 +2300,7 @@ void Guest::SpendMoney(money64& peep_expend_type, money64 amount, ExpenditureTyp
 
     FinancePayment(-amount, expenditure);
 
-    if (gConfigGeneral.ShowGuestPurchases && !(gScreenFlags & SCREEN_FLAGS_TITLE_DEMO))
-    {
-        // HACK Currently disabled for multiplayer due to limitation of all sprites
-        //      needing to be synchronised
-        if (NetworkGetMode() == NETWORK_MODE_NONE && !gOpenRCT2Headless)
-        {
-            MoneyEffect::CreateAt(amount, GetLocation(), true);
-        }
-    }
+    MoneyEffect::CreateAt(amount, GetLocation(), true);
 
     OpenRCT2::Audio::Play3D(OpenRCT2::Audio::SoundId::Purchase, GetLocation());
 }

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -37,7 +37,7 @@ template<> bool EntityBase::Is<MoneyEffect>() const
  *
  *  rct2: 0x0067351F
  */
-void MoneyEffect::CreateAt(money64 value, const CoordsXYZ& effectPos, bool vertical)
+void MoneyEffect::CreateAt(money64 value, const CoordsXYZ& effectPos, bool guestPurchase)
 {
     if (value == 0.00_GBP)
         return;
@@ -47,7 +47,7 @@ void MoneyEffect::CreateAt(money64 value, const CoordsXYZ& effectPos, bool verti
         return;
 
     moneyEffect->Value = value;
-    moneyEffect->Vertical = (vertical ? 1 : 0);
+    moneyEffect->GuestPurchase = (guestPurchase ? 1 : 0);
     moneyEffect->sprite_width = 64;
     moneyEffect->sprite_height_negative = 20;
     moneyEffect->sprite_height_positive = 30;
@@ -123,7 +123,7 @@ void MoneyEffect::Update()
     int32_t newZ = z;
     MoveDelay = 0;
 
-    if (Vertical)
+    if (GuestPurchase)
     {
         newZ += 1;
     }
@@ -143,8 +143,8 @@ void MoneyEffect::Update()
 
 std::pair<StringId, money64> MoneyEffect::GetStringId() const
 {
-    StringId spentStringId = Vertical ? STR_MONEY_EFFECT_SPEND_HIGHP : STR_MONEY_EFFECT_SPEND;
-    StringId receiveStringId = Vertical ? STR_MONEY_EFFECT_RECEIVE_HIGHP : STR_MONEY_EFFECT_RECEIVE;
+    StringId spentStringId = GuestPurchase ? STR_MONEY_EFFECT_SPEND_HIGHP : STR_MONEY_EFFECT_SPEND;
+    StringId receiveStringId = GuestPurchase ? STR_MONEY_EFFECT_RECEIVE_HIGHP : STR_MONEY_EFFECT_RECEIVE;
     StringId stringId = receiveStringId;
     money64 outValue = Value;
     if (Value < 0)
@@ -162,7 +162,7 @@ void MoneyEffect::Serialise(DataSerialiser& stream)
     stream << frame;
     stream << MoveDelay;
     stream << NumMovements;
-    stream << Vertical;
+    stream << GuestPurchase;
     stream << Value;
     stream << OffsetX;
     stream << Wiggle;

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -9,6 +9,7 @@
 #include "MoneyEffect.h"
 
 #include "../OpenRCT2.h"
+#include "../config/Config.h"
 #include "../core/DataSerialiser.h"
 #include "../drawing/Drawing.h"
 #include "../interface/Viewport.h"
@@ -171,6 +172,18 @@ void MoneyEffect::Serialise(DataSerialiser& stream)
 void MoneyEffect::Paint(PaintSession& session, int32_t imageDirection) const
 {
     PROFILED_FUNCTION();
+
+    if (gScreenFlags & SCREEN_FLAGS_TITLE_DEMO)
+    {
+        // Don't render any money in the title screen.
+        return;
+    }
+
+    if (GuestPurchase && !gConfigGeneral.ShowGuestPurchases)
+    {
+        // Don't show the money effect for guest purchases when the option is disabled.
+        return;
+    }
 
     DrawPixelInfo& dpi = session.DPI;
     if (dpi.zoom_level > ZoomLevel{ 0 })

--- a/src/openrct2/entity/MoneyEffect.h
+++ b/src/openrct2/entity/MoneyEffect.h
@@ -22,12 +22,12 @@ struct MoneyEffect : EntityBase
     uint16_t frame;
     uint16_t MoveDelay;
     uint8_t NumMovements;
-    uint8_t Vertical;
+    uint8_t GuestPurchase;
     money64 Value;
     int16_t OffsetX;
     uint16_t Wiggle;
 
-    static void CreateAt(money64 value, const CoordsXYZ& effectPos, bool vertical);
+    static void CreateAt(money64 value, const CoordsXYZ& effectPos, bool guestPurchase);
     static void Create(money64 value, const CoordsXYZ& loc);
     void Update();
     std::pair<StringId, money64> GetStringId() const;

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "13"
+#define NETWORK_STREAM_VERSION "14"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -2311,7 +2311,7 @@ namespace OpenRCT2
         ReadWriteEntityCommon(cs, moneyEffect);
         cs.ReadWrite(moneyEffect.MoveDelay);
         cs.ReadWrite(moneyEffect.NumMovements);
-        cs.ReadWrite(moneyEffect.Vertical);
+        cs.ReadWrite(moneyEffect.GuestPurchase);
         cs.ReadWrite(moneyEffect.Value);
         cs.ReadWrite(moneyEffect.OffsetX);
         cs.ReadWrite(moneyEffect.Wiggle);

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -2966,7 +2966,7 @@ namespace RCT1
         ImportEntityCommonProperties(dst, src);
         dst->MoveDelay = src->MoveDelay;
         dst->NumMovements = src->NumMovements;
-        dst->Vertical = src->Vertical;
+        dst->GuestPurchase = src->Vertical;
         dst->Value = src->Value;
         dst->OffsetX = src->OffsetX;
         dst->Wiggle = src->Wiggle;

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -2197,7 +2197,7 @@ namespace RCT2
         ImportEntityCommonProperties(dst, src);
         dst->MoveDelay = src->MoveDelay;
         dst->NumMovements = src->NumMovements;
-        dst->Vertical = src->Vertical;
+        dst->GuestPurchase = src->Vertical;
         dst->Value = src->Value;
         dst->OffsetX = src->OffsetX;
         dst->Wiggle = src->Wiggle;


### PR DESCRIPTION
I renamed Vertical to GuestPurchase as this also better matches the actual usage of the variable. Money will no longer be conditionally created for guest purchases and instead hides the money when the option to show guest purchases is disabled which keeps the game state identical regardless of the user choice.

This makes it also safe for network play, people can now turn the option on or off without having any side effects on the entity registry. This most likely will invalidate bpb replay

Closes #19694