### PR TITLE
Fix #19296: Race condition for parallel object loading

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -1,5 +1,6 @@
 0.4.5 (in development)
 ------------------------------------------------------------------------
+- Fix: [#19296] Crash due to a race condition for parallel object loading.
 - Fix: [#19756] Crash with title sequences containing no commands.
 
 0.4.4 (2023-03-28)

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -636,6 +636,7 @@ private:
                 continue;
             }
             requiredObject.LoadedObject = loadedObject;
+            objects.push_back(loadedObject);
         }
 
         // Load objects

--- a/src/openrct2/object/ObjectManager.cpp
+++ b/src/openrct2/object/ObjectManager.cpp
@@ -580,18 +580,18 @@ private:
 
         // Create a list of objects that are currently not loaded but required.
         std::vector<const ObjectRepositoryItem*> objectsToLoad;
-        for (auto& otl : requiredObjects)
+        for (auto& requiredObject : requiredObjects)
         {
-            auto* requiredObject = otl.RepositoryItem;
-            if (requiredObject == nullptr)
+            auto* repositoryItem = requiredObject.RepositoryItem;
+            if (repositoryItem == nullptr)
             {
                 continue;
             }
 
-            auto* loadedObject = requiredObject->LoadedObject.get();
+            auto* loadedObject = repositoryItem->LoadedObject.get();
             if (loadedObject == nullptr)
             {
-                objectsToLoad.push_back(requiredObject);
+                objectsToLoad.push_back(repositoryItem);
             }
         }
 


### PR DESCRIPTION
Finally managed to reproduce the issue and investigate it. It's racing `LoadedObject` because `requiredObjects` can contain multiple entries that point to the same repository object so two threads can potentially try loading the object at the same time where normally if the object is already loaded it wouldn't have to do it. The PR creates now a list of objects that are not yet loaded and de-duplicates them before loading them, after loading it will simply assign to the required object the loaded object making it thread safe.

Closes #19296 and all of https://github.com/OpenRCT2/OpenRCT2/issues?q=is%3Aissue+is%3Aopen+ObjectManager%3A%3ALoadObjects