### PR TITLE
Fix VS debug builds not finding gtestd.lib

### DIFF
--- a/test/tests/tests.vcxproj
+++ b/test/tests/tests.vcxproj
@@ -62,7 +62,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>libopenrct2.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">gtestd.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Configuration)'=='Debug'">gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)'!='Debug'">gtest.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
     </Link>


### PR DESCRIPTION
Regression from #19790, we probably should add at least a single debug build to the CI to ensure our setup actually builds.