### PR TITLE
Improve check whether path is connected

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,7 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#19296] Crash due to a race condition for parallel object loading.
 - Fix: [#19756] Crash with title sequences containing no commands.
-- Fix: [#19767] No alert/message when fence is blocking ride exit and is therefore unreachable for mechanics
+- Fix: [#19767] No message when path is not connected to ride exit and is therefore unreachable for mechanics.
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -2,6 +2,7 @@
 ------------------------------------------------------------------------
 - Fix: [#19296] Crash due to a race condition for parallel object loading.
 - Fix: [#19756] Crash with title sequences containing no commands.
+- Fix: [#19767] No alert/message when fence is blocking ride exit and is therefore unreachable for mechanics
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -703,7 +703,7 @@ bool MapCoordIsConnected(const TileCoordsXYZ& loc, uint8_t faceDirection)
         }
         else
         {
-            if (loc.z == tileElement->BaseHeight)
+            if (loc.z == tileElement->BaseHeight && (tileElement->AsPath()->GetEdges() & (faceDirection << 1)))
                 return true;
         }
     } while (!(tileElement++)->IsLastForTile());

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -703,7 +703,7 @@ bool MapCoordIsConnected(const TileCoordsXYZ& loc, uint8_t faceDirection)
         }
         else
         {
-            if (loc.z == tileElement->BaseHeight && (tileElement->AsPath()->GetEdges() & (faceDirection << 1)))
+            if (loc.z == tileElement->BaseHeight && (tileElement->AsPath()->GetEdges() & (1 << faceDirection)))
                 return true;
         }
     } while (!(tileElement++)->IsLastForTile());


### PR DESCRIPTION
Add a check in the game logic that checks if buildings are connected to a path to verify that the path is connected to the entrance, instead of just on the tile in front of the entrance.

Fixes #19767