### PR TITLE
Fix #19692: Windows artifact upload failing

### DIFF
--- a/scripts/upload-build
+++ b/scripts/upload-build
@@ -33,7 +33,11 @@ if [ -z "$OPENRCT2_ORG_TOKEN" ]; then
     echo -e "\033[0;31mOPENRCT2_ORG_TOKEN not set"
     exit 1
 fi
+# Use HTTP1.1 as a workaround for curl bug:
+# https://github.com/actions/runner-images/issues/7329
+# https://github.com/curl/curl/issues/10591
 curl --include -m 300 --connect-timeout 5 -o - \
+    --http1.1 \
     --form "key=$OPENRCT2_ORG_TOKEN" \
     --form "fileName=$filename" \
     --form "version=$version" \


### PR DESCRIPTION
I was able to reproduce missing server response in github actions in default curl configuration and expected output when using http1.1.

Job logs are at
https://github.com/OpenRCT2/OpenRCT2/actions/runs/4535411162/jobs/7990845440