### PR TITLE
Fix #9534: Screams cut off on steep diagonal drops

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -6,6 +6,7 @@
 - Improved: [#20393, #20410] Add Cyrillic characters Ґґ, Ѕѕ, Єє, Іі, Її, and Јј to the sprite font. 
 - Change: [#20110] Fix a few RCT1 build height parity discrepancies.
 - Fix: [#6152] Camera and UI are no longer locked at 40 Hz, providing a smoother experience.
+- Fix: [#9534] Screams no longer cut-off on steep diagonal drops
 - Fix: [#19823] Parkobj: disallow overriding objects of different object types.
 - Fix: [#20083] Cannot use terrain surfaces with ID > 32 and terrain edges with ID > 16.
 - Fix: [#20111] All coaster types can access the new diagonal slope pieces.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "8"
+#define NETWORK_STREAM_VERSION "9"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -5529,6 +5529,10 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
                 continue;
             if (vehicle2->Pitch <= 15)
                 return ProduceScreamSound(totalNumPeeps);
+            // Pitch 52 occurs on steep diagonal backward drops.
+            // (50 and 51 occur on gentle ones.)
+            if (vehicle2->Pitch == 52)
+                return ProduceScreamSound(totalNumPeeps);
         }
         return OpenRCT2::Audio::SoundId::Null;
     }
@@ -5546,6 +5550,10 @@ OpenRCT2::Audio::SoundId Vehicle::UpdateScreamSound()
         if (vehicle2->Pitch < 17)
             continue;
         if (vehicle2->Pitch <= 23)
+            return ProduceScreamSound(totalNumPeeps);
+        // Pitch 55 occurs on steep diagonal drops.
+        // (53 and 54 occur on gentle ones.)
+        if (vehicle2->Pitch == 55)
             return ProduceScreamSound(totalNumPeeps);
     }
     return OpenRCT2::Audio::SoundId::Null;


### PR DESCRIPTION
Added the Pitch values for steep diagonal drops to the checks in `UpdateScreamSound` in `Vehicle.cpp`.  
With this, guests' screams will not be cut-off anymore once all cars have reached the straight part of a steep diagonal drop.

Closes #9534.