### PR TITLE
Move duplicate RCT1 scenarios to "Other Parks" category

### DIFF
--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -751,7 +751,7 @@ static void InitialiseListItems(WindowBase* w)
         ScenarioListItem scenarioItem;
         scenarioItem.type = ListItemType::Scenario;
         scenarioItem.scenario.scenario = scenario;
-        if (IsLockingEnabled(w))
+        if (IsLockingEnabled(w) && scenario->Category <= SCENARIO_CATEGORY_EXPERT)
         {
             scenarioItem.scenario.is_locked = numUnlocks <= 0;
             if (scenario->Highscore == nullptr)

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -770,7 +770,7 @@ static void InitialiseListItems(WindowBase* w)
             // If scenario is Mega Park, keep a reference to it
             if (scenario->ScenarioId == SC_MEGA_PARK)
             {
-                megaParkListItemIndex = _listItems.size() - 1;
+                megaParkListItemIndex = _listItems.size();
             }
         }
         else
@@ -788,7 +788,7 @@ static void InitialiseListItems(WindowBase* w)
         if (megaParkLocked && gConfigGeneral.ScenarioHideMegaPark)
         {
             // Remove mega park
-            _listItems.pop_back();
+            _listItems.erase(_listItems.begin() + megaParkListItemIndex);
 
             // Remove empty headings
             for (auto it = _listItems.begin(); it != _listItems.end();)

--- a/src/openrct2/scenario/ScenarioRepository.cpp
+++ b/src/openrct2/scenario/ScenarioRepository.cpp
@@ -124,7 +124,7 @@ class ScenarioFileIndex final : public FileIndex<ScenarioIndexEntry>
 {
 private:
     static constexpr uint32_t MAGIC_NUMBER = 0x58444953; // SIDX
-    static constexpr uint16_t VERSION = 8;
+    static constexpr uint16_t VERSION = 9;
     static constexpr auto PATTERN = "*.sc4;*.sc6;*.sea;*.park";
 
 public:
@@ -306,6 +306,13 @@ private:
             entry.SourceIndex = desc.index;
             entry.SourceGame = ScenarioSource{ desc.source };
             entry.Category = desc.category;
+
+            // Put remakes of RCT1 scenarios in the other category if RCT1 is installed.
+            if (entry.SourceGame < ScenarioSource::RCT2 && !gConfigGeneral.RCT1Path.empty())
+            {
+                entry.SourceIndex = -1;
+                entry.Category = SCENARIO_CATEGORY_OTHER;
+            }
         }
         else
         {


### PR DESCRIPTION
When you have both RCT: Classic and RCT1 installed or have any of the other RCT1 scenario remakes in the custom content folder you will end up with duplicate entries on the RCT1 scenario tabs. This also messes up the park unlock progression as the duplicate parks need to be unlocked as well.

![image](https://user-images.githubusercontent.com/129334871/228669975-9a3d0ab3-ce09-444c-99c6-8ad55107f86f.png)

This PR moves the duplicate scenarios to the "Other Parks" category within the same tab allowing the player to easily see the difference between the original scenarios and the remakes without resorting to debug tools or deleting scenarios.

![image](https://user-images.githubusercontent.com/129334871/228670129-4a60f5cf-bb9f-40fc-98a7-008bf8bb48f4.png)

When sorting by difficulty level the scenarios all end up together in the "Other Parks" tab.

![image](https://user-images.githubusercontent.com/129334871/228671147-0fdeb0b4-a69f-472c-bb9c-32a073743c94.png)

This behavior only happens if remakes are found when the RCT1 path is set in the settings. So it won't affect users who exclusively use RCT: Classic or have other remakes in their custom content without having RCT1 installed.