### PR TITLE
Fix #19803. Crash when invalid scenery element for sign

### DIFF
--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -250,7 +250,10 @@ public:
 
             main_colour_btn->type = WindowWidgetType::Empty;
             text_colour_btn->type = WindowWidgetType::Empty;
-
+            if (wallEntry == nullptr)
+            {
+                return;
+            }
             if (wallEntry->flags & WALL_SCENERY_HAS_PRIMARY_COLOUR)
             {
                 main_colour_btn->type = WindowWidgetType::ColourBtn;
@@ -266,7 +269,10 @@ public:
 
             main_colour_btn->type = WindowWidgetType::Empty;
             text_colour_btn->type = WindowWidgetType::Empty;
-
+            if (sceneryEntry == nullptr)
+            {
+                return;
+            }
             if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_PRIMARY_COLOUR)
             {
                 main_colour_btn->type = WindowWidgetType::ColourBtn;


### PR DESCRIPTION
Probably caused by a plugin swapping out underlying scenery whilst the window is open