### PR TITLE
Fix #13771: Refactor EditorObjectiveOptions to use Window class

### DIFF
--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -153,11 +153,11 @@ public:
         {
             case WIDX_CLOSE:
                 Close();
-                break;
+                return;
             case WIDX_TAB_1:
             case WIDX_TAB_2:
                 SetPage(widgetIndex - WIDX_TAB_1);
-                break;
+                return;
         }
 
         if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN)
@@ -264,6 +264,16 @@ public:
         {
             OnScrollDraw(scrollIndex, dpi);
         }
+    }
+
+    ScreenSize OnScrollGetSize(int32_t scrollIndex) override
+    {
+        if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
+        {
+            return OnScrollGetSize(scrollIndex);
+        }
+
+        return {};
     }
 
 private:
@@ -1006,6 +1016,19 @@ private:
             no_list_items = numItems;
             Invalidate();
         }
+    }
+
+    /**
+     *
+     *  rct2: 0x006724BF
+     */
+    ScreenSize OnScrollGetSizeRides(int32_t scrollIndex)
+    {
+        ScreenSize newSize;
+        newSize.height = no_list_items * 12;
+        newSize.width = width;
+
+        return newSize;
     }
 
     /**

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -13,24 +13,20 @@
 #include "Window.h"
 
 #include <algorithm>
-#include <iterator>
 #include <openrct2/Context.h>
 #include <openrct2/GameState.h>
 #include <openrct2/OpenRCT2.h>
 #include <openrct2/actions/ParkSetNameAction.h>
-#include <openrct2/core/String.hpp>
 #include <openrct2/drawing/Drawing.h>
 #include <openrct2/drawing/Font.h>
 #include <openrct2/interface/Colour.h>
 #include <openrct2/localisation/Date.h>
 #include <openrct2/localisation/Formatter.h>
 #include <openrct2/localisation/Language.h>
-#include <openrct2/localisation/Localisation.h>
 #include <openrct2/localisation/StringIds.h>
 #include <openrct2/ride/Ride.h>
 #include <openrct2/scenario/Scenario.h>
 #include <openrct2/sprites.h>
-#include <openrct2/util/Util.h>
 #include <openrct2/world/Park.h>
 
 static constexpr const StringId WINDOW_TITLE = STR_OBJECTIVE_SELECTION;
@@ -191,7 +187,930 @@ static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
 
 #pragma endregion
 
-static void WindowEditorObjectiveOptionsUpdateDisabledWidgets(WindowBase* w);
+class EditorObjectiveOptionsWindow : public Window
+{
+public:
+    void OnOpen() override
+    {
+        widgets = window_editor_objective_options_main_widgets;
+        pressed_widgets = 0;
+        hold_down_widgets = window_editor_objective_options_page_hold_down_widgets[WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN];
+        InitScrollWidgets();
+        selected_tab = WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN;
+        no_list_items = 0;
+        selected_list_item = -1;
+        UpdateDisabledWidgets();
+    }
+
+    void OnResize() override
+    {
+    }
+
+    void OnPrepareDraw() override
+    {
+    }
+
+private:
+    /**
+     *
+     *  rct2: 0x00668496
+     */
+    void SetPage(int32_t newPage)
+    {
+        if (page == newPage)
+            return;
+
+        page = newPage;
+        frame_no = 0;
+        var_492 = 0;
+        no_list_items = 0;
+        selected_list_item = -1;
+        hold_down_widgets = window_editor_objective_options_page_hold_down_widgets[newPage];
+        event_handlers = window_editor_objective_options_page_events[newPage];
+        widgets = window_editor_objective_options_widgets[newPage];
+        Invalidate();
+        UpdateDisabledWidgets();
+        OnResize();
+        OnPrepareDraw();
+        InitScrollWidgets();
+        Invalidate();
+    }
+
+    /**
+     *
+     *  rct2: 0x00672609
+     */
+    void UpdateDisabledWidgets()
+    {
+        // Check if there are any rides (not shops or facilities)
+        const auto& rideManager = GetRideManager();
+        if (std::any_of(rideManager.begin(), rideManager.end(), [](const Ride& ride) { return ride.IsRide(); }))
+        {
+            disabled_widgets &= ~(1uLL << WIDX_TAB_2);
+        }
+        else
+        {
+            disabled_widgets |= (1uLL << WIDX_TAB_2);
+        }
+    }
+
+    void SetPressedTab()
+    {
+        int32_t i;
+        for (i = WIDX_TAB_1; i <= WIDX_TAB_2; i++)
+            pressed_widgets &= ~(1 << i);
+        pressed_widgets |= 1LL << (WIDX_TAB_1 + page);
+    }
+
+    void AnchorBorderWidgets()
+    {
+        ResizeFrameWithPage();
+    }
+
+    void DrawTabImages(DrawPixelInfo* dpi)
+    {
+        Widget* widget;
+        int32_t spriteIndex;
+
+        // Tab 1
+        widget = &widgets[WIDX_TAB_1];
+
+        spriteIndex = SPR_TAB_OBJECTIVE_0;
+        if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN)
+            spriteIndex += (frame_no / 4) % 16;
+
+        GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+
+        // Tab 2
+        if (!IsWidgetDisabled(WIDX_TAB_2))
+        {
+            widget = &widgets[WIDX_TAB_2];
+            spriteIndex = SPR_TAB_RIDE_0;
+            if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
+                spriteIndex += (frame_no / 4) % 16;
+
+            GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x0067201D
+     */
+    void SetObjective(int32_t objective)
+    {
+        gScenarioObjective.Type = objective;
+        Invalidate();
+
+        // Set default objective arguments
+        switch (objective)
+        {
+            case OBJECTIVE_NONE:
+            case OBJECTIVE_HAVE_FUN:
+            case OBJECTIVE_BUILD_THE_BEST:
+            case OBJECTIVE_10_ROLLERCOASTERS:
+                break;
+            case OBJECTIVE_GUESTS_BY:
+                gScenarioObjective.Year = 3;
+                gScenarioObjective.NumGuests = 1500;
+                break;
+            case OBJECTIVE_PARK_VALUE_BY:
+                gScenarioObjective.Year = 3;
+                gScenarioObjective.Currency = 50000.00_GBP;
+                break;
+            case OBJECTIVE_GUESTS_AND_RATING:
+                gScenarioObjective.NumGuests = 2000;
+                break;
+            case OBJECTIVE_MONTHLY_RIDE_INCOME:
+                gScenarioObjective.Currency = 10000.00_GBP;
+                break;
+            case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
+                gScenarioObjective.MinimumLength = 1200;
+                break;
+            case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
+                gScenarioObjective.MinimumExcitement = FIXED_2DP(6, 70);
+                break;
+            case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
+                gScenarioObjective.Currency = 50000.00_GBP;
+                break;
+            case OBJECTIVE_MONTHLY_FOOD_INCOME:
+                gScenarioObjective.Currency = 1000.00_GBP;
+                break;
+        }
+    }
+
+    void ShowObjectiveDropdown()
+    {
+        int32_t numItems = 0, objectiveType;
+        Widget* dropdownWidget;
+        uint32_t parkFlags;
+
+        dropdownWidget = &widgets[WIDX_OBJECTIVE];
+        parkFlags = gParkFlags;
+
+        for (auto i = 0; i < OBJECTIVE_COUNT; i++)
+        {
+            if (i == OBJECTIVE_NONE || i == OBJECTIVE_BUILD_THE_BEST)
+                continue;
+
+            const bool objectiveAllowedByMoneyUsage = !(parkFlags & PARK_FLAGS_NO_MONEY) || !ObjectiveNeedsMoney(i);
+            // This objective can only work if the player can ask money for rides.
+            const bool objectiveAllowedByPaymentSettings = (i != OBJECTIVE_MONTHLY_RIDE_INCOME) || ParkRidePricesUnlocked();
+            if (objectiveAllowedByMoneyUsage && objectiveAllowedByPaymentSettings)
+            {
+                gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
+                gDropdownItems[numItems].Args = ObjectiveDropdownOptionNames[i];
+                numItems++;
+            }
+        }
+
+        WindowDropdownShowTextCustomWidth(
+            { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1, colours[1],
+            0, Dropdown::Flag::StayOpen, numItems, dropdownWidget->width() - 3);
+
+        objectiveType = gScenarioObjective.Type;
+        for (int32_t j = 0; j < numItems; j++)
+        {
+            if (gDropdownItems[j].Args - STR_OBJECTIVE_DROPDOWN_NONE == objectiveType)
+            {
+                Dropdown::SetChecked(j, true);
+                break;
+            }
+        }
+    }
+
+    void ShowCategoryDropdown()
+    {
+        int32_t i;
+        Widget* dropdownWidget;
+
+        dropdownWidget = &widgets[WIDX_CATEGORY];
+
+        for (i = SCENARIO_CATEGORY_BEGINNER; i <= SCENARIO_CATEGORY_OTHER; i++)
+        {
+            gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
+            gDropdownItems[i].Args = ScenarioCategoryStringIds[i];
+        }
+        WindowDropdownShowTextCustomWidth(
+            { windowPos.x + dropdownWidget->left, windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1, colours[1],
+            0, Dropdown::Flag::StayOpen, 5, dropdownWidget->width() - 3);
+        Dropdown::SetChecked(gScenarioCategory, true);
+    }
+
+    void Arg1Increase()
+    {
+        switch (gScenarioObjective.Type)
+        {
+            case OBJECTIVE_PARK_VALUE_BY:
+            case OBJECTIVE_MONTHLY_RIDE_INCOME:
+            case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
+                if (gScenarioObjective.Currency >= 2000000.00_GBP)
+                {
+                    ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
+                }
+                else
+                {
+                    gScenarioObjective.Currency += 1000.00_GBP;
+                    Invalidate();
+                }
+                break;
+            case OBJECTIVE_MONTHLY_FOOD_INCOME:
+                if (gScenarioObjective.Currency >= 2000000.00_GBP)
+                {
+                    ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
+                }
+                else
+                {
+                    gScenarioObjective.Currency += 100.00_GBP;
+                    Invalidate();
+                }
+                break;
+            case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
+                if (gScenarioObjective.MinimumLength >= 5000)
+                {
+                    ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
+                }
+                else
+                {
+                    gScenarioObjective.MinimumLength += 100;
+                    Invalidate();
+                }
+                break;
+            case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
+                if (gScenarioObjective.MinimumExcitement >= FIXED_2DP(9, 90))
+                {
+                    ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
+                }
+                else
+                {
+                    gScenarioObjective.MinimumExcitement += FIXED_2DP(0, 10);
+                    Invalidate();
+                }
+                break;
+            default:
+                if (gScenarioObjective.NumGuests >= MaxObjectiveGuests)
+                {
+                    ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
+                }
+                else
+                {
+                    gScenarioObjective.NumGuests += 50;
+                    Invalidate();
+                }
+                break;
+        }
+    }
+
+    void Arg1Decrease()
+    {
+        switch (gScenarioObjective.Type)
+        {
+            case OBJECTIVE_PARK_VALUE_BY:
+            case OBJECTIVE_MONTHLY_RIDE_INCOME:
+            case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
+                if (gScenarioObjective.Currency <= 1000.00_GBP)
+                {
+                    ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
+                }
+                else
+                {
+                    gScenarioObjective.Currency -= 1000.00_GBP;
+                    Invalidate();
+                }
+                break;
+            case OBJECTIVE_MONTHLY_FOOD_INCOME:
+                if (gScenarioObjective.Currency <= 1000.00_GBP)
+                {
+                    ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
+                }
+                else
+                {
+                    gScenarioObjective.Currency -= 100.00_GBP;
+                    Invalidate();
+                }
+                break;
+            case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
+                if (gScenarioObjective.MinimumLength <= 1000)
+                {
+                    ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
+                }
+                else
+                {
+                    gScenarioObjective.MinimumLength -= 100;
+                    Invalidate();
+                }
+                break;
+            case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
+                if (gScenarioObjective.MinimumExcitement <= FIXED_2DP(4, 00))
+                {
+                    ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
+                }
+                else
+                {
+                    gScenarioObjective.MinimumExcitement -= FIXED_2DP(0, 10);
+                    Invalidate();
+                }
+                break;
+            default:
+                if (gScenarioObjective.NumGuests <= 250)
+                {
+                    ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
+                }
+                else
+                {
+                    gScenarioObjective.NumGuests -= 50;
+                    Invalidate();
+                }
+                break;
+        }
+    }
+
+    void Arg2Increase()
+    {
+        if (gScenarioObjective.Year >= 25)
+        {
+            ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
+        }
+        else
+        {
+            gScenarioObjective.Year++;
+            Invalidate();
+        }
+    }
+
+    void Arg2Decrease()
+    {
+        if (gScenarioObjective.Year <= 1)
+        {
+            ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
+        }
+        else
+        {
+            gScenarioObjective.Year--;
+            Invalidate();
+        }
+    }
+
+#pragma region Main
+
+    /**
+     *
+     *  rct2: 0x006719CA
+     */
+    void OnMouseUpMain(WidgetIndex widgetIndex)
+    {
+        switch (widgetIndex)
+        {
+            case WIDX_CLOSE:
+                Close();
+                break;
+            case WIDX_TAB_1:
+            case WIDX_TAB_2:
+                SetPage(widgetIndex - WIDX_TAB_1);
+                break;
+            case WIDX_PARK_NAME:
+            {
+                auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                WindowTextInputRawOpen(
+                    this, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, park.Name.c_str(), ParkNameMaxLength);
+                break;
+            }
+            case WIDX_SCENARIO_NAME:
+                WindowTextInputRawOpen(
+                    this, WIDX_SCENARIO_NAME, STR_SCENARIO_NAME, STR_ENTER_SCENARIO_NAME, {}, gScenarioName.c_str(),
+                    ScenarioNameMaxLength);
+                break;
+            case WIDX_DETAILS:
+                WindowTextInputRawOpen(
+                    this, WIDX_DETAILS, STR_PARK_SCENARIO_DETAILS, STR_ENTER_SCENARIO_DESCRIPTION, {}, gScenarioDetails.c_str(),
+                    ScenarioDetailsNameMaxLength);
+                break;
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x00672254
+     */
+    void OnResizeMain()
+    {
+        WindowSetResize(*this, 450, 229, 450, 229);
+    }
+
+    /**
+     *
+     *  rct2: 0x00671A0D
+     */
+    void OnMouseDownMain(WidgetIndex widgetIndex)
+    {
+        switch (widgetIndex)
+        {
+            case WIDX_OBJECTIVE_DROPDOWN:
+                ShowObjectiveDropdown();
+                break;
+            case WIDX_OBJECTIVE_ARG_1_INCREASE:
+                Arg1Increase();
+                break;
+            case WIDX_OBJECTIVE_ARG_1_DECREASE:
+                Arg1Decrease();
+                break;
+            case WIDX_OBJECTIVE_ARG_2_INCREASE:
+                Arg2Increase();
+                break;
+            case WIDX_OBJECTIVE_ARG_2_DECREASE:
+                Arg2Decrease();
+                break;
+            case WIDX_CATEGORY_DROPDOWN:
+                ShowCategoryDropdown();
+                break;
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x00671A54
+     */
+    void OnDropdownMain(WidgetIndex widgetIndex, int32_t dropdownIndex)
+    {
+        uint8_t newObjectiveType;
+
+        if (dropdownIndex == -1)
+            return;
+
+        switch (widgetIndex)
+        {
+            case WIDX_OBJECTIVE_DROPDOWN:
+                // TODO: Don't rely on string ID order
+                newObjectiveType = static_cast<uint8_t>(gDropdownItems[dropdownIndex].Args - STR_OBJECTIVE_DROPDOWN_NONE);
+                if (gScenarioObjective.Type != newObjectiveType)
+                    SetObjective(newObjectiveType);
+                break;
+            case WIDX_CATEGORY_DROPDOWN:
+                if (gScenarioCategory != static_cast<uint8_t>(dropdownIndex))
+                {
+                    gScenarioCategory = static_cast<SCENARIO_CATEGORY>(dropdownIndex);
+                    Invalidate();
+                }
+                break;
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x006721E7
+     */
+    void OnUpdateMain()
+    {
+        uint32_t parkFlags;
+        uint8_t objectiveType;
+
+        frame_no++;
+        OnPrepareDraw();
+        InvalidateWidget(WIDX_TAB_1);
+
+        parkFlags = gParkFlags;
+        objectiveType = gScenarioObjective.Type;
+
+        // Check if objective is allowed by money and pay-per-ride settings.
+        const bool objectiveAllowedByMoneyUsage = !(parkFlags & PARK_FLAGS_NO_MONEY) || !ObjectiveNeedsMoney(objectiveType);
+        // This objective can only work if the player can ask money for rides.
+        const bool objectiveAllowedByPaymentSettings = (objectiveType != OBJECTIVE_MONTHLY_RIDE_INCOME)
+            || ParkRidePricesUnlocked();
+        if (!objectiveAllowedByMoneyUsage || !objectiveAllowedByPaymentSettings)
+        {
+            // Reset objective
+            SetObjective(OBJECTIVE_GUESTS_AND_RATING);
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x00671A73
+     */
+    void OnTextInputMain(WidgetIndex widgetIndex, const char* text)
+    {
+        if (text == nullptr)
+            return;
+
+        switch (widgetIndex)
+        {
+            case WIDX_PARK_NAME:
+            {
+                auto action = ParkSetNameAction(text);
+                GameActions::Execute(&action);
+
+                if (gScenarioName.empty())
+                {
+                    auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+                    gScenarioName = park.Name;
+                }
+                break;
+            }
+            case WIDX_SCENARIO_NAME:
+                gScenarioName = text;
+                Invalidate();
+                break;
+            case WIDX_DETAILS:
+                gScenarioDetails = text;
+                Invalidate();
+                break;
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x0067161C
+     */
+    void OnPrepareDrawMain()
+    {
+        auto widgetsToSet = window_editor_objective_options_widgets[page];
+        if (widgets != widgetsToSet)
+        {
+            widgets = widgetsToSet;
+            InitScrollWidgets();
+        }
+
+        SetPressedTab();
+
+        switch (gScenarioObjective.Type)
+        {
+            case OBJECTIVE_GUESTS_BY:
+            case OBJECTIVE_PARK_VALUE_BY:
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1].type = WindowWidgetType::Spinner;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WindowWidgetType::Button;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WindowWidgetType::Button;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2].type = WindowWidgetType::Spinner;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WindowWidgetType::Button;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WindowWidgetType::Button;
+                break;
+            case OBJECTIVE_GUESTS_AND_RATING:
+            case OBJECTIVE_MONTHLY_RIDE_INCOME:
+            case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
+            case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
+            case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
+            case OBJECTIVE_MONTHLY_FOOD_INCOME:
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1].type = WindowWidgetType::Spinner;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WindowWidgetType::Button;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WindowWidgetType::Button;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2].type = WindowWidgetType::Empty;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WindowWidgetType::Empty;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WindowWidgetType::Empty;
+                break;
+            default:
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1].type = WindowWidgetType::Empty;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WindowWidgetType::Empty;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WindowWidgetType::Empty;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2].type = WindowWidgetType::Empty;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WindowWidgetType::Empty;
+                window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WindowWidgetType::Empty;
+                break;
+        }
+
+        window_editor_objective_options_main_widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
+            ? WindowWidgetType::Empty
+            : WindowWidgetType::CloseBox;
+
+        AnchorBorderWidgets();
+    }
+
+    /**
+     *
+     *  rct2: 0x0067161C
+     */
+    void OnDrawMain(DrawPixelInfo* dpi)
+    {
+        int32_t width;
+        StringId stringId;
+
+        DrawWidgets(*dpi);
+        DrawTabImages(dpi);
+
+        // Objective label
+        auto screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_OBJECTIVE].top };
+        DrawTextBasic(*dpi, screenCoords, STR_OBJECTIVE_WINDOW);
+
+        // Objective value
+        screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_OBJECTIVE].left + 1, widgets[WIDX_OBJECTIVE].top };
+        auto ft = Formatter();
+        ft.Add<StringId>(ObjectiveDropdownOptionNames[gScenarioObjective.Type]);
+        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+
+        if (widgets[WIDX_OBJECTIVE_ARG_1].type != WindowWidgetType::Empty)
+        {
+            // Objective argument 1 label
+            screenCoords = windowPos + ScreenCoordsXY{ 28, widgets[WIDX_OBJECTIVE_ARG_1].top };
+            switch (gScenarioObjective.Type)
+            {
+                case OBJECTIVE_GUESTS_BY:
+                case OBJECTIVE_GUESTS_AND_RATING:
+                    stringId = STR_WINDOW_OBJECTIVE_GUEST_COUNT;
+                    break;
+                case OBJECTIVE_PARK_VALUE_BY:
+                case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
+                    stringId = STR_WINDOW_OBJECTIVE_PARK_VALUE;
+                    break;
+                case OBJECTIVE_MONTHLY_RIDE_INCOME:
+                    stringId = STR_WINDOW_OBJECTIVE_MONTHLY_INCOME;
+                    break;
+                case OBJECTIVE_MONTHLY_FOOD_INCOME:
+                    stringId = STR_WINDOW_OBJECTIVE_MONTHLY_PROFIT;
+                    break;
+                case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
+                    stringId = STR_WINDOW_OBJECTIVE_MINIMUM_LENGTH;
+                    break;
+                default:
+                    stringId = STR_WINDOW_OBJECTIVE_EXCITEMENT_RATING;
+                    break;
+            }
+            DrawTextBasic(*dpi, screenCoords, stringId);
+
+            // Objective argument 1 value
+            screenCoords = windowPos
+                + ScreenCoordsXY{ widgets[WIDX_OBJECTIVE_ARG_1].left + 1, widgets[WIDX_OBJECTIVE_ARG_1].top };
+            ft = Formatter();
+            switch (gScenarioObjective.Type)
+            {
+                case OBJECTIVE_GUESTS_BY:
+                case OBJECTIVE_GUESTS_AND_RATING:
+                    stringId = STR_WINDOW_COLOUR_2_COMMA16;
+                    ft.Add<uint16_t>(gScenarioObjective.NumGuests);
+                    break;
+                case OBJECTIVE_PARK_VALUE_BY:
+                case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
+                case OBJECTIVE_MONTHLY_RIDE_INCOME:
+                case OBJECTIVE_MONTHLY_FOOD_INCOME:
+                    stringId = STR_CURRENCY_FORMAT_LABEL;
+                    ft.Add<money64>(gScenarioObjective.Currency);
+                    break;
+                case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
+                    stringId = STR_WINDOW_COLOUR_2_LENGTH;
+                    ft.Add<uint16_t>(gScenarioObjective.MinimumLength);
+                    break;
+                case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
+                    stringId = STR_WINDOW_COLOUR_2_COMMA2DP32;
+                    ft.Add<uint16_t>(gScenarioObjective.MinimumExcitement);
+                    break;
+                default:
+                    stringId = STR_WINDOW_COLOUR_2_COMMA2DP32;
+                    ft.Add<money64>(gScenarioObjective.Currency);
+                    break;
+            }
+            DrawTextBasic(*dpi, screenCoords, stringId, ft, COLOUR_BLACK);
+        }
+
+        if (widgets[WIDX_OBJECTIVE_ARG_2].type != WindowWidgetType::Empty)
+        {
+            // Objective argument 2 label
+            screenCoords = windowPos + ScreenCoordsXY{ 28, widgets[WIDX_OBJECTIVE_ARG_2].top };
+            DrawTextBasic(*dpi, screenCoords, STR_WINDOW_OBJECTIVE_DATE);
+
+            // Objective argument 2 value
+            screenCoords = windowPos
+                + ScreenCoordsXY{ widgets[WIDX_OBJECTIVE_ARG_2].left + 1, widgets[WIDX_OBJECTIVE_ARG_2].top };
+            ft = Formatter();
+            ft.Add<uint16_t>((gScenarioObjective.Year * MONTH_COUNT) - 1);
+            DrawTextBasic(*dpi, screenCoords, STR_WINDOW_OBJECTIVE_VALUE_DATE, ft);
+        }
+
+        // Park name
+        screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_PARK_NAME].top };
+        width = widgets[WIDX_PARK_NAME].left - 16;
+
+        {
+            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
+            auto parkName = park.Name.c_str();
+
+            ft = Formatter();
+            ft.Add<StringId>(STR_STRING);
+            ft.Add<const char*>(parkName);
+            DrawTextEllipsised(*dpi, screenCoords, width, STR_WINDOW_PARK_NAME, ft);
+        }
+
+        // Scenario name
+        screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_SCENARIO_NAME].top };
+        width = widgets[WIDX_SCENARIO_NAME].left - 16;
+
+        ft = Formatter();
+        ft.Add<StringId>(STR_STRING);
+        ft.Add<const char*>(gScenarioName.c_str());
+        DrawTextEllipsised(*dpi, screenCoords, width, STR_WINDOW_SCENARIO_NAME, ft);
+
+        // Scenario details label
+        screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_DETAILS].top };
+        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_PARK_DETAILS);
+
+        // Scenario details value
+        screenCoords = windowPos + ScreenCoordsXY{ 16, widgets[WIDX_DETAILS].top + 10 };
+        width = widgets[WIDX_DETAILS].left - 4;
+
+        ft = Formatter();
+        ft.Add<StringId>(STR_STRING);
+        ft.Add<const char*>(gScenarioDetails.c_str());
+        DrawTextWrapped(*dpi, screenCoords, width, STR_BLACK_STRING, ft);
+
+        // Scenario category label
+        screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_CATEGORY].top };
+        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_SCENARIO_GROUP);
+
+        // Scenario category value
+        screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_CATEGORY].left + 1, widgets[WIDX_CATEGORY].top };
+        ft = Formatter();
+        ft.Add<StringId>(ScenarioCategoryStringIds[gScenarioCategory]);
+        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+    }
+
+#pragma endregion
+
+#pragma region Rides
+
+    /**
+     *
+     *  rct2: 0x006724A4
+     */
+    void OnMouseUpRides(WidgetIndex widgetIndex)
+    {
+        switch (widgetIndex)
+        {
+            case WIDX_CLOSE:
+                Close();
+                break;
+            case WIDX_TAB_1:
+            case WIDX_TAB_2:
+                SetPage(widgetIndex - WIDX_TAB_1);
+                break;
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x006725A8
+     */
+    void OnResizeRides()
+    {
+        WindowSetResize(*this, 380, 224, 380, 224);
+    }
+
+    /**
+     *
+     *  rct2: 0x00672544
+     */
+    void OnUpdateRides()
+    {
+        frame_no++;
+        OnPrepareDraw();
+        OnResize();
+        InvalidateWidget(WIDX_TAB_2);
+
+        auto numItems = 0;
+        for (auto& ride : GetRideManager())
+        {
+            if (ride.IsRide())
+            {
+                list_item_positions[numItems] = ride.id.ToUnderlying();
+                numItems++;
+            }
+        }
+
+        if (no_list_items != numItems)
+        {
+            no_list_items = numItems;
+            Invalidate();
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x006724BF
+     */
+    void OnScrollGetHeightRides(WindowBase* w, int32_t scrollIndex, int32_t* width, int32_t* height)
+    {
+        *height = no_list_items * 12;
+    }
+
+    /**
+     *
+     *  rct2: 0x006724FC
+     */
+    void OnScrollMouseDownRides(int32_t scrollIndex, const ScreenCoordsXY& screenCoords)
+    {
+        auto i = screenCoords.y / 12;
+        if (i < 0 || i >= no_list_items)
+            return;
+
+        const auto rideId = RideId::FromUnderlying(list_item_positions[i]);
+        auto ride = GetRide(rideId);
+        if (ride != nullptr)
+        {
+            ride->lifecycle_flags ^= RIDE_LIFECYCLE_INDESTRUCTIBLE;
+        }
+        Invalidate();
+    }
+
+    /**
+     *
+     *  rct2: 0x006724CC
+     */
+    void OnScrollMouseOverRides(int32_t scrollIndex, const ScreenCoordsXY& screenCoords)
+    {
+        int32_t i;
+
+        i = screenCoords.y / 12;
+        if (i < 0 || i >= no_list_items)
+            return;
+
+        if (selected_list_item != i)
+        {
+            selected_list_item = i;
+            Invalidate();
+        }
+    }
+
+    /**
+     *
+     *  rct2: 0x006722B5
+     */
+    void OnPrepareDrawRides()
+    {
+        Widget* widgetsToSet = window_editor_objective_options_widgets[page];
+        if (widgets != widgetsToSet)
+        {
+            widgets = widgetsToSet;
+            InitScrollWidgets();
+        }
+
+        SetPressedTab();
+
+        window_editor_objective_options_main_widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
+            ? WindowWidgetType::Empty
+            : WindowWidgetType::CloseBox;
+
+        AnchorBorderWidgets();
+    }
+
+    /**
+     *
+     *  rct2: 0x00672340
+     */
+    void OnDrawRides(DrawPixelInfo* dpi)
+    {
+        DrawWidgets(*dpi);
+        DrawTabImages(dpi);
+
+        DrawTextBasic(
+            *dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PAGE_BACKGROUND].top + 3 }, STR_WINDOW_PRESERVATION_ORDER);
+    }
+
+    /**
+     *
+     *  rct2: 0x0067236F
+     */
+    void OnScrollDrawRides(DrawPixelInfo* dpi, int32_t scrollIndex)
+    {
+        int32_t colour = ColourMapA[colours[1]].mid_light;
+        GfxFillRect(dpi, { { dpi->x, dpi->y }, { dpi->x + dpi->width - 1, dpi->y + dpi->height - 1 } }, colour);
+
+        for (int32_t i = 0; i < no_list_items; i++)
+        {
+            int32_t y = i * 12;
+
+            if (y + 12 < dpi->y || y >= dpi->y + dpi->height)
+                continue;
+
+            // Checkbox
+            GfxFillRectInset(dpi, { { 2, y }, { 11, y + 10 } }, colours[1], INSET_RECT_F_E0);
+
+            // Highlighted
+            auto stringId = STR_BLACK_STRING;
+            if (i == selected_list_item)
+            {
+                stringId = STR_WINDOW_COLOUR_2_STRINGID;
+                GfxFilterRect(dpi, { 0, y, width, y + 11 }, FilterPaletteID::PaletteDarken1);
+            }
+
+            // Checkbox mark
+            const auto rideId = RideId::FromUnderlying(list_item_positions[i]);
+            auto ride = GetRide(rideId);
+            if (ride != nullptr)
+            {
+                if (ride->lifecycle_flags & RIDE_LIFECYCLE_INDESTRUCTIBLE)
+                {
+                    auto darkness = stringId == STR_WINDOW_COLOUR_2_STRINGID ? TextDarkness::ExtraDark : TextDarkness::Dark;
+                    GfxDrawString(
+                        *dpi, { 2, y }, static_cast<const char*>(CheckBoxMarkString),
+                        { static_cast<colour_t>(colours[1] & 0x7F), FontStyle::Medium, darkness });
+                }
+
+                // Ride name
+
+                Formatter ft;
+                ride->FormatNameTo(ft);
+                DrawTextBasic(*dpi, { 15, y }, stringId, ft);
+            }
+        }
+    }
+
+#pragma endregion
+};
 
 /**
  *
@@ -199,917 +1118,11 @@ static void WindowEditorObjectiveOptionsUpdateDisabledWidgets(WindowBase* w);
  */
 WindowBase* WindowEditorObjectiveOptionsOpen()
 {
-    WindowBase* w;
-
-    w = WindowBringToFrontByClass(WindowClass::EditorObjectiveOptions);
+    auto w = WindowBringToFrontByClass(WindowClass::EditorObjectiveOptions);
     if (w != nullptr)
         return w;
 
     w = WindowCreateCentred(450, 228, &window_objective_options_main_events, WindowClass::EditorObjectiveOptions, WF_10);
-    w->widgets = window_editor_objective_options_main_widgets;
-    w->pressed_widgets = 0;
-    w->hold_down_widgets = window_editor_objective_options_page_hold_down_widgets[WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN];
-    WindowInitScrollWidgets(*w);
-    w->selected_tab = WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN;
-    w->no_list_items = 0;
-    w->selected_list_item = -1;
-    WindowEditorObjectiveOptionsUpdateDisabledWidgets(w);
 
     return w;
-}
-
-static void WindowEditorObjectiveOptionsSetPressedTab(WindowBase* w)
-{
-    int32_t i;
-    for (i = WIDX_TAB_1; i <= WIDX_TAB_2; i++)
-        w->pressed_widgets &= ~(1 << i);
-    w->pressed_widgets |= 1LL << (WIDX_TAB_1 + w->page);
-}
-
-static void WindowEditorObjectiveOptionsAnchorBorderWidgets(WindowBase* w)
-{
-    w->ResizeFrameWithPage();
-}
-
-static void WindowEditorObjectiveOptionsDrawTabImages(WindowBase* w, DrawPixelInfo* dpi)
-{
-    Widget* widget;
-    int32_t spriteIndex;
-
-    // Tab 1
-    widget = &w->widgets[WIDX_TAB_1];
-
-    spriteIndex = SPR_TAB_OBJECTIVE_0;
-    if (w->page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN)
-        spriteIndex += (w->frame_no / 4) % 16;
-
-    GfxDrawSprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget->left, widget->top });
-
-    // Tab 2
-    if (!WidgetIsDisabled(*w, WIDX_TAB_2))
-    {
-        widget = &w->widgets[WIDX_TAB_2];
-        spriteIndex = SPR_TAB_RIDE_0;
-        if (w->page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
-            spriteIndex += (w->frame_no / 4) % 16;
-
-        GfxDrawSprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget->left, widget->top });
-    }
-}
-
-/**
- *
- *  rct2: 0x00668496
- */
-static void WindowEditorObjectiveOptionsSetPage(WindowBase* w, int32_t page)
-{
-    if (w->page == page)
-        return;
-
-    w->page = page;
-    w->frame_no = 0;
-    w->var_492 = 0;
-    w->no_list_items = 0;
-    w->selected_list_item = -1;
-    w->hold_down_widgets = window_editor_objective_options_page_hold_down_widgets[page];
-    w->event_handlers = window_editor_objective_options_page_events[page];
-    w->widgets = window_editor_objective_options_widgets[page];
-    w->Invalidate();
-    WindowEditorObjectiveOptionsUpdateDisabledWidgets(w);
-    WindowEventResizeCall(w);
-    WindowEventInvalidateCall(w);
-    WindowInitScrollWidgets(*w);
-    w->Invalidate();
-}
-
-/**
- *
- *  rct2: 0x0067201D
- */
-static void WindowEditorObjectiveOptionsSetObjective(WindowBase* w, int32_t objective)
-{
-    gScenarioObjective.Type = objective;
-    w->Invalidate();
-
-    // Set default objective arguments
-    switch (objective)
-    {
-        case OBJECTIVE_NONE:
-        case OBJECTIVE_HAVE_FUN:
-        case OBJECTIVE_BUILD_THE_BEST:
-        case OBJECTIVE_10_ROLLERCOASTERS:
-            break;
-        case OBJECTIVE_GUESTS_BY:
-            gScenarioObjective.Year = 3;
-            gScenarioObjective.NumGuests = 1500;
-            break;
-        case OBJECTIVE_PARK_VALUE_BY:
-            gScenarioObjective.Year = 3;
-            gScenarioObjective.Currency = 50000.00_GBP;
-            break;
-        case OBJECTIVE_GUESTS_AND_RATING:
-            gScenarioObjective.NumGuests = 2000;
-            break;
-        case OBJECTIVE_MONTHLY_RIDE_INCOME:
-            gScenarioObjective.Currency = 10000.00_GBP;
-            break;
-        case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
-            gScenarioObjective.MinimumLength = 1200;
-            break;
-        case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
-            gScenarioObjective.MinimumExcitement = FIXED_2DP(6, 70);
-            break;
-        case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
-            gScenarioObjective.Currency = 50000.00_GBP;
-            break;
-        case OBJECTIVE_MONTHLY_FOOD_INCOME:
-            gScenarioObjective.Currency = 1000.00_GBP;
-            break;
-    }
-}
-
-/**
- *
- *  rct2: 0x006719CA
- */
-static void WindowEditorObjectiveOptionsMainMouseup(WindowBase* w, WidgetIndex widgetIndex)
-{
-    switch (widgetIndex)
-    {
-        case WIDX_CLOSE:
-            WindowClose(*w);
-            break;
-        case WIDX_TAB_1:
-        case WIDX_TAB_2:
-            WindowEditorObjectiveOptionsSetPage(w, widgetIndex - WIDX_TAB_1);
-            break;
-        case WIDX_PARK_NAME:
-        {
-            auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
-            WindowTextInputRawOpen(
-                w, WIDX_PARK_NAME, STR_PARK_NAME, STR_ENTER_PARK_NAME, {}, park.Name.c_str(), ParkNameMaxLength);
-            break;
-        }
-        case WIDX_SCENARIO_NAME:
-            WindowTextInputRawOpen(
-                w, WIDX_SCENARIO_NAME, STR_SCENARIO_NAME, STR_ENTER_SCENARIO_NAME, {}, gScenarioName.c_str(),
-                ScenarioNameMaxLength);
-            break;
-        case WIDX_DETAILS:
-            WindowTextInputRawOpen(
-                w, WIDX_DETAILS, STR_PARK_SCENARIO_DETAILS, STR_ENTER_SCENARIO_DESCRIPTION, {}, gScenarioDetails.c_str(),
-                ScenarioDetailsNameMaxLength);
-            break;
-    }
-}
-
-/**
- *
- *  rct2: 0x00672254
- */
-static void WindowEditorObjectiveOptionsMainResize(WindowBase* w)
-{
-    WindowSetResize(*w, 450, 229, 450, 229);
-}
-
-static void WindowEditorObjectiveOptionsShowObjectiveDropdown(WindowBase* w)
-{
-    int32_t numItems = 0, objectiveType;
-    Widget* dropdownWidget;
-    uint32_t parkFlags;
-
-    dropdownWidget = &w->widgets[WIDX_OBJECTIVE];
-    parkFlags = gParkFlags;
-
-    for (auto i = 0; i < OBJECTIVE_COUNT; i++)
-    {
-        if (i == OBJECTIVE_NONE || i == OBJECTIVE_BUILD_THE_BEST)
-            continue;
-
-        const bool objectiveAllowedByMoneyUsage = !(parkFlags & PARK_FLAGS_NO_MONEY) || !ObjectiveNeedsMoney(i);
-        // This objective can only work if the player can ask money for rides.
-        const bool objectiveAllowedByPaymentSettings = (i != OBJECTIVE_MONTHLY_RIDE_INCOME) || ParkRidePricesUnlocked();
-        if (objectiveAllowedByMoneyUsage && objectiveAllowedByPaymentSettings)
-        {
-            gDropdownItems[numItems].Format = STR_DROPDOWN_MENU_LABEL;
-            gDropdownItems[numItems].Args = ObjectiveDropdownOptionNames[i];
-            numItems++;
-        }
-    }
-
-    WindowDropdownShowTextCustomWidth(
-        { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-        w->colours[1], 0, Dropdown::Flag::StayOpen, numItems, dropdownWidget->width() - 3);
-
-    objectiveType = gScenarioObjective.Type;
-    for (int32_t j = 0; j < numItems; j++)
-    {
-        if (gDropdownItems[j].Args - STR_OBJECTIVE_DROPDOWN_NONE == objectiveType)
-        {
-            Dropdown::SetChecked(j, true);
-            break;
-        }
-    }
-}
-
-static void WindowEditorObjectiveOptionsShowCategoryDropdown(WindowBase* w)
-{
-    int32_t i;
-    Widget* dropdownWidget;
-
-    dropdownWidget = &w->widgets[WIDX_CATEGORY];
-
-    for (i = SCENARIO_CATEGORY_BEGINNER; i <= SCENARIO_CATEGORY_OTHER; i++)
-    {
-        gDropdownItems[i].Format = STR_DROPDOWN_MENU_LABEL;
-        gDropdownItems[i].Args = ScenarioCategoryStringIds[i];
-    }
-    WindowDropdownShowTextCustomWidth(
-        { w->windowPos.x + dropdownWidget->left, w->windowPos.y + dropdownWidget->top }, dropdownWidget->height() + 1,
-        w->colours[1], 0, Dropdown::Flag::StayOpen, 5, dropdownWidget->width() - 3);
-    Dropdown::SetChecked(gScenarioCategory, true);
-}
-
-static void WindowEditorObjectiveOptionsArg1Increase(WindowBase* w)
-{
-    switch (gScenarioObjective.Type)
-    {
-        case OBJECTIVE_PARK_VALUE_BY:
-        case OBJECTIVE_MONTHLY_RIDE_INCOME:
-        case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
-            if (gScenarioObjective.Currency >= 2000000.00_GBP)
-            {
-                ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
-            }
-            else
-            {
-                gScenarioObjective.Currency += 1000.00_GBP;
-                w->Invalidate();
-            }
-            break;
-        case OBJECTIVE_MONTHLY_FOOD_INCOME:
-            if (gScenarioObjective.Currency >= 2000000.00_GBP)
-            {
-                ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
-            }
-            else
-            {
-                gScenarioObjective.Currency += 100.00_GBP;
-                w->Invalidate();
-            }
-            break;
-        case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
-            if (gScenarioObjective.MinimumLength >= 5000)
-            {
-                ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
-            }
-            else
-            {
-                gScenarioObjective.MinimumLength += 100;
-                w->Invalidate();
-            }
-            break;
-        case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
-            if (gScenarioObjective.MinimumExcitement >= FIXED_2DP(9, 90))
-            {
-                ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
-            }
-            else
-            {
-                gScenarioObjective.MinimumExcitement += FIXED_2DP(0, 10);
-                w->Invalidate();
-            }
-            break;
-        default:
-            if (gScenarioObjective.NumGuests >= MaxObjectiveGuests)
-            {
-                ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
-            }
-            else
-            {
-                gScenarioObjective.NumGuests += 50;
-                w->Invalidate();
-            }
-            break;
-    }
-}
-
-static void WindowEditorObjectiveOptionsArg1Decrease(WindowBase* w)
-{
-    switch (gScenarioObjective.Type)
-    {
-        case OBJECTIVE_PARK_VALUE_BY:
-        case OBJECTIVE_MONTHLY_RIDE_INCOME:
-        case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
-            if (gScenarioObjective.Currency <= 1000.00_GBP)
-            {
-                ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
-            }
-            else
-            {
-                gScenarioObjective.Currency -= 1000.00_GBP;
-                w->Invalidate();
-            }
-            break;
-        case OBJECTIVE_MONTHLY_FOOD_INCOME:
-            if (gScenarioObjective.Currency <= 1000.00_GBP)
-            {
-                ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
-            }
-            else
-            {
-                gScenarioObjective.Currency -= 100.00_GBP;
-                w->Invalidate();
-            }
-            break;
-        case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
-            if (gScenarioObjective.MinimumLength <= 1000)
-            {
-                ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
-            }
-            else
-            {
-                gScenarioObjective.MinimumLength -= 100;
-                w->Invalidate();
-            }
-            break;
-        case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
-            if (gScenarioObjective.MinimumExcitement <= FIXED_2DP(4, 00))
-            {
-                ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
-            }
-            else
-            {
-                gScenarioObjective.MinimumExcitement -= FIXED_2DP(0, 10);
-                w->Invalidate();
-            }
-            break;
-        default:
-            if (gScenarioObjective.NumGuests <= 250)
-            {
-                ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
-            }
-            else
-            {
-                gScenarioObjective.NumGuests -= 50;
-                w->Invalidate();
-            }
-            break;
-    }
-}
-
-static void WindowEditorObjectiveOptionsArg2Increase(WindowBase* w)
-{
-    if (gScenarioObjective.Year >= 25)
-    {
-        ContextShowError(STR_CANT_INCREASE_FURTHER, STR_NONE, {});
-    }
-    else
-    {
-        gScenarioObjective.Year++;
-        w->Invalidate();
-    }
-}
-
-static void WindowEditorObjectiveOptionsArg2Decrease(WindowBase* w)
-{
-    if (gScenarioObjective.Year <= 1)
-    {
-        ContextShowError(STR_CANT_REDUCE_FURTHER, STR_NONE, {});
-    }
-    else
-    {
-        gScenarioObjective.Year--;
-        w->Invalidate();
-    }
-}
-
-/**
- *
- *  rct2: 0x00671A0D
- */
-static void WindowEditorObjectiveOptionsMainMousedown(WindowBase* w, WidgetIndex widgetIndex, Widget* widget)
-{
-    switch (widgetIndex)
-    {
-        case WIDX_OBJECTIVE_DROPDOWN:
-            WindowEditorObjectiveOptionsShowObjectiveDropdown(w);
-            break;
-        case WIDX_OBJECTIVE_ARG_1_INCREASE:
-            WindowEditorObjectiveOptionsArg1Increase(w);
-            break;
-        case WIDX_OBJECTIVE_ARG_1_DECREASE:
-            WindowEditorObjectiveOptionsArg1Decrease(w);
-            break;
-        case WIDX_OBJECTIVE_ARG_2_INCREASE:
-            WindowEditorObjectiveOptionsArg2Increase(w);
-            break;
-        case WIDX_OBJECTIVE_ARG_2_DECREASE:
-            WindowEditorObjectiveOptionsArg2Decrease(w);
-            break;
-        case WIDX_CATEGORY_DROPDOWN:
-            WindowEditorObjectiveOptionsShowCategoryDropdown(w);
-            break;
-    }
-}
-
-/**
- *
- *  rct2: 0x00671A54
- */
-static void WindowEditorObjectiveOptionsMainDropdown(WindowBase* w, WidgetIndex widgetIndex, int32_t dropdownIndex)
-{
-    uint8_t newObjectiveType;
-
-    if (dropdownIndex == -1)
-        return;
-
-    switch (widgetIndex)
-    {
-        case WIDX_OBJECTIVE_DROPDOWN:
-            // TODO: Don't rely on string ID order
-            newObjectiveType = static_cast<uint8_t>(gDropdownItems[dropdownIndex].Args - STR_OBJECTIVE_DROPDOWN_NONE);
-            if (gScenarioObjective.Type != newObjectiveType)
-                WindowEditorObjectiveOptionsSetObjective(w, newObjectiveType);
-            break;
-        case WIDX_CATEGORY_DROPDOWN:
-            if (gScenarioCategory != static_cast<uint8_t>(dropdownIndex))
-            {
-                gScenarioCategory = static_cast<SCENARIO_CATEGORY>(dropdownIndex);
-                w->Invalidate();
-            }
-            break;
-    }
-}
-
-/**
- *
- *  rct2: 0x006721E7
- */
-static void WindowEditorObjectiveOptionsMainUpdate(WindowBase* w)
-{
-    uint32_t parkFlags;
-    uint8_t objectiveType;
-
-    w->frame_no++;
-    WindowEventInvalidateCall(w);
-    WidgetInvalidate(*w, WIDX_TAB_1);
-
-    parkFlags = gParkFlags;
-    objectiveType = gScenarioObjective.Type;
-
-    // Check if objective is allowed by money and pay-per-ride settings.
-    const bool objectiveAllowedByMoneyUsage = !(parkFlags & PARK_FLAGS_NO_MONEY) || !ObjectiveNeedsMoney(objectiveType);
-    // This objective can only work if the player can ask money for rides.
-    const bool objectiveAllowedByPaymentSettings = (objectiveType != OBJECTIVE_MONTHLY_RIDE_INCOME) || ParkRidePricesUnlocked();
-    if (!objectiveAllowedByMoneyUsage || !objectiveAllowedByPaymentSettings)
-    {
-        // Reset objective
-        WindowEditorObjectiveOptionsSetObjective(w, OBJECTIVE_GUESTS_AND_RATING);
-    }
-}
-
-/**
- *
- *  rct2: 0x00671A73
- */
-static void WindowEditorObjectiveOptionsMainTextinput(WindowBase* w, WidgetIndex widgetIndex, const char* text)
-{
-    if (text == nullptr)
-        return;
-
-    switch (widgetIndex)
-    {
-        case WIDX_PARK_NAME:
-        {
-            auto action = ParkSetNameAction(text);
-            GameActions::Execute(&action);
-
-            if (gScenarioName.empty())
-            {
-                auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
-                gScenarioName = park.Name;
-            }
-            break;
-        }
-        case WIDX_SCENARIO_NAME:
-            gScenarioName = text;
-            w->Invalidate();
-            break;
-        case WIDX_DETAILS:
-            gScenarioDetails = text;
-            w->Invalidate();
-            break;
-    }
-}
-
-/**
- *
- *  rct2: 0x0067161C
- */
-static void WindowEditorObjectiveOptionsMainInvalidate(WindowBase* w)
-{
-    auto widgets = window_editor_objective_options_widgets[w->page];
-    if (w->widgets != widgets)
-    {
-        w->widgets = widgets;
-        WindowInitScrollWidgets(*w);
-    }
-
-    WindowEditorObjectiveOptionsSetPressedTab(w);
-
-    switch (gScenarioObjective.Type)
-    {
-        case OBJECTIVE_GUESTS_BY:
-        case OBJECTIVE_PARK_VALUE_BY:
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1].type = WindowWidgetType::Spinner;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WindowWidgetType::Button;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WindowWidgetType::Button;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2].type = WindowWidgetType::Spinner;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WindowWidgetType::Button;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WindowWidgetType::Button;
-            break;
-        case OBJECTIVE_GUESTS_AND_RATING:
-        case OBJECTIVE_MONTHLY_RIDE_INCOME:
-        case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
-        case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
-        case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
-        case OBJECTIVE_MONTHLY_FOOD_INCOME:
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1].type = WindowWidgetType::Spinner;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WindowWidgetType::Button;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WindowWidgetType::Button;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2].type = WindowWidgetType::Empty;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WindowWidgetType::Empty;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WindowWidgetType::Empty;
-            break;
-        default:
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1].type = WindowWidgetType::Empty;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_INCREASE].type = WindowWidgetType::Empty;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_1_DECREASE].type = WindowWidgetType::Empty;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2].type = WindowWidgetType::Empty;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_INCREASE].type = WindowWidgetType::Empty;
-            window_editor_objective_options_main_widgets[WIDX_OBJECTIVE_ARG_2_DECREASE].type = WindowWidgetType::Empty;
-            break;
-    }
-
-    window_editor_objective_options_main_widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
-        ? WindowWidgetType::Empty
-        : WindowWidgetType::CloseBox;
-
-    WindowEditorObjectiveOptionsAnchorBorderWidgets(w);
-}
-
-/**
- *
- *  rct2: 0x0067161C
- */
-static void WindowEditorObjectiveOptionsMainPaint(WindowBase* w, DrawPixelInfo* dpi)
-{
-    int32_t width;
-    StringId stringId;
-
-    WindowDrawWidgets(*w, dpi);
-    WindowEditorObjectiveOptionsDrawTabImages(w, dpi);
-
-    // Objective label
-    auto screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_OBJECTIVE].top };
-    DrawTextBasic(*dpi, screenCoords, STR_OBJECTIVE_WINDOW);
-
-    // Objective value
-    screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_OBJECTIVE].left + 1, w->widgets[WIDX_OBJECTIVE].top };
-    auto ft = Formatter();
-    ft.Add<StringId>(ObjectiveDropdownOptionNames[gScenarioObjective.Type]);
-    DrawTextBasic(*dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
-
-    if (w->widgets[WIDX_OBJECTIVE_ARG_1].type != WindowWidgetType::Empty)
-    {
-        // Objective argument 1 label
-        screenCoords = w->windowPos + ScreenCoordsXY{ 28, w->widgets[WIDX_OBJECTIVE_ARG_1].top };
-        switch (gScenarioObjective.Type)
-        {
-            case OBJECTIVE_GUESTS_BY:
-            case OBJECTIVE_GUESTS_AND_RATING:
-                stringId = STR_WINDOW_OBJECTIVE_GUEST_COUNT;
-                break;
-            case OBJECTIVE_PARK_VALUE_BY:
-            case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
-                stringId = STR_WINDOW_OBJECTIVE_PARK_VALUE;
-                break;
-            case OBJECTIVE_MONTHLY_RIDE_INCOME:
-                stringId = STR_WINDOW_OBJECTIVE_MONTHLY_INCOME;
-                break;
-            case OBJECTIVE_MONTHLY_FOOD_INCOME:
-                stringId = STR_WINDOW_OBJECTIVE_MONTHLY_PROFIT;
-                break;
-            case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
-                stringId = STR_WINDOW_OBJECTIVE_MINIMUM_LENGTH;
-                break;
-            default:
-                stringId = STR_WINDOW_OBJECTIVE_EXCITEMENT_RATING;
-                break;
-        }
-        DrawTextBasic(*dpi, screenCoords, stringId);
-
-        // Objective argument 1 value
-        screenCoords = w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_OBJECTIVE_ARG_1].left + 1, w->widgets[WIDX_OBJECTIVE_ARG_1].top };
-        ft = Formatter();
-        switch (gScenarioObjective.Type)
-        {
-            case OBJECTIVE_GUESTS_BY:
-            case OBJECTIVE_GUESTS_AND_RATING:
-                stringId = STR_WINDOW_COLOUR_2_COMMA16;
-                ft.Add<uint16_t>(gScenarioObjective.NumGuests);
-                break;
-            case OBJECTIVE_PARK_VALUE_BY:
-            case OBJECTIVE_REPAY_LOAN_AND_PARK_VALUE:
-            case OBJECTIVE_MONTHLY_RIDE_INCOME:
-            case OBJECTIVE_MONTHLY_FOOD_INCOME:
-                stringId = STR_CURRENCY_FORMAT_LABEL;
-                ft.Add<money64>(gScenarioObjective.Currency);
-                break;
-            case OBJECTIVE_10_ROLLERCOASTERS_LENGTH:
-                stringId = STR_WINDOW_COLOUR_2_LENGTH;
-                ft.Add<uint16_t>(gScenarioObjective.MinimumLength);
-                break;
-            case OBJECTIVE_FINISH_5_ROLLERCOASTERS:
-                stringId = STR_WINDOW_COLOUR_2_COMMA2DP32;
-                ft.Add<uint16_t>(gScenarioObjective.MinimumExcitement);
-                break;
-            default:
-                stringId = STR_WINDOW_COLOUR_2_COMMA2DP32;
-                ft.Add<money64>(gScenarioObjective.Currency);
-                break;
-        }
-        DrawTextBasic(*dpi, screenCoords, stringId, ft, COLOUR_BLACK);
-    }
-
-    if (w->widgets[WIDX_OBJECTIVE_ARG_2].type != WindowWidgetType::Empty)
-    {
-        // Objective argument 2 label
-        screenCoords = w->windowPos + ScreenCoordsXY{ 28, w->widgets[WIDX_OBJECTIVE_ARG_2].top };
-        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_OBJECTIVE_DATE);
-
-        // Objective argument 2 value
-        screenCoords = w->windowPos
-            + ScreenCoordsXY{ w->widgets[WIDX_OBJECTIVE_ARG_2].left + 1, w->widgets[WIDX_OBJECTIVE_ARG_2].top };
-        ft = Formatter();
-        ft.Add<uint16_t>((gScenarioObjective.Year * MONTH_COUNT) - 1);
-        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_OBJECTIVE_VALUE_DATE, ft);
-    }
-
-    // Park name
-    screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_PARK_NAME].top };
-    width = w->widgets[WIDX_PARK_NAME].left - 16;
-
-    {
-        auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
-        auto parkName = park.Name.c_str();
-
-        ft = Formatter();
-        ft.Add<StringId>(STR_STRING);
-        ft.Add<const char*>(parkName);
-        DrawTextEllipsised(*dpi, screenCoords, width, STR_WINDOW_PARK_NAME, ft);
-    }
-
-    // Scenario name
-    screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_SCENARIO_NAME].top };
-    width = w->widgets[WIDX_SCENARIO_NAME].left - 16;
-
-    ft = Formatter();
-    ft.Add<StringId>(STR_STRING);
-    ft.Add<const char*>(gScenarioName.c_str());
-    DrawTextEllipsised(*dpi, screenCoords, width, STR_WINDOW_SCENARIO_NAME, ft);
-
-    // Scenario details label
-    screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_DETAILS].top };
-    DrawTextBasic(*dpi, screenCoords, STR_WINDOW_PARK_DETAILS);
-
-    // Scenario details value
-    screenCoords = w->windowPos + ScreenCoordsXY{ 16, w->widgets[WIDX_DETAILS].top + 10 };
-    width = w->widgets[WIDX_DETAILS].left - 4;
-
-    ft = Formatter();
-    ft.Add<StringId>(STR_STRING);
-    ft.Add<const char*>(gScenarioDetails.c_str());
-    DrawTextWrapped(*dpi, screenCoords, width, STR_BLACK_STRING, ft);
-
-    // Scenario category label
-    screenCoords = w->windowPos + ScreenCoordsXY{ 8, w->widgets[WIDX_CATEGORY].top };
-    DrawTextBasic(*dpi, screenCoords, STR_WINDOW_SCENARIO_GROUP);
-
-    // Scenario category value
-    screenCoords = w->windowPos + ScreenCoordsXY{ w->widgets[WIDX_CATEGORY].left + 1, w->widgets[WIDX_CATEGORY].top };
-    ft = Formatter();
-    ft.Add<StringId>(ScenarioCategoryStringIds[gScenarioCategory]);
-    DrawTextBasic(*dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
-}
-
-/**
- *
- *  rct2: 0x006724A4
- */
-static void WindowEditorObjectiveOptionsRidesMouseup(WindowBase* w, WidgetIndex widgetIndex)
-{
-    switch (widgetIndex)
-    {
-        case WIDX_CLOSE:
-            WindowClose(*w);
-            break;
-        case WIDX_TAB_1:
-        case WIDX_TAB_2:
-            WindowEditorObjectiveOptionsSetPage(w, widgetIndex - WIDX_TAB_1);
-            break;
-    }
-}
-
-/**
- *
- *  rct2: 0x006725A8
- */
-static void WindowEditorObjectiveOptionsRidesResize(WindowBase* w)
-{
-    WindowSetResize(*w, 380, 224, 380, 224);
-}
-
-/**
- *
- *  rct2: 0x00672544
- */
-static void WindowEditorObjectiveOptionsRidesUpdate(WindowBase* w)
-{
-    w->frame_no++;
-    WindowEventInvalidateCall(w);
-    WindowEventResizeCall(w);
-    WidgetInvalidate(*w, WIDX_TAB_2);
-
-    auto numItems = 0;
-    for (auto& ride : GetRideManager())
-    {
-        if (ride.IsRide())
-        {
-            w->list_item_positions[numItems] = ride.id.ToUnderlying();
-            numItems++;
-        }
-    }
-
-    if (w->no_list_items != numItems)
-    {
-        w->no_list_items = numItems;
-        w->Invalidate();
-    }
-}
-
-/**
- *
- *  rct2: 0x006724BF
- */
-static void WindowEditorObjectiveOptionsRidesScrollgetheight(
-    WindowBase* w, int32_t scrollIndex, int32_t* width, int32_t* height)
-{
-    *height = w->no_list_items * 12;
-}
-
-/**
- *
- *  rct2: 0x006724FC
- */
-static void WindowEditorObjectiveOptionsRidesScrollmousedown(
-    WindowBase* w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords)
-{
-    auto i = screenCoords.y / 12;
-    if (i < 0 || i >= w->no_list_items)
-        return;
-
-    const auto rideId = RideId::FromUnderlying(w->list_item_positions[i]);
-    auto ride = GetRide(rideId);
-    if (ride != nullptr)
-    {
-        ride->lifecycle_flags ^= RIDE_LIFECYCLE_INDESTRUCTIBLE;
-    }
-    w->Invalidate();
-}
-
-/**
- *
- *  rct2: 0x006724CC
- */
-static void WindowEditorObjectiveOptionsRidesScrollmouseover(
-    WindowBase* w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords)
-{
-    int32_t i;
-
-    i = screenCoords.y / 12;
-    if (i < 0 || i >= w->no_list_items)
-        return;
-
-    if (w->selected_list_item != i)
-    {
-        w->selected_list_item = i;
-        w->Invalidate();
-    }
-}
-
-/**
- *
- *  rct2: 0x006722B5
- */
-static void WindowEditorObjectiveOptionsRidesInvalidate(WindowBase* w)
-{
-    Widget* widgets;
-
-    widgets = window_editor_objective_options_widgets[w->page];
-    if (w->widgets != widgets)
-    {
-        w->widgets = widgets;
-        WindowInitScrollWidgets(*w);
-    }
-
-    WindowEditorObjectiveOptionsSetPressedTab(w);
-
-    window_editor_objective_options_main_widgets[WIDX_CLOSE].type = (gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR)
-        ? WindowWidgetType::Empty
-        : WindowWidgetType::CloseBox;
-
-    WindowEditorObjectiveOptionsAnchorBorderWidgets(w);
-}
-
-/**
- *
- *  rct2: 0x00672340
- */
-static void WindowEditorObjectiveOptionsRidesPaint(WindowBase* w, DrawPixelInfo* dpi)
-{
-    WindowDrawWidgets(*w, dpi);
-    WindowEditorObjectiveOptionsDrawTabImages(w, dpi);
-
-    DrawTextBasic(
-        *dpi, w->windowPos + ScreenCoordsXY{ 6, w->widgets[WIDX_PAGE_BACKGROUND].top + 3 }, STR_WINDOW_PRESERVATION_ORDER);
-}
-
-/**
- *
- *  rct2: 0x0067236F
- */
-static void WindowEditorObjectiveOptionsRidesScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32_t scrollIndex)
-{
-    int32_t colour = ColourMapA[w->colours[1]].mid_light;
-    GfxFillRect(dpi, { { dpi->x, dpi->y }, { dpi->x + dpi->width - 1, dpi->y + dpi->height - 1 } }, colour);
-
-    for (int32_t i = 0; i < w->no_list_items; i++)
-    {
-        int32_t y = i * 12;
-
-        if (y + 12 < dpi->y || y >= dpi->y + dpi->height)
-            continue;
-
-        // Checkbox
-        GfxFillRectInset(dpi, { { 2, y }, { 11, y + 10 } }, w->colours[1], INSET_RECT_F_E0);
-
-        // Highlighted
-        auto stringId = STR_BLACK_STRING;
-        if (i == w->selected_list_item)
-        {
-            stringId = STR_WINDOW_COLOUR_2_STRINGID;
-            GfxFilterRect(dpi, { 0, y, w->width, y + 11 }, FilterPaletteID::PaletteDarken1);
-        }
-
-        // Checkbox mark
-        const auto rideId = RideId::FromUnderlying(w->list_item_positions[i]);
-        auto ride = GetRide(rideId);
-        if (ride != nullptr)
-        {
-            if (ride->lifecycle_flags & RIDE_LIFECYCLE_INDESTRUCTIBLE)
-            {
-                auto darkness = stringId == STR_WINDOW_COLOUR_2_STRINGID ? TextDarkness::ExtraDark : TextDarkness::Dark;
-                GfxDrawString(
-                    *dpi, { 2, y }, static_cast<const char*>(CheckBoxMarkString),
-                    { static_cast<colour_t>(w->colours[1] & 0x7F), FontStyle::Medium, darkness });
-            }
-
-            // Ride name
-
-            Formatter ft;
-            ride->FormatNameTo(ft);
-            DrawTextBasic(*dpi, { 15, y }, stringId, ft);
-        }
-    }
-}
-
-/**
- *
- *  rct2: 0x00672609
- */
-static void WindowEditorObjectiveOptionsUpdateDisabledWidgets(WindowBase* w)
-{
-    // Check if there are any rides (not shops or facilities)
-    const auto& rideManager = GetRideManager();
-    if (std::any_of(rideManager.begin(), rideManager.end(), [](const Ride& ride) { return ride.IsRide(); }))
-    {
-        w->disabled_widgets &= ~(1uLL << WIDX_TAB_2);
-    }
-    else
-    {
-        w->disabled_widgets |= (1uLL << WIDX_TAB_2);
-    }
 }

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -270,7 +270,7 @@ public:
     {
         if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
         {
-            return OnScrollGetSize(scrollIndex);
+            return OnScrollGetSizeRides(scrollIndex);
         }
 
         return {};
@@ -1026,7 +1026,6 @@ private:
     {
         ScreenSize newSize;
         newSize.height = no_list_items * 12;
-        newSize.width = width;
 
         return newSize;
     }

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -118,61 +118,6 @@ static Widget *window_editor_objective_options_widgets[] = {
 
 #pragma endregion
 
-#pragma region Events
-
-static void WindowEditorObjectiveOptionsMainMouseup(WindowBase *w, WidgetIndex widgetIndex);
-static void WindowEditorObjectiveOptionsMainResize(WindowBase *w);
-static void WindowEditorObjectiveOptionsMainMousedown(WindowBase *w, WidgetIndex widgetIndex, Widget* widget);
-static void WindowEditorObjectiveOptionsMainDropdown(WindowBase *w, WidgetIndex widgetIndex, int32_t dropdownIndex);
-static void WindowEditorObjectiveOptionsMainUpdate(WindowBase *w);
-static void WindowEditorObjectiveOptionsMainTextinput(WindowBase *w, WidgetIndex widgetIndex, const char *text);
-static void WindowEditorObjectiveOptionsMainInvalidate(WindowBase *w);
-static void WindowEditorObjectiveOptionsMainPaint(WindowBase *w, DrawPixelInfo *dpi);
-
-static void WindowEditorObjectiveOptionsRidesMouseup(WindowBase *w, WidgetIndex widgetIndex);
-static void WindowEditorObjectiveOptionsRidesResize(WindowBase *w);
-static void WindowEditorObjectiveOptionsRidesUpdate(WindowBase *w);
-static void WindowEditorObjectiveOptionsRidesScrollgetheight(WindowBase *w, int32_t scrollIndex, int32_t *width, int32_t *height);
-static void WindowEditorObjectiveOptionsRidesScrollmousedown(WindowBase *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
-static void WindowEditorObjectiveOptionsRidesScrollmouseover(WindowBase *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
-static void WindowEditorObjectiveOptionsRidesInvalidate(WindowBase *w);
-static void WindowEditorObjectiveOptionsRidesPaint(WindowBase *w, DrawPixelInfo *dpi);
-static void WindowEditorObjectiveOptionsRidesScrollpaint(WindowBase *w, DrawPixelInfo *dpi, int32_t scrollIndex);
-
-// 0x009A9DF4
-static WindowEventList window_objective_options_main_events([](auto& events)
-{
-    events.mouse_up = &WindowEditorObjectiveOptionsMainMouseup;
-    events.resize = &WindowEditorObjectiveOptionsMainResize;
-    events.mouse_down = &WindowEditorObjectiveOptionsMainMousedown;
-    events.dropdown = &WindowEditorObjectiveOptionsMainDropdown;
-    events.update = &WindowEditorObjectiveOptionsMainUpdate;
-    events.text_input = &WindowEditorObjectiveOptionsMainTextinput;
-    events.invalidate = &WindowEditorObjectiveOptionsMainInvalidate;
-    events.paint = &WindowEditorObjectiveOptionsMainPaint;
-});
-
-// 0x009A9F58
-static WindowEventList window_objective_options_rides_events([](auto& events)
-{
-    events.mouse_up = &WindowEditorObjectiveOptionsRidesMouseup;
-    events.resize = &WindowEditorObjectiveOptionsRidesResize;
-    events.update = &WindowEditorObjectiveOptionsRidesUpdate;
-    events.get_scroll_size = &WindowEditorObjectiveOptionsRidesScrollgetheight;
-    events.scroll_mousedown = &WindowEditorObjectiveOptionsRidesScrollmousedown;
-    events.scroll_mouseover = &WindowEditorObjectiveOptionsRidesScrollmouseover;
-    events.invalidate = &WindowEditorObjectiveOptionsRidesInvalidate;
-    events.paint = &WindowEditorObjectiveOptionsRidesPaint;
-    events.scroll_paint = &WindowEditorObjectiveOptionsRidesScrollpaint;
-});
-
-static WindowEventList *window_editor_objective_options_page_events[] = {
-    &window_objective_options_main_events,
-    &window_objective_options_rides_events,
-};
-
-#pragma endregion
-
 #pragma region Enabled widgets
 
 static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
@@ -202,12 +147,123 @@ public:
         UpdateDisabledWidgets();
     }
 
+    void OnMouseUp(WidgetIndex widgetIndex) override
+    {
+        switch (widgetIndex)
+        {
+            case WIDX_CLOSE:
+                Close();
+                break;
+            case WIDX_TAB_1:
+            case WIDX_TAB_2:
+                SetPage(widgetIndex - WIDX_TAB_1);
+                break;
+        }
+
+        if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN)
+        {
+            OnMouseUpMain(widgetIndex);
+        }
+    }
+
     void OnResize() override
     {
+        switch (page)
+        {
+            case WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN:
+                OnResizeMain();
+                break;
+            case WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES:
+                OnResizeRides();
+                break;
+        }
     }
 
     void OnPrepareDraw() override
     {
+        switch (page)
+        {
+            case WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN:
+                OnPrepareDrawMain();
+                break;
+            case WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES:
+                OnPrepareDrawRides();
+                break;
+        }
+    }
+
+    void OnUpdate() override
+    {
+        switch (page)
+        {
+            case WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN:
+                OnUpdateMain();
+                break;
+            case WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES:
+                OnUpdateRides();
+                break;
+        }
+    }
+
+    void OnDraw(DrawPixelInfo& dpi) override
+    {
+        switch (page)
+        {
+            case WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN:
+                OnDrawMain(&dpi);
+                break;
+            case WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES:
+                OnDrawRides(&dpi);
+                break;
+        }
+    }
+
+    void OnMouseDown(WidgetIndex widgetIndex) override
+    {
+        if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN)
+        {
+            OnMouseDownMain(widgetIndex);
+        }
+    }
+
+    void OnDropdown(WidgetIndex widgetIndex, int32_t selectedIndex) override
+    {
+        if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN)
+        {
+            OnDropdownMain(widgetIndex, selectedIndex);
+        }
+    }
+
+    void OnTextInput(WidgetIndex widgetIndex, std::string_view text) override
+    {
+        if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN)
+        {
+            OnTextInputMain(widgetIndex, text);
+        }
+    }
+
+    void OnScrollMouseDown(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override
+    {
+        if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
+        {
+            OnScrollMouseDownRides(scrollIndex, screenCoords);
+        }
+    }
+
+    void OnScrollMouseOver(int32_t scrollIndex, const ScreenCoordsXY& screenCoords) override
+    {
+        if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
+        {
+            OnScrollMouseOver(scrollIndex, screenCoords);
+        }
+    }
+
+    void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
+    {
+        if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
+        {
+            OnScrollDraw(scrollIndex, dpi);
+        }
     }
 
 private:
@@ -226,7 +282,6 @@ private:
         no_list_items = 0;
         selected_list_item = -1;
         hold_down_widgets = window_editor_objective_options_page_hold_down_widgets[newPage];
-        event_handlers = window_editor_objective_options_page_events[newPage];
         widgets = window_editor_objective_options_widgets[newPage];
         Invalidate();
         UpdateDisabledWidgets();
@@ -561,13 +616,6 @@ private:
     {
         switch (widgetIndex)
         {
-            case WIDX_CLOSE:
-                Close();
-                break;
-            case WIDX_TAB_1:
-            case WIDX_TAB_2:
-                SetPage(widgetIndex - WIDX_TAB_1);
-                break;
             case WIDX_PARK_NAME:
             {
                 auto& park = OpenRCT2::GetContext()->GetGameState()->GetPark();
@@ -687,16 +735,16 @@ private:
      *
      *  rct2: 0x00671A73
      */
-    void OnTextInputMain(WidgetIndex widgetIndex, const char* text)
+    void OnTextInputMain(WidgetIndex widgetIndex, std::string_view text)
     {
-        if (text == nullptr)
+        if (text.empty())
             return;
 
         switch (widgetIndex)
         {
             case WIDX_PARK_NAME:
             {
-                auto action = ParkSetNameAction(text);
+                auto action = ParkSetNameAction(std::string(text));
                 GameActions::Execute(&action);
 
                 if (gScenarioName.empty())
@@ -922,24 +970,6 @@ private:
 #pragma endregion
 
 #pragma region Rides
-
-    /**
-     *
-     *  rct2: 0x006724A4
-     */
-    void OnMouseUpRides(WidgetIndex widgetIndex)
-    {
-        switch (widgetIndex)
-        {
-            case WIDX_CLOSE:
-                Close();
-                break;
-            case WIDX_TAB_1:
-            case WIDX_TAB_2:
-                SetPage(widgetIndex - WIDX_TAB_1);
-                break;
-        }
-    }
 
     /**
      *

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -1010,15 +1010,6 @@ private:
 
     /**
      *
-     *  rct2: 0x006724BF
-     */
-    void OnScrollGetHeightRides(WindowBase* w, int32_t scrollIndex, int32_t* widthToSet, int32_t* heightToSet)
-    {
-        *heightToSet = no_list_items * 12;
-    }
-
-    /**
-     *
      *  rct2: 0x006724FC
      */
     void OnScrollMouseDownRides(int32_t scrollIndex, const ScreenCoordsXY& screenCoords)

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -132,7 +132,7 @@ static uint64_t window_editor_objective_options_page_hold_down_widgets[] = {
 
 #pragma endregion
 
-class EditorObjectiveOptionsWindow : public Window
+class EditorObjectiveOptionsWindow final : public Window
 {
 public:
     void OnOpen() override


### PR DESCRIPTION
This PR refactors EditorObjectiveOptions to use the Window class. It also removes a few unused includes.

The refactored code was tested on a Windows x86 build and compared against equivalent behaviour in the latest release to ensure that all behaviour renamed unchanged. Some of the local variables were updated as the compiler was giving warnings about the names shadowing the outer scope - I tried to ensure that the meaning was as similar to the original as possible (i.e., change "width" to "currentWidth". 

I had a minor query in relation to a method in the original code called `WindowEditorObjectiveOptionsRidesScrollgetheight`. There does not seem to be a corresponding Window event for this in the same way that there is for other scroll event like `OnScrollMouseOver` or `OnScrollMouseDown`, so I wasn't sure what to do with this. Because this method doesn't seem to be called anywhere, I just renamed it in a similar convention to the other scroll events and left it in the class, but perhaps further edits are required here - if so just let me know and I will incorporate.  