### PR TITLE
CMakeLists.txt: Do not force download of OpenMSX/OpenSFX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,8 @@ option(PORTABLE "Create a portable build (-rpath=$ORIGIN)" OFF)
 option(APPIMAGE "Create an appimage build (-rpath=$ORIGIN/../lib)" OFF)
 option(DOWNLOAD_TITLE_SEQUENCES "Download title sequences during installation." ON)
 option(DOWNLOAD_OBJECTS "Download objects during installation." ON)
-option(DOWNLOAD_OPENSFX "Download OpenSoundEffects during installation." OFF)
-option(DOWNLOAD_OPENMSX "Download OpenMusic during installation." OFF)
+option(DOWNLOAD_OPENSFX "Download OpenSoundEffects during installation." ON)
+option(DOWNLOAD_OPENMSX "Download OpenMusic during installation." ON)
 CMAKE_DEPENDENT_OPTION(DOWNLOAD_REPLAYS "Download replays during installation." ON
     "WITH_TESTS" OFF)
 CMAKE_DEPENDENT_OPTION(MACOS_USE_DEPENDENCIES "Use OpenRCT2 dependencies instead of system libraries" ON
@@ -159,12 +159,6 @@ if (MACOS_USE_DEPENDENCIES)
         endif()
     endif ()
 endif ()
-
-# If OS is Linux, import OpenSoundEffects and OpenMusic
-if(UNIX AND NOT APPLE)
-    set(DOWNLOAD_OPENMSX ON)
-    set(DOWNLOAD_OPENSFX ON)
-endif()
 
 # LIST of supported flags, use SET_CHECK_CXX_FLAGS() to apply to target.
 # Use ADD_CHECK_CXX_COMPILER_FLAG() to add to list.


### PR DESCRIPTION
This change removes the hardcoded enable for Linuxsystems, where DOWNLOAD_OPENMSX and DOWNLOAD_OPENSFX is always set to ON and as a result overwriting users choice not to download those files.

This fixes https://github.com/OpenRCT2/OpenRCT2/issues/19763
Signed-off-by: Conrad Kostecki <conikost@gentoo.org>