### PR TITLE
Pass DrawPixelInfo by reference in most places

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -145,7 +145,7 @@ public:
     void Draw(DrawPixelInfo* dpi) override
     {
         auto bgColour = ThemeGetColour(WindowClass::Chat, 0);
-        ChatDraw(dpi, bgColour);
+        ChatDraw(*dpi, bgColour);
         _inGameConsole.Draw(*dpi);
     }
 

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -146,7 +146,7 @@ public:
     {
         auto bgColour = ThemeGetColour(WindowClass::Chat, 0);
         ChatDraw(dpi, bgColour);
-        _inGameConsole.Draw(dpi);
+        _inGameConsole.Draw(*dpi);
     }
 
     // Window

--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -142,11 +142,11 @@ public:
         _inGameConsole.Update();
     }
 
-    void Draw(DrawPixelInfo* dpi) override
+    void Draw(DrawPixelInfo& dpi) override
     {
         auto bgColour = ThemeGetColour(WindowClass::Chat, 0);
-        ChatDraw(*dpi, bgColour);
-        _inGameConsole.Draw(*dpi);
+        ChatDraw(dpi, bgColour);
+        _inGameConsole.Draw(dpi);
     }
 
     // Window
@@ -291,12 +291,12 @@ public:
         return std::make_shared<DrawingEngineFactory>();
     }
 
-    void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, DrawPixelInfo* dpi, DrawWeatherFunc drawFunc) override
+    void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, DrawPixelInfo& dpi, DrawWeatherFunc drawFunc) override
     {
-        int32_t left = dpi->x;
-        int32_t right = left + dpi->width;
-        int32_t top = dpi->y;
-        int32_t bottom = top + dpi->height;
+        int32_t left = dpi.x;
+        int32_t right = left + dpi.width;
+        int32_t top = dpi.y;
+        int32_t bottom = top + dpi.height;
 
         for (auto& w : g_window_list)
         {
@@ -888,7 +888,7 @@ private:
     }
 
     static void DrawWeatherWindow(
-        DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, WindowBase* original_w, int16_t left, int16_t right, int16_t top,
+        DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, WindowBase* original_w, int16_t left, int16_t right, int16_t top,
         int16_t bottom, DrawWeatherFunc drawFunc)
     {
         WindowBase* w{};

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -340,7 +340,7 @@ public:
         const OpenGLFramebuffer& framebuffer = _drawingContext->GetFinalFramebuffer();
         framebuffer.Bind();
         framebuffer.GetPixels(_bitsDPI);
-        std::string result = ScreenshotDumpPNG(&_bitsDPI);
+        std::string result = ScreenshotDumpPNG(_bitsDPI);
         return result;
     }
 

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -325,7 +325,7 @@ public:
         _drawingContext->CalculcateClipping(&_bitsDPI);
 
         WindowUpdateAllViewports();
-        WindowDrawAll(&_bitsDPI, 0, 0, _width, _height);
+        WindowDrawAll(_bitsDPI, 0, 0, _width, _height);
     }
 
     void PaintWeather() override

--- a/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/OpenGLDrawingEngine.cpp
@@ -131,7 +131,7 @@ public:
     }
 
     virtual void Draw(
-        DrawPixelInfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+        DrawPixelInfo& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
         const uint8_t* weatherpattern) override
     {
         const uint8_t* pattern = weatherpattern;
@@ -141,7 +141,7 @@ public:
         uint8_t patternStartXOffset = xStart % patternXSpace;
         uint8_t patternStartYOffset = yStart % patternYSpace;
 
-        uint32_t pixelOffset = (dpi->pitch + dpi->width) * y + x;
+        uint32_t pixelOffset = (dpi.pitch + dpi.width) * y + x;
         uint8_t patternYPos = patternStartYOffset % patternYSpace;
 
         for (; height != 0; height--)
@@ -157,14 +157,14 @@ public:
                 auto patternPixel = pattern[patternYPos * 2 + 1];
                 for (; xPixelOffset < finalPixelOffset; xPixelOffset += patternXSpace)
                 {
-                    int32_t pixelX = xPixelOffset % dpi->width;
-                    int32_t pixelY = (xPixelOffset / dpi->width) % dpi->height;
+                    int32_t pixelX = xPixelOffset % dpi.width;
+                    int32_t pixelY = (xPixelOffset / dpi.width) % dpi.height;
 
-                    _drawingContext->DrawLine(dpi, patternPixel, { { pixelX, pixelY }, { pixelX + 1, pixelY + 1 } });
+                    _drawingContext->DrawLine(&dpi, patternPixel, { { pixelX, pixelY }, { pixelX + 1, pixelY + 1 } });
                 }
             }
 
-            pixelOffset += dpi->pitch + dpi->width;
+            pixelOffset += dpi.pitch + dpi.width;
             patternYPos++;
             patternYPos %= patternYSpace;
         }
@@ -332,7 +332,7 @@ public:
     {
         _drawingContext->CalculcateClipping(&_bitsDPI);
 
-        DrawWeather(&_bitsDPI, &_weatherDrawer);
+        DrawWeather(_bitsDPI, &_weatherDrawer);
     }
 
     std::string Screenshot() override

--- a/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
+++ b/src/openrct2-ui/drawing/engines/opengl/TextureCache.cpp
@@ -222,7 +222,7 @@ void TextureCache::GeneratePaletteTexture()
             const auto* element = GfxGetG1Element(g1Index.value());
             if (element != nullptr)
             {
-                GfxDrawSpriteSoftware(&dpi, ImageId(g1Index.value()), { -element->x_offset, y - element->y_offset });
+                GfxDrawSpriteSoftware(dpi, ImageId(g1Index.value()), { -element->x_offset, y - element->y_offset });
             }
         }
     }
@@ -357,7 +357,7 @@ DrawPixelInfo TextureCache::GetImageAsDPI(const ImageId imageId)
     int32_t height = g1Element->height;
 
     DrawPixelInfo dpi = CreateDPI(width, height);
-    GfxDrawSpriteSoftware(&dpi, imageId, { -g1Element->x_offset, -g1Element->y_offset });
+    GfxDrawSpriteSoftware(dpi, imageId, { -g1Element->x_offset, -g1Element->y_offset });
     return dpi;
 }
 
@@ -370,7 +370,7 @@ DrawPixelInfo TextureCache::GetGlyphAsDPI(const ImageId imageId, const PaletteMa
     DrawPixelInfo dpi = CreateDPI(width, height);
 
     const auto glyphCoords = ScreenCoordsXY{ -g1Element->x_offset, -g1Element->y_offset };
-    GfxDrawSpritePaletteSetSoftware(&dpi, imageId, glyphCoords, palette);
+    GfxDrawSpritePaletteSetSoftware(dpi, imageId, glyphCoords, palette);
     return dpi;
 }
 

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -16,7 +16,7 @@
 
 namespace Graph
 {
-    static void DrawMonths(DrawPixelInfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
+    static void DrawMonths(DrawPixelInfo& dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
         auto& date = GetDate();
         int32_t currentMonth = date.GetMonth();
@@ -31,11 +31,11 @@ namespace Graph
                 auto ft = Formatter();
                 ft.Add<uint32_t>(DateGameShortMonthNames[DateGetMonth((yearOver32 / 4) + MONTH_COUNT)]);
                 DrawTextBasic(
-                    *dpi, screenCoords - ScreenCoordsXY{ 0, 10 }, STR_GRAPH_LABEL, ft,
+                    dpi, screenCoords - ScreenCoordsXY{ 0, 10 }, STR_GRAPH_LABEL, ft,
                     { FontStyle::Small, TextAlignment::CENTRE });
 
                 // Draw month mark
-                GfxFillRect(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_10);
+                GfxFillRect(&dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_10);
             }
 
             yearOver32 = (yearOver32 + 1) % 32;
@@ -43,7 +43,7 @@ namespace Graph
         }
     }
 
-    static void DrawLineA(DrawPixelInfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
+    static void DrawLineA(DrawPixelInfo& dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
         auto lastCoords = ScreenCoordsXY{ -1, -1 };
         auto coords = origCoords;
@@ -59,11 +59,11 @@ namespace Graph
                     auto rightBottom1 = coords + ScreenCoordsXY{ 1, 1 };
                     auto leftTop2 = lastCoords + ScreenCoordsXY{ 0, 1 };
                     auto rightBottom2 = coords + ScreenCoordsXY{ 0, 1 };
-                    GfxDrawLine(dpi, { leftTop1, rightBottom1 }, PALETTE_INDEX_10);
-                    GfxDrawLine(dpi, { leftTop2, rightBottom2 }, PALETTE_INDEX_10);
+                    GfxDrawLine(&dpi, { leftTop1, rightBottom1 }, PALETTE_INDEX_10);
+                    GfxDrawLine(&dpi, { leftTop2, rightBottom2 }, PALETTE_INDEX_10);
                 }
                 if (i == 0)
-                    GfxFillRect(dpi, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
+                    GfxFillRect(&dpi, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
 
                 lastCoords = coords;
             }
@@ -71,7 +71,7 @@ namespace Graph
         }
     }
 
-    static void DrawLineB(DrawPixelInfo* dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
+    static void DrawLineB(DrawPixelInfo& dpi, const uint8_t* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
         auto lastCoords = ScreenCoordsXY{ -1, -1 };
         auto coords = origCoords;
@@ -85,10 +85,10 @@ namespace Graph
                 {
                     auto leftTop = lastCoords;
                     auto rightBottom = coords;
-                    GfxDrawLine(dpi, { leftTop, rightBottom }, PALETTE_INDEX_21);
+                    GfxDrawLine(&dpi, { leftTop, rightBottom }, PALETTE_INDEX_21);
                 }
                 if (i == 0)
-                    GfxFillRect(dpi, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PALETTE_INDEX_21);
+                    GfxFillRect(&dpi, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PALETTE_INDEX_21);
 
                 lastCoords = coords;
             }
@@ -96,7 +96,7 @@ namespace Graph
         }
     }
 
-    void Draw(DrawPixelInfo* dpi, uint8_t* history, int32_t count, const ScreenCoordsXY& screenPos)
+    void Draw(DrawPixelInfo& dpi, uint8_t* history, int32_t count, const ScreenCoordsXY& screenPos)
     {
         DrawMonths(dpi, history, count, screenPos);
         DrawLineA(dpi, history, count, screenPos);
@@ -152,7 +152,7 @@ static const FinancialTooltipInfo FinanceTooltipInfoFromMoney(
 
 namespace Graph
 {
-    static void DrawMonths(DrawPixelInfo* dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords)
+    static void DrawMonths(DrawPixelInfo& dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords)
     {
         auto& date = GetDate();
         int32_t currentMonth = date.GetMonth();
@@ -167,11 +167,11 @@ namespace Graph
                 auto ft = Formatter();
                 ft.Add<StringId>(DateGameShortMonthNames[DateGetMonth((yearOver32 / 4) + MONTH_COUNT)]);
                 DrawTextBasic(
-                    *dpi, screenCoords - ScreenCoordsXY{ 0, 10 }, STR_GRAPH_LABEL, ft,
+                    dpi, screenCoords - ScreenCoordsXY{ 0, 10 }, STR_GRAPH_LABEL, ft,
                     { FontStyle::Small, TextAlignment::CENTRE });
 
                 // Draw month mark
-                GfxFillRect(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_10);
+                GfxFillRect(&dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_10);
             }
 
             yearOver32 = (yearOver32 + 1) % 32;
@@ -180,7 +180,7 @@ namespace Graph
     }
 
     static void DrawLineA(
-        DrawPixelInfo* dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords, int32_t modifier,
+        DrawPixelInfo& dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords, int32_t modifier,
         int32_t offset)
     {
         auto lastCoords = ScreenCoordsXY{ -1, -1 };
@@ -197,11 +197,11 @@ namespace Graph
                     auto rightBottom1 = coords + ScreenCoordsXY{ 1, 1 };
                     auto leftTop2 = lastCoords + ScreenCoordsXY{ 0, 1 };
                     auto rightBottom2 = coords + ScreenCoordsXY{ 0, 1 };
-                    GfxDrawLine(dpi, { leftTop1, rightBottom1 }, PALETTE_INDEX_10);
-                    GfxDrawLine(dpi, { leftTop2, rightBottom2 }, PALETTE_INDEX_10);
+                    GfxDrawLine(&dpi, { leftTop1, rightBottom1 }, PALETTE_INDEX_10);
+                    GfxDrawLine(&dpi, { leftTop2, rightBottom2 }, PALETTE_INDEX_10);
                 }
                 if (i == 0)
-                    GfxFillRect(dpi, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
+                    GfxFillRect(&dpi, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
 
                 lastCoords = coords;
             }
@@ -210,7 +210,7 @@ namespace Graph
     }
 
     static void DrawLineB(
-        DrawPixelInfo* dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords, int32_t modifier,
+        DrawPixelInfo& dpi, const money64* history, int32_t count, const ScreenCoordsXY& origCoords, int32_t modifier,
         int32_t offset)
     {
         auto lastCoords = ScreenCoordsXY{ -1, -1 };
@@ -225,10 +225,10 @@ namespace Graph
                 {
                     auto leftTop = lastCoords;
                     auto rightBottom = coords;
-                    GfxDrawLine(dpi, { leftTop, rightBottom }, PALETTE_INDEX_21);
+                    GfxDrawLine(&dpi, { leftTop, rightBottom }, PALETTE_INDEX_21);
                 }
                 if (i == 0)
-                    GfxFillRect(dpi, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PALETTE_INDEX_21);
+                    GfxFillRect(&dpi, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PALETTE_INDEX_21);
 
                 lastCoords = coords;
             }
@@ -237,7 +237,7 @@ namespace Graph
     }
 
     static void DrawHoveredValue(
-        DrawPixelInfo* dpi, const money64* history, const int32_t historyCount, const ScreenCoordsXY& screenCoords,
+        DrawPixelInfo& dpi, const money64* history, const int32_t historyCount, const ScreenCoordsXY& screenCoords,
         const int32_t modifier, const int32_t offset)
     {
         const auto cursorPosition = ContextGetCursorPositionScaled();
@@ -254,26 +254,26 @@ namespace Graph
         {
             return;
         }
-        GfxDrawDashedLine(dpi, { { info.coords.x, chartFrame.GetTop() }, info.coords }, DefaultDashedLength, 0);
-        GfxDrawDashedLine(dpi, { { chartFrame.GetLeft() - 10, info.coords.y }, info.coords }, DefaultDashedLength, 0);
+        GfxDrawDashedLine(&dpi, { { info.coords.x, chartFrame.GetTop() }, info.coords }, DefaultDashedLength, 0);
+        GfxDrawDashedLine(&dpi, { { chartFrame.GetLeft() - 10, info.coords.y }, info.coords }, DefaultDashedLength, 0);
 
         if (cursorPosition.y > info.coords.y)
         {
-            GfxDrawDashedLine(dpi, { info.coords, { info.coords.x, cursorPosition.y } }, DefaultDashedLength, 0);
+            GfxDrawDashedLine(&dpi, { info.coords, { info.coords.x, cursorPosition.y } }, DefaultDashedLength, 0);
         }
 
         auto ft = Formatter();
         ft.Add<money64>(info.money);
         DrawTextBasic(
-            *dpi, info.coords - ScreenCoordsXY{ 0, 16 }, STR_FINANCES_SUMMARY_EXPENDITURE_VALUE, ft, { TextAlignment::CENTRE });
+            dpi, info.coords - ScreenCoordsXY{ 0, 16 }, STR_FINANCES_SUMMARY_EXPENDITURE_VALUE, ft, { TextAlignment::CENTRE });
 
-        GfxFillRect(dpi, { { info.coords - ScreenCoordsXY{ 2, 2 } }, info.coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
+        GfxFillRect(&dpi, { { info.coords - ScreenCoordsXY{ 2, 2 } }, info.coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
         GfxFillRect(
-            dpi, { { info.coords - ScreenCoordsXY{ 1, 1 } }, { info.coords + ScreenCoordsXY{ 1, 1 } } }, PALETTE_INDEX_21);
+            &dpi, { { info.coords - ScreenCoordsXY{ 1, 1 } }, { info.coords + ScreenCoordsXY{ 1, 1 } } }, PALETTE_INDEX_21);
     }
 
     void Draw(
-        DrawPixelInfo* dpi, const money64* history, const int32_t count, const ScreenCoordsXY& screenCoords,
+        DrawPixelInfo& dpi, const money64* history, const int32_t count, const ScreenCoordsXY& screenCoords,
         const int32_t modifier, const int32_t offset)
     {
         DrawMonths(dpi, history, count, screenCoords);

--- a/src/openrct2-ui/interface/Graph.cpp
+++ b/src/openrct2-ui/interface/Graph.cpp
@@ -35,7 +35,7 @@ namespace Graph
                     { FontStyle::Small, TextAlignment::CENTRE });
 
                 // Draw month mark
-                GfxFillRect(&dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_10);
+                GfxFillRect(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_10);
             }
 
             yearOver32 = (yearOver32 + 1) % 32;
@@ -59,11 +59,11 @@ namespace Graph
                     auto rightBottom1 = coords + ScreenCoordsXY{ 1, 1 };
                     auto leftTop2 = lastCoords + ScreenCoordsXY{ 0, 1 };
                     auto rightBottom2 = coords + ScreenCoordsXY{ 0, 1 };
-                    GfxDrawLine(&dpi, { leftTop1, rightBottom1 }, PALETTE_INDEX_10);
-                    GfxDrawLine(&dpi, { leftTop2, rightBottom2 }, PALETTE_INDEX_10);
+                    GfxDrawLine(dpi, { leftTop1, rightBottom1 }, PALETTE_INDEX_10);
+                    GfxDrawLine(dpi, { leftTop2, rightBottom2 }, PALETTE_INDEX_10);
                 }
                 if (i == 0)
-                    GfxFillRect(&dpi, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
+                    GfxFillRect(dpi, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
 
                 lastCoords = coords;
             }
@@ -85,10 +85,10 @@ namespace Graph
                 {
                     auto leftTop = lastCoords;
                     auto rightBottom = coords;
-                    GfxDrawLine(&dpi, { leftTop, rightBottom }, PALETTE_INDEX_21);
+                    GfxDrawLine(dpi, { leftTop, rightBottom }, PALETTE_INDEX_21);
                 }
                 if (i == 0)
-                    GfxFillRect(&dpi, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PALETTE_INDEX_21);
+                    GfxFillRect(dpi, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PALETTE_INDEX_21);
 
                 lastCoords = coords;
             }
@@ -171,7 +171,7 @@ namespace Graph
                     { FontStyle::Small, TextAlignment::CENTRE });
 
                 // Draw month mark
-                GfxFillRect(&dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_10);
+                GfxFillRect(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_10);
             }
 
             yearOver32 = (yearOver32 + 1) % 32;
@@ -197,11 +197,11 @@ namespace Graph
                     auto rightBottom1 = coords + ScreenCoordsXY{ 1, 1 };
                     auto leftTop2 = lastCoords + ScreenCoordsXY{ 0, 1 };
                     auto rightBottom2 = coords + ScreenCoordsXY{ 0, 1 };
-                    GfxDrawLine(&dpi, { leftTop1, rightBottom1 }, PALETTE_INDEX_10);
-                    GfxDrawLine(&dpi, { leftTop2, rightBottom2 }, PALETTE_INDEX_10);
+                    GfxDrawLine(dpi, { leftTop1, rightBottom1 }, PALETTE_INDEX_10);
+                    GfxDrawLine(dpi, { leftTop2, rightBottom2 }, PALETTE_INDEX_10);
                 }
                 if (i == 0)
-                    GfxFillRect(&dpi, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
+                    GfxFillRect(dpi, { coords, coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
 
                 lastCoords = coords;
             }
@@ -225,10 +225,10 @@ namespace Graph
                 {
                     auto leftTop = lastCoords;
                     auto rightBottom = coords;
-                    GfxDrawLine(&dpi, { leftTop, rightBottom }, PALETTE_INDEX_21);
+                    GfxDrawLine(dpi, { leftTop, rightBottom }, PALETTE_INDEX_21);
                 }
                 if (i == 0)
-                    GfxFillRect(&dpi, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PALETTE_INDEX_21);
+                    GfxFillRect(dpi, { coords - ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 1, 1 } }, PALETTE_INDEX_21);
 
                 lastCoords = coords;
             }
@@ -254,12 +254,12 @@ namespace Graph
         {
             return;
         }
-        GfxDrawDashedLine(&dpi, { { info.coords.x, chartFrame.GetTop() }, info.coords }, DefaultDashedLength, 0);
-        GfxDrawDashedLine(&dpi, { { chartFrame.GetLeft() - 10, info.coords.y }, info.coords }, DefaultDashedLength, 0);
+        GfxDrawDashedLine(dpi, { { info.coords.x, chartFrame.GetTop() }, info.coords }, DefaultDashedLength, 0);
+        GfxDrawDashedLine(dpi, { { chartFrame.GetLeft() - 10, info.coords.y }, info.coords }, DefaultDashedLength, 0);
 
         if (cursorPosition.y > info.coords.y)
         {
-            GfxDrawDashedLine(&dpi, { info.coords, { info.coords.x, cursorPosition.y } }, DefaultDashedLength, 0);
+            GfxDrawDashedLine(dpi, { info.coords, { info.coords.x, cursorPosition.y } }, DefaultDashedLength, 0);
         }
 
         auto ft = Formatter();
@@ -267,9 +267,9 @@ namespace Graph
         DrawTextBasic(
             dpi, info.coords - ScreenCoordsXY{ 0, 16 }, STR_FINANCES_SUMMARY_EXPENDITURE_VALUE, ft, { TextAlignment::CENTRE });
 
-        GfxFillRect(&dpi, { { info.coords - ScreenCoordsXY{ 2, 2 } }, info.coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
+        GfxFillRect(dpi, { { info.coords - ScreenCoordsXY{ 2, 2 } }, info.coords + ScreenCoordsXY{ 2, 2 } }, PALETTE_INDEX_10);
         GfxFillRect(
-            &dpi, { { info.coords - ScreenCoordsXY{ 1, 1 } }, { info.coords + ScreenCoordsXY{ 1, 1 } } }, PALETTE_INDEX_21);
+            dpi, { { info.coords - ScreenCoordsXY{ 1, 1 } }, { info.coords + ScreenCoordsXY{ 1, 1 } } }, PALETTE_INDEX_21);
     }
 
     void Draw(

--- a/src/openrct2-ui/interface/Graph.h
+++ b/src/openrct2-ui/interface/Graph.h
@@ -15,8 +15,8 @@
 
 namespace Graph
 {
-    void Draw(DrawPixelInfo* dpi, uint8_t* history, int32_t count, const ScreenCoordsXY& screenPos);
+    void Draw(DrawPixelInfo& dpi, uint8_t* history, int32_t count, const ScreenCoordsXY& screenPos);
     void Draw(
-        DrawPixelInfo* dpi, const money64* history, const int32_t count, const ScreenCoordsXY& coords, const int32_t modifier,
+        DrawPixelInfo& dpi, const money64* history, const int32_t count, const ScreenCoordsXY& coords, const int32_t modifier,
         const int32_t offset);
 } // namespace Graph

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -264,7 +264,7 @@ void InGameConsole::Update()
     _consoleCaretTicks = (_consoleCaretTicks + 1) % 30;
 }
 
-void InGameConsole::Draw(DrawPixelInfo* dpi) const
+void InGameConsole::Draw(DrawPixelInfo& dpi) const
 {
     if (!_isOpen)
         return;
@@ -292,18 +292,18 @@ void InGameConsole::Draw(DrawPixelInfo* dpi) const
     Invalidate();
 
     // Give console area a translucent effect.
-    GfxFilterRect(dpi, { _consoleTopLeft, _consoleBottomRight }, FilterPaletteID::Palette51);
+    GfxFilterRect(&dpi, { _consoleTopLeft, _consoleBottomRight }, FilterPaletteID::Palette51);
 
     // Make input area more opaque.
     GfxFilterRect(
-        dpi, { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 10 }, _consoleBottomRight - ScreenCoordsXY{ 0, 1 } },
+        &dpi, { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 10 }, _consoleBottomRight - ScreenCoordsXY{ 0, 1 } },
         FilterPaletteID::Palette51);
 
     // Paint background colour.
     uint8_t backgroundColour = ThemeGetColour(WindowClass::Console, 0);
-    GfxFillRectInset(dpi, { _consoleTopLeft, _consoleBottomRight }, backgroundColour, INSET_RECT_FLAG_FILL_NONE);
+    GfxFillRectInset(&dpi, { _consoleTopLeft, _consoleBottomRight }, backgroundColour, INSET_RECT_FLAG_FILL_NONE);
     GfxFillRectInset(
-        dpi, { _consoleTopLeft + ScreenCoordsXY{ 1, 1 }, _consoleBottomRight - ScreenCoordsXY{ 1, 1 } }, backgroundColour,
+        &dpi, { _consoleTopLeft + ScreenCoordsXY{ 1, 1 }, _consoleBottomRight - ScreenCoordsXY{ 1, 1 } }, backgroundColour,
         INSET_RECT_FLAG_BORDER_INSET);
 
     std::string lineBuffer;
@@ -314,7 +314,7 @@ void InGameConsole::Draw(DrawPixelInfo* dpi) const
     {
         const size_t index = i + _consoleScrollPos;
         lineBuffer = _colourFormatStr + _consoleLines[index];
-        GfxDrawString(*dpi, screenCoords, lineBuffer.c_str(), { textColour, InGameConsoleGetFontStyle() });
+        GfxDrawString(dpi, screenCoords, lineBuffer.c_str(), { textColour, InGameConsoleGetFontStyle() });
         screenCoords.y += lineHeight;
     }
 
@@ -322,14 +322,14 @@ void InGameConsole::Draw(DrawPixelInfo* dpi) const
 
     // Draw current line
     lineBuffer = _colourFormatStr + _consoleCurrentLine;
-    DrawText(*dpi, screenCoords, { TEXT_COLOUR_255, InGameConsoleGetFontStyle() }, lineBuffer.c_str(), true);
+    DrawText(dpi, screenCoords, { TEXT_COLOUR_255, InGameConsoleGetFontStyle() }, lineBuffer.c_str(), true);
 
     // Draw caret
     if (_consoleCaretTicks < CONSOLE_CARET_FLASH_THRESHOLD)
     {
         auto caret = screenCoords + ScreenCoordsXY{ _caretScreenPosX, lineHeight };
         uint8_t caretColour = ColourMapA[BASE_COLOUR(textColour)].lightest;
-        GfxFillRect(dpi, { caret, caret + ScreenCoordsXY{ CONSOLE_CARET_WIDTH, 1 } }, caretColour);
+        GfxFillRect(&dpi, { caret, caret + ScreenCoordsXY{ CONSOLE_CARET_WIDTH, 1 } }, caretColour);
     }
 
     // What about border colours?
@@ -338,21 +338,21 @@ void InGameConsole::Draw(DrawPixelInfo* dpi) const
 
     // Input area top border
     GfxFillRect(
-        dpi,
+        &dpi,
         { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 11 },
           { _consoleBottomRight.x, _consoleBottomRight.y - lineHeight - 11 } },
         borderColour1);
     GfxFillRect(
-        dpi,
+        &dpi,
         { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 10 },
           { _consoleBottomRight.x, _consoleBottomRight.y - lineHeight - 10 } },
         borderColour2);
 
     // Input area bottom border
     GfxFillRect(
-        dpi, { { _consoleTopLeft.x, _consoleBottomRight.y - 1 }, { _consoleBottomRight.x, _consoleBottomRight.y - 1 } },
+        &dpi, { { _consoleTopLeft.x, _consoleBottomRight.y - 1 }, { _consoleBottomRight.x, _consoleBottomRight.y - 1 } },
         borderColour1);
-    GfxFillRect(dpi, { { _consoleTopLeft.x, _consoleBottomRight.y }, _consoleBottomRight }, borderColour2);
+    GfxFillRect(&dpi, { { _consoleTopLeft.x, _consoleBottomRight.y }, _consoleBottomRight }, borderColour2);
 }
 
 // Calculates the amount of visible lines, based on the console size, excluding the input line.

--- a/src/openrct2-ui/interface/InGameConsole.cpp
+++ b/src/openrct2-ui/interface/InGameConsole.cpp
@@ -292,18 +292,18 @@ void InGameConsole::Draw(DrawPixelInfo& dpi) const
     Invalidate();
 
     // Give console area a translucent effect.
-    GfxFilterRect(&dpi, { _consoleTopLeft, _consoleBottomRight }, FilterPaletteID::Palette51);
+    GfxFilterRect(dpi, { _consoleTopLeft, _consoleBottomRight }, FilterPaletteID::Palette51);
 
     // Make input area more opaque.
     GfxFilterRect(
-        &dpi, { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 10 }, _consoleBottomRight - ScreenCoordsXY{ 0, 1 } },
+        dpi, { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 10 }, _consoleBottomRight - ScreenCoordsXY{ 0, 1 } },
         FilterPaletteID::Palette51);
 
     // Paint background colour.
     uint8_t backgroundColour = ThemeGetColour(WindowClass::Console, 0);
-    GfxFillRectInset(&dpi, { _consoleTopLeft, _consoleBottomRight }, backgroundColour, INSET_RECT_FLAG_FILL_NONE);
+    GfxFillRectInset(dpi, { _consoleTopLeft, _consoleBottomRight }, backgroundColour, INSET_RECT_FLAG_FILL_NONE);
     GfxFillRectInset(
-        &dpi, { _consoleTopLeft + ScreenCoordsXY{ 1, 1 }, _consoleBottomRight - ScreenCoordsXY{ 1, 1 } }, backgroundColour,
+        dpi, { _consoleTopLeft + ScreenCoordsXY{ 1, 1 }, _consoleBottomRight - ScreenCoordsXY{ 1, 1 } }, backgroundColour,
         INSET_RECT_FLAG_BORDER_INSET);
 
     std::string lineBuffer;
@@ -329,7 +329,7 @@ void InGameConsole::Draw(DrawPixelInfo& dpi) const
     {
         auto caret = screenCoords + ScreenCoordsXY{ _caretScreenPosX, lineHeight };
         uint8_t caretColour = ColourMapA[BASE_COLOUR(textColour)].lightest;
-        GfxFillRect(&dpi, { caret, caret + ScreenCoordsXY{ CONSOLE_CARET_WIDTH, 1 } }, caretColour);
+        GfxFillRect(dpi, { caret, caret + ScreenCoordsXY{ CONSOLE_CARET_WIDTH, 1 } }, caretColour);
     }
 
     // What about border colours?
@@ -338,21 +338,21 @@ void InGameConsole::Draw(DrawPixelInfo& dpi) const
 
     // Input area top border
     GfxFillRect(
-        &dpi,
+        dpi,
         { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 11 },
           { _consoleBottomRight.x, _consoleBottomRight.y - lineHeight - 11 } },
         borderColour1);
     GfxFillRect(
-        &dpi,
+        dpi,
         { { _consoleTopLeft.x, _consoleBottomRight.y - lineHeight - 10 },
           { _consoleBottomRight.x, _consoleBottomRight.y - lineHeight - 10 } },
         borderColour2);
 
     // Input area bottom border
     GfxFillRect(
-        &dpi, { { _consoleTopLeft.x, _consoleBottomRight.y - 1 }, { _consoleBottomRight.x, _consoleBottomRight.y - 1 } },
+        dpi, { { _consoleTopLeft.x, _consoleBottomRight.y - 1 }, { _consoleBottomRight.x, _consoleBottomRight.y - 1 } },
         borderColour1);
-    GfxFillRect(&dpi, { { _consoleTopLeft.x, _consoleBottomRight.y }, _consoleBottomRight }, borderColour2);
+    GfxFillRect(dpi, { { _consoleTopLeft.x, _consoleBottomRight.y }, _consoleBottomRight }, borderColour2);
 }
 
 // Calculates the amount of visible lines, based on the console size, excluding the input line.

--- a/src/openrct2-ui/interface/InGameConsole.h
+++ b/src/openrct2-ui/interface/InGameConsole.h
@@ -65,7 +65,7 @@ namespace OpenRCT2::Ui
         void Scroll(int32_t linesToScroll);
 
         void Update();
-        void Draw(DrawPixelInfo* dpi) const;
+        void Draw(DrawPixelInfo& dpi) const;
 
     private:
         void ClearInput();

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -144,7 +144,7 @@ static void WidgetFrameDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widge
 
     // Draw the resize sprite at the bottom right corner
     leftTop = w.windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
-    GfxDrawSprite(dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
+    GfxDrawSprite(*dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
 }
 
 /**
@@ -175,7 +175,7 @@ static void WidgetResizeDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
 
     // Draw the resize sprite at the bottom right corner
     leftTop = w.windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
-    GfxDrawSprite(dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
+    GfxDrawSprite(*dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
 }
 
 /**
@@ -256,7 +256,7 @@ static void WidgetTabDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetI
     auto image = widget.image.WithIndex(newIndex).WithPrimary(colour);
 
     // Draw disabled image
-    GfxDrawSprite(dpi, image, leftTop);
+    GfxDrawSprite(*dpi, image, leftTop);
 }
 
 /**
@@ -844,7 +844,7 @@ static void WidgetDrawImage(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widge
         else
             image = image.WithPrimary(colour);
 
-        GfxDrawSprite(dpi, image, screenCoords);
+        GfxDrawSprite(*dpi, image, screenCoords);
     }
 }
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -722,7 +722,7 @@ static void WidgetScrollDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
 
     // Draw the scroll contents
     if (scroll_dpi.width > 0 && scroll_dpi.height > 0)
-        WindowEventScrollPaintCall(&w, &scroll_dpi, scrollIndex);
+        WindowEventScrollPaintCall(&w, scroll_dpi, scrollIndex);
 }
 
 static void WidgetHScrollbarDraw(

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -134,7 +134,7 @@ static void WidgetFrameDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widge
     uint8_t colour = w.colours[widget.colour];
 
     // Draw the frame
-    GfxFillRectInset(&dpi, { leftTop, { r, b } }, colour, press);
+    GfxFillRectInset(dpi, { leftTop, { r, b } }, colour, press);
 
     // Check if the window can be resized
     if (!(w.flags & WF_RESIZABLE))
@@ -165,7 +165,7 @@ static void WidgetResizeDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widg
     uint8_t colour = w.colours[widget.colour];
 
     // Draw the panel
-    GfxFillRectInset(&dpi, { leftTop, { r, b } }, colour, 0);
+    GfxFillRectInset(dpi, { leftTop, { r, b } }, colour, 0);
 
     // Check if the window can be resized
     if (!(w.flags & WF_RESIZABLE))
@@ -200,12 +200,12 @@ static void WidgetButtonDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widg
     if (static_cast<int32_t>(widget.image.ToUInt32()) == -2)
     {
         // Draw border with no fill
-        GfxFillRectInset(&dpi, rect, colour, press | INSET_RECT_FLAG_FILL_NONE);
+        GfxFillRectInset(dpi, rect, colour, press | INSET_RECT_FLAG_FILL_NONE);
         return;
     }
 
     // Draw the border with fill
-    GfxFillRectInset(&dpi, rect, colour, press);
+    GfxFillRectInset(dpi, rect, colour, press);
 
     WidgetDrawImage(dpi, w, widgetIndex);
 }
@@ -287,12 +287,12 @@ static void WidgetFlatButtonDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex 
         if (static_cast<int32_t>(widget.image.ToUInt32()) == -2)
         {
             // Draw border with no fill
-            GfxFillRectInset(&dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_NONE);
+            GfxFillRectInset(dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_NONE);
             return;
         }
 
         // Draw the border with fill
-        GfxFillRectInset(&dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET);
+        GfxFillRectInset(dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET);
     }
 
     // Draw image
@@ -317,7 +317,7 @@ static void WidgetTextButton(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widg
 
     // Border
     uint8_t press = WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
-    GfxFillRectInset(&dpi, rect, colour, press);
+    GfxFillRectInset(dpi, rect, colour, press);
 
     // Button caption
     if (widget.type != WindowWidgetType::TableHeader)
@@ -441,7 +441,7 @@ static void WidgetTextInset(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widge
     // Get the colour
     uint8_t colour = w.colours[widget.colour];
 
-    GfxFillRectInset(&dpi, rect, colour, INSET_RECT_F_60);
+    GfxFillRectInset(dpi, rect, colour, INSET_RECT_F_60);
     WidgetText(dpi, w, widgetIndex);
 }
 
@@ -506,24 +506,24 @@ static void WidgetGroupboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex wi
     uint8_t colour = w.colours[widget.colour] & 0x7F;
 
     // Border left of text
-    GfxFillRect(&dpi, { { l, t }, { l + 4, t } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { l + 1, t + 1 }, { l + 4, t + 1 } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l, t }, { l + 4, t } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + 1, t + 1 }, { l + 4, t + 1 } }, ColourMapA[colour].lighter);
 
     // Border right of text
-    GfxFillRect(&dpi, { { textRight, t }, { r - 1, t } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { textRight, t + 1 }, { r - 2, t + 1 } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { textRight, t }, { r - 1, t } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { textRight, t + 1 }, { r - 2, t + 1 } }, ColourMapA[colour].lighter);
 
     // Border right
-    GfxFillRect(&dpi, { { r - 1, t + 1 }, { r - 1, b - 1 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { r, t }, { r, b } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { r - 1, t + 1 }, { r - 1, b - 1 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { r, t }, { r, b } }, ColourMapA[colour].lighter);
 
     // Border bottom
-    GfxFillRect(&dpi, { { l, b - 1 }, { r - 2, b - 1 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { l, b }, { r - 1, b } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l, b - 1 }, { r - 2, b - 1 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l, b }, { r - 1, b } }, ColourMapA[colour].lighter);
 
     // Border left
-    GfxFillRect(&dpi, { { l, t + 1 }, { l, b - 2 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { l + 1, t + 2 }, { l + 1, b - 2 } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l, t + 1 }, { l, b - 2 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + 1, t + 2 }, { l + 1, b - 2 } }, ColourMapA[colour].lighter);
 }
 
 /**
@@ -546,15 +546,15 @@ static void WidgetCaptionDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex wid
     if (w.flags & WF_10)
         press |= INSET_RECT_FLAG_FILL_MID_LIGHT;
 
-    GfxFillRectInset(&dpi, { topLeft, bottomRight }, colour, press);
+    GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, press);
 
     // Black caption bars look slightly green, this fixes that
     if (colour == 0)
         GfxFillRect(
-            &dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } }, ColourMapA[colour].dark);
+            dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } }, ColourMapA[colour].dark);
     else
         GfxFilterRect(
-            &dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
+            dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
             FilterPaletteID::PaletteDarken3);
 
     // Draw text
@@ -599,7 +599,7 @@ static void WidgetCloseboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex wi
     uint8_t colour = w.colours[widget.colour];
 
     // Draw the button
-    GfxFillRectInset(&dpi, { topLeft, bottomRight }, colour, press);
+    GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, press);
 
     if (widget.text == STR_NONE)
         return;
@@ -630,7 +630,7 @@ static void WidgetCheckboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex wi
     colour_t colour = w.colours[widget.colour];
 
     // checkbox
-    GfxFillRectInset(&dpi, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, INSET_RECT_F_60);
+    GfxFillRectInset(dpi, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, INSET_RECT_F_60);
 
     if (WidgetIsDisabled(w, widgetIndex))
     {
@@ -672,7 +672,7 @@ static void WidgetScrollDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widg
     uint8_t colour = w.colours[widget.colour];
 
     // Draw the border
-    GfxFillRectInset(&dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
+    GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
 
     // Inflate by -1
     topLeft.x++;
@@ -730,18 +730,18 @@ static void WidgetHScrollbarDraw(
 {
     colour &= 0x7F;
     // Trough
-    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t }, { r - SCROLLBAR_WIDTH, b } }, ColourMapA[colour].lighter);
-    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t }, { r - SCROLLBAR_WIDTH, b } }, 0x1000000 | ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t + 2 }, { r - SCROLLBAR_WIDTH, t + 2 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t + 3 }, { r - SCROLLBAR_WIDTH, t + 3 } }, ColourMapA[colour].lighter);
-    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t + 7 }, { r - SCROLLBAR_WIDTH, t + 7 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t + 8 }, { r - SCROLLBAR_WIDTH, t + 8 } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t }, { r - SCROLLBAR_WIDTH, b } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t }, { r - SCROLLBAR_WIDTH, b } }, 0x1000000 | ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 2 }, { r - SCROLLBAR_WIDTH, t + 2 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 3 }, { r - SCROLLBAR_WIDTH, t + 3 } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 7 }, { r - SCROLLBAR_WIDTH, t + 7 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 8 }, { r - SCROLLBAR_WIDTH, t + 8 } }, ColourMapA[colour].lighter);
 
     // Left button
     {
         uint8_t flags = (scroll.flags & HSCROLLBAR_LEFT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-        GfxFillRectInset(&dpi, { { l, t }, { l + (SCROLLBAR_WIDTH - 1), b } }, colour, flags);
+        GfxFillRectInset(dpi, { { l, t }, { l + (SCROLLBAR_WIDTH - 1), b } }, colour, flags);
         GfxDrawString(dpi, { l + 1, t }, static_cast<const char*>(BlackLeftArrowString), {});
     }
 
@@ -751,14 +751,14 @@ static void WidgetHScrollbarDraw(
         int16_t right = std::min(r - SCROLLBAR_WIDTH, l + scroll.h_thumb_right - 1);
         uint8_t flags = (scroll.flags & HSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-        GfxFillRectInset(&dpi, { { left, t }, { right, b } }, colour, flags);
+        GfxFillRectInset(dpi, { { left, t }, { right, b } }, colour, flags);
     }
 
     // Right button
     {
         uint8_t flags = (scroll.flags & HSCROLLBAR_RIGHT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-        GfxFillRectInset(&dpi, { { r - (SCROLLBAR_WIDTH - 1), t }, { r, b } }, colour, flags);
+        GfxFillRectInset(dpi, { { r - (SCROLLBAR_WIDTH - 1), t }, { r, b } }, colour, flags);
         GfxDrawString(dpi, { r - 6, t }, static_cast<const char*>(BlackRightArrowString), {});
     }
 }
@@ -768,29 +768,29 @@ static void WidgetVScrollbarDraw(
 {
     colour &= 0x7F;
     // Trough
-    GfxFillRect(&dpi, { { l, t + SCROLLBAR_WIDTH }, { r, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
-    GfxFillRect(&dpi, { { l, t + SCROLLBAR_WIDTH }, { r, b - SCROLLBAR_WIDTH } }, 0x1000000 | ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { l + 2, t + SCROLLBAR_WIDTH }, { l + 2, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { l + 3, t + SCROLLBAR_WIDTH }, { l + 3, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
-    GfxFillRect(&dpi, { { l + 7, t + SCROLLBAR_WIDTH }, { l + 7, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(&dpi, { { l + 8, t + SCROLLBAR_WIDTH }, { l + 8, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l, t + SCROLLBAR_WIDTH }, { r, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l, t + SCROLLBAR_WIDTH }, { r, b - SCROLLBAR_WIDTH } }, 0x1000000 | ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + 2, t + SCROLLBAR_WIDTH }, { l + 2, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + 3, t + SCROLLBAR_WIDTH }, { l + 3, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
+    GfxFillRect(dpi, { { l + 7, t + SCROLLBAR_WIDTH }, { l + 7, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(dpi, { { l + 8, t + SCROLLBAR_WIDTH }, { l + 8, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
 
     // Up button
     GfxFillRectInset(
-        &dpi, { { l, t }, { r, t + (SCROLLBAR_WIDTH - 1) } }, colour,
+        dpi, { { l, t }, { r, t + (SCROLLBAR_WIDTH - 1) } }, colour,
         ((scroll.flags & VSCROLLBAR_UP_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
     GfxDrawString(dpi, { l + 1, t - 1 }, static_cast<const char*>(BlackUpArrowString), {});
 
     // Thumb
     GfxFillRectInset(
-        &dpi,
+        dpi,
         { { l, std::max(t + SCROLLBAR_WIDTH, t + scroll.v_thumb_top - 1) },
           { r, std::min(b - SCROLLBAR_WIDTH, t + scroll.v_thumb_bottom - 1) } },
         colour, ((scroll.flags & VSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
 
     // Down button
     GfxFillRectInset(
-        &dpi, { { l, b - (SCROLLBAR_WIDTH - 1) }, { r, b } }, colour,
+        dpi, { { l, b - (SCROLLBAR_WIDTH - 1) }, { r, b } }, colour,
         ((scroll.flags & VSCROLLBAR_DOWN_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
     GfxDrawString(dpi, { l + 1, b - (SCROLLBAR_WIDTH - 1) }, static_cast<const char*>(BlackDownArrowString), {});
 }
@@ -1136,8 +1136,8 @@ static void WidgetTextBoxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex wid
     bool active = w.classification == gCurrentTextBox.window.classification && w.number == gCurrentTextBox.window.number
         && widgetIndex == gCurrentTextBox.widget_index;
 
-    // GfxFillRectInset(&dpi, l, t, r, b, colour, 0x20 | (!active ? 0x40 : 0x00));
-    GfxFillRectInset(&dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
+    // GfxFillRectInset(dpi, l, t, r, b, colour, 0x20 | (!active ? 0x40 : 0x00));
+    GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
 
     // Figure out where the text should be positioned vertically.
     topLeft.y = w.windowPos.y + widget.textTop();
@@ -1180,7 +1180,7 @@ static void WidgetTextBoxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex wid
     {
         colour = ColourMapA[w.colours[1]].mid_light;
         auto y = topLeft.y + (widget.height() - 1);
-        GfxFillRect(&dpi, { { curX, y }, { curX + width, y } }, colour + 5);
+        GfxFillRect(dpi, { { curX, y }, { curX + width, y } }, colour + 5);
     }
 }
 

--- a/src/openrct2-ui/interface/Widget.cpp
+++ b/src/openrct2-ui/interface/Widget.cpp
@@ -22,32 +22,32 @@
 #include <openrct2/sprites.h>
 #include <openrct2/util/Util.h>
 
-static void WidgetFrameDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetResizeDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetButtonDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetTabDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetFlatButtonDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetTextButton(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetTextCentred(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetText(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetTextInset(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetTextBoxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetGroupboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetCaptionDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetCheckboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetCloseboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
-static void WidgetScrollDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetFrameDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetResizeDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetButtonDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetTabDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetFlatButtonDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetTextButton(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetTextCentred(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetText(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetTextInset(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetTextBoxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetGroupboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetCaptionDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetCheckboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetCloseboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
+static void WidgetScrollDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
 static void WidgetHScrollbarDraw(
-    DrawPixelInfo* dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour);
+    DrawPixelInfo& dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour);
 static void WidgetVScrollbarDraw(
-    DrawPixelInfo* dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour);
-static void WidgetDrawImage(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
+    DrawPixelInfo& dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour);
+static void WidgetDrawImage(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
 
 /**
  *
  *  rct2: 0x006EB2A8
  */
-void WidgetDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+void WidgetDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     const auto* widget = GetWidgetByIndex(w, widgetIndex);
     if (widget == nullptr)
@@ -117,7 +117,7 @@ void WidgetDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
  *
  *  rct2: 0x006EB6CE
  */
-static void WidgetFrameDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetFrameDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -134,7 +134,7 @@ static void WidgetFrameDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widge
     uint8_t colour = w.colours[widget.colour];
 
     // Draw the frame
-    GfxFillRectInset(dpi, { leftTop, { r, b } }, colour, press);
+    GfxFillRectInset(&dpi, { leftTop, { r, b } }, colour, press);
 
     // Check if the window can be resized
     if (!(w.flags & WF_RESIZABLE))
@@ -144,14 +144,14 @@ static void WidgetFrameDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widge
 
     // Draw the resize sprite at the bottom right corner
     leftTop = w.windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
-    GfxDrawSprite(*dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
+    GfxDrawSprite(dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
 }
 
 /**
  *
  *  rct2: 0x006EB765
  */
-static void WidgetResizeDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetResizeDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -165,7 +165,7 @@ static void WidgetResizeDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
     uint8_t colour = w.colours[widget.colour];
 
     // Draw the panel
-    GfxFillRectInset(dpi, { leftTop, { r, b } }, colour, 0);
+    GfxFillRectInset(&dpi, { leftTop, { r, b } }, colour, 0);
 
     // Check if the window can be resized
     if (!(w.flags & WF_RESIZABLE))
@@ -175,14 +175,14 @@ static void WidgetResizeDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
 
     // Draw the resize sprite at the bottom right corner
     leftTop = w.windowPos + ScreenCoordsXY{ widget.right - 18, widget.bottom - 18 };
-    GfxDrawSprite(*dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
+    GfxDrawSprite(dpi, ImageId(SPR_RESIZE, colour & 0x7F), leftTop);
 }
 
 /**
  *
  *  rct2: 0x006EB8E5
  */
-static void WidgetButtonDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetButtonDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -200,12 +200,12 @@ static void WidgetButtonDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
     if (static_cast<int32_t>(widget.image.ToUInt32()) == -2)
     {
         // Draw border with no fill
-        GfxFillRectInset(dpi, rect, colour, press | INSET_RECT_FLAG_FILL_NONE);
+        GfxFillRectInset(&dpi, rect, colour, press | INSET_RECT_FLAG_FILL_NONE);
         return;
     }
 
     // Draw the border with fill
-    GfxFillRectInset(dpi, rect, colour, press);
+    GfxFillRectInset(&dpi, rect, colour, press);
 
     WidgetDrawImage(dpi, w, widgetIndex);
 }
@@ -214,7 +214,7 @@ static void WidgetButtonDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
  *
  *  rct2: 0x006EB806
  */
-static void WidgetTabDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetTabDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     auto& widget = w.widgets[widgetIndex];
@@ -256,14 +256,14 @@ static void WidgetTabDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetI
     auto image = widget.image.WithIndex(newIndex).WithPrimary(colour);
 
     // Draw disabled image
-    GfxDrawSprite(*dpi, image, leftTop);
+    GfxDrawSprite(dpi, image, leftTop);
 }
 
 /**
  *
  *  rct2: 0x006EB861
  */
-static void WidgetFlatButtonDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetFlatButtonDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     if (!WidgetIsDisabled(w, widgetIndex) && WidgetIsHighlighted(w, widgetIndex))
     {
@@ -287,12 +287,12 @@ static void WidgetFlatButtonDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex 
         if (static_cast<int32_t>(widget.image.ToUInt32()) == -2)
         {
             // Draw border with no fill
-            GfxFillRectInset(dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_NONE);
+            GfxFillRectInset(&dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_NONE);
             return;
         }
 
         // Draw the border with fill
-        GfxFillRectInset(dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET);
+        GfxFillRectInset(&dpi, rect, colour, INSET_RECT_FLAG_BORDER_INSET);
     }
 
     // Draw image
@@ -303,7 +303,7 @@ static void WidgetFlatButtonDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex 
  *
  *  rct2: 0x006EBBEB
  */
-static void WidgetTextButton(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetTextButton(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -317,7 +317,7 @@ static void WidgetTextButton(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
 
     // Border
     uint8_t press = WidgetIsPressed(w, widgetIndex) || WidgetIsActiveTool(w, widgetIndex) ? INSET_RECT_FLAG_BORDER_INSET : 0;
-    GfxFillRectInset(dpi, rect, colour, press);
+    GfxFillRectInset(&dpi, rect, colour, press);
 
     // Button caption
     if (widget.type != WindowWidgetType::TableHeader)
@@ -334,7 +334,7 @@ static void WidgetTextButton(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
  *
  *  rct2: 0x006EBC41
  */
-static void WidgetTextCentred(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetTextCentred(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -368,11 +368,11 @@ static void WidgetTextCentred(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wid
     ScreenCoordsXY coords = { (topLeft.x + r + 1) / 2 - 1, topLeft.y };
     if (widget.type == WindowWidgetType::LabelCentred)
     {
-        DrawTextWrapped(*dpi, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
+        DrawTextWrapped(dpi, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
     }
     else
     {
-        DrawTextEllipsised(*dpi, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
+        DrawTextEllipsised(dpi, coords, widget.width() - 2, stringId, ft, { colour, TextAlignment::CENTRE });
     }
 }
 
@@ -380,7 +380,7 @@ static void WidgetTextCentred(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wid
  *
  *  rct2: 0x006EBD52
  */
-static void WidgetText(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetText(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -417,11 +417,11 @@ static void WidgetText(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetInde
     ScreenCoordsXY coords = { l + 1, t };
     if (widget.type == WindowWidgetType::LabelCentred)
     {
-        DrawTextWrapped(*dpi, coords, r - l, stringId, ft, { colour, TextAlignment::CENTRE });
+        DrawTextWrapped(dpi, coords, r - l, stringId, ft, { colour, TextAlignment::CENTRE });
     }
     else
     {
-        DrawTextEllipsised(*dpi, coords, r - l, stringId, ft, colour);
+        DrawTextEllipsised(dpi, coords, r - l, stringId, ft, colour);
     }
 }
 
@@ -429,7 +429,7 @@ static void WidgetText(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetInde
  *
  *  rct2: 0x006EBD1F
  */
-static void WidgetTextInset(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetTextInset(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -441,7 +441,7 @@ static void WidgetTextInset(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widge
     // Get the colour
     uint8_t colour = w.colours[widget.colour];
 
-    GfxFillRectInset(dpi, rect, colour, INSET_RECT_F_60);
+    GfxFillRectInset(&dpi, rect, colour, INSET_RECT_F_60);
     WidgetText(dpi, w, widgetIndex);
 }
 
@@ -469,7 +469,7 @@ static std::pair<StringId, void*> WidgetGetStringidAndArgs(const Widget& widget)
  *
  *  rct2: 0x006EB535
  */
-static void WidgetGroupboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetGroupboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -491,7 +491,7 @@ static void WidgetGroupboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wi
         OpenRCT2::FormatStringLegacy(buffer, sizeof(buffer), stringId, formatArgs);
         auto ft = Formatter();
         ft.Add<utf8*>(buffer);
-        DrawTextBasic(*dpi, { l, t }, STR_STRING, ft, { colour });
+        DrawTextBasic(dpi, { l, t }, STR_STRING, ft, { colour });
         textRight = l + GfxGetStringWidth(buffer, FontStyle::Medium) + 1;
     }
 
@@ -506,31 +506,31 @@ static void WidgetGroupboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wi
     uint8_t colour = w.colours[widget.colour] & 0x7F;
 
     // Border left of text
-    GfxFillRect(dpi, { { l, t }, { l + 4, t } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + 1, t + 1 }, { l + 4, t + 1 } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { l, t }, { l + 4, t } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { l + 1, t + 1 }, { l + 4, t + 1 } }, ColourMapA[colour].lighter);
 
     // Border right of text
-    GfxFillRect(dpi, { { textRight, t }, { r - 1, t } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { textRight, t + 1 }, { r - 2, t + 1 } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { textRight, t }, { r - 1, t } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { textRight, t + 1 }, { r - 2, t + 1 } }, ColourMapA[colour].lighter);
 
     // Border right
-    GfxFillRect(dpi, { { r - 1, t + 1 }, { r - 1, b - 1 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { r, t }, { r, b } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { r - 1, t + 1 }, { r - 1, b - 1 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { r, t }, { r, b } }, ColourMapA[colour].lighter);
 
     // Border bottom
-    GfxFillRect(dpi, { { l, b - 1 }, { r - 2, b - 1 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l, b }, { r - 1, b } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { l, b - 1 }, { r - 2, b - 1 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { l, b }, { r - 1, b } }, ColourMapA[colour].lighter);
 
     // Border left
-    GfxFillRect(dpi, { { l, t + 1 }, { l, b - 2 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + 1, t + 2 }, { l + 1, b - 2 } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { l, t + 1 }, { l, b - 2 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { l + 1, t + 2 }, { l + 1, b - 2 } }, ColourMapA[colour].lighter);
 }
 
 /**
  *
  *  rct2: 0x006EB2F9
  */
-static void WidgetCaptionDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetCaptionDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto* widget = &w.widgets[widgetIndex];
@@ -546,15 +546,15 @@ static void WidgetCaptionDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wid
     if (w.flags & WF_10)
         press |= INSET_RECT_FLAG_FILL_MID_LIGHT;
 
-    GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, press);
+    GfxFillRectInset(&dpi, { topLeft, bottomRight }, colour, press);
 
     // Black caption bars look slightly green, this fixes that
     if (colour == 0)
         GfxFillRect(
-            dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } }, ColourMapA[colour].dark);
+            &dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } }, ColourMapA[colour].dark);
     else
         GfxFilterRect(
-            dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
+            &dpi, { { topLeft + ScreenCoordsXY{ 1, 1 } }, { bottomRight - ScreenCoordsXY{ 1, 1 } } },
             FilterPaletteID::PaletteDarken3);
 
     // Draw text
@@ -571,7 +571,7 @@ static void WidgetCaptionDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wid
     }
     topLeft.x += width / 2;
     DrawTextEllipsised(
-        *dpi, topLeft, width, widget->text, Formatter::Common(),
+        dpi, topLeft, width, widget->text, Formatter::Common(),
         { COLOUR_WHITE | static_cast<uint8_t>(COLOUR_FLAG_OUTLINE), TextAlignment::CENTRE });
 }
 
@@ -579,7 +579,7 @@ static void WidgetCaptionDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wid
  *
  *  rct2: 0x006EBB85
  */
-static void WidgetCloseboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetCloseboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -599,7 +599,7 @@ static void WidgetCloseboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wi
     uint8_t colour = w.colours[widget.colour];
 
     // Draw the button
-    GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, press);
+    GfxFillRectInset(&dpi, { topLeft, bottomRight }, colour, press);
 
     if (widget.text == STR_NONE)
         return;
@@ -609,14 +609,14 @@ static void WidgetCloseboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wi
     if (WidgetIsDisabled(w, widgetIndex))
         colour |= COLOUR_FLAG_INSET;
 
-    DrawTextEllipsised(*dpi, topLeft, widget.width() - 2, widget.text, Formatter::Common(), { colour, TextAlignment::CENTRE });
+    DrawTextEllipsised(dpi, topLeft, widget.width() - 2, widget.text, Formatter::Common(), { colour, TextAlignment::CENTRE });
 }
 
 /**
  *
  *  rct2: 0x006EBAD9
  */
-static void WidgetCheckboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetCheckboxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -630,7 +630,7 @@ static void WidgetCheckboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wi
     colour_t colour = w.colours[widget.colour];
 
     // checkbox
-    GfxFillRectInset(dpi, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, INSET_RECT_F_60);
+    GfxFillRectInset(&dpi, { midLeft - ScreenCoordsXY{ 0, 5 }, midLeft + ScreenCoordsXY{ 9, 4 } }, colour, INSET_RECT_F_60);
 
     if (WidgetIsDisabled(w, widgetIndex))
     {
@@ -641,7 +641,7 @@ static void WidgetCheckboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wi
     if (WidgetIsPressed(w, widgetIndex))
     {
         GfxDrawString(
-            *dpi, { midLeft - ScreenCoordsXY{ 0, 5 } }, static_cast<const char*>(CheckBoxMarkString),
+            dpi, { midLeft - ScreenCoordsXY{ 0, 5 } }, static_cast<const char*>(CheckBoxMarkString),
             { static_cast<colour_t>(NOT_TRANSLUCENT(colour)) });
     }
 
@@ -650,14 +650,14 @@ static void WidgetCheckboxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wi
         return;
 
     auto [stringId, formatArgs] = WidgetGetStringidAndArgs(widget);
-    GfxDrawStringLeftCentred(*dpi, stringId, formatArgs, colour, { midLeft + ScreenCoordsXY{ 14, 0 } });
+    GfxDrawStringLeftCentred(dpi, stringId, formatArgs, colour, { midLeft + ScreenCoordsXY{ 14, 0 } });
 }
 
 /**
  *
  *  rct2: 0x006EBD96
  */
-static void WidgetScrollDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetScrollDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     int32_t scrollIndex = WindowGetScrollDataIndex(w, widgetIndex);
@@ -672,7 +672,7 @@ static void WidgetScrollDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
     uint8_t colour = w.colours[widget.colour];
 
     // Draw the border
-    GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
+    GfxFillRectInset(&dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
 
     // Inflate by -1
     topLeft.x++;
@@ -703,22 +703,22 @@ static void WidgetScrollDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
     bottomRight.x++;
 
     // Create a new inner scroll dpi
-    DrawPixelInfo scroll_dpi = *dpi;
+    DrawPixelInfo scroll_dpi = dpi;
 
     // Clip the scroll dpi against the outer dpi
-    int32_t cl = std::max<int32_t>(dpi->x, topLeft.x);
-    int32_t ct = std::max<int32_t>(dpi->y, topLeft.y);
-    int32_t cr = std::min<int32_t>(dpi->x + dpi->width, bottomRight.x);
-    int32_t cb = std::min<int32_t>(dpi->y + dpi->height, bottomRight.y);
+    int32_t cl = std::max<int32_t>(dpi.x, topLeft.x);
+    int32_t ct = std::max<int32_t>(dpi.y, topLeft.y);
+    int32_t cr = std::min<int32_t>(dpi.x + dpi.width, bottomRight.x);
+    int32_t cb = std::min<int32_t>(dpi.y + dpi.height, bottomRight.y);
 
     // Set the respective dpi attributes
     scroll_dpi.x = cl - topLeft.x + scroll.h_left;
     scroll_dpi.y = ct - topLeft.y + scroll.v_top;
     scroll_dpi.width = cr - cl;
     scroll_dpi.height = cb - ct;
-    scroll_dpi.bits += cl - dpi->x;
-    scroll_dpi.bits += (ct - dpi->y) * (dpi->width + dpi->pitch);
-    scroll_dpi.pitch = (dpi->width + dpi->pitch) - scroll_dpi.width;
+    scroll_dpi.bits += cl - dpi.x;
+    scroll_dpi.bits += (ct - dpi.y) * (dpi.width + dpi.pitch);
+    scroll_dpi.pitch = (dpi.width + dpi.pitch) - scroll_dpi.width;
 
     // Draw the scroll contents
     if (scroll_dpi.width > 0 && scroll_dpi.height > 0)
@@ -726,23 +726,23 @@ static void WidgetScrollDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widg
 }
 
 static void WidgetHScrollbarDraw(
-    DrawPixelInfo* dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour)
+    DrawPixelInfo& dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour)
 {
     colour &= 0x7F;
     // Trough
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t }, { r - SCROLLBAR_WIDTH, b } }, ColourMapA[colour].lighter);
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t }, { r - SCROLLBAR_WIDTH, b } }, 0x1000000 | ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 2 }, { r - SCROLLBAR_WIDTH, t + 2 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 3 }, { r - SCROLLBAR_WIDTH, t + 3 } }, ColourMapA[colour].lighter);
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 7 }, { r - SCROLLBAR_WIDTH, t + 7 } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + SCROLLBAR_WIDTH, t + 8 }, { r - SCROLLBAR_WIDTH, t + 8 } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t }, { r - SCROLLBAR_WIDTH, b } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t }, { r - SCROLLBAR_WIDTH, b } }, 0x1000000 | ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t + 2 }, { r - SCROLLBAR_WIDTH, t + 2 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t + 3 }, { r - SCROLLBAR_WIDTH, t + 3 } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t + 7 }, { r - SCROLLBAR_WIDTH, t + 7 } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { l + SCROLLBAR_WIDTH, t + 8 }, { r - SCROLLBAR_WIDTH, t + 8 } }, ColourMapA[colour].lighter);
 
     // Left button
     {
         uint8_t flags = (scroll.flags & HSCROLLBAR_LEFT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-        GfxFillRectInset(dpi, { { l, t }, { l + (SCROLLBAR_WIDTH - 1), b } }, colour, flags);
-        GfxDrawString(*dpi, { l + 1, t }, static_cast<const char*>(BlackLeftArrowString), {});
+        GfxFillRectInset(&dpi, { { l, t }, { l + (SCROLLBAR_WIDTH - 1), b } }, colour, flags);
+        GfxDrawString(dpi, { l + 1, t }, static_cast<const char*>(BlackLeftArrowString), {});
     }
 
     // Thumb
@@ -751,55 +751,55 @@ static void WidgetHScrollbarDraw(
         int16_t right = std::min(r - SCROLLBAR_WIDTH, l + scroll.h_thumb_right - 1);
         uint8_t flags = (scroll.flags & HSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-        GfxFillRectInset(dpi, { { left, t }, { right, b } }, colour, flags);
+        GfxFillRectInset(&dpi, { { left, t }, { right, b } }, colour, flags);
     }
 
     // Right button
     {
         uint8_t flags = (scroll.flags & HSCROLLBAR_RIGHT_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0;
 
-        GfxFillRectInset(dpi, { { r - (SCROLLBAR_WIDTH - 1), t }, { r, b } }, colour, flags);
-        GfxDrawString(*dpi, { r - 6, t }, static_cast<const char*>(BlackRightArrowString), {});
+        GfxFillRectInset(&dpi, { { r - (SCROLLBAR_WIDTH - 1), t }, { r, b } }, colour, flags);
+        GfxDrawString(dpi, { r - 6, t }, static_cast<const char*>(BlackRightArrowString), {});
     }
 }
 
 static void WidgetVScrollbarDraw(
-    DrawPixelInfo* dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour)
+    DrawPixelInfo& dpi, const ScrollBar& scroll, int32_t l, int32_t t, int32_t r, int32_t b, int32_t colour)
 {
     colour &= 0x7F;
     // Trough
-    GfxFillRect(dpi, { { l, t + SCROLLBAR_WIDTH }, { r, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
-    GfxFillRect(dpi, { { l, t + SCROLLBAR_WIDTH }, { r, b - SCROLLBAR_WIDTH } }, 0x1000000 | ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + 2, t + SCROLLBAR_WIDTH }, { l + 2, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + 3, t + SCROLLBAR_WIDTH }, { l + 3, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
-    GfxFillRect(dpi, { { l + 7, t + SCROLLBAR_WIDTH }, { l + 7, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].mid_dark);
-    GfxFillRect(dpi, { { l + 8, t + SCROLLBAR_WIDTH }, { l + 8, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { l, t + SCROLLBAR_WIDTH }, { r, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { l, t + SCROLLBAR_WIDTH }, { r, b - SCROLLBAR_WIDTH } }, 0x1000000 | ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { l + 2, t + SCROLLBAR_WIDTH }, { l + 2, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { l + 3, t + SCROLLBAR_WIDTH }, { l + 3, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
+    GfxFillRect(&dpi, { { l + 7, t + SCROLLBAR_WIDTH }, { l + 7, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].mid_dark);
+    GfxFillRect(&dpi, { { l + 8, t + SCROLLBAR_WIDTH }, { l + 8, b - SCROLLBAR_WIDTH } }, ColourMapA[colour].lighter);
 
     // Up button
     GfxFillRectInset(
-        dpi, { { l, t }, { r, t + (SCROLLBAR_WIDTH - 1) } }, colour,
+        &dpi, { { l, t }, { r, t + (SCROLLBAR_WIDTH - 1) } }, colour,
         ((scroll.flags & VSCROLLBAR_UP_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    GfxDrawString(*dpi, { l + 1, t - 1 }, static_cast<const char*>(BlackUpArrowString), {});
+    GfxDrawString(dpi, { l + 1, t - 1 }, static_cast<const char*>(BlackUpArrowString), {});
 
     // Thumb
     GfxFillRectInset(
-        dpi,
+        &dpi,
         { { l, std::max(t + SCROLLBAR_WIDTH, t + scroll.v_thumb_top - 1) },
           { r, std::min(b - SCROLLBAR_WIDTH, t + scroll.v_thumb_bottom - 1) } },
         colour, ((scroll.flags & VSCROLLBAR_THUMB_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
 
     // Down button
     GfxFillRectInset(
-        dpi, { { l, b - (SCROLLBAR_WIDTH - 1) }, { r, b } }, colour,
+        &dpi, { { l, b - (SCROLLBAR_WIDTH - 1) }, { r, b } }, colour,
         ((scroll.flags & VSCROLLBAR_DOWN_PRESSED) ? INSET_RECT_FLAG_BORDER_INSET : 0));
-    GfxDrawString(*dpi, { l + 1, b - (SCROLLBAR_WIDTH - 1) }, static_cast<const char*>(BlackDownArrowString), {});
+    GfxDrawString(dpi, { l + 1, b - (SCROLLBAR_WIDTH - 1) }, static_cast<const char*>(BlackDownArrowString), {});
 }
 
 /**
  *
  *  rct2: 0x006EB951
  */
-static void WidgetDrawImage(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetDrawImage(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -825,12 +825,12 @@ static void WidgetDrawImage(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widge
         // Draw greyed out (light border bottom right shadow)
         colour = w.colours[widget.colour];
         colour = ColourMapA[NOT_TRANSLUCENT(colour)].lighter;
-        GfxDrawSpriteSolid(dpi, image, screenCoords + ScreenCoordsXY{ 1, 1 }, colour);
+        GfxDrawSpriteSolid(&dpi, image, screenCoords + ScreenCoordsXY{ 1, 1 }, colour);
 
         // Draw greyed out (dark)
         colour = w.colours[widget.colour];
         colour = ColourMapA[NOT_TRANSLUCENT(colour)].mid_light;
-        GfxDrawSpriteSolid(dpi, image, screenCoords, colour);
+        GfxDrawSpriteSolid(&dpi, image, screenCoords, colour);
     }
     else
     {
@@ -844,7 +844,7 @@ static void WidgetDrawImage(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widge
         else
             image = image.WithPrimary(colour);
 
-        GfxDrawSprite(*dpi, image, screenCoords);
+        GfxDrawSprite(dpi, image, screenCoords);
     }
 }
 
@@ -1121,7 +1121,7 @@ void WidgetSetCheckboxValue(WindowBase& w, WidgetIndex widgetIndex, bool value)
     WidgetSetPressed(w, widgetIndex, value);
 }
 
-static void WidgetTextBoxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex)
+static void WidgetTextBoxDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex)
 {
     // Get the widget
     const auto& widget = w.widgets[widgetIndex];
@@ -1136,8 +1136,8 @@ static void WidgetTextBoxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wid
     bool active = w.classification == gCurrentTextBox.window.classification && w.number == gCurrentTextBox.window.number
         && widgetIndex == gCurrentTextBox.widget_index;
 
-    // GfxFillRectInset(dpi, l, t, r, b, colour, 0x20 | (!active ? 0x40 : 0x00));
-    GfxFillRectInset(dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
+    // GfxFillRectInset(&dpi, l, t, r, b, colour, 0x20 | (!active ? 0x40 : 0x00));
+    GfxFillRectInset(&dpi, { topLeft, bottomRight }, colour, INSET_RECT_F_60);
 
     // Figure out where the text should be positioned vertically.
     topLeft.y = w.windowPos.y + widget.textTop();
@@ -1148,7 +1148,7 @@ static void WidgetTextBoxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wid
         {
             u8string wrappedString;
             GfxWrapString(widget.string, bottomRight.x - topLeft.x - 5, FontStyle::Medium, &wrappedString, nullptr);
-            DrawText(*dpi, { topLeft.x + 2, topLeft.y }, { w.colours[1] }, wrappedString.c_str(), true);
+            DrawText(dpi, { topLeft.x + 2, topLeft.y }, { w.colours[1] }, wrappedString.c_str(), true);
         }
         return;
     }
@@ -1158,7 +1158,7 @@ static void WidgetTextBoxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wid
     u8string wrappedString;
     GfxWrapString(gTextBoxInput, bottomRight.x - topLeft.x - 5 - 6, FontStyle::Medium, &wrappedString, nullptr);
 
-    DrawText(*dpi, { topLeft.x + 2, topLeft.y }, { w.colours[1] }, wrappedString.c_str(), true);
+    DrawText(dpi, { topLeft.x + 2, topLeft.y }, { w.colours[1] }, wrappedString.c_str(), true);
 
     // Make a trimmed view of the string for measuring the width.
     int32_t curX = topLeft.x
@@ -1180,7 +1180,7 @@ static void WidgetTextBoxDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex wid
     {
         colour = ColourMapA[w.colours[1]].mid_light;
         auto y = topLeft.y + (widget.height() - 1);
-        GfxFillRect(dpi, { { curX, y }, { curX + width, y } }, colour + 5);
+        GfxFillRect(&dpi, { { curX, y }, { curX + width, y } }, colour + 5);
     }
 }
 

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -629,14 +629,14 @@ void WindowInitScrollWidgets(WindowBase& w)
  *
  *  rct2: 0x006EB15C
  */
-void WindowDrawWidgets(WindowBase& w, DrawPixelInfo* dpi)
+void WindowDrawWidgets(WindowBase& w, DrawPixelInfo& dpi)
 {
     Widget* widget;
     WidgetIndex widgetIndex;
 
     if ((w.flags & WF_TRANSPARENT) && !(w.flags & WF_NO_BACKGROUND))
         GfxFilterRect(
-            dpi, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, FilterPaletteID::Palette51);
+            &dpi, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, FilterPaletteID::Palette51);
 
     // todo: some code missing here? Between 006EB18C and 006EB260
 
@@ -646,14 +646,14 @@ void WindowDrawWidgets(WindowBase& w, DrawPixelInfo* dpi)
         if (widget->IsVisible())
         {
             // Check if widget is outside the draw region
-            if (w.windowPos.x + widget->left < dpi->x + dpi->width && w.windowPos.x + widget->right >= dpi->x)
+            if (w.windowPos.x + widget->left < dpi.x + dpi.width && w.windowPos.x + widget->right >= dpi.x)
             {
-                if (w.windowPos.y + widget->top < dpi->y + dpi->height && w.windowPos.y + widget->bottom >= dpi->y)
+                if (w.windowPos.y + widget->top < dpi.y + dpi.height && w.windowPos.y + widget->bottom >= dpi.y)
                 {
                     if (w.IsLegacy())
-                        WidgetDraw(dpi, w, widgetIndex);
+                        WidgetDraw(&dpi, w, widgetIndex);
                     else
-                        w.OnDrawWidget(widgetIndex, *dpi);
+                        w.OnDrawWidget(widgetIndex, dpi);
                 }
             }
         }
@@ -665,7 +665,7 @@ void WindowDrawWidgets(WindowBase& w, DrawPixelInfo* dpi)
     if (w.flags & WF_WHITE_BORDER_MASK)
     {
         GfxFillRectInset(
-            dpi, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, COLOUR_WHITE,
+            &dpi, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, COLOUR_WHITE,
             INSET_RECT_FLAG_FILL_NONE);
     }
 }
@@ -710,7 +710,7 @@ bool Window::IsLegacy()
 
 void Window::OnDraw(DrawPixelInfo& dpi)
 {
-    WindowDrawWidgets(*this, &dpi);
+    WindowDrawWidgets(*this, dpi);
 }
 
 void Window::OnDrawWidget(WidgetIndex widgetIndex, DrawPixelInfo& dpi)
@@ -760,7 +760,7 @@ void Window::SetCheckboxValue(WidgetIndex widgetIndex, bool value)
 
 void Window::DrawWidgets(DrawPixelInfo& dpi)
 {
-    WindowDrawWidgets(*this, &dpi);
+    WindowDrawWidgets(*this, dpi);
 }
 
 void Window::Close()

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -651,7 +651,7 @@ void WindowDrawWidgets(WindowBase& w, DrawPixelInfo& dpi)
                 if (w.windowPos.y + widget->top < dpi.y + dpi.height && w.windowPos.y + widget->bottom >= dpi.y)
                 {
                     if (w.IsLegacy())
-                        WidgetDraw(&dpi, w, widgetIndex);
+                        WidgetDraw(dpi, w, widgetIndex);
                     else
                         w.OnDrawWidget(widgetIndex, dpi);
                 }
@@ -715,7 +715,7 @@ void Window::OnDraw(DrawPixelInfo& dpi)
 
 void Window::OnDrawWidget(WidgetIndex widgetIndex, DrawPixelInfo& dpi)
 {
-    WidgetDraw(&dpi, *this, widgetIndex);
+    WidgetDraw(dpi, *this, widgetIndex);
 }
 
 void Window::InitScrollWidgets()

--- a/src/openrct2-ui/interface/Window.cpp
+++ b/src/openrct2-ui/interface/Window.cpp
@@ -636,7 +636,7 @@ void WindowDrawWidgets(WindowBase& w, DrawPixelInfo& dpi)
 
     if ((w.flags & WF_TRANSPARENT) && !(w.flags & WF_NO_BACKGROUND))
         GfxFilterRect(
-            &dpi, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, FilterPaletteID::Palette51);
+            dpi, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, FilterPaletteID::Palette51);
 
     // todo: some code missing here? Between 006EB18C and 006EB260
 
@@ -665,7 +665,7 @@ void WindowDrawWidgets(WindowBase& w, DrawPixelInfo& dpi)
     if (w.flags & WF_WHITE_BORDER_MASK)
     {
         GfxFillRectInset(
-            &dpi, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, COLOUR_WHITE,
+            dpi, { w.windowPos, w.windowPos + ScreenCoordsXY{ w.width - 1, w.height - 1 } }, COLOUR_WHITE,
             INSET_RECT_FLAG_FILL_NONE);
     }
 }

--- a/src/openrct2-ui/scripting/CustomImages.cpp
+++ b/src/openrct2-ui/scripting/CustomImages.cpp
@@ -439,7 +439,7 @@ namespace OpenRCT2::Scripting
             std::memset(dpi.bits, 0, bufferSize);
 
             // Draw the original image if we are creating a new one
-            GfxDrawSprite(&dpi, ImageId(id), { 0, 0 });
+            GfxDrawSprite(dpi, ImageId(id), { 0, 0 });
         }
         else
         {

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -552,7 +552,7 @@ void CustomListView::MouseUp(const ScreenCoordsXY& pos)
 void CustomListView::Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollBar* scroll) const
 {
     auto paletteIndex = ColourMapA[w->colours[1]].mid_light;
-    GfxFillRect(&dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } }, paletteIndex);
+    GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } }, paletteIndex);
 
     int32_t y = ShowColumnHeaders ? COLUMN_HEADER_HEIGHT : 0;
     for (size_t i = 0; i < Items.size(); i++)
@@ -583,19 +583,19 @@ void CustomListView::Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollBar* s
                 if (isSelected)
                 {
                     GfxFilterRect(
-                        &dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (LIST_ROW_HEIGHT - 1) } },
+                        dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (LIST_ROW_HEIGHT - 1) } },
                         FilterPaletteID::PaletteDarken2);
                 }
                 else if (isHighlighted)
                 {
                     GfxFilterRect(
-                        &dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (LIST_ROW_HEIGHT - 1) } },
+                        dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (LIST_ROW_HEIGHT - 1) } },
                         FilterPaletteID::PaletteDarken2);
                 }
                 else if (isStriped)
                 {
                     GfxFillRect(
-                        &dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (LIST_ROW_HEIGHT - 1) } },
+                        dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (LIST_ROW_HEIGHT - 1) } },
                         ColourMapA[w->colours[1]].lighter | 0x1000000);
                 }
 
@@ -641,7 +641,7 @@ void CustomListView::Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollBar* s
         y = scroll->v_top;
 
         auto bgColour = ColourMapA[w->colours[1]].mid_light;
-        GfxFillRect(&dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + 12 } }, bgColour);
+        GfxFillRect(dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + 12 } }, bgColour);
 
         int32_t x = 0;
         for (int32_t j = 0; j < static_cast<int32_t>(Columns.size()); j++)
@@ -673,7 +673,7 @@ void CustomListView::PaintHeading(
     {
         boxFlags = INSET_RECT_FLAG_BORDER_INSET;
     }
-    GfxFillRectInset(&dpi, { pos, pos + ScreenCoordsXY{ size.width - 1, size.height - 1 } }, w->colours[1], boxFlags);
+    GfxFillRectInset(dpi, { pos, pos + ScreenCoordsXY{ size.width - 1, size.height - 1 } }, w->colours[1], boxFlags);
     if (!text.empty())
     {
         PaintCell(dpi, pos, size, text.c_str(), false);
@@ -723,32 +723,32 @@ void CustomListView::PaintSeperator(
         // Draw light horizontal rule
         auto lightLineLeftTop1 = ScreenCoordsXY{ left, lineY0 };
         auto lightLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY0 };
-        GfxDrawLine(&dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
+        GfxDrawLine(dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
 
         auto lightLineLeftTop2 = ScreenCoordsXY{ strRight, lineY0 };
         auto lightLineRightBottom2 = ScreenCoordsXY{ right, lineY0 };
-        GfxDrawLine(&dpi, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
+        GfxDrawLine(dpi, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
 
         // Draw dark horizontal rule
         auto darkLineLeftTop1 = ScreenCoordsXY{ left, lineY1 };
         auto darkLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY1 };
-        GfxDrawLine(&dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
+        GfxDrawLine(dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
 
         auto darkLineLeftTop2 = ScreenCoordsXY{ strRight, lineY1 };
         auto darkLineRightBottom2 = ScreenCoordsXY{ right, lineY1 };
-        GfxDrawLine(&dpi, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
+        GfxDrawLine(dpi, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
     }
     else
     {
         // Draw light horizontal rule
         auto lightLineLeftTop1 = ScreenCoordsXY{ left, lineY0 };
         auto lightLineRightBottom1 = ScreenCoordsXY{ right, lineY0 };
-        GfxDrawLine(&dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
+        GfxDrawLine(dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
 
         // Draw dark horizontal rule
         auto darkLineLeftTop1 = ScreenCoordsXY{ left, lineY1 };
         auto darkLineRightBottom1 = ScreenCoordsXY{ right, lineY1 };
-        GfxDrawLine(&dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
+        GfxDrawLine(dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
     }
 }
 

--- a/src/openrct2-ui/scripting/CustomListView.cpp
+++ b/src/openrct2-ui/scripting/CustomListView.cpp
@@ -549,21 +549,21 @@ void CustomListView::MouseUp(const ScreenCoordsXY& pos)
     }
 }
 
-void CustomListView::Paint(WindowBase* w, DrawPixelInfo* dpi, const ScrollBar* scroll) const
+void CustomListView::Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollBar* scroll) const
 {
     auto paletteIndex = ColourMapA[w->colours[1]].mid_light;
-    GfxFillRect(dpi, { { dpi->x, dpi->y }, { dpi->x + dpi->width, dpi->y + dpi->height } }, paletteIndex);
+    GfxFillRect(&dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } }, paletteIndex);
 
     int32_t y = ShowColumnHeaders ? COLUMN_HEADER_HEIGHT : 0;
     for (size_t i = 0; i < Items.size(); i++)
     {
-        if (y > dpi->y + dpi->height)
+        if (y > dpi.y + dpi.height)
         {
             // Past the scroll view area
             break;
         }
 
-        if (y + LIST_ROW_HEIGHT >= dpi->y)
+        if (y + LIST_ROW_HEIGHT >= dpi.y)
         {
             const auto& itemIndex = static_cast<int32_t>(SortedItems[i]);
             const auto& item = Items[itemIndex];
@@ -583,19 +583,19 @@ void CustomListView::Paint(WindowBase* w, DrawPixelInfo* dpi, const ScrollBar* s
                 if (isSelected)
                 {
                     GfxFilterRect(
-                        dpi, { { dpi->x, y }, { dpi->x + dpi->width, y + (LIST_ROW_HEIGHT - 1) } },
+                        &dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (LIST_ROW_HEIGHT - 1) } },
                         FilterPaletteID::PaletteDarken2);
                 }
                 else if (isHighlighted)
                 {
                     GfxFilterRect(
-                        dpi, { { dpi->x, y }, { dpi->x + dpi->width, y + (LIST_ROW_HEIGHT - 1) } },
+                        &dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (LIST_ROW_HEIGHT - 1) } },
                         FilterPaletteID::PaletteDarken2);
                 }
                 else if (isStriped)
                 {
                     GfxFillRect(
-                        dpi, { { dpi->x, y }, { dpi->x + dpi->width, y + (LIST_ROW_HEIGHT - 1) } },
+                        &dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + (LIST_ROW_HEIGHT - 1) } },
                         ColourMapA[w->colours[1]].lighter | 0x1000000);
                 }
 
@@ -641,7 +641,7 @@ void CustomListView::Paint(WindowBase* w, DrawPixelInfo* dpi, const ScrollBar* s
         y = scroll->v_top;
 
         auto bgColour = ColourMapA[w->colours[1]].mid_light;
-        GfxFillRect(dpi, { { dpi->x, y }, { dpi->x + dpi->width, y + 12 } }, bgColour);
+        GfxFillRect(&dpi, { { dpi.x, y }, { dpi.x + dpi.width, y + 12 } }, bgColour);
 
         int32_t x = 0;
         for (int32_t j = 0; j < static_cast<int32_t>(Columns.size()); j++)
@@ -665,7 +665,7 @@ void CustomListView::Paint(WindowBase* w, DrawPixelInfo* dpi, const ScrollBar* s
 }
 
 void CustomListView::PaintHeading(
-    WindowBase* w, DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
+    WindowBase* w, DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
     ColumnSortOrder sortOrder, bool isPressed) const
 {
     auto boxFlags = 0;
@@ -673,7 +673,7 @@ void CustomListView::PaintHeading(
     {
         boxFlags = INSET_RECT_FLAG_BORDER_INSET;
     }
-    GfxFillRectInset(dpi, { pos, pos + ScreenCoordsXY{ size.width - 1, size.height - 1 } }, w->colours[1], boxFlags);
+    GfxFillRectInset(&dpi, { pos, pos + ScreenCoordsXY{ size.width - 1, size.height - 1 } }, w->colours[1], boxFlags);
     if (!text.empty())
     {
         PaintCell(dpi, pos, size, text.c_str(), false);
@@ -683,18 +683,18 @@ void CustomListView::PaintHeading(
     {
         auto ft = Formatter();
         ft.Add<StringId>(STR_UP);
-        DrawTextBasic(*dpi, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, { TextAlignment::RIGHT });
+        DrawTextBasic(dpi, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, { TextAlignment::RIGHT });
     }
     else if (sortOrder == ColumnSortOrder::Descending)
     {
         auto ft = Formatter();
         ft.Add<StringId>(STR_DOWN);
-        DrawTextBasic(*dpi, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, { TextAlignment::RIGHT });
+        DrawTextBasic(dpi, pos + ScreenCoordsXY{ size.width - 1, 0 }, STR_BLACK_STRING, ft, { TextAlignment::RIGHT });
     }
 }
 
 void CustomListView::PaintSeperator(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const
+    DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const
 {
     auto hasText = text != nullptr && text[0] != '\0';
     auto left = pos.x + 4;
@@ -712,7 +712,7 @@ void CustomListView::PaintSeperator(
         // Draw string
         Formatter ft;
         ft.Add<const char*>(text);
-        DrawTextBasic(*dpi, { centreX, pos.y }, STR_STRING, ft, { baseColour, TextAlignment::CENTRE });
+        DrawTextBasic(dpi, { centreX, pos.y }, STR_STRING, ft, { baseColour, TextAlignment::CENTRE });
 
         // Get string dimensions
         FormatStringLegacy(gCommonStringFormatBuffer, sizeof(gCommonStringFormatBuffer), STR_STRING, ft.Data());
@@ -723,44 +723,44 @@ void CustomListView::PaintSeperator(
         // Draw light horizontal rule
         auto lightLineLeftTop1 = ScreenCoordsXY{ left, lineY0 };
         auto lightLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY0 };
-        GfxDrawLine(dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
+        GfxDrawLine(&dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
 
         auto lightLineLeftTop2 = ScreenCoordsXY{ strRight, lineY0 };
         auto lightLineRightBottom2 = ScreenCoordsXY{ right, lineY0 };
-        GfxDrawLine(dpi, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
+        GfxDrawLine(&dpi, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
 
         // Draw dark horizontal rule
         auto darkLineLeftTop1 = ScreenCoordsXY{ left, lineY1 };
         auto darkLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY1 };
-        GfxDrawLine(dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
+        GfxDrawLine(&dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
 
         auto darkLineLeftTop2 = ScreenCoordsXY{ strRight, lineY1 };
         auto darkLineRightBottom2 = ScreenCoordsXY{ right, lineY1 };
-        GfxDrawLine(dpi, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
+        GfxDrawLine(&dpi, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
     }
     else
     {
         // Draw light horizontal rule
         auto lightLineLeftTop1 = ScreenCoordsXY{ left, lineY0 };
         auto lightLineRightBottom1 = ScreenCoordsXY{ right, lineY0 };
-        GfxDrawLine(dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
+        GfxDrawLine(&dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
 
         // Draw dark horizontal rule
         auto darkLineLeftTop1 = ScreenCoordsXY{ left, lineY1 };
         auto darkLineRightBottom1 = ScreenCoordsXY{ right, lineY1 };
-        GfxDrawLine(dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
+        GfxDrawLine(&dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
     }
 }
 
 void CustomListView::PaintCell(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const
+    DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const
 {
     StringId stringId = isHighlighted ? STR_WINDOW_COLOUR_2_STRINGID : STR_BLACK_STRING;
 
     auto ft = Formatter();
     ft.Add<StringId>(STR_STRING);
     ft.Add<const char*>(text);
-    DrawTextEllipsised(*dpi, pos, size.width, stringId, ft, {});
+    DrawTextEllipsised(dpi, pos, size.width, stringId, ft, {});
 }
 
 std::optional<RowColumn> CustomListView::GetItemIndexAt(const ScreenCoordsXY& pos)

--- a/src/openrct2-ui/scripting/CustomListView.h
+++ b/src/openrct2-ui/scripting/CustomListView.h
@@ -136,15 +136,15 @@ namespace OpenRCT2::Ui::Windows
         void MouseOver(const ScreenCoordsXY& pos, bool isMouseDown);
         void MouseDown(const ScreenCoordsXY& pos);
         void MouseUp(const ScreenCoordsXY& pos);
-        void Paint(WindowBase* w, DrawPixelInfo* dpi, const ScrollBar* scroll) const;
+        void Paint(WindowBase* w, DrawPixelInfo& dpi, const ScrollBar* scroll) const;
 
     private:
         void PaintHeading(
-            WindowBase* w, DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
+            WindowBase* w, DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const std::string& text,
             ColumnSortOrder sortOrder, bool isPressed) const;
-        void PaintSeperator(DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const;
+        void PaintSeperator(DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text) const;
         void PaintCell(
-            DrawPixelInfo* dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const;
+            DrawPixelInfo& dpi, const ScreenCoordsXY& pos, const ScreenSize& size, const char* text, bool isHighlighted) const;
         std::optional<RowColumn> GetItemIndexAt(const ScreenCoordsXY& pos);
         Widget* GetWidget() const;
         void Invalidate();

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -866,7 +866,7 @@ namespace OpenRCT2::Ui::Windows
                         auto imageOffset = frame % tab.imageFrameCount;
                         image = image.WithIndex(image.GetIndex() + imageOffset);
                     }
-                    GfxDrawSprite(&dpi, image, leftTop);
+                    GfxDrawSprite(dpi, image, leftTop);
                 }
                 tabIndex++;
             }

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -751,7 +751,7 @@ namespace OpenRCT2::Ui::Windows
             const auto& info = GetInfo(this);
             if (scrollIndex < static_cast<int32_t>(info.ListViews.size()))
             {
-                info.ListViews[scrollIndex].Paint(this, &dpi, &scrolls[scrollIndex]);
+                info.ListViews[scrollIndex].Paint(this, dpi, &scrolls[scrollIndex]);
             }
         }
 

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -530,14 +530,14 @@ namespace OpenRCT2::Ui::Windows
 
         void OnDraw(DrawPixelInfo& dpi) override
         {
-            WindowDrawWidgets(*this, &dpi);
+            WindowDrawWidgets(*this, dpi);
             DrawTabImages(dpi);
             if (viewport != nullptr)
             {
                 auto widgetIndex = GetViewportWidgetIndex();
                 if (WidgetIsVisible(*this, widgetIndex.value_or(false)))
                 {
-                    WindowDrawViewport(&dpi, *this);
+                    WindowDrawViewport(dpi, *this);
                 }
             }
         }

--- a/src/openrct2-ui/scripting/CustomWindow.cpp
+++ b/src/openrct2-ui/scripting/CustomWindow.cpp
@@ -554,7 +554,7 @@ namespace OpenRCT2::Ui::Windows
                 {
                     DrawPixelInfo widgetDpi;
                     if (ClipDrawPixelInfo(
-                            &widgetDpi, &dpi, { windowPos.x + widget.left, windowPos.y + widget.top }, widget.width(),
+                            widgetDpi, dpi, { windowPos.x + widget.left, windowPos.y + widget.top }, widget.width(),
                             widget.height()))
                     {
                         auto ctx = onDraw.context();

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -181,7 +181,7 @@ namespace OpenRCT2::Scripting
         void clip(int32_t x, int32_t y, int32_t width, int32_t height)
         {
             DrawPixelInfo newDpi;
-            ClipDrawPixelInfo(&newDpi, &_dpi, { x, y }, width, height);
+            ClipDrawPixelInfo(newDpi, _dpi, { x, y }, width, height);
             _dpi = newDpi;
         }
 

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -163,13 +163,13 @@ namespace OpenRCT2::Scripting
 
         void box(int32_t x, int32_t y, int32_t width, int32_t height)
         {
-            GfxFillRectInset(&_dpi, { x, y, x + width - 1, y + height - 1 }, _colour.value_or(0), 0);
+            GfxFillRectInset(_dpi, { x, y, x + width - 1, y + height - 1 }, _colour.value_or(0), 0);
         }
 
         void well(int32_t x, int32_t y, int32_t width, int32_t height)
         {
             GfxFillRectInset(
-                &_dpi, { x, y, x + width - 1, y + height - 1 }, _colour.value_or(0),
+                _dpi, { x, y, x + width - 1, y + height - 1 }, _colour.value_or(0),
                 INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_DONT_LIGHTEN);
         }
 
@@ -210,7 +210,7 @@ namespace OpenRCT2::Scripting
 
         void line(int32_t x1, int32_t y1, int32_t x2, int32_t y2)
         {
-            GfxDrawLine(&_dpi, { { x1, y1 }, { x2, y2 } }, _stroke);
+            GfxDrawLine(_dpi, { { x1, y1 }, { x2, y2 } }, _stroke);
         }
 
         void rect(int32_t x, int32_t y, int32_t width, int32_t height)
@@ -229,7 +229,7 @@ namespace OpenRCT2::Scripting
             }
             if (_fill != 0)
             {
-                GfxFillRect(&_dpi, { x, y, x + width - 1, y + height - 1 }, _fill);
+                GfxFillRect(_dpi, { x, y, x + width - 1, y + height - 1 }, _fill);
             }
         }
 

--- a/src/openrct2-ui/scripting/ScGraphicsContext.hpp
+++ b/src/openrct2-ui/scripting/ScGraphicsContext.hpp
@@ -205,7 +205,7 @@ namespace OpenRCT2::Scripting
                 }
             }
 
-            GfxDrawSprite(&_dpi, img.WithTertiary(_tertiaryColour.value_or(0)), { x, y });
+            GfxDrawSprite(_dpi, img.WithTertiary(_tertiaryColour.value_or(0)), { x, y });
         }
 
         void line(int32_t x1, int32_t y1, int32_t x2, int32_t y2)

--- a/src/openrct2-ui/windows/About.cpp
+++ b/src/openrct2-ui/windows/About.cpp
@@ -201,7 +201,7 @@ private:
         // Draw logo on placeholder widget
         ScreenCoordsXY logoCoords = windowPos
             + ScreenCoordsXY(widgets[WIDX_OPENRCT2_LOGO].left, widgets[WIDX_OPENRCT2_LOGO].top);
-        GfxDrawSprite(&dpi, ImageId(SPR_G2_LOGO), logoCoords);
+        GfxDrawSprite(dpi, ImageId(SPR_G2_LOGO), logoCoords);
         // Version info
         utf8 buffer[256];
         utf8* ch = buffer;
@@ -255,7 +255,7 @@ private:
         DrawTextBasic(dpi, screenCoords, STR_LICENSED_TO_INFOGRAMES_INTERACTIVE_INC, {}, { TextAlignment::CENTRE });
 
         // Images
-        GfxDrawSprite(&dpi, ImageId(SPR_CREDITS_CHRIS_SAWYER_SMALL), { windowPos.x + 92, yPage + 24 });
+        GfxDrawSprite(dpi, ImageId(SPR_CREDITS_CHRIS_SAWYER_SMALL), { windowPos.x + 92, yPage + 24 });
 
         // Licence
     }

--- a/src/openrct2-ui/windows/AssetPacks.cpp
+++ b/src/openrct2-ui/windows/AssetPacks.cpp
@@ -193,7 +193,7 @@ public:
     {
         auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
         GfxFillRect(
-            &dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
+            dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
 
         auto assetPackManager = GetContext()->GetAssetPackManager();
         if (assetPackManager == nullptr)
@@ -240,12 +240,12 @@ private:
         auto fillRectangle = ScreenRect{ { 0, y }, { listWidth, y + ItemHeight - 1 } };
         if (isSelected)
         {
-            GfxFillRect(&dpi, fillRectangle, ColourMapA[colours[1]].mid_dark);
+            GfxFillRect(dpi, fillRectangle, ColourMapA[colours[1]].mid_dark);
             stringId = STR_WINDOW_COLOUR_2_STRINGID;
         }
         else if (isHighlighted)
         {
-            GfxFillRect(&dpi, fillRectangle, ColourMapA[colours[1]].mid_dark);
+            GfxFillRect(dpi, fillRectangle, ColourMapA[colours[1]].mid_dark);
         }
 
         DrawTextEllipsised(dpi, { 16, y + 1 }, listWidth, stringId, ft);
@@ -256,7 +256,7 @@ private:
 
     void PaintCheckbox(DrawPixelInfo& dpi, const ScreenRect& rect, bool checked)
     {
-        GfxFillRectInset(&dpi, rect, colours[1], INSET_RECT_F_E0);
+        GfxFillRectInset(dpi, rect, colours[1], INSET_RECT_F_E0);
         if (checked)
         {
             auto checkmark = Formatter();

--- a/src/openrct2-ui/windows/Banner.cpp
+++ b/src/openrct2-ui/windows/Banner.cpp
@@ -262,7 +262,7 @@ public:
 
         if (viewport != nullptr)
         {
-            WindowDrawViewport(&dpi, *this);
+            WindowDrawViewport(dpi, *this);
         }
     }
 

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -667,7 +667,7 @@ private:
             if (page == WINDOW_CHEATS_PAGE_MONEY)
                 sprite_idx += (frame_no / 2) % 8;
             GfxDrawSprite(
-                &dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
+                dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
         }
 
         // Guests tab
@@ -677,14 +677,14 @@ private:
             if (page == WINDOW_CHEATS_PAGE_GUESTS)
                 sprite_idx += (frame_no / 3) % 8;
             GfxDrawSprite(
-                &dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
+                dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
         }
 
         // Misc tab
         if (!IsWidgetDisabled(WIDX_TAB_3))
         {
             GfxDrawSprite(
-                &dpi, ImageId(SPR_TAB_PARK), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
+                dpi, ImageId(SPR_TAB_PARK), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
         }
 
         // Rides tab
@@ -694,7 +694,7 @@ private:
             if (page == WINDOW_CHEATS_PAGE_RIDES)
                 sprite_idx += (frame_no / 4) % 16;
             GfxDrawSprite(
-                &dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_4].left, widgets[WIDX_TAB_4].top });
+                dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_4].left, widgets[WIDX_TAB_4].top });
         }
     }
 

--- a/src/openrct2-ui/windows/DemolishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/DemolishRidePrompt.cpp
@@ -76,7 +76,7 @@ public:
 
     void OnDraw(DrawPixelInfo& dpi) override
     {
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
 
         auto currentRide = GetRide(rideId);
         if (currentRide != nullptr)

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -161,13 +161,13 @@ public:
                 if (colours[0] & COLOUR_FLAG_TRANSLUCENT)
                 {
                     TranslucentWindowPalette palette = TranslucentWindowPalettes[BASE_COLOUR(colours[0])];
-                    GfxFilterRect(&dpi, { leftTop, rightBottom }, palette.highlight);
-                    GfxFilterRect(&dpi, { leftTop + shadowOffset, rightBottom + shadowOffset }, palette.shadow);
+                    GfxFilterRect(dpi, { leftTop, rightBottom }, palette.highlight);
+                    GfxFilterRect(dpi, { leftTop + shadowOffset, rightBottom + shadowOffset }, palette.shadow);
                 }
                 else
                 {
-                    GfxFillRect(&dpi, { leftTop, rightBottom }, ColourMapA[colours[0]].mid_dark);
-                    GfxFillRect(&dpi, { leftTop + shadowOffset, rightBottom + shadowOffset }, ColourMapA[colours[0]].lightest);
+                    GfxFillRect(dpi, { leftTop, rightBottom }, ColourMapA[colours[0]].mid_dark);
+                    GfxFillRect(dpi, { leftTop + shadowOffset, rightBottom + shadowOffset }, ColourMapA[colours[0]].lightest);
                 }
             }
             else
@@ -176,7 +176,7 @@ public:
                 {
                     // Darken the cell's background slightly when highlighted
                     const ScreenCoordsXY rightBottom = screenCoords + ScreenCoordsXY{ ItemWidth - 1, ItemHeight - 1 };
-                    GfxFilterRect(&dpi, { screenCoords, rightBottom }, FilterPaletteID::PaletteDarken3);
+                    GfxFilterRect(dpi, { screenCoords, rightBottom }, FilterPaletteID::PaletteDarken3);
                 }
 
                 StringId item = gDropdownItems[i].Format;

--- a/src/openrct2-ui/windows/Dropdown.cpp
+++ b/src/openrct2-ui/windows/Dropdown.cpp
@@ -187,7 +187,7 @@ public:
                                            : ImageId::FromUInt32(static_cast<uint32_t>(gDropdownItems[i].Args));
                     if (item == Dropdown::FormatColourPicker && highlightedIndex == i)
                         image = image.WithIndexOffset(1);
-                    GfxDrawSprite(&dpi, image, screenCoords);
+                    GfxDrawSprite(dpi, image, screenCoords);
                 }
                 else
                 {

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -283,7 +283,7 @@ private:
         auto previousWidget = widgets[WIDX_PREVIOUS_IMAGE];
         auto leftTop = windowPos + ScreenCoordsXY{ previousWidget.left, previousWidget.top };
         auto rightBottom = windowPos + ScreenCoordsXY{ previousWidget.right, previousWidget.bottom };
-        GfxFilterRect(&dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+        GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
     }
 
     void DrawLeftButton(DrawPixelInfo& dpi)
@@ -292,7 +292,7 @@ private:
             + ScreenCoordsXY{ widgets[WIDX_PREVIOUS_IMAGE].left + 1, widgets[WIDX_PREVIOUS_IMAGE].top + 1 };
         const auto bottomRight = windowPos
             + ScreenCoordsXY{ widgets[WIDX_PREVIOUS_IMAGE].right - 1, widgets[WIDX_PREVIOUS_IMAGE].bottom - 1 };
-        GfxFillRectInset(&dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
+        GfxFillRectInset(dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
 
         GfxDrawSprite(
             dpi, ImageId(SPR_PREVIOUS),
@@ -321,7 +321,7 @@ private:
         auto nextWidget = widgets[WIDX_NEXT_IMAGE];
         auto leftTop = windowPos + ScreenCoordsXY{ nextWidget.left, nextWidget.top };
         auto rightBottom = windowPos + ScreenCoordsXY{ nextWidget.right, nextWidget.bottom };
-        GfxFilterRect(&dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+        GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
     }
 
     void DrawRightButton(DrawPixelInfo& dpi)
@@ -329,7 +329,7 @@ private:
         const auto topLeft = windowPos + ScreenCoordsXY{ widgets[WIDX_NEXT_IMAGE].left + 1, widgets[WIDX_NEXT_IMAGE].top + 1 };
         const auto bottomRight = windowPos
             + ScreenCoordsXY{ widgets[WIDX_NEXT_IMAGE].right - 1, widgets[WIDX_NEXT_IMAGE].bottom - 1 };
-        GfxFillRectInset(&dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
+        GfxFillRectInset(dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
 
         GfxDrawSprite(
             dpi, ImageId(SPR_NEXT),

--- a/src/openrct2-ui/windows/EditorBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/EditorBottomToolbar.cpp
@@ -295,7 +295,7 @@ private:
         GfxFillRectInset(&dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
 
         GfxDrawSprite(
-            &dpi, ImageId(SPR_PREVIOUS),
+            dpi, ImageId(SPR_PREVIOUS),
             windowPos + ScreenCoordsXY{ widgets[WIDX_PREVIOUS_IMAGE].left + 6, widgets[WIDX_PREVIOUS_IMAGE].top + 6 });
 
         colour_t textColour = NOT_TRANSLUCENT(colours[1]);
@@ -332,7 +332,7 @@ private:
         GfxFillRectInset(&dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_30);
 
         GfxDrawSprite(
-            &dpi, ImageId(SPR_NEXT),
+            dpi, ImageId(SPR_NEXT),
             windowPos + ScreenCoordsXY{ widgets[WIDX_NEXT_IMAGE].right - 29, widgets[WIDX_NEXT_IMAGE].top + 6 });
 
         colour_t textColour = NOT_TRANSLUCENT(colours[1]);

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -396,7 +396,7 @@ public:
             screenPos = windowPos + ScreenCoordsXY{ bkWidget.left + 1, bkWidget.top + 1 };
             const auto clipWidth = bkWidget.width() - 1;
             const auto clipHeight = bkWidget.height() - 1;
-            if (ClipDrawPixelInfo(&clipDPI, &dpi, screenPos, clipWidth, clipHeight))
+            if (ClipDrawPixelInfo(clipDPI, dpi, screenPos, clipWidth, clipHeight))
             {
                 object->DrawPreview(clipDPI, clipWidth, clipHeight);
             }

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -296,7 +296,7 @@ public:
                     bottom = itemY;
                 }
 
-                GfxFilterRect(&dpi, { 0, top, boxWidth, bottom }, FilterPaletteID::PaletteDarken1);
+                GfxFilterRect(dpi, { 0, top, boxWidth, bottom }, FilterPaletteID::PaletteDarken1);
             }
 
             if (dragItem != nullptr && researchItem == *dragItem)
@@ -367,7 +367,7 @@ public:
         // Preview background
         auto& bkWidget = widgets[WIDX_PREVIEW];
         GfxFillRect(
-            &dpi,
+            dpi,
             { windowPos + ScreenCoordsXY{ bkWidget.left + 1, bkWidget.top + 1 },
               windowPos + ScreenCoordsXY{ bkWidget.right - 1, bkWidget.bottom - 1 } },
             ColourMapA[colours[1]].darkest);

--- a/src/openrct2-ui/windows/EditorInventionsList.cpp
+++ b/src/openrct2-ui/windows/EditorInventionsList.cpp
@@ -352,7 +352,7 @@ public:
 
         // Tab image
         auto screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top };
-        GfxDrawSprite(&dpi, ImageId(SPR_TAB_FINANCES_RESEARCH_0 + (frame_no / 2) % 8), screenPos);
+        GfxDrawSprite(dpi, ImageId(SPR_TAB_FINANCES_RESEARCH_0 + (frame_no / 2) % 8), screenPos);
 
         // Pre-researched items label
         screenPos = windowPos

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -707,7 +707,7 @@ public:
             {
                 // Draw checkbox
                 if (!(gScreenFlags & SCREEN_FLAGS_TRACK_MANAGER) && !(*listItem.flags & 0x20))
-                    GfxFillRectInset(&dpi, { { 2, screenCoords.y }, { 11, screenCoords.y + 10 } }, colours[1], INSET_RECT_F_E0);
+                    GfxFillRectInset(dpi, { { 2, screenCoords.y }, { 11, screenCoords.y + 10 } }, colours[1], INSET_RECT_F_E0);
 
                 // Highlight background
                 auto highlighted = i == static_cast<size_t>(selected_list_item)
@@ -715,7 +715,7 @@ public:
                 if (highlighted)
                 {
                     auto bottom = screenCoords.y + (SCROLLABLE_ROW_HEIGHT - 1);
-                    GfxFilterRect(&dpi, { 0, screenCoords.y, width, bottom }, FilterPaletteID::PaletteDarken1);
+                    GfxFilterRect(dpi, { 0, screenCoords.y, width, bottom }, FilterPaletteID::PaletteDarken1);
                 }
 
                 // Draw checkmark
@@ -1005,7 +1005,7 @@ public:
         // Preview background
         const auto& previewWidget = widgets[WIDX_PREVIEW];
         GfxFillRect(
-            &dpi,
+            dpi,
             { windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 },
               windowPos + ScreenCoordsXY{ previewWidget.right - 1, previewWidget.bottom - 1 } },
             ColourMapA[colours[1]].darkest);

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1057,7 +1057,7 @@ public:
             auto screenPos = windowPos + ScreenCoordsXY{ previewWidget.left + 1, previewWidget.top + 1 };
             _width = previewWidget.width() - 1;
             int32_t _height = previewWidget.height() - 1;
-            if (ClipDrawPixelInfo(&clipDPI, &dpi, screenPos, _width, _height))
+            if (ClipDrawPixelInfo(clipDPI, dpi, screenPos, _width, _height))
             {
                 _loadedObject->DrawPreview(clipDPI, _width, _height);
             }

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -1073,8 +1073,8 @@ public:
             DrawTextEllipsised(dpi, screenPos, _width, STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
         }
 
-        DrawDescriptions(&dpi);
-        DrawDebugData(&dpi);
+        DrawDescriptions(dpi);
+        DrawDebugData(dpi);
     }
 
 private:
@@ -1185,7 +1185,7 @@ private:
         _listItems.shrink_to_fit();
     }
 
-    void DrawDescriptions(DrawPixelInfo* dpi)
+    void DrawDescriptions(DrawPixelInfo& dpi)
     {
         const auto& widget = widgets[WIDX_PREVIEW];
         auto screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_LIST].right + 4, widget.bottom + 23 };
@@ -1194,7 +1194,7 @@ private:
         if (_loadedObject->IsCompatibilityObject())
         {
             screenPos.y += DrawTextWrapped(
-                               *dpi, screenPos, _width2, STR_OBJECT_SELECTION_COMPAT_OBJECT_DESCRIPTION, {},
+                               dpi, screenPos, _width2, STR_OBJECT_SELECTION_COMPAT_OBJECT_DESCRIPTION, {},
                                { COLOUR_BRIGHT_RED })
                 + LIST_ROW_HEIGHT;
         }
@@ -1206,7 +1206,7 @@ private:
             ft.Add<StringId>(STR_STRING);
             ft.Add<const char*>(description.c_str());
 
-            screenPos.y += DrawTextWrapped(*dpi, screenPos, _width2, STR_WINDOW_COLOUR_2_STRINGID, ft) + LIST_ROW_HEIGHT;
+            screenPos.y += DrawTextWrapped(dpi, screenPos, _width2, STR_WINDOW_COLOUR_2_STRINGID, ft) + LIST_ROW_HEIGHT;
         }
         if (GetSelectedObjectType() == ObjectType::Ride)
         {
@@ -1227,7 +1227,7 @@ private:
                 }
                 auto ft = Formatter();
                 ft.Add<const char*>(sells.c_str());
-                screenPos.y += DrawTextWrapped(*dpi, screenPos, _width2, STR_RIDE_OBJECT_SHOP_SELLS, ft) + 2;
+                screenPos.y += DrawTextWrapped(dpi, screenPos, _width2, STR_RIDE_OBJECT_SHOP_SELLS, ft) + 2;
             }
         }
         else if (GetSelectedObjectType() == ObjectType::SceneryGroup)
@@ -1235,11 +1235,11 @@ private:
             const auto* sceneryGroupObject = reinterpret_cast<SceneryGroupObject*>(_loadedObject.get());
             auto ft = Formatter();
             ft.Add<uint16_t>(sceneryGroupObject->GetNumIncludedObjects());
-            screenPos.y += DrawTextWrapped(*dpi, screenPos, _width2, STR_INCLUDES_X_OBJECTS, ft) + 2;
+            screenPos.y += DrawTextWrapped(dpi, screenPos, _width2, STR_INCLUDES_X_OBJECTS, ft) + 2;
         }
         else if (GetSelectedObjectType() == ObjectType::Music)
         {
-            screenPos.y += DrawTextWrapped(*dpi, screenPos, _width2, STR_MUSIC_OBJECT_TRACK_HEADER) + 2;
+            screenPos.y += DrawTextWrapped(dpi, screenPos, _width2, STR_MUSIC_OBJECT_TRACK_HEADER) + 2;
             const auto* musicObject = reinterpret_cast<MusicObject*>(_loadedObject.get());
             for (size_t i = 0; i < musicObject->GetTrackCount(); i++)
             {
@@ -1252,12 +1252,12 @@ private:
                 auto ft = Formatter();
                 ft.Add<const char*>(track->Name.c_str());
                 ft.Add<const char*>(track->Composer.c_str());
-                screenPos.y += DrawTextWrapped(*dpi, screenPos + ScreenCoordsXY{ 10, 0 }, _width2, stringId, ft);
+                screenPos.y += DrawTextWrapped(dpi, screenPos + ScreenCoordsXY{ 10, 0 }, _width2, stringId, ft);
             }
         }
     }
 
-    void DrawDebugData(DrawPixelInfo* dpi)
+    void DrawDebugData(DrawPixelInfo& dpi)
     {
         ObjectListItem* listItem = &_listItems[selected_list_item];
         auto screenPos = windowPos + ScreenCoordsXY{ width - 5, height - (LIST_ROW_HEIGHT * 6) };
@@ -1265,7 +1265,7 @@ private:
         // Draw fallback image warning
         if (_loadedObject && _loadedObject->UsesFallbackImages())
         {
-            DrawTextBasic(*dpi, screenPos, STR_OBJECT_USES_FALLBACK_IMAGES, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
+            DrawTextBasic(dpi, screenPos, STR_OBJECT_USES_FALLBACK_IMAGES, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
         }
         screenPos.y += LIST_ROW_HEIGHT;
 
@@ -1273,14 +1273,14 @@ private:
         if (GetSelectedObjectType() == ObjectType::Ride)
         {
             auto stringId = GetRideTypeStringId(listItem->repositoryItem);
-            DrawTextBasic(*dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
+            DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
         }
 
         screenPos.y += LIST_ROW_HEIGHT;
 
         // Draw object source
         auto stringId = ObjectManagerGetSourceGameString(listItem->repositoryItem->GetFirstSourceGame());
-        DrawTextBasic(*dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
+        DrawTextBasic(dpi, screenPos, stringId, {}, { COLOUR_WHITE, TextAlignment::RIGHT });
         screenPos.y += LIST_ROW_HEIGHT;
 
         // Draw object filename
@@ -1290,7 +1290,7 @@ private:
             ft.Add<StringId>(STR_STRING);
             ft.Add<const utf8*>(path.c_str());
             DrawTextBasic(
-                *dpi, { windowPos.x + this->width - 5, screenPos.y }, STR_WINDOW_COLOUR_2_STRINGID, ft,
+                dpi, { windowPos.x + this->width - 5, screenPos.y }, STR_WINDOW_COLOUR_2_STRINGID, ft,
                 { COLOUR_BLACK, TextAlignment::RIGHT });
             screenPos.y += LIST_ROW_HEIGHT;
         }
@@ -1310,7 +1310,7 @@ private:
             ft.Add<StringId>(STR_STRING);
             ft.Add<const char*>(authorsString.c_str());
             DrawTextEllipsised(
-                *dpi, { windowPos.x + width - 5, screenPos.y }, width - widgets[WIDX_LIST].right - 4,
+                dpi, { windowPos.x + width - 5, screenPos.y }, width - widgets[WIDX_LIST].right - 4,
                 STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::RIGHT });
         }
     }

--- a/src/openrct2-ui/windows/EditorObjectSelection.cpp
+++ b/src/openrct2-ui/windows/EditorObjectSelection.cpp
@@ -968,7 +968,7 @@ public:
             {
                 auto image = ImageId(ObjectSelectionPages[i].Image);
                 auto screenPos = windowPos + ScreenCoordsXY{ widget.left, widget.top };
-                GfxDrawSprite(&dpi, image, screenPos);
+                GfxDrawSprite(dpi, image, screenPos);
             }
         }
 
@@ -998,7 +998,7 @@ public:
                 spriteIndex += (i == 4 ? ThrillRidesTabAnimationSequence[frame] : frame);
 
                 auto screenPos = windowPos + ScreenCoordsXY{ widget.left, widget.top };
-                GfxDrawSprite(&dpi, ImageId(spriteIndex, colours[1]), screenPos);
+                GfxDrawSprite(dpi, ImageId(spriteIndex, colours[1]), screenPos);
             }
         }
 

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -262,7 +262,7 @@ public:
     {
         if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
         {
-            OnScrollDrawRides(&dpi, scrollIndex);
+            OnScrollDrawRides(dpi, scrollIndex);
         }
     }
 

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -1110,7 +1110,7 @@ private:
     void OnScrollDrawRides(DrawPixelInfo& dpi, int32_t scrollIndex)
     {
         int32_t colour = ColourMapA[colours[1]].mid_light;
-        GfxFillRect(&dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, colour);
+        GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, colour);
 
         for (int32_t i = 0; i < no_list_items; i++)
         {
@@ -1120,14 +1120,14 @@ private:
                 continue;
 
             // Checkbox
-            GfxFillRectInset(&dpi, { { 2, y }, { 11, y + 10 } }, colours[1], INSET_RECT_F_E0);
+            GfxFillRectInset(dpi, { { 2, y }, { 11, y + 10 } }, colours[1], INSET_RECT_F_E0);
 
             // Highlighted
             auto stringId = STR_BLACK_STRING;
             if (i == selected_list_item)
             {
                 stringId = STR_WINDOW_COLOUR_2_STRINGID;
-                GfxFilterRect(&dpi, { 0, y, width, y + 11 }, FilterPaletteID::PaletteDarken1);
+                GfxFilterRect(dpi, { 0, y, width, y + 11 }, FilterPaletteID::PaletteDarken1);
             }
 
             // Checkbox mark

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -210,10 +210,10 @@ public:
         switch (page)
         {
             case WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN:
-                OnDrawMain(&dpi);
+                OnDrawMain(dpi);
                 break;
             case WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES:
-                OnDrawRides(&dpi);
+                OnDrawRides(dpi);
                 break;
         }
     }
@@ -332,7 +332,7 @@ private:
         ResizeFrameWithPage();
     }
 
-    void DrawTabImages(DrawPixelInfo* dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         Widget* widget;
         int32_t spriteIndex;
@@ -344,7 +344,7 @@ private:
         if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN)
             spriteIndex += (frame_no / 4) % 16;
 
-        GfxDrawSprite(*dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+        GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
 
         // Tab 2
         if (!IsWidgetDisabled(WIDX_TAB_2))
@@ -354,7 +354,7 @@ private:
             if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
                 spriteIndex += (frame_no / 4) % 16;
 
-            GfxDrawSprite(*dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+            GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
         }
     }
 
@@ -835,23 +835,23 @@ private:
      *
      *  rct2: 0x0067161C
      */
-    void OnDrawMain(DrawPixelInfo* dpi)
+    void OnDrawMain(DrawPixelInfo& dpi)
     {
         int32_t widthToSet;
         StringId stringId;
 
-        DrawWidgets(*dpi);
+        DrawWidgets(dpi);
         DrawTabImages(dpi);
 
         // Objective label
         auto screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_OBJECTIVE].top };
-        DrawTextBasic(*dpi, screenCoords, STR_OBJECTIVE_WINDOW);
+        DrawTextBasic(dpi, screenCoords, STR_OBJECTIVE_WINDOW);
 
         // Objective value
         screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_OBJECTIVE].left + 1, widgets[WIDX_OBJECTIVE].top };
         auto ft = Formatter();
         ft.Add<StringId>(ObjectiveDropdownOptionNames[gScenarioObjective.Type]);
-        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+        DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
 
         if (widgets[WIDX_OBJECTIVE_ARG_1].type != WindowWidgetType::Empty)
         {
@@ -880,7 +880,7 @@ private:
                     stringId = STR_WINDOW_OBJECTIVE_EXCITEMENT_RATING;
                     break;
             }
-            DrawTextBasic(*dpi, screenCoords, stringId);
+            DrawTextBasic(dpi, screenCoords, stringId);
 
             // Objective argument 1 value
             screenCoords = windowPos
@@ -913,21 +913,21 @@ private:
                     ft.Add<money64>(gScenarioObjective.Currency);
                     break;
             }
-            DrawTextBasic(*dpi, screenCoords, stringId, ft, COLOUR_BLACK);
+            DrawTextBasic(dpi, screenCoords, stringId, ft, COLOUR_BLACK);
         }
 
         if (widgets[WIDX_OBJECTIVE_ARG_2].type != WindowWidgetType::Empty)
         {
             // Objective argument 2 label
             screenCoords = windowPos + ScreenCoordsXY{ 28, widgets[WIDX_OBJECTIVE_ARG_2].top };
-            DrawTextBasic(*dpi, screenCoords, STR_WINDOW_OBJECTIVE_DATE);
+            DrawTextBasic(dpi, screenCoords, STR_WINDOW_OBJECTIVE_DATE);
 
             // Objective argument 2 value
             screenCoords = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_OBJECTIVE_ARG_2].left + 1, widgets[WIDX_OBJECTIVE_ARG_2].top };
             ft = Formatter();
             ft.Add<uint16_t>((gScenarioObjective.Year * MONTH_COUNT) - 1);
-            DrawTextBasic(*dpi, screenCoords, STR_WINDOW_OBJECTIVE_VALUE_DATE, ft);
+            DrawTextBasic(dpi, screenCoords, STR_WINDOW_OBJECTIVE_VALUE_DATE, ft);
         }
 
         // Park name
@@ -941,7 +941,7 @@ private:
             ft = Formatter();
             ft.Add<StringId>(STR_STRING);
             ft.Add<const char*>(parkName);
-            DrawTextEllipsised(*dpi, screenCoords, widthToSet, STR_WINDOW_PARK_NAME, ft);
+            DrawTextEllipsised(dpi, screenCoords, widthToSet, STR_WINDOW_PARK_NAME, ft);
         }
 
         // Scenario name
@@ -951,11 +951,11 @@ private:
         ft = Formatter();
         ft.Add<StringId>(STR_STRING);
         ft.Add<const char*>(gScenarioName.c_str());
-        DrawTextEllipsised(*dpi, screenCoords, widthToSet, STR_WINDOW_SCENARIO_NAME, ft);
+        DrawTextEllipsised(dpi, screenCoords, widthToSet, STR_WINDOW_SCENARIO_NAME, ft);
 
         // Scenario details label
         screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_DETAILS].top };
-        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_PARK_DETAILS);
+        DrawTextBasic(dpi, screenCoords, STR_WINDOW_PARK_DETAILS);
 
         // Scenario details value
         screenCoords = windowPos + ScreenCoordsXY{ 16, widgets[WIDX_DETAILS].top + 10 };
@@ -964,17 +964,17 @@ private:
         ft = Formatter();
         ft.Add<StringId>(STR_STRING);
         ft.Add<const char*>(gScenarioDetails.c_str());
-        DrawTextWrapped(*dpi, screenCoords, widthToSet, STR_BLACK_STRING, ft);
+        DrawTextWrapped(dpi, screenCoords, widthToSet, STR_BLACK_STRING, ft);
 
         // Scenario category label
         screenCoords = windowPos + ScreenCoordsXY{ 8, widgets[WIDX_CATEGORY].top };
-        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_SCENARIO_GROUP);
+        DrawTextBasic(dpi, screenCoords, STR_WINDOW_SCENARIO_GROUP);
 
         // Scenario category value
         screenCoords = windowPos + ScreenCoordsXY{ widgets[WIDX_CATEGORY].left + 1, widgets[WIDX_CATEGORY].top };
         ft = Formatter();
         ft.Add<StringId>(ScenarioCategoryStringIds[gScenarioCategory]);
-        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+        DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
     }
 
 #pragma endregion
@@ -1094,40 +1094,40 @@ private:
      *
      *  rct2: 0x00672340
      */
-    void OnDrawRides(DrawPixelInfo* dpi)
+    void OnDrawRides(DrawPixelInfo& dpi)
     {
-        DrawWidgets(*dpi);
+        DrawWidgets(dpi);
         DrawTabImages(dpi);
 
         DrawTextBasic(
-            *dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PAGE_BACKGROUND].top + 3 }, STR_WINDOW_PRESERVATION_ORDER);
+            dpi, windowPos + ScreenCoordsXY{ 6, widgets[WIDX_PAGE_BACKGROUND].top + 3 }, STR_WINDOW_PRESERVATION_ORDER);
     }
 
     /**
      *
      *  rct2: 0x0067236F
      */
-    void OnScrollDrawRides(DrawPixelInfo* dpi, int32_t scrollIndex)
+    void OnScrollDrawRides(DrawPixelInfo& dpi, int32_t scrollIndex)
     {
         int32_t colour = ColourMapA[colours[1]].mid_light;
-        GfxFillRect(dpi, { { dpi->x, dpi->y }, { dpi->x + dpi->width - 1, dpi->y + dpi->height - 1 } }, colour);
+        GfxFillRect(&dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, colour);
 
         for (int32_t i = 0; i < no_list_items; i++)
         {
             int32_t y = i * 12;
 
-            if (y + 12 < dpi->y || y >= dpi->y + dpi->height)
+            if (y + 12 < dpi.y || y >= dpi.y + dpi.height)
                 continue;
 
             // Checkbox
-            GfxFillRectInset(dpi, { { 2, y }, { 11, y + 10 } }, colours[1], INSET_RECT_F_E0);
+            GfxFillRectInset(&dpi, { { 2, y }, { 11, y + 10 } }, colours[1], INSET_RECT_F_E0);
 
             // Highlighted
             auto stringId = STR_BLACK_STRING;
             if (i == selected_list_item)
             {
                 stringId = STR_WINDOW_COLOUR_2_STRINGID;
-                GfxFilterRect(dpi, { 0, y, width, y + 11 }, FilterPaletteID::PaletteDarken1);
+                GfxFilterRect(&dpi, { 0, y, width, y + 11 }, FilterPaletteID::PaletteDarken1);
             }
 
             // Checkbox mark
@@ -1139,7 +1139,7 @@ private:
                 {
                     auto darkness = stringId == STR_WINDOW_COLOUR_2_STRINGID ? TextDarkness::ExtraDark : TextDarkness::Dark;
                     GfxDrawString(
-                        *dpi, { 2, y }, static_cast<const char*>(CheckBoxMarkString),
+                        dpi, { 2, y }, static_cast<const char*>(CheckBoxMarkString),
                         { static_cast<colour_t>(colours[1] & 0x7F), FontStyle::Medium, darkness });
                 }
 
@@ -1147,7 +1147,7 @@ private:
 
                 Formatter ft;
                 currentRide->FormatNameTo(ft);
-                DrawTextBasic(*dpi, { 15, y }, stringId, ft);
+                DrawTextBasic(dpi, { 15, y }, stringId, ft);
             }
         }
     }

--- a/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
+++ b/src/openrct2-ui/windows/EditorObjectiveOptions.cpp
@@ -344,7 +344,7 @@ private:
         if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_MAIN)
             spriteIndex += (frame_no / 4) % 16;
 
-        GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+        GfxDrawSprite(*dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
 
         // Tab 2
         if (!IsWidgetDisabled(WIDX_TAB_2))
@@ -354,7 +354,7 @@ private:
             if (page == WINDOW_EDITOR_OBJECTIVE_OPTIONS_PAGE_RIDES)
                 spriteIndex += (frame_no / 4) % 16;
 
-            GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+            GfxDrawSprite(*dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
         }
     }
 

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -333,7 +333,7 @@ private:
         if (page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_FINANCIAL)
             spriteIndex += (frame_no / 2) % 8;
 
-        GfxDrawSprite(&dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+        GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
 
         // Tab 2
         widget = &widgets[WIDX_TAB_2];
@@ -341,12 +341,12 @@ private:
         if (page == WINDOW_EDITOR_SCENARIO_OPTIONS_PAGE_GUESTS)
             spriteIndex += (frame_no / 4) % 8;
 
-        GfxDrawSprite(&dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+        GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
 
         // Tab 3
         widget = &widgets[WIDX_TAB_3];
         spriteIndex = SPR_TAB_PARK;
-        GfxDrawSprite(&dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
+        GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget->left, widget->top });
     }
 
     void SetPage(int32_t newPage)

--- a/src/openrct2-ui/windows/EditorScenarioOptions.cpp
+++ b/src/openrct2-ui/windows/EditorScenarioOptions.cpp
@@ -613,7 +613,7 @@ private:
     {
         ScreenCoordsXY screenCoords{};
 
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
         DrawTabImages(dpi);
 
         const auto& initialCashWidget = widgets[WIDX_INITIAL_CASH];
@@ -861,7 +861,7 @@ private:
     {
         ScreenCoordsXY screenCoords{};
 
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
         DrawTabImages(dpi);
 
         const auto& cashPerGuestWidget = widgets[WIDX_CASH_PER_GUEST];
@@ -1180,7 +1180,7 @@ private:
     {
         ScreenCoordsXY screenCoords{};
 
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
         DrawTabImages(dpi);
 
         const auto& landCostWidget = widgets[WIDX_LAND_COST];

--- a/src/openrct2-ui/windows/Error.cpp
+++ b/src/openrct2-ui/windows/Error.cpp
@@ -63,34 +63,34 @@ public:
         ScreenCoordsXY rightTop{ rightBottom.x, leftTop.y };
 
         GfxFilterRect(
-            &dpi, ScreenRect{ leftTop + ScreenCoordsXY{ 1, 1 }, rightBottom - ScreenCoordsXY{ 1, 1 } },
+            dpi, ScreenRect{ leftTop + ScreenCoordsXY{ 1, 1 }, rightBottom - ScreenCoordsXY{ 1, 1 } },
             FilterPaletteID::Palette45);
-        GfxFilterRect(&dpi, ScreenRect{ leftTop, rightBottom }, FilterPaletteID::PaletteGlassSaturatedRed);
+        GfxFilterRect(dpi, ScreenRect{ leftTop, rightBottom }, FilterPaletteID::PaletteGlassSaturatedRed);
 
         GfxFilterRect(
-            &dpi, ScreenRect{ leftTop + ScreenCoordsXY{ 0, 2 }, leftBottom - ScreenCoordsXY{ 0, 2 } },
+            dpi, ScreenRect{ leftTop + ScreenCoordsXY{ 0, 2 }, leftBottom - ScreenCoordsXY{ 0, 2 } },
             FilterPaletteID::PaletteDarken3);
         GfxFilterRect(
-            &dpi, ScreenRect{ rightTop + ScreenCoordsXY{ 0, 2 }, rightBottom - ScreenCoordsXY{ 0, 2 } },
+            dpi, ScreenRect{ rightTop + ScreenCoordsXY{ 0, 2 }, rightBottom - ScreenCoordsXY{ 0, 2 } },
             FilterPaletteID::PaletteDarken3);
         GfxFilterRect(
-            &dpi, ScreenRect{ leftBottom + ScreenCoordsXY{ 2, 0 }, rightBottom - ScreenCoordsXY{ 2, 0 } },
+            dpi, ScreenRect{ leftBottom + ScreenCoordsXY{ 2, 0 }, rightBottom - ScreenCoordsXY{ 2, 0 } },
             FilterPaletteID::PaletteDarken3);
         GfxFilterRect(
-            &dpi, ScreenRect{ leftTop + ScreenCoordsXY{ 2, 0 }, rightTop - ScreenCoordsXY{ 2, 0 } },
+            dpi, ScreenRect{ leftTop + ScreenCoordsXY{ 2, 0 }, rightTop - ScreenCoordsXY{ 2, 0 } },
             FilterPaletteID::PaletteDarken3);
 
         GfxFilterRect(
-            &dpi, ScreenRect{ rightTop + ScreenCoordsXY{ 1, 1 }, rightTop + ScreenCoordsXY{ 1, 1 } },
+            dpi, ScreenRect{ rightTop + ScreenCoordsXY{ 1, 1 }, rightTop + ScreenCoordsXY{ 1, 1 } },
             FilterPaletteID::PaletteDarken3);
         GfxFilterRect(
-            &dpi, ScreenRect{ rightTop + ScreenCoordsXY{ -1, 1 }, rightTop + ScreenCoordsXY{ -1, 1 } },
+            dpi, ScreenRect{ rightTop + ScreenCoordsXY{ -1, 1 }, rightTop + ScreenCoordsXY{ -1, 1 } },
             FilterPaletteID::PaletteDarken3);
         GfxFilterRect(
-            &dpi, ScreenRect{ leftBottom + ScreenCoordsXY{ 1, -1 }, leftBottom + ScreenCoordsXY{ 1, -1 } },
+            dpi, ScreenRect{ leftBottom + ScreenCoordsXY{ 1, -1 }, leftBottom + ScreenCoordsXY{ 1, -1 } },
             FilterPaletteID::PaletteDarken3);
         GfxFilterRect(
-            &dpi, ScreenRect{ rightBottom - ScreenCoordsXY{ 1, 1 }, rightBottom - ScreenCoordsXY{ 1, 1 } },
+            dpi, ScreenRect{ rightBottom - ScreenCoordsXY{ 1, 1 }, rightBottom - ScreenCoordsXY{ 1, 1 } },
             FilterPaletteID::PaletteDarken3);
 
         DrawStringCentredRaw(

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -988,7 +988,7 @@ public:
 
     void OnDrawResearch(DrawPixelInfo& dpi)
     {
-        WindowResearchFundingPagePaint(this, &dpi, WIDX_RESEARCH_FUNDING);
+        WindowResearchFundingPagePaint(this, dpi, WIDX_RESEARCH_FUNDING);
     }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -656,7 +656,7 @@ public:
 
         // X axis labels and values
         coords = graphTopLeft + ScreenCoordsXY{ 98, 17 };
-        Graph::Draw(&dpi, gCashHistory, 64, coords, yAxisScale, 128);
+        Graph::Draw(dpi, gCashHistory, 64, coords, yAxisScale, 128);
     }
 
 #pragma endregion
@@ -713,7 +713,7 @@ public:
 
         // X axis labels and values
         coords = graphTopLeft + ScreenCoordsXY{ 98, 17 };
-        Graph::Draw(&dpi, gParkValueHistory, 64, coords, yAxisScale, 0);
+        Graph::Draw(dpi, gParkValueHistory, 64, coords, yAxisScale, 0);
     }
 
 #pragma endregion
@@ -772,7 +772,7 @@ public:
 
         // X axis labels and values
         screenPos = graphTopLeft + ScreenCoordsXY{ 98, 17 };
-        Graph::Draw(&dpi, gWeeklyProfitHistory, 64, screenPos, yAxisScale, 128);
+        Graph::Draw(dpi, gWeeklyProfitHistory, 64, screenPos, yAxisScale, 128);
     }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -372,7 +372,7 @@ public:
             // Darken every even row
             if (i % 2 == 0)
                 GfxFillRect(
-                    &dpi,
+                    dpi,
                     { screenCoords - ScreenCoordsXY{ 0, 1 },
                       screenCoords + ScreenCoordsXY{ row_width, (TABLE_CELL_HEIGHT - 2) } },
                     ColourMapA[colours[1]].lighter | 0x1000000);
@@ -426,8 +426,7 @@ public:
                 dpi, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, 0 }, format, ft, { TextAlignment::RIGHT });
 
             GfxFillRect(
-                &dpi,
-                { screenCoords + ScreenCoordsXY{ 10, -2 }, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, -2 } },
+                dpi, { screenCoords + ScreenCoordsXY{ 10, -2 }, screenCoords + ScreenCoordsXY{ EXPENDITURE_COLUMN_WIDTH, -2 } },
                 PALETTE_INDEX_10);
 
             screenCoords.x += EXPENDITURE_COLUMN_WIDTH;
@@ -542,7 +541,7 @@ public:
             // Darken every even row
             if (i % 2 == 0)
                 GfxFillRect(
-                    &dpi,
+                    dpi,
                     { screenCoords - ScreenCoordsXY{ 0, 1 }, screenCoords + ScreenCoordsXY{ 121, (TABLE_CELL_HEIGHT - 2) } },
                     ColourMapA[colours[1]].lighter | 0x1000000);
 
@@ -552,7 +551,7 @@ public:
 
         // Horizontal rule below expenditure / income table
         GfxFillRectInset(
-            &dpi, { windowPos + ScreenCoordsXY{ 8, 272 }, windowPos + ScreenCoordsXY{ 8 + 513, 272 + 1 } }, colours[1],
+            dpi, { windowPos + ScreenCoordsXY{ 8, 272 }, windowPos + ScreenCoordsXY{ 8 + 513, 272 + 1 } }, colours[1],
             INSET_RECT_FLAG_BORDER_INSET);
 
         // Loan and interest rate
@@ -618,7 +617,7 @@ public:
             ft);
 
         // Graph
-        GfxFillRectInset(&dpi, { graphTopLeft, graphBottomRight }, colours[1], INSET_RECT_F_30);
+        GfxFillRectInset(dpi, { graphTopLeft, graphBottomRight }, colours[1], INSET_RECT_F_30);
 
         // Calculate the Y axis scale (log2 of highest [+/-]balance)
         int32_t yAxisScale = 0;
@@ -649,7 +648,7 @@ public:
                 dpi, coords + ScreenCoordsXY{ 70, 0 }, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, ft,
                 { FontStyle::Small, TextAlignment::RIGHT });
             GfxFillRectInset(
-                &dpi, { coords + ScreenCoordsXY{ 70, 5 }, { graphTopLeft.x + 482, coords.y + 5 } }, colours[2],
+                dpi, { coords + ScreenCoordsXY{ 70, 5 }, { graphTopLeft.x + 482, coords.y + 5 } }, colours[2],
                 INSET_RECT_FLAG_BORDER_INSET);
             coords.y += 39;
         }
@@ -675,7 +674,7 @@ public:
         DrawTextBasic(dpi, graphTopLeft - ScreenCoordsXY{ 0, 11 }, STR_FINANCES_PARK_VALUE, ft);
 
         // Graph
-        GfxFillRectInset(&dpi, { graphTopLeft, graphBottomRight }, colours[1], INSET_RECT_F_30);
+        GfxFillRectInset(dpi, { graphTopLeft, graphBottomRight }, colours[1], INSET_RECT_F_30);
 
         // Calculate the Y axis scale (log2 of highest [+/-]balance)
         int32_t yAxisScale = 0;
@@ -706,7 +705,7 @@ public:
                 dpi, coords + ScreenCoordsXY{ 70, 0 }, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, ft,
                 { FontStyle::Small, TextAlignment::RIGHT });
             GfxFillRectInset(
-                &dpi, { coords + ScreenCoordsXY{ 70, 5 }, { graphTopLeft.x + 482, coords.y + 5 } }, colours[2],
+                dpi, { coords + ScreenCoordsXY{ 70, 5 }, { graphTopLeft.x + 482, coords.y + 5 } }, colours[2],
                 INSET_RECT_FLAG_BORDER_INSET);
             coords.y += 39;
         }
@@ -734,7 +733,7 @@ public:
             gCurrentProfit >= 0 ? STR_FINANCES_WEEKLY_PROFIT_POSITIVE : STR_FINANCES_WEEKLY_PROFIT_LOSS, ft);
 
         // Graph
-        GfxFillRectInset(&dpi, { graphTopLeft, graphBottomRight }, colours[1], INSET_RECT_F_30);
+        GfxFillRectInset(dpi, { graphTopLeft, graphBottomRight }, colours[1], INSET_RECT_F_30);
 
         // Calculate the Y axis scale (log2 of highest [+/-]balance)
         int32_t yAxisScale = 0;
@@ -765,7 +764,7 @@ public:
                 dpi, screenPos + ScreenCoordsXY{ 70, 0 }, STR_FINANCES_FINANCIAL_GRAPH_CASH_VALUE, ft,
                 { FontStyle::Small, TextAlignment::RIGHT });
             GfxFillRectInset(
-                &dpi, { screenPos + ScreenCoordsXY{ 70, 5 }, { graphTopLeft.x + 482, screenPos.y + 5 } }, colours[2],
+                dpi, { screenPos + ScreenCoordsXY{ 70, 5 }, { graphTopLeft.x + 482, screenPos.y + 5 } }, colours[2],
                 INSET_RECT_FLAG_BORDER_INSET);
             screenPos.y += 39;
         }

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -1014,7 +1014,7 @@ public:
             }
 
             GfxDrawSprite(
-                &dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
+                dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
         }
     }
 

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -482,7 +482,7 @@ public:
                 screenCoords = this->windowPos
                     + ScreenCoordsXY{ window_footpath_widgets[WIDX_CONSTRUCT].midX(),
                                       window_footpath_widgets[WIDX_CONSTRUCT].bottom - 60 };
-                GfxDrawSprite(&dpi, ImageId(image), screenCoords);
+                GfxDrawSprite(dpi, ImageId(image), screenCoords);
             }
 
             // Draw build this... label
@@ -623,7 +623,7 @@ private:
     void WindowFootpathDrawDropdownButton(DrawPixelInfo* dpi, WidgetIndex widgetIndex, ImageIndex image)
     {
         const auto& widget = widgets[widgetIndex];
-        GfxDrawSprite(dpi, ImageId(image), { windowPos.x + widget.left, windowPos.y + widget.top });
+        GfxDrawSprite(*dpi, ImageId(image), { windowPos.x + widget.left, windowPos.y + widget.top });
     }
 
     /**

--- a/src/openrct2-ui/windows/Footpath.cpp
+++ b/src/openrct2-ui/windows/Footpath.cpp
@@ -432,8 +432,8 @@ public:
     void OnDraw(DrawPixelInfo& dpi) override
     {
         ScreenCoordsXY screenCoords;
-        WindowDrawWidgets(*this, &dpi);
-        WindowFootpathDrawDropdownButtons(&dpi);
+        WindowDrawWidgets(*this, dpi);
+        WindowFootpathDrawDropdownButtons(dpi);
 
         if (!IsWidgetDisabled(WIDX_CONSTRUCT))
         {
@@ -568,7 +568,7 @@ private:
         }
     }
 
-    void WindowFootpathDrawDropdownButtons(DrawPixelInfo* dpi)
+    void WindowFootpathDrawDropdownButtons(DrawPixelInfo& dpi)
     {
         if (gFootpathSelection.LegacyPath == OBJECT_ENTRY_INDEX_NULL)
         {
@@ -620,10 +620,10 @@ private:
         }
     }
 
-    void WindowFootpathDrawDropdownButton(DrawPixelInfo* dpi, WidgetIndex widgetIndex, ImageIndex image)
+    void WindowFootpathDrawDropdownButton(DrawPixelInfo& dpi, WidgetIndex widgetIndex, ImageIndex image)
     {
         const auto& widget = widgets[widgetIndex];
-        GfxDrawSprite(*dpi, ImageId(image), { windowPos.x + widget.left, windowPos.y + widget.top });
+        GfxDrawSprite(dpi, ImageId(image), { windowPos.x + widget.left, windowPos.y + widget.top });
     }
 
     /**

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -72,16 +72,16 @@ uint8_t gToolbarDirtyFlags;
 static void WindowGameBottomToolbarMouseup(WindowBase *w, WidgetIndex widgetIndex);
 static OpenRCT2String WindowGameBottomToolbarTooltip(WindowBase* w, const WidgetIndex widgetIndex, const StringId fallback);
 static void WindowGameBottomToolbarInvalidate(WindowBase *w);
-static void WindowGameBottomToolbarPaint(WindowBase *w, DrawPixelInfo *dpi);
+static void WindowGameBottomToolbarPaint(WindowBase *w, DrawPixelInfo& dpi);
 static void WindowGameBottomToolbarUpdate(WindowBase* w);
 static void WindowGameBottomToolbarCursor(WindowBase *w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords, CursorID *cursorId);
 static void WindowGameBottomToolbarUnknown05(WindowBase *w);
 
-static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo *dpi, WindowBase *w);
-static void WindowGameBottomToolbarDrawParkRating(DrawPixelInfo *dpi, WindowBase *w, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor);
-static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo *dpi, WindowBase *w);
-static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo *dpi, WindowBase *w);
-static void WindowGameBottomToolbarDrawMiddlePanel(DrawPixelInfo *dpi, WindowBase *w);
+static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo& dpi, WindowBase *w);
+static void WindowGameBottomToolbarDrawParkRating(DrawPixelInfo& dpi, WindowBase *w, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor);
+static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo& dpi, WindowBase *w);
+static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo& dpi, WindowBase *w);
+static void WindowGameBottomToolbarDrawMiddlePanel(DrawPixelInfo& dpi, WindowBase *w);
 
 /**
  *
@@ -338,7 +338,7 @@ void WindowGameBottomToolbarInvalidateNewsItem()
  *
  *  rct2: 0x0066BC87
  */
-static void WindowGameBottomToolbarPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowGameBottomToolbarPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     auto leftWidget = window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET];
     auto rightWidget = window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET];
@@ -347,18 +347,18 @@ static void WindowGameBottomToolbarPaint(WindowBase* w, DrawPixelInfo* dpi)
     // Draw panel grey backgrounds
     auto leftTop = w->windowPos + ScreenCoordsXY{ leftWidget.left, leftWidget.top };
     auto rightBottom = w->windowPos + ScreenCoordsXY{ leftWidget.right, leftWidget.bottom };
-    GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+    GfxFilterRect(&dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
 
     leftTop = w->windowPos + ScreenCoordsXY{ rightWidget.left, rightWidget.top };
     rightBottom = w->windowPos + ScreenCoordsXY{ rightWidget.right, rightWidget.bottom };
-    GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+    GfxFilterRect(&dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
 
     if (ThemeGetFlags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR)
     {
         // Draw grey background
         leftTop = w->windowPos + ScreenCoordsXY{ middleWidget.left, middleWidget.top };
         rightBottom = w->windowPos + ScreenCoordsXY{ middleWidget.right, middleWidget.bottom };
-        GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+        GfxFilterRect(&dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
     }
 
     WindowDrawWidgets(*w, dpi);
@@ -376,7 +376,7 @@ static void WindowGameBottomToolbarPaint(WindowBase* w, DrawPixelInfo* dpi)
     }
 }
 
-static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo* dpi, WindowBase* w)
+static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo& dpi, WindowBase* w)
 {
     const auto topLeft = w->windowPos
         + ScreenCoordsXY{ window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].left + 1,
@@ -385,7 +385,7 @@ static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo* dpi, WindowBase*
         + ScreenCoordsXY{ window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].right - 1,
                           window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].bottom - 1 };
     // Draw green inset rectangle on panel
-    GfxFillRectInset(dpi, { topLeft, bottomRight }, w->colours[1], INSET_RECT_F_30);
+    GfxFillRectInset(&dpi, { topLeft, bottomRight }, w->colours[1], INSET_RECT_F_30);
 
     // Figure out how much line height we have to work with.
     uint32_t line_height = FontGetLineHeight(FontStyle::Medium);
@@ -404,7 +404,7 @@ static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo* dpi, WindowBase*
         StringId stringId = gCash < 0 ? STR_BOTTOM_TOOLBAR_CASH_NEGATIVE : STR_BOTTOM_TOOLBAR_CASH;
         auto ft = Formatter();
         ft.Add<money64>(gCash);
-        DrawTextBasic(*dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
+        DrawTextBasic(dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
     }
 
     static constexpr const StringId _guestCountFormats[] = {
@@ -432,7 +432,7 @@ static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo* dpi, WindowBase*
                    : NOT_TRANSLUCENT(w->colours[0]));
         auto ft = Formatter();
         ft.Add<uint32_t>(gNumGuestsInPark);
-        DrawTextBasic(*dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
+        DrawTextBasic(dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
     }
 
     // Draw park rating
@@ -450,27 +450,27 @@ static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo* dpi, WindowBase*
  *  rct2: 0x0066C76C
  */
 static void WindowGameBottomToolbarDrawParkRating(
-    DrawPixelInfo* dpi, WindowBase* w, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor)
+    DrawPixelInfo& dpi, WindowBase* w, int32_t colour, const ScreenCoordsXY& coords, uint8_t factor)
 {
     int16_t bar_width;
 
     bar_width = (factor * 114) / 255;
     GfxFillRectInset(
-        dpi, { coords + ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 114, 9 } }, w->colours[1], INSET_RECT_F_30);
+        &dpi, { coords + ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 114, 9 } }, w->colours[1], INSET_RECT_F_30);
     if (!(colour & BAR_BLINK) || GameIsPaused() || (gCurrentRealTimeTicks & 8))
     {
         if (bar_width > 2)
         {
-            GfxFillRectInset(dpi, { coords + ScreenCoordsXY{ 2, 2 }, coords + ScreenCoordsXY{ bar_width - 1, 8 } }, colour, 0);
+            GfxFillRectInset(&dpi, { coords + ScreenCoordsXY{ 2, 2 }, coords + ScreenCoordsXY{ bar_width - 1, 8 } }, colour, 0);
         }
     }
 
     // Draw thumbs on the sides
-    GfxDrawSprite(*dpi, ImageId(SPR_RATING_LOW), coords - ScreenCoordsXY{ 14, 0 });
-    GfxDrawSprite(*dpi, ImageId(SPR_RATING_HIGH), coords + ScreenCoordsXY{ 114, 0 });
+    GfxDrawSprite(dpi, ImageId(SPR_RATING_LOW), coords - ScreenCoordsXY{ 14, 0 });
+    GfxDrawSprite(dpi, ImageId(SPR_RATING_HIGH), coords + ScreenCoordsXY{ 114, 0 });
 }
 
-static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase* w)
+static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo& dpi, WindowBase* w)
 {
     const auto topLeft = w->windowPos
         + ScreenCoordsXY{ window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left + 1,
@@ -479,7 +479,7 @@ static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase
         + ScreenCoordsXY{ window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].right - 1,
                           window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].bottom - 1 };
     // Draw green inset rectangle on panel
-    GfxFillRectInset(dpi, { topLeft, bottomRight }, w->colours[1], INSET_RECT_F_30);
+    GfxFillRectInset(&dpi, { topLeft, bottomRight }, w->colours[1], INSET_RECT_F_30);
 
     auto screenCoords = ScreenCoordsXY{ (window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left
                                          + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].right)
@@ -502,7 +502,7 @@ static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase
     ft.Add<StringId>(DateDayNames[day]);
     ft.Add<int16_t>(month);
     ft.Add<int16_t>(year);
-    DrawTextBasic(*dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
+    DrawTextBasic(dpi, screenCoords, stringId, ft, { colour, TextAlignment::CENTRE });
 
     // Figure out how much line height we have to work with.
     uint32_t line_height = FontGetLineHeight(FontStyle::Medium);
@@ -520,12 +520,12 @@ static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase
     }
     ft = Formatter();
     ft.Add<int16_t>(temperature);
-    DrawTextBasic(*dpi, screenCoords + ScreenCoordsXY{ 0, 6 }, format, ft);
+    DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ 0, 6 }, format, ft);
     screenCoords.x += 30;
 
     // Current weather
     auto currentWeatherSpriteId = ClimateGetWeatherSpriteId(gClimateCurrent);
-    GfxDrawSprite(*dpi, ImageId(currentWeatherSpriteId), screenCoords);
+    GfxDrawSprite(dpi, ImageId(currentWeatherSpriteId), screenCoords);
 
     // Next weather
     auto nextWeatherSpriteId = ClimateGetWeatherSpriteId(gClimateNext);
@@ -533,8 +533,8 @@ static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase
     {
         if (gClimateUpdateTimer < 960)
         {
-            GfxDrawSprite(*dpi, ImageId(SPR_NEXT_WEATHER), screenCoords + ScreenCoordsXY{ 27, 5 });
-            GfxDrawSprite(*dpi, ImageId(nextWeatherSpriteId), screenCoords + ScreenCoordsXY{ 40, 0 });
+            GfxDrawSprite(dpi, ImageId(SPR_NEXT_WEATHER), screenCoords + ScreenCoordsXY{ 27, 5 });
+            GfxDrawSprite(dpi, ImageId(nextWeatherSpriteId), screenCoords + ScreenCoordsXY{ 40, 0 });
         }
     }
 }
@@ -543,7 +543,7 @@ static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase
  *
  *  rct2: 0x0066BFA5
  */
-static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, WindowBase* w)
+static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo& dpi, WindowBase* w)
 {
     int32_t width;
     News::Item* newsItem;
@@ -554,7 +554,7 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, WindowBase* 
 
     // Current news item
     GfxFillRectInset(
-        dpi,
+        &dpi,
         { w->windowPos + ScreenCoordsXY{ middleOutsetWidget->left + 1, middleOutsetWidget->top + 1 },
           w->windowPos + ScreenCoordsXY{ middleOutsetWidget->right - 1, middleOutsetWidget->bottom - 1 } },
         w->colours[2], INSET_RECT_F_30);
@@ -563,7 +563,7 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, WindowBase* 
     auto screenCoords = w->windowPos + ScreenCoordsXY{ middleOutsetWidget->midX(), middleOutsetWidget->top + 11 };
     width = middleOutsetWidget->width() - 62;
     DrawNewsTicker(
-        *dpi, screenCoords, width, COLOUR_BRIGHT_GREEN, STR_BOTTOM_TOOLBAR_NEWS_TEXT, newsItem->Text, newsItem->Ticks);
+        dpi, screenCoords, width, COLOUR_BRIGHT_GREEN, STR_BOTTOM_TOOLBAR_NEWS_TEXT, newsItem->Text, newsItem->Ticks);
 
     screenCoords = w->windowPos
         + ScreenCoordsXY{ window_game_bottom_toolbar_widgets[WIDX_NEWS_SUBJECT].left,
@@ -571,7 +571,7 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, WindowBase* 
     switch (newsItem->Type)
     {
         case News::ItemType::Ride:
-            GfxDrawSprite(*dpi, ImageId(SPR_RIDE), screenCoords);
+            GfxDrawSprite(dpi, ImageId(SPR_RIDE), screenCoords);
             break;
         case News::ItemType::PeepOnRide:
         case News::ItemType::Peep:
@@ -580,7 +580,7 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, WindowBase* 
                 break;
 
             DrawPixelInfo cliped_dpi;
-            if (!ClipDrawPixelInfo(&cliped_dpi, dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
+            if (!ClipDrawPixelInfo(&cliped_dpi, &dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
             {
                 break;
             }
@@ -623,19 +623,19 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, WindowBase* 
         }
         case News::ItemType::Money:
         case News::ItemType::Campaign:
-            GfxDrawSprite(*dpi, ImageId(SPR_FINANCE), screenCoords);
+            GfxDrawSprite(dpi, ImageId(SPR_FINANCE), screenCoords);
             break;
         case News::ItemType::Research:
-            GfxDrawSprite(*dpi, ImageId(newsItem->Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
+            GfxDrawSprite(dpi, ImageId(newsItem->Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
             break;
         case News::ItemType::Peeps:
-            GfxDrawSprite(*dpi, ImageId(SPR_GUESTS), screenCoords);
+            GfxDrawSprite(dpi, ImageId(SPR_GUESTS), screenCoords);
             break;
         case News::ItemType::Award:
-            GfxDrawSprite(*dpi, ImageId(SPR_AWARD), screenCoords);
+            GfxDrawSprite(dpi, ImageId(SPR_AWARD), screenCoords);
             break;
         case News::ItemType::Graph:
-            GfxDrawSprite(*dpi, ImageId(SPR_GRAPH), screenCoords);
+            GfxDrawSprite(dpi, ImageId(SPR_GRAPH), screenCoords);
             break;
         case News::ItemType::Null:
         case News::ItemType::Blank:
@@ -644,12 +644,12 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, WindowBase* 
     }
 }
 
-static void WindowGameBottomToolbarDrawMiddlePanel(DrawPixelInfo* dpi, WindowBase* w)
+static void WindowGameBottomToolbarDrawMiddlePanel(DrawPixelInfo& dpi, WindowBase* w)
 {
     Widget* middleOutsetWidget = &window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET];
 
     GfxFillRectInset(
-        dpi,
+        &dpi,
         { w->windowPos + ScreenCoordsXY{ middleOutsetWidget->left + 1, middleOutsetWidget->top + 1 },
           w->windowPos + ScreenCoordsXY{ middleOutsetWidget->right - 1, middleOutsetWidget->bottom - 1 } },
         w->colours[1], INSET_RECT_F_30);
@@ -668,12 +668,12 @@ static void WindowGameBottomToolbarDrawMiddlePanel(DrawPixelInfo* dpi, WindowBas
     if (stringId == STR_NONE)
     {
         DrawTextWrapped(
-            *dpi, middleWidgetCoords, width, STR_TITLE_SEQUENCE_OPENRCT2, ft, { w->colours[0], TextAlignment::CENTRE });
+            dpi, middleWidgetCoords, width, STR_TITLE_SEQUENCE_OPENRCT2, ft, { w->colours[0], TextAlignment::CENTRE });
     }
     else
     {
         // Show tooltip in bottom toolbar
-        DrawTextWrapped(*dpi, middleWidgetCoords, width, STR_STRINGID, ft, { w->colours[0], TextAlignment::CENTRE });
+        DrawTextWrapped(dpi, middleWidgetCoords, width, STR_STRINGID, ft, { w->colours[0], TextAlignment::CENTRE });
     }
 }
 

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -466,8 +466,8 @@ static void WindowGameBottomToolbarDrawParkRating(
     }
 
     // Draw thumbs on the sides
-    GfxDrawSprite(dpi, ImageId(SPR_RATING_LOW), coords - ScreenCoordsXY{ 14, 0 });
-    GfxDrawSprite(dpi, ImageId(SPR_RATING_HIGH), coords + ScreenCoordsXY{ 114, 0 });
+    GfxDrawSprite(*dpi, ImageId(SPR_RATING_LOW), coords - ScreenCoordsXY{ 14, 0 });
+    GfxDrawSprite(*dpi, ImageId(SPR_RATING_HIGH), coords + ScreenCoordsXY{ 114, 0 });
 }
 
 static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase* w)
@@ -525,7 +525,7 @@ static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase
 
     // Current weather
     auto currentWeatherSpriteId = ClimateGetWeatherSpriteId(gClimateCurrent);
-    GfxDrawSprite(dpi, ImageId(currentWeatherSpriteId), screenCoords);
+    GfxDrawSprite(*dpi, ImageId(currentWeatherSpriteId), screenCoords);
 
     // Next weather
     auto nextWeatherSpriteId = ClimateGetWeatherSpriteId(gClimateNext);
@@ -533,8 +533,8 @@ static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo* dpi, WindowBase
     {
         if (gClimateUpdateTimer < 960)
         {
-            GfxDrawSprite(dpi, ImageId(SPR_NEXT_WEATHER), screenCoords + ScreenCoordsXY{ 27, 5 });
-            GfxDrawSprite(dpi, ImageId(nextWeatherSpriteId), screenCoords + ScreenCoordsXY{ 40, 0 });
+            GfxDrawSprite(*dpi, ImageId(SPR_NEXT_WEATHER), screenCoords + ScreenCoordsXY{ 27, 5 });
+            GfxDrawSprite(*dpi, ImageId(nextWeatherSpriteId), screenCoords + ScreenCoordsXY{ 40, 0 });
         }
     }
 }
@@ -571,7 +571,7 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, WindowBase* 
     switch (newsItem->Type)
     {
         case News::ItemType::Ride:
-            GfxDrawSprite(dpi, ImageId(SPR_RIDE), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(SPR_RIDE), screenCoords);
             break;
         case News::ItemType::PeepOnRide:
         case News::ItemType::Peep:
@@ -601,41 +601,41 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo* dpi, WindowBase* 
             image_id_base++;
 
             auto image_id = ImageId(image_id_base, peep->TshirtColour, peep->TrousersColour);
-            GfxDrawSprite(&cliped_dpi, image_id, clipCoords);
+            GfxDrawSprite(cliped_dpi, image_id, clipCoords);
 
             auto* guest = peep->As<Guest>();
             if (guest != nullptr)
             {
                 if (image_id_base >= 0x2A1D && image_id_base < 0x2A3D)
                 {
-                    GfxDrawSprite(&cliped_dpi, ImageId(image_id_base + 32, guest->BalloonColour), clipCoords);
+                    GfxDrawSprite(cliped_dpi, ImageId(image_id_base + 32, guest->BalloonColour), clipCoords);
                 }
                 else if (image_id_base >= 0x2BBD && image_id_base < 0x2BDD)
                 {
-                    GfxDrawSprite(&cliped_dpi, ImageId(image_id_base + 32, guest->UmbrellaColour), clipCoords);
+                    GfxDrawSprite(cliped_dpi, ImageId(image_id_base + 32, guest->UmbrellaColour), clipCoords);
                 }
                 else if (image_id_base >= 0x29DD && image_id_base < 0x29FD)
                 {
-                    GfxDrawSprite(&cliped_dpi, ImageId(image_id_base + 32, guest->HatColour), clipCoords);
+                    GfxDrawSprite(cliped_dpi, ImageId(image_id_base + 32, guest->HatColour), clipCoords);
                 }
             }
             break;
         }
         case News::ItemType::Money:
         case News::ItemType::Campaign:
-            GfxDrawSprite(dpi, ImageId(SPR_FINANCE), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(SPR_FINANCE), screenCoords);
             break;
         case News::ItemType::Research:
-            GfxDrawSprite(dpi, ImageId(newsItem->Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(newsItem->Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
             break;
         case News::ItemType::Peeps:
-            GfxDrawSprite(dpi, ImageId(SPR_GUESTS), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(SPR_GUESTS), screenCoords);
             break;
         case News::ItemType::Award:
-            GfxDrawSprite(dpi, ImageId(SPR_AWARD), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(SPR_AWARD), screenCoords);
             break;
         case News::ItemType::Graph:
-            GfxDrawSprite(dpi, ImageId(SPR_GRAPH), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(SPR_GRAPH), screenCoords);
             break;
         case News::ItemType::Null:
         case News::ItemType::Blank:

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -347,18 +347,18 @@ static void WindowGameBottomToolbarPaint(WindowBase* w, DrawPixelInfo& dpi)
     // Draw panel grey backgrounds
     auto leftTop = w->windowPos + ScreenCoordsXY{ leftWidget.left, leftWidget.top };
     auto rightBottom = w->windowPos + ScreenCoordsXY{ leftWidget.right, leftWidget.bottom };
-    GfxFilterRect(&dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+    GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
 
     leftTop = w->windowPos + ScreenCoordsXY{ rightWidget.left, rightWidget.top };
     rightBottom = w->windowPos + ScreenCoordsXY{ rightWidget.right, rightWidget.bottom };
-    GfxFilterRect(&dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+    GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
 
     if (ThemeGetFlags() & UITHEME_FLAG_USE_FULL_BOTTOM_TOOLBAR)
     {
         // Draw grey background
         leftTop = w->windowPos + ScreenCoordsXY{ middleWidget.left, middleWidget.top };
         rightBottom = w->windowPos + ScreenCoordsXY{ middleWidget.right, middleWidget.bottom };
-        GfxFilterRect(&dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
+        GfxFilterRect(dpi, { leftTop, rightBottom }, FilterPaletteID::Palette51);
     }
 
     WindowDrawWidgets(*w, dpi);
@@ -385,7 +385,7 @@ static void WindowGameBottomToolbarDrawLeftPanel(DrawPixelInfo& dpi, WindowBase*
         + ScreenCoordsXY{ window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].right - 1,
                           window_game_bottom_toolbar_widgets[WIDX_LEFT_OUTSET].bottom - 1 };
     // Draw green inset rectangle on panel
-    GfxFillRectInset(&dpi, { topLeft, bottomRight }, w->colours[1], INSET_RECT_F_30);
+    GfxFillRectInset(dpi, { topLeft, bottomRight }, w->colours[1], INSET_RECT_F_30);
 
     // Figure out how much line height we have to work with.
     uint32_t line_height = FontGetLineHeight(FontStyle::Medium);
@@ -456,12 +456,12 @@ static void WindowGameBottomToolbarDrawParkRating(
 
     bar_width = (factor * 114) / 255;
     GfxFillRectInset(
-        &dpi, { coords + ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 114, 9 } }, w->colours[1], INSET_RECT_F_30);
+        dpi, { coords + ScreenCoordsXY{ 1, 1 }, coords + ScreenCoordsXY{ 114, 9 } }, w->colours[1], INSET_RECT_F_30);
     if (!(colour & BAR_BLINK) || GameIsPaused() || (gCurrentRealTimeTicks & 8))
     {
         if (bar_width > 2)
         {
-            GfxFillRectInset(&dpi, { coords + ScreenCoordsXY{ 2, 2 }, coords + ScreenCoordsXY{ bar_width - 1, 8 } }, colour, 0);
+            GfxFillRectInset(dpi, { coords + ScreenCoordsXY{ 2, 2 }, coords + ScreenCoordsXY{ bar_width - 1, 8 } }, colour, 0);
         }
     }
 
@@ -479,7 +479,7 @@ static void WindowGameBottomToolbarDrawRightPanel(DrawPixelInfo& dpi, WindowBase
         + ScreenCoordsXY{ window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].right - 1,
                           window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].bottom - 1 };
     // Draw green inset rectangle on panel
-    GfxFillRectInset(&dpi, { topLeft, bottomRight }, w->colours[1], INSET_RECT_F_30);
+    GfxFillRectInset(dpi, { topLeft, bottomRight }, w->colours[1], INSET_RECT_F_30);
 
     auto screenCoords = ScreenCoordsXY{ (window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].left
                                          + window_game_bottom_toolbar_widgets[WIDX_RIGHT_OUTSET].right)
@@ -554,7 +554,7 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo& dpi, WindowBase* 
 
     // Current news item
     GfxFillRectInset(
-        &dpi,
+        dpi,
         { w->windowPos + ScreenCoordsXY{ middleOutsetWidget->left + 1, middleOutsetWidget->top + 1 },
           w->windowPos + ScreenCoordsXY{ middleOutsetWidget->right - 1, middleOutsetWidget->bottom - 1 } },
         w->colours[2], INSET_RECT_F_30);
@@ -649,7 +649,7 @@ static void WindowGameBottomToolbarDrawMiddlePanel(DrawPixelInfo& dpi, WindowBas
     Widget* middleOutsetWidget = &window_game_bottom_toolbar_widgets[WIDX_MIDDLE_OUTSET];
 
     GfxFillRectInset(
-        &dpi,
+        dpi,
         { w->windowPos + ScreenCoordsXY{ middleOutsetWidget->left + 1, middleOutsetWidget->top + 1 },
           w->windowPos + ScreenCoordsXY{ middleOutsetWidget->right - 1, middleOutsetWidget->bottom - 1 } },
         w->colours[1], INSET_RECT_F_30);

--- a/src/openrct2-ui/windows/GameBottomToolbar.cpp
+++ b/src/openrct2-ui/windows/GameBottomToolbar.cpp
@@ -580,7 +580,7 @@ static void WindowGameBottomToolbarDrawNewsItem(DrawPixelInfo& dpi, WindowBase* 
                 break;
 
             DrawPixelInfo cliped_dpi;
-            if (!ClipDrawPixelInfo(&cliped_dpi, &dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
+            if (!ClipDrawPixelInfo(cliped_dpi, dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
             {
                 break;
             }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -552,7 +552,7 @@ private:
         animationFrame += animationFrameOffset;
 
         auto spriteId = ImageId(animationFrame, peep->TshirtColour, peep->TrousersColour);
-        GfxDrawSprite(&clipDpi, spriteId, screenCoords);
+        GfxDrawSprite(clipDpi, spriteId, screenCoords);
 
         auto* guest = peep->As<Guest>();
         if (guest != nullptr)
@@ -560,19 +560,19 @@ private:
             // If holding a balloon
             if (animationFrame >= 0x2A1D && animationFrame < 0x2A3D)
             {
-                GfxDrawSprite(&clipDpi, ImageId(animationFrame + 32, guest->BalloonColour), screenCoords);
+                GfxDrawSprite(clipDpi, ImageId(animationFrame + 32, guest->BalloonColour), screenCoords);
             }
 
             // If holding umbrella
             if (animationFrame >= 0x2BBD && animationFrame < 0x2BDD)
             {
-                GfxDrawSprite(&clipDpi, ImageId(animationFrame + 32, guest->UmbrellaColour), screenCoords);
+                GfxDrawSprite(clipDpi, ImageId(animationFrame + 32, guest->UmbrellaColour), screenCoords);
             }
 
             // If wearing hat
             if (animationFrame >= 0x29DD && animationFrame < 0x29FD)
             {
-                GfxDrawSprite(&clipDpi, ImageId(animationFrame + 32, guest->HatColour), screenCoords);
+                GfxDrawSprite(clipDpi, ImageId(animationFrame + 32, guest->HatColour), screenCoords);
             }
         }
     }
@@ -755,7 +755,7 @@ private:
             WindowDrawViewport(&dpi, *this);
             if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
             {
-                GfxDrawSprite(&dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
+                GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
             }
         }
 
@@ -1016,7 +1016,7 @@ private:
                     break;
             }
         }
-        GfxDrawSprite(&dpi, ImageId(imageId), screenCoords);
+        GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
     }
 
     void OnUpdateStats()
@@ -1219,7 +1219,7 @@ private:
             imageId += (frame_no / 4) & 0xF;
         }
 
-        GfxDrawSprite(&dpi, ImageId(imageId), screenCoords);
+        GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
     }
 
     void OnUpdateRides()
@@ -1394,7 +1394,7 @@ private:
             imageId += (frame_no / 2) & 0x7;
         }
 
-        GfxDrawSprite(&dpi, ImageId(imageId), screenCoords);
+        GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
     }
 
     void OnUpdateFinance()
@@ -1532,7 +1532,7 @@ private:
             imageId += (frame_no / 2) & 0x7;
         }
 
-        GfxDrawSprite(&dpi, ImageId(imageId), screenCoords);
+        GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
     }
 
     void OnUpdateThoughts()
@@ -1607,7 +1607,7 @@ private:
         const auto& widget = widgets[WIDX_TAB_6];
         auto screenCoords = windowPos + ScreenCoordsXY{ widget.left, widget.top };
 
-        GfxDrawSprite(&dpi, ImageId(SPR_TAB_GUEST_INVENTORY), screenCoords);
+        GfxDrawSprite(dpi, ImageId(SPR_TAB_GUEST_INVENTORY), screenCoords);
     }
 
     void OnUpdateInventory()
@@ -1802,7 +1802,7 @@ private:
             imageId += (frame_no / 2) & 0x3;
         }
 
-        GfxDrawSprite(&dpi, ImageId(imageId), screenCoords);
+        GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
     }
 
     void OnUpdateDebug()

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -1041,7 +1041,7 @@ private:
         }
 
         GfxFillRectInset(
-            &dpi, { coords + ScreenCoordsXY{ 61, 1 }, coords + ScreenCoordsXY{ 61 + 121, 9 } }, colours[1], INSET_RECT_F_30);
+            dpi, { coords + ScreenCoordsXY{ 61, 1 }, coords + ScreenCoordsXY{ 61 + 121, 9 } }, colours[1], INSET_RECT_F_30);
 
         if (!blinkFlag || GameIsPaused() || (gCurrentRealTimeTicks & 8) == 0)
         {
@@ -1052,7 +1052,7 @@ private:
                 return;
 
             GfxFillRectInset(
-                &dpi, { coords + ScreenCoordsXY{ 63, 2 }, coords + ScreenCoordsXY{ 63 + value - 1, 8 } }, colour, 0);
+                dpi, { coords + ScreenCoordsXY{ 63, 2 }, coords + ScreenCoordsXY{ 63 + value - 1, 8 } }, colour, 0);
         }
     }
 
@@ -1157,7 +1157,7 @@ private:
 
         screenCoords.y += LIST_ROW_HEIGHT + 9;
         GfxFillRectInset(
-            &dpi, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 179, -5 } }, colours[1],
+            dpi, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 179, -5 } }, colours[1],
             INSET_RECT_FLAG_BORDER_INSET);
 
         // Preferred Ride
@@ -1354,7 +1354,7 @@ private:
     void OnScrollDrawRides(int32_t scrollIndex, DrawPixelInfo& dpi)
     {
         auto colour = ColourMapA[colours[1]].mid_light;
-        GfxFillRect(&dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, colour);
+        GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, colour);
 
         for (int32_t listIndex = 0; listIndex < no_list_items; listIndex++)
         {
@@ -1362,7 +1362,7 @@ private:
             StringId stringId = STR_BLACK_STRING;
             if (listIndex == selected_list_item)
             {
-                GfxFilterRect(&dpi, { 0, y, 800, y + 9 }, FilterPaletteID::PaletteDarken1);
+                GfxFilterRect(dpi, { 0, y, 800, y + 9 }, FilterPaletteID::PaletteDarken1);
                 stringId = STR_WINDOW_COLOUR_2_STRINGID;
             }
 
@@ -1443,7 +1443,7 @@ private:
         }
 
         GfxFillRectInset(
-            &dpi, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 179, -5 } }, colours[1],
+            dpi, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 179, -5 } }, colours[1],
             INSET_RECT_FLAG_BORDER_INSET);
 
         // Paid to enter

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -527,7 +527,7 @@ private:
             widgHeight++;
 
         DrawPixelInfo clipDpi;
-        if (!ClipDrawPixelInfo(&clipDpi, &dpi, screenCoords, widgWidth, widgHeight))
+        if (!ClipDrawPixelInfo(clipDpi, dpi, screenCoords, widgWidth, widgHeight))
         {
             return;
         }
@@ -783,7 +783,7 @@ private:
         int32_t top = marqueeWidget.top + windowPos.y;
         int32_t marqHeight = marqueeWidget.height();
         DrawPixelInfo dpiMarquee;
-        if (!ClipDrawPixelInfo(&dpiMarquee, &dpi, { left, top }, marqWidth, marqHeight))
+        if (!ClipDrawPixelInfo(dpiMarquee, dpi, { left, top }, marqWidth, marqHeight))
         {
             return;
         }

--- a/src/openrct2-ui/windows/Guest.cpp
+++ b/src/openrct2-ui/windows/Guest.cpp
@@ -752,7 +752,7 @@ private:
         // Draw the viewport no sound sprite
         if (viewport != nullptr)
         {
-            WindowDrawViewport(&dpi, *this);
+            WindowDrawViewport(dpi, *this);
             if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
             {
                 GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -589,7 +589,7 @@ public:
     void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         GfxFillRect(
-            &dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
+            dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
         switch (_selectedTab)
         {
             case TabId::Individual:
@@ -669,7 +669,7 @@ private:
                 StringId format = STR_BLACK_STRING;
                 if (index == _highlightedIndex)
                 {
-                    GfxFilterRect(&dpi, { 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1 }, FilterPaletteID::PaletteDarken1);
+                    GfxFilterRect(dpi, { 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1 }, FilterPaletteID::PaletteDarken1);
                     format = STR_WINDOW_COLOUR_2_STRINGID;
                 }
 
@@ -739,7 +739,7 @@ private:
                 StringId format = STR_BLACK_STRING;
                 if (index == _highlightedIndex)
                 {
-                    GfxFilterRect(&dpi, { 0, y, 800, y + SUMMARISED_GUEST_ROW_HEIGHT }, FilterPaletteID::PaletteDarken1);
+                    GfxFilterRect(dpi, { 0, y, 800, y + SUMMARISED_GUEST_ROW_HEIGHT }, FilterPaletteID::PaletteDarken1);
                     format = STR_WINDOW_COLOUR_2_STRINGID;
                 }
 

--- a/src/openrct2-ui/windows/GuestList.cpp
+++ b/src/openrct2-ui/windows/GuestList.cpp
@@ -645,13 +645,13 @@ private:
         auto i = (_selectedTab == TabId::Individual ? _tabAnimationIndex & ~3 : 0);
         i += GetPeepAnimation(PeepSpriteType::Normal).base_image + 1;
         GfxDrawSprite(
-            &dpi, ImageId(i, COLOUR_GREY, COLOUR_DARK_OLIVE_GREEN),
+            dpi, ImageId(i, COLOUR_GREY, COLOUR_DARK_OLIVE_GREEN),
             windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].midX(), widgets[WIDX_TAB_1].bottom - 6 });
 
         // Tab 2 image
         i = (_selectedTab == TabId::Summarised ? _tabAnimationIndex / 4 : 0);
         GfxDrawSprite(
-            &dpi, ImageId(SPR_TAB_GUESTS_0 + i),
+            dpi, ImageId(SPR_TAB_GUESTS_0 + i),
             windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
     }
 
@@ -687,11 +687,11 @@ private:
                 {
                     case GuestViewType::Actions:
                         // Guest face
-                        GfxDrawSprite(&dpi, ImageId(GetPeepFaceSpriteSmall(peep)), { 118, y + 1 });
+                        GfxDrawSprite(dpi, ImageId(GetPeepFaceSpriteSmall(peep)), { 118, y + 1 });
 
                         // Tracking icon
                         if (peep->PeepFlags & PEEP_FLAGS_TRACKING)
-                            GfxDrawSprite(&dpi, ImageId(STR_ENTER_SELECTION_SIZE), { 112, y + 1 });
+                            GfxDrawSprite(dpi, ImageId(STR_ENTER_SELECTION_SIZE), { 112, y + 1 });
 
                         // Action
                         ft = Formatter();
@@ -747,7 +747,7 @@ private:
                 for (uint32_t j = 0; j < std::size(group.Faces) && j < group.NumGuests; j++)
                 {
                     GfxDrawSprite(
-                        &dpi, ImageId(group.Faces[j] + SPR_PEEP_SMALL_FACE_VERY_VERY_UNHAPPY),
+                        dpi, ImageId(group.Faces[j] + SPR_PEEP_SMALL_FACE_VERY_VERY_UNHAPPY),
                         { static_cast<int32_t>(j) * 8, y + 12 });
                 }
 

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -154,7 +154,7 @@ public:
         Widget* widget = &window_install_track_widgets[WIDX_TRACK_PREVIEW];
         auto screenPos = windowPos + ScreenCoordsXY{ widget->left + 1, widget->top + 1 };
         int32_t colour = ColourMapA[colours[0]].darkest;
-        GfxFillRect(&dpi, { screenPos, screenPos + ScreenCoordsXY{ 369, 216 } }, colour);
+        GfxFillRect(dpi, { screenPos, screenPos + ScreenCoordsXY{ 369, 216 } }, colour);
 
         G1Element g1temp = {};
         g1temp.offset = _trackDesignPreviewPixels.data() + (_currentTrackPieceDirection * TRACK_PREVIEW_IMAGE_SIZE);

--- a/src/openrct2-ui/windows/InstallTrack.cpp
+++ b/src/openrct2-ui/windows/InstallTrack.cpp
@@ -163,7 +163,7 @@ public:
         g1temp.flags = G1_FLAG_HAS_TRANSPARENCY;
         GfxSetG1Element(SPR_TEMP, &g1temp);
         DrawingEngineInvalidateImage(SPR_TEMP);
-        GfxDrawSprite(&dpi, ImageId(SPR_TEMP), screenPos);
+        GfxDrawSprite(dpi, ImageId(SPR_TEMP), screenPos);
 
         screenPos = windowPos + ScreenCoordsXY{ widget->midX(), widget->bottom - 12 };
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -252,7 +252,7 @@ public:
         {
             screenCoords = { windowPos.x + previewWidget->left, windowPos.y + previewWidget->top };
             auto sprite = ImageId(gLandToolSize % 2 == 0 ? SPR_G2_MOUNTAIN_TOOL_EVEN : SPR_G2_MOUNTAIN_TOOL_ODD);
-            GfxDrawSprite(&dpi, sprite, screenCoords);
+            GfxDrawSprite(dpi, sprite, screenCoords);
             WidgetDraw(&dpi, *this, WIDX_DECREMENT);
             WidgetDraw(&dpi, *this, WIDX_INCREMENT);
         }
@@ -334,7 +334,7 @@ private:
     void DrawDropdownButton(DrawPixelInfo& dpi, WidgetIndex widgetIndex, ImageId image)
     {
         const auto& widget = widgets[widgetIndex];
-        GfxDrawSprite(&dpi, image, { windowPos.x + widget.left, windowPos.y + widget.top });
+        GfxDrawSprite(dpi, image, { windowPos.x + widget.left, windowPos.y + widget.top });
     }
 };
 

--- a/src/openrct2-ui/windows/Land.cpp
+++ b/src/openrct2-ui/windows/Land.cpp
@@ -253,8 +253,8 @@ public:
             screenCoords = { windowPos.x + previewWidget->left, windowPos.y + previewWidget->top };
             auto sprite = ImageId(gLandToolSize % 2 == 0 ? SPR_G2_MOUNTAIN_TOOL_EVEN : SPR_G2_MOUNTAIN_TOOL_ODD);
             GfxDrawSprite(dpi, sprite, screenCoords);
-            WidgetDraw(&dpi, *this, WIDX_DECREMENT);
-            WidgetDraw(&dpi, *this, WIDX_INCREMENT);
+            WidgetDraw(dpi, *this, WIDX_DECREMENT);
+            WidgetDraw(dpi, *this, WIDX_INCREMENT);
         }
 
         screenCoords = { windowPos.x + previewWidget->midX(), windowPos.y + previewWidget->bottom + 5 };

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -970,7 +970,7 @@ public:
     void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         GfxFillRect(
-            &dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
+            dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
         const int32_t listWidth = widgets[WIDX_SCROLL].width();
         const int32_t dateAnchor = widgets[WIDX_SORT_DATE].left + maxDateWidth + DATE_TIME_GAP;
 
@@ -989,7 +989,7 @@ public:
             if (i == selected_list_item)
             {
                 stringId = STR_WINDOW_COLOUR_2_STRINGID;
-                GfxFilterRect(&dpi, { 0, y, listWidth, y + SCROLLABLE_ROW_HEIGHT }, FilterPaletteID::PaletteDarken1);
+                GfxFilterRect(dpi, { 0, y, listWidth, y + SCROLLABLE_ROW_HEIGHT }, FilterPaletteID::PaletteDarken1);
             }
             // display a marker next to the currently loaded game file
             if (_listItems[i].loaded)

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -1112,7 +1112,7 @@ static Widget window_overwrite_prompt_widgets[] = {
 };
 
 static void WindowOverwritePromptMouseup(WindowBase* w, WidgetIndex widgetIndex);
-static void WindowOverwritePromptPaint(WindowBase* w, DrawPixelInfo* dpi);
+static void WindowOverwritePromptPaint(WindowBase* w, DrawPixelInfo& dpi);
 
 static WindowEventList window_overwrite_prompt_events([](auto& events) {
     events.mouse_up = &WindowOverwritePromptMouseup;
@@ -1164,7 +1164,7 @@ static void WindowOverwritePromptMouseup(WindowBase* w, WidgetIndex widgetIndex)
     }
 }
 
-static void WindowOverwritePromptPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowOverwritePromptPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
 
@@ -1173,7 +1173,7 @@ static void WindowOverwritePromptPaint(WindowBase* w, DrawPixelInfo* dpi)
     ft.Add<char*>(_window_overwrite_prompt_name);
 
     ScreenCoordsXY stringCoords(w->windowPos.x + w->width / 2, w->windowPos.y + (w->height / 2) - 3);
-    DrawTextWrapped(*dpi, stringCoords, w->width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, ft, { TextAlignment::CENTRE });
+    DrawTextWrapped(dpi, stringCoords, w->width - 4, STR_FILEBROWSER_OVERWRITE_PROMPT, ft, { TextAlignment::CENTRE });
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Main.cpp
+++ b/src/openrct2-ui/windows/Main.cpp
@@ -45,7 +45,7 @@ public:
 
     void OnDraw(DrawPixelInfo& dpi) override
     {
-        ViewportRender(&dpi, viewport, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } });
+        ViewportRender(dpi, viewport, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } });
     }
 
 private:

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -719,13 +719,13 @@ public:
 
         if (selected_tab == PAGE_PEEPS)
         {
-            PaintPeepOverlay(&dpi);
+            PaintPeepOverlay(dpi);
         }
         else
         {
-            PaintTrainOverlay(&dpi);
+            PaintTrainOverlay(dpi);
         }
-        PaintHudRectangle(&dpi);
+        PaintHudRectangle(dpi);
     }
 
     void OnPrepareDraw() override
@@ -855,7 +855,7 @@ public:
     void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
-        DrawTabImages(&dpi);
+        DrawTabImages(dpi);
 
         auto screenCoords = windowPos
             + ScreenCoordsXY{ window_map_widgets[WIDX_LAND_TOOL].midX(), window_map_widgets[WIDX_LAND_TOOL].midY() };
@@ -1161,7 +1161,7 @@ private:
         return colourB;
     }
 
-    void PaintPeepOverlay(DrawPixelInfo* dpi)
+    void PaintPeepOverlay(DrawPixelInfo& dpi)
     {
         auto flashColour = GetGuestFlashColour();
         for (auto guest : EntityList<Guest>())
@@ -1175,7 +1175,7 @@ private:
         }
     }
 
-    void DrawMapPeepPixel(Peep* peep, const uint8_t flashColour, DrawPixelInfo* dpi)
+    void DrawMapPeepPixel(Peep* peep, const uint8_t flashColour, DrawPixelInfo& dpi)
     {
         if (peep->x == LOCATION_NULL)
             return;
@@ -1194,7 +1194,7 @@ private:
             }
         }
 
-        GfxFillRect(dpi, { leftTop, rightBottom }, colour);
+        GfxFillRect(&dpi, { leftTop, rightBottom }, colour);
     }
 
     static uint8_t GetGuestFlashColour()
@@ -1221,7 +1221,7 @@ private:
         return colour;
     }
 
-    void PaintTrainOverlay(DrawPixelInfo* dpi)
+    void PaintTrainOverlay(DrawPixelInfo& dpi)
     {
         for (auto train : TrainManager::View())
         {
@@ -1232,7 +1232,7 @@ private:
 
                 MapCoordsXY c = TransformToMapCoords({ vehicle->x, vehicle->y });
 
-                GfxFillRect(dpi, { { c.x, c.y }, { c.x, c.y } }, PALETTE_INDEX_171);
+                GfxFillRect(&dpi, { { c.x, c.y }, { c.x, c.y } }, PALETTE_INDEX_171);
             }
         }
     }
@@ -1241,7 +1241,7 @@ private:
      * The call to GfxFillRect was originally wrapped in Sub68DABD which made sure that arguments were ordered correctly,
      * but it doesn't look like it's ever necessary here so the call was removed.
      */
-    void PaintHudRectangle(DrawPixelInfo* dpi)
+    void PaintHudRectangle(DrawPixelInfo& dpi)
     {
         WindowBase* mainWindow = WindowGetMain();
         if (mainWindow == nullptr)
@@ -1259,23 +1259,23 @@ private:
         auto leftBottom = ScreenCoordsXY{ leftTop.x, rightBottom.y };
 
         // top horizontal lines
-        GfxFillRect(dpi, { leftTop, leftTop + ScreenCoordsXY{ 3, 0 } }, PALETTE_INDEX_56);
-        GfxFillRect(dpi, { rightTop - ScreenCoordsXY{ 3, 0 }, rightTop }, PALETTE_INDEX_56);
+        GfxFillRect(&dpi, { leftTop, leftTop + ScreenCoordsXY{ 3, 0 } }, PALETTE_INDEX_56);
+        GfxFillRect(&dpi, { rightTop - ScreenCoordsXY{ 3, 0 }, rightTop }, PALETTE_INDEX_56);
 
         // left vertical lines
-        GfxFillRect(dpi, { leftTop, leftTop + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_56);
-        GfxFillRect(dpi, { leftBottom - ScreenCoordsXY{ 0, 3 }, leftBottom }, PALETTE_INDEX_56);
+        GfxFillRect(&dpi, { leftTop, leftTop + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_56);
+        GfxFillRect(&dpi, { leftBottom - ScreenCoordsXY{ 0, 3 }, leftBottom }, PALETTE_INDEX_56);
 
         // bottom horizontal lines
-        GfxFillRect(dpi, { leftBottom, leftBottom + ScreenCoordsXY{ 3, 0 } }, PALETTE_INDEX_56);
-        GfxFillRect(dpi, { rightBottom - ScreenCoordsXY{ 3, 0 }, rightBottom }, PALETTE_INDEX_56);
+        GfxFillRect(&dpi, { leftBottom, leftBottom + ScreenCoordsXY{ 3, 0 } }, PALETTE_INDEX_56);
+        GfxFillRect(&dpi, { rightBottom - ScreenCoordsXY{ 3, 0 }, rightBottom }, PALETTE_INDEX_56);
 
         // right vertical lines
-        GfxFillRect(dpi, { rightTop, rightTop + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_56);
-        GfxFillRect(dpi, { rightBottom - ScreenCoordsXY{ 0, 3 }, rightBottom }, PALETTE_INDEX_56);
+        GfxFillRect(&dpi, { rightTop, rightTop + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_56);
+        GfxFillRect(&dpi, { rightBottom - ScreenCoordsXY{ 0, 3 }, rightBottom }, PALETTE_INDEX_56);
     }
 
-    void DrawTabImages(DrawPixelInfo* dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         // Guest tab image (animated)
         uint32_t guestTabImage = SPR_TAB_GUESTS_0;
@@ -1283,7 +1283,7 @@ private:
             guestTabImage += list_information_type / 4;
 
         GfxDrawSprite(
-            *dpi, ImageId(guestTabImage),
+            dpi, ImageId(guestTabImage),
             windowPos + ScreenCoordsXY{ widgets[WIDX_PEOPLE_TAB].left, widgets[WIDX_PEOPLE_TAB].top });
 
         // Ride/stall tab image (animated)
@@ -1292,7 +1292,7 @@ private:
             rideTabImage += list_information_type / 4;
 
         GfxDrawSprite(
-            *dpi, ImageId(rideTabImage),
+            dpi, ImageId(rideTabImage),
             windowPos + ScreenCoordsXY{ widgets[WIDX_RIDES_TAB].left, widgets[WIDX_RIDES_TAB].top });
     }
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -715,7 +715,7 @@ public:
         g1temp.y_offset = -8;
         GfxSetG1Element(SPR_TEMP, &g1temp);
         DrawingEngineInvalidateImage(SPR_TEMP);
-        GfxDrawSprite(&dpi, ImageId(SPR_TEMP), { 0, 0 });
+        GfxDrawSprite(dpi, ImageId(SPR_TEMP), { 0, 0 });
 
         if (selected_tab == PAGE_PEEPS)
         {
@@ -875,7 +875,7 @@ public:
             screenCoords = windowPos
                 + ScreenCoordsXY{ widgets[WIDX_PEOPLE_STARTING_POSITION].left + 12,
                                   widgets[WIDX_PEOPLE_STARTING_POSITION].top + 18 };
-            GfxDrawSprite(&dpi, ImageId(SPR_6410, COLOUR_BRIGHT_RED, COLOUR_LIGHT_BROWN), screenCoords);
+            GfxDrawSprite(dpi, ImageId(SPR_6410, COLOUR_BRIGHT_RED, COLOUR_LIGHT_BROWN), screenCoords);
         }
 
         if (!(gScreenFlags & SCREEN_FLAGS_SCENARIO_EDITOR) && !gCheatsSandboxMode)
@@ -1283,7 +1283,7 @@ private:
             guestTabImage += list_information_type / 4;
 
         GfxDrawSprite(
-            dpi, ImageId(guestTabImage),
+            *dpi, ImageId(guestTabImage),
             windowPos + ScreenCoordsXY{ widgets[WIDX_PEOPLE_TAB].left, widgets[WIDX_PEOPLE_TAB].top });
 
         // Ride/stall tab image (animated)
@@ -1292,7 +1292,7 @@ private:
             rideTabImage += list_information_type / 4;
 
         GfxDrawSprite(
-            dpi, ImageId(rideTabImage),
+            *dpi, ImageId(rideTabImage),
             windowPos + ScreenCoordsXY{ widgets[WIDX_RIDES_TAB].left, widgets[WIDX_RIDES_TAB].top });
     }
 

--- a/src/openrct2-ui/windows/Map.cpp
+++ b/src/openrct2-ui/windows/Map.cpp
@@ -894,7 +894,7 @@ public:
                 for (uint32_t i = 0; i < std::size(RideKeyColours); i++)
                 {
                     GfxFillRect(
-                        &dpi, { screenCoords + ScreenCoordsXY{ 0, 2 }, screenCoords + ScreenCoordsXY{ 6, 8 } },
+                        dpi, { screenCoords + ScreenCoordsXY{ 0, 2 }, screenCoords + ScreenCoordsXY{ 6, 8 } },
                         RideKeyColours[i]);
                     DrawTextBasic(dpi, screenCoords + ScreenCoordsXY{ LIST_ROW_HEIGHT, 0 }, _mapLabels[i], {});
                     screenCoords.y += LIST_ROW_HEIGHT;
@@ -1194,7 +1194,7 @@ private:
             }
         }
 
-        GfxFillRect(&dpi, { leftTop, rightBottom }, colour);
+        GfxFillRect(dpi, { leftTop, rightBottom }, colour);
     }
 
     static uint8_t GetGuestFlashColour()
@@ -1232,7 +1232,7 @@ private:
 
                 MapCoordsXY c = TransformToMapCoords({ vehicle->x, vehicle->y });
 
-                GfxFillRect(&dpi, { { c.x, c.y }, { c.x, c.y } }, PALETTE_INDEX_171);
+                GfxFillRect(dpi, { { c.x, c.y }, { c.x, c.y } }, PALETTE_INDEX_171);
             }
         }
     }
@@ -1259,20 +1259,20 @@ private:
         auto leftBottom = ScreenCoordsXY{ leftTop.x, rightBottom.y };
 
         // top horizontal lines
-        GfxFillRect(&dpi, { leftTop, leftTop + ScreenCoordsXY{ 3, 0 } }, PALETTE_INDEX_56);
-        GfxFillRect(&dpi, { rightTop - ScreenCoordsXY{ 3, 0 }, rightTop }, PALETTE_INDEX_56);
+        GfxFillRect(dpi, { leftTop, leftTop + ScreenCoordsXY{ 3, 0 } }, PALETTE_INDEX_56);
+        GfxFillRect(dpi, { rightTop - ScreenCoordsXY{ 3, 0 }, rightTop }, PALETTE_INDEX_56);
 
         // left vertical lines
-        GfxFillRect(&dpi, { leftTop, leftTop + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_56);
-        GfxFillRect(&dpi, { leftBottom - ScreenCoordsXY{ 0, 3 }, leftBottom }, PALETTE_INDEX_56);
+        GfxFillRect(dpi, { leftTop, leftTop + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_56);
+        GfxFillRect(dpi, { leftBottom - ScreenCoordsXY{ 0, 3 }, leftBottom }, PALETTE_INDEX_56);
 
         // bottom horizontal lines
-        GfxFillRect(&dpi, { leftBottom, leftBottom + ScreenCoordsXY{ 3, 0 } }, PALETTE_INDEX_56);
-        GfxFillRect(&dpi, { rightBottom - ScreenCoordsXY{ 3, 0 }, rightBottom }, PALETTE_INDEX_56);
+        GfxFillRect(dpi, { leftBottom, leftBottom + ScreenCoordsXY{ 3, 0 } }, PALETTE_INDEX_56);
+        GfxFillRect(dpi, { rightBottom - ScreenCoordsXY{ 3, 0 }, rightBottom }, PALETTE_INDEX_56);
 
         // right vertical lines
-        GfxFillRect(&dpi, { rightTop, rightTop + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_56);
-        GfxFillRect(&dpi, { rightBottom - ScreenCoordsXY{ 0, 3 }, rightBottom }, PALETTE_INDEX_56);
+        GfxFillRect(dpi, { rightTop, rightTop + ScreenCoordsXY{ 0, 3 } }, PALETTE_INDEX_56);
+        GfxFillRect(dpi, { rightBottom - ScreenCoordsXY{ 0, 3 }, rightBottom }, PALETTE_INDEX_56);
     }
 
     void DrawTabImages(DrawPixelInfo& dpi)

--- a/src/openrct2-ui/windows/MapGen.cpp
+++ b/src/openrct2-ui/windows/MapGen.cpp
@@ -386,7 +386,7 @@ private:
             }
 
             GfxDrawSprite(
-                &dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
+                dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
         }
     }
 
@@ -659,7 +659,7 @@ private:
         }
         else
         {
-            GfxDrawSprite(&dpi, image, pos);
+            GfxDrawSprite(dpi, image, pos);
         }
     }
 

--- a/src/openrct2-ui/windows/MapTooltip.cpp
+++ b/src/openrct2-ui/windows/MapTooltip.cpp
@@ -24,7 +24,7 @@ static Widget window_map_tooltip_widgets[] = {
 };
 
 static void WindowMapTooltipUpdate(WindowBase *w);
-static void WindowMapTooltipPaint(WindowBase *w, DrawPixelInfo *dpi);
+static void WindowMapTooltipPaint(WindowBase *w, DrawPixelInfo& dpi);
 
 static WindowEventList window_map_tooltip_events([](auto& events)
 {
@@ -137,7 +137,7 @@ static void WindowMapTooltipUpdate(WindowBase* w)
  *
  *  rct2: 0x006EE894
  */
-static void WindowMapTooltipPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowMapTooltipPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     StringId stringId;
     std::memcpy(&stringId, _mapTooltipArgs.Data(), sizeof(StringId));
@@ -147,5 +147,5 @@ static void WindowMapTooltipPaint(WindowBase* w, DrawPixelInfo* dpi)
     }
 
     ScreenCoordsXY stringCoords(w->windowPos.x + (w->width / 2), w->windowPos.y + (w->height / 2));
-    DrawTextWrapped(*dpi, stringCoords, w->width, STR_MAP_TOOLTIP_STRINGID, _mapTooltipArgs, { TextAlignment::CENTRE });
+    DrawTextWrapped(dpi, stringCoords, w->width, STR_MAP_TOOLTIP_STRINGID, _mapTooltipArgs, { TextAlignment::CENTRE });
 }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -1016,7 +1016,7 @@ static void WindowMultiplayerDrawTabImage(WindowBase* w, DrawPixelInfo* dpi, int
         }
 
         GfxDrawSprite(
-            dpi, ImageId(spriteIndex),
+            *dpi, ImageId(spriteIndex),
             w->windowPos + ScreenCoordsXY{ w->widgets[widgetIndex].left, w->widgets[widgetIndex].top });
     }
 }

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -401,7 +401,7 @@ static void WindowMultiplayerInformationPaint(WindowBase* w, DrawPixelInfo& dpi)
     WindowMultiplayerDrawTabImages(w, dpi);
 
     DrawPixelInfo clippedDPI;
-    if (ClipDrawPixelInfo(&clippedDPI, &dpi, w->windowPos, w->width, w->height))
+    if (ClipDrawPixelInfo(clippedDPI, dpi, w->windowPos, w->width, w->height))
     {
         auto screenCoords = ScreenCoordsXY{ 3, 50 };
         int32_t width = w->width - 6;

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -124,7 +124,7 @@ static void WindowMultiplayerInformationMouseup(WindowBase *w, WidgetIndex widge
 static void WindowMultiplayerInformationResize(WindowBase *w);
 static void WindowMultiplayerInformationUpdate(WindowBase *w);
 static void WindowMultiplayerInformationInvalidate(WindowBase *w);
-static void WindowMultiplayerInformationPaint(WindowBase *w, DrawPixelInfo *dpi);
+static void WindowMultiplayerInformationPaint(WindowBase *w, DrawPixelInfo& dpi);
 
 static void WindowMultiplayerPlayersMouseup(WindowBase *w, WidgetIndex widgetIndex);
 static void WindowMultiplayerPlayersResize(WindowBase *w);
@@ -133,8 +133,8 @@ static void WindowMultiplayerPlayersScrollgetsize(WindowBase *w, int32_t scrollI
 static void WindowMultiplayerPlayersScrollmousedown(WindowBase *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void WindowMultiplayerPlayersScrollmouseover(WindowBase *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void WindowMultiplayerPlayersInvalidate(WindowBase *w);
-static void WindowMultiplayerPlayersPaint(WindowBase *w, DrawPixelInfo *dpi);
-static void WindowMultiplayerPlayersScrollpaint(WindowBase *w, DrawPixelInfo *dpi, int32_t scrollIndex);
+static void WindowMultiplayerPlayersPaint(WindowBase *w, DrawPixelInfo& dpi);
+static void WindowMultiplayerPlayersScrollpaint(WindowBase *w, DrawPixelInfo& dpi, int32_t scrollIndex);
 
 static void WindowMultiplayerGroupsMouseup(WindowBase *w, WidgetIndex widgetIndex);
 static void WindowMultiplayerGroupsResize(WindowBase *w);
@@ -146,14 +146,14 @@ static void WindowMultiplayerGroupsScrollmousedown(WindowBase *w, int32_t scroll
 static void WindowMultiplayerGroupsScrollmouseover(WindowBase *w, int32_t scrollIndex, const ScreenCoordsXY& screenCoords);
 static void WindowMultiplayerGroupsTextInput(WindowBase *w, WidgetIndex widgetIndex, const char *text);
 static void WindowMultiplayerGroupsInvalidate(WindowBase *w);
-static void WindowMultiplayerGroupsPaint(WindowBase *w, DrawPixelInfo *dpi);
-static void WindowMultiplayerGroupsScrollpaint(WindowBase *w, DrawPixelInfo *dpi, int32_t scrollIndex);
+static void WindowMultiplayerGroupsPaint(WindowBase *w, DrawPixelInfo& dpi);
+static void WindowMultiplayerGroupsScrollpaint(WindowBase *w, DrawPixelInfo& dpi, int32_t scrollIndex);
 
 static void WindowMultiplayerOptionsMouseup(WindowBase *w, WidgetIndex widgetIndex);
 static void WindowMultiplayerOptionsResize(WindowBase *w);
 static void WindowMultiplayerOptionsUpdate(WindowBase *w);
 static void WindowMultiplayerOptionsInvalidate(WindowBase *w);
-static void WindowMultiplayerOptionsPaint(WindowBase *w, DrawPixelInfo *dpi);
+static void WindowMultiplayerOptionsPaint(WindowBase *w, DrawPixelInfo& dpi);
 
 static WindowEventList window_multiplayer_information_events([](auto& events)
 {
@@ -223,7 +223,7 @@ static constexpr const int32_t window_multiplayer_animation_frames[] = {
     4,
 };
 
-static void WindowMultiplayerDrawTabImages(WindowBase* w, DrawPixelInfo* dpi);
+static void WindowMultiplayerDrawTabImages(WindowBase* w, DrawPixelInfo& dpi);
 static void WindowMultiplayerSetPage(WindowBase* w, int32_t page);
 
 static bool _windowInformationSizeDirty;
@@ -395,16 +395,14 @@ static void WindowMultiplayerInformationInvalidate(WindowBase* w)
     WindowAlignTabs(w, WIDX_TAB1, WIDX_TAB4);
 }
 
-static void WindowMultiplayerInformationPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowMultiplayerInformationPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowMultiplayerDrawTabImages(w, dpi);
 
     DrawPixelInfo clippedDPI;
-    if (ClipDrawPixelInfo(&clippedDPI, dpi, w->windowPos, w->width, w->height))
+    if (ClipDrawPixelInfo(&clippedDPI, &dpi, w->windowPos, w->width, w->height))
     {
-        dpi = &clippedDPI;
-
         auto screenCoords = ScreenCoordsXY{ 3, 50 };
         int32_t width = w->width - 6;
 
@@ -412,7 +410,7 @@ static void WindowMultiplayerInformationPaint(WindowBase* w, DrawPixelInfo* dpi)
         {
             auto ft = Formatter();
             ft.Add<const char*>(name.c_str());
-            screenCoords.y += DrawTextWrapped(*dpi, screenCoords, width, STR_STRING, ft, { w->colours[1] });
+            screenCoords.y += DrawTextWrapped(clippedDPI, screenCoords, width, STR_STRING, ft, { w->colours[1] });
             screenCoords.y += LIST_ROW_HEIGHT / 2;
         }
 
@@ -421,7 +419,7 @@ static void WindowMultiplayerInformationPaint(WindowBase* w, DrawPixelInfo* dpi)
         {
             auto ft = Formatter();
             ft.Add<const char*>(description.c_str());
-            screenCoords.y += DrawTextWrapped(*dpi, screenCoords, width, STR_STRING, ft, { w->colours[1] });
+            screenCoords.y += DrawTextWrapped(clippedDPI, screenCoords, width, STR_STRING, ft, { w->colours[1] });
             screenCoords.y += LIST_ROW_HEIGHT / 2;
         }
 
@@ -430,7 +428,7 @@ static void WindowMultiplayerInformationPaint(WindowBase* w, DrawPixelInfo* dpi)
         {
             auto ft = Formatter();
             ft.Add<const char*>(providerName.c_str());
-            DrawTextBasic(*dpi, screenCoords, STR_PROVIDER_NAME, ft);
+            DrawTextBasic(clippedDPI, screenCoords, STR_PROVIDER_NAME, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
         }
 
@@ -439,7 +437,7 @@ static void WindowMultiplayerInformationPaint(WindowBase* w, DrawPixelInfo* dpi)
         {
             auto ft = Formatter();
             ft.Add<const char*>(providerEmail.c_str());
-            DrawTextBasic(*dpi, screenCoords, STR_PROVIDER_EMAIL, ft);
+            DrawTextBasic(clippedDPI, screenCoords, STR_PROVIDER_EMAIL, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
         }
 
@@ -448,7 +446,7 @@ static void WindowMultiplayerInformationPaint(WindowBase* w, DrawPixelInfo* dpi)
         {
             auto ft = Formatter();
             ft.Add<const char*>(providerWebsite.c_str());
-            DrawTextBasic(*dpi, screenCoords, STR_PROVIDER_WEBSITE, ft);
+            DrawTextBasic(clippedDPI, screenCoords, STR_PROVIDER_WEBSITE, ft);
         }
     }
 }
@@ -557,7 +555,7 @@ static void WindowMultiplayerPlayersInvalidate(WindowBase* w)
     WindowAlignTabs(w, WIDX_TAB1, WIDX_TAB4);
 }
 
-static void WindowMultiplayerPlayersPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowMultiplayerPlayersPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     StringId stringId;
 
@@ -569,10 +567,10 @@ static void WindowMultiplayerPlayersPaint(WindowBase* w, DrawPixelInfo* dpi)
     auto screenCoords = w->windowPos + ScreenCoordsXY{ 4, w->widgets[WIDX_LIST].bottom + 2 };
     auto ft = Formatter();
     ft.Add<uint16_t>(w->no_list_items);
-    DrawTextBasic(*dpi, screenCoords, stringId, ft, { w->colours[2] });
+    DrawTextBasic(dpi, screenCoords, stringId, ft, { w->colours[2] });
 }
 
-static void WindowMultiplayerPlayersScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32_t scrollIndex)
+static void WindowMultiplayerPlayersScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32_t scrollIndex)
 {
     ScreenCoordsXY screenCoords;
     screenCoords.y = 0;
@@ -582,12 +580,12 @@ static void WindowMultiplayerPlayersScrollpaint(WindowBase* w, DrawPixelInfo* dp
 
     for (int32_t player = firstPlayerInList; player < NetworkGetNumPlayers(); player++)
     {
-        if (screenCoords.y > dpi->y + dpi->height)
+        if (screenCoords.y > dpi.y + dpi.height)
         {
             break;
         }
 
-        if (screenCoords.y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi->y)
+        if (screenCoords.y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi.y)
         {
             thread_local std::string _buffer;
             _buffer.reserve(512);
@@ -598,7 +596,7 @@ static void WindowMultiplayerPlayersScrollpaint(WindowBase* w, DrawPixelInfo* dp
             if (listPosition == w->selected_list_item)
             {
                 GfxFilterRect(
-                    dpi, { 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 },
+                    &dpi, { 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 },
                     FilterPaletteID::PaletteDarken1);
                 _buffer += NetworkGetPlayerName(player);
                 colour = w->colours[2];
@@ -617,7 +615,7 @@ static void WindowMultiplayerPlayersScrollpaint(WindowBase* w, DrawPixelInfo* dp
             }
             screenCoords.x = 0;
             GfxClipString(_buffer.data(), 230, FontStyle::Medium);
-            GfxDrawString(*dpi, screenCoords, _buffer.c_str(), { colour });
+            GfxDrawString(dpi, screenCoords, _buffer.c_str(), { colour });
 
             // Draw group name
             _buffer.resize(0);
@@ -628,7 +626,7 @@ static void WindowMultiplayerPlayersScrollpaint(WindowBase* w, DrawPixelInfo* dp
                 screenCoords.x = 173;
                 _buffer += NetworkGetGroupName(group);
                 GfxClipString(_buffer.data(), 80, FontStyle::Medium);
-                GfxDrawString(*dpi, screenCoords, _buffer.c_str(), { colour });
+                GfxDrawString(dpi, screenCoords, _buffer.c_str(), { colour });
             }
 
             // Draw last action
@@ -642,7 +640,7 @@ static void WindowMultiplayerPlayersScrollpaint(WindowBase* w, DrawPixelInfo* dp
             {
                 ft.Add<StringId>(STR_ACTION_NA);
             }
-            DrawTextEllipsised(*dpi, { 256, screenCoords.y }, 100, STR_BLACK_STRING, ft);
+            DrawTextEllipsised(dpi, { 256, screenCoords.y }, 100, STR_BLACK_STRING, ft);
 
             // Draw ping
             _buffer.resize(0);
@@ -665,7 +663,7 @@ static void WindowMultiplayerPlayersScrollpaint(WindowBase* w, DrawPixelInfo* dp
             _buffer += pingBuffer;
 
             screenCoords.x = 356;
-            GfxDrawString(*dpi, screenCoords, _buffer.c_str(), { colour });
+            GfxDrawString(dpi, screenCoords, _buffer.c_str(), { colour });
         }
         screenCoords.y += SCROLLABLE_ROW_HEIGHT;
         listPosition++;
@@ -841,7 +839,7 @@ static void WindowMultiplayerGroupsInvalidate(WindowBase* w)
     }
 }
 
-static void WindowMultiplayerGroupsPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowMultiplayerGroupsPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     thread_local std::string _buffer;
 
@@ -858,7 +856,7 @@ static void WindowMultiplayerGroupsPaint(WindowBase* w, DrawPixelInfo* dpi)
         auto ft = Formatter();
         ft.Add<const char*>(_buffer.c_str());
         DrawTextEllipsised(
-            *dpi, w->windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
+            dpi, w->windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
             { TextAlignment::CENTRE });
     }
 
@@ -866,12 +864,12 @@ static void WindowMultiplayerGroupsPaint(WindowBase* w, DrawPixelInfo* dpi)
         + ScreenCoordsXY{ window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].left + 4,
                           window_multiplayer_groups_widgets[WIDX_CONTENT_PANEL].top + 4 };
 
-    DrawTextBasic(*dpi, screenPos, STR_DEFAULT_GROUP, {}, { w->colours[2] });
+    DrawTextBasic(dpi, screenPos, STR_DEFAULT_GROUP, {}, { w->colours[2] });
 
     screenPos.y += 20;
 
     GfxFillRectInset(
-        dpi, { screenPos - ScreenCoordsXY{ 0, 6 }, screenPos + ScreenCoordsXY{ 310, -5 } }, w->colours[1],
+        &dpi, { screenPos - ScreenCoordsXY{ 0, 6 }, screenPos + ScreenCoordsXY{ 310, -5 } }, w->colours[1],
         INSET_RECT_FLAG_BORDER_INSET);
 
     widget = &window_multiplayer_groups_widgets[WIDX_SELECTED_GROUP];
@@ -883,32 +881,32 @@ static void WindowMultiplayerGroupsPaint(WindowBase* w, DrawPixelInfo* dpi)
         auto ft = Formatter();
         ft.Add<const char*>(_buffer.c_str());
         DrawTextEllipsised(
-            *dpi, w->windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
+            dpi, w->windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
             { TextAlignment::CENTRE });
     }
 }
 
-static void WindowMultiplayerGroupsScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32_t scrollIndex)
+static void WindowMultiplayerGroupsScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32_t scrollIndex)
 {
     auto screenCoords = ScreenCoordsXY{ 0, 0 };
 
-    auto dpiCoords = ScreenCoordsXY{ dpi->x, dpi->y };
+    auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
     GfxFillRect(
-        dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi->width - 1, dpi->height - 1 } }, ColourMapA[w->colours[1]].mid_light);
+        &dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[w->colours[1]].mid_light);
 
     for (int32_t i = 0; i < NetworkGetNumActions(); i++)
     {
         if (i == w->selected_list_item)
         {
             GfxFilterRect(
-                dpi, { 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 }, FilterPaletteID::PaletteDarken1);
+                &dpi, { 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 }, FilterPaletteID::PaletteDarken1);
         }
-        if (screenCoords.y > dpi->y + dpi->height)
+        if (screenCoords.y > dpi.y + dpi.height)
         {
             break;
         }
 
-        if (screenCoords.y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi->y)
+        if (screenCoords.y + SCROLLABLE_ROW_HEIGHT + 1 >= dpi.y)
         {
             int32_t groupindex = NetworkGetGroupIndex(_selectedGroup);
             if (groupindex != -1)
@@ -916,14 +914,14 @@ static void WindowMultiplayerGroupsScrollpaint(WindowBase* w, DrawPixelInfo* dpi
                 if (NetworkCanPerformAction(groupindex, static_cast<NetworkPermission>(i)))
                 {
                     screenCoords.x = 0;
-                    GfxDrawString(*dpi, screenCoords, u8"{WINDOW_COLOUR_2}✓", {});
+                    GfxDrawString(dpi, screenCoords, u8"{WINDOW_COLOUR_2}✓", {});
                 }
             }
 
             // Draw action name
             auto ft = Formatter();
             ft.Add<uint16_t>(NetworkGetActionNameStringID(i));
-            DrawTextBasic(*dpi, { 10, screenCoords.y }, STR_WINDOW_COLOUR_2_STRINGID, ft);
+            DrawTextBasic(dpi, { 10, screenCoords.y }, STR_WINDOW_COLOUR_2_STRINGID, ft);
         }
         screenCoords.y += SCROLLABLE_ROW_HEIGHT;
     }
@@ -991,7 +989,7 @@ static void WindowMultiplayerOptionsInvalidate(WindowBase* w)
     WidgetSetCheckboxValue(*w, WIDX_KNOWN_KEYS_ONLY_CHECKBOX, gConfigNetwork.KnownKeysOnly);
 }
 
-static void WindowMultiplayerOptionsPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowMultiplayerOptionsPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowMultiplayerDrawTabImages(w, dpi);
@@ -999,7 +997,7 @@ static void WindowMultiplayerOptionsPaint(WindowBase* w, DrawPixelInfo* dpi)
 
 #pragma endregion
 
-static void WindowMultiplayerDrawTabImage(WindowBase* w, DrawPixelInfo* dpi, int32_t page, int32_t spriteIndex)
+static void WindowMultiplayerDrawTabImage(WindowBase* w, DrawPixelInfo& dpi, int32_t page, int32_t spriteIndex)
 {
     WidgetIndex widgetIndex = WIDX_TAB1 + page;
 
@@ -1016,12 +1014,12 @@ static void WindowMultiplayerDrawTabImage(WindowBase* w, DrawPixelInfo* dpi, int
         }
 
         GfxDrawSprite(
-            *dpi, ImageId(spriteIndex),
+            dpi, ImageId(spriteIndex),
             w->windowPos + ScreenCoordsXY{ w->widgets[widgetIndex].left, w->widgets[widgetIndex].top });
     }
 }
 
-static void WindowMultiplayerDrawTabImages(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowMultiplayerDrawTabImages(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowMultiplayerDrawTabImage(w, dpi, WINDOW_MULTIPLAYER_PAGE_INFORMATION, SPR_TAB_KIOSKS_AND_FACILITIES_0);
     WindowMultiplayerDrawTabImage(w, dpi, WINDOW_MULTIPLAYER_PAGE_PLAYERS, SPR_TAB_GUESTS_0);

--- a/src/openrct2-ui/windows/Multiplayer.cpp
+++ b/src/openrct2-ui/windows/Multiplayer.cpp
@@ -596,7 +596,7 @@ static void WindowMultiplayerPlayersScrollpaint(WindowBase* w, DrawPixelInfo& dp
             if (listPosition == w->selected_list_item)
             {
                 GfxFilterRect(
-                    &dpi, { 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 },
+                    dpi, { 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 },
                     FilterPaletteID::PaletteDarken1);
                 _buffer += NetworkGetPlayerName(player);
                 colour = w->colours[2];
@@ -869,7 +869,7 @@ static void WindowMultiplayerGroupsPaint(WindowBase* w, DrawPixelInfo& dpi)
     screenPos.y += 20;
 
     GfxFillRectInset(
-        &dpi, { screenPos - ScreenCoordsXY{ 0, 6 }, screenPos + ScreenCoordsXY{ 310, -5 } }, w->colours[1],
+        dpi, { screenPos - ScreenCoordsXY{ 0, 6 }, screenPos + ScreenCoordsXY{ 310, -5 } }, w->colours[1],
         INSET_RECT_FLAG_BORDER_INSET);
 
     widget = &window_multiplayer_groups_widgets[WIDX_SELECTED_GROUP];
@@ -892,14 +892,14 @@ static void WindowMultiplayerGroupsScrollpaint(WindowBase* w, DrawPixelInfo& dpi
 
     auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
     GfxFillRect(
-        &dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[w->colours[1]].mid_light);
+        dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[w->colours[1]].mid_light);
 
     for (int32_t i = 0; i < NetworkGetNumActions(); i++)
     {
         if (i == w->selected_list_item)
         {
             GfxFilterRect(
-                &dpi, { 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 }, FilterPaletteID::PaletteDarken1);
+                dpi, { 0, screenCoords.y, 800, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 }, FilterPaletteID::PaletteDarken1);
         }
         if (screenCoords.y > dpi.y + dpi.height)
         {

--- a/src/openrct2-ui/windows/NetworkStatus.cpp
+++ b/src/openrct2-ui/windows/NetworkStatus.cpp
@@ -99,7 +99,7 @@ public:
 
     void OnDraw(DrawPixelInfo& dpi) override
     {
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
         thread_local std::string _buffer;
         _buffer.assign("{BLACK}");
         _buffer += _windowNetworkStatusText;

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -986,7 +986,7 @@ private:
             spriteIndex += tab == THRILL_TAB ? ThrillRidesTabAnimationSequence[frame] : frame;
 
             GfxDrawSprite(
-                &dpi, ImageId(spriteIndex, colours[1]),
+                dpi, ImageId(spriteIndex, colours[1]),
                 windowPos + ScreenCoordsXY{ widgets[widgetIndex].left, widgets[widgetIndex].top });
         }
     }

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -427,7 +427,7 @@ public:
         }
         else
         {
-            WindowResearchDevelopmentPagePaint(this, &dpi, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
+            WindowResearchDevelopmentPagePaint(this, dpi, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
         }
     }
 

--- a/src/openrct2-ui/windows/NewRide.cpp
+++ b/src/openrct2-ui/windows/NewRide.cpp
@@ -490,7 +490,7 @@ public:
                 buttonFlags |= INSET_RECT_FLAG_BORDER_INSET;
             if (new_ride.HighlightedRide == *listItem || buttonFlags != 0)
                 GfxFillRectInset(
-                    &dpi, { coords, coords + ScreenCoordsXY{ 115, 115 } }, colours[1],
+                    dpi, { coords, coords + ScreenCoordsXY{ 115, 115 } }, colours[1],
                     INSET_RECT_FLAG_FILL_MID_LIGHT | buttonFlags);
 
             // Draw ride image with feathered border

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -226,7 +226,7 @@ public:
                 switch (newsItem.Type)
                 {
                     case News::ItemType::Ride:
-                        GfxDrawSprite(&dpi, ImageId(SPR_RIDE), screenCoords);
+                        GfxDrawSprite(dpi, ImageId(SPR_RIDE), screenCoords);
                         break;
                     case News::ItemType::Peep:
                     case News::ItemType::PeepOnRide:
@@ -260,24 +260,24 @@ public:
 
                         ImageIndex imageId = GetPeepAnimation(spriteType).base_image + 1;
                         auto image = ImageId(imageId, peep->TshirtColour, peep->TrousersColour);
-                        GfxDrawSprite(&cliped_dpi, image, clipCoords);
+                        GfxDrawSprite(cliped_dpi, image, clipCoords);
                         break;
                     }
                     case News::ItemType::Money:
                     case News::ItemType::Campaign:
-                        GfxDrawSprite(&dpi, ImageId(SPR_FINANCE), screenCoords);
+                        GfxDrawSprite(dpi, ImageId(SPR_FINANCE), screenCoords);
                         break;
                     case News::ItemType::Research:
-                        GfxDrawSprite(&dpi, ImageId(newsItem.Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
+                        GfxDrawSprite(dpi, ImageId(newsItem.Assoc < 0x10000 ? SPR_NEW_SCENERY : SPR_NEW_RIDE), screenCoords);
                         break;
                     case News::ItemType::Peeps:
-                        GfxDrawSprite(&dpi, ImageId(SPR_GUESTS), screenCoords);
+                        GfxDrawSprite(dpi, ImageId(SPR_GUESTS), screenCoords);
                         break;
                     case News::ItemType::Award:
-                        GfxDrawSprite(&dpi, ImageId(SPR_AWARD), screenCoords);
+                        GfxDrawSprite(dpi, ImageId(SPR_AWARD), screenCoords);
                         break;
                     case News::ItemType::Graph:
-                        GfxDrawSprite(&dpi, ImageId(SPR_GRAPH), screenCoords);
+                        GfxDrawSprite(dpi, ImageId(SPR_GRAPH), screenCoords);
                         break;
                     case News::ItemType::Null:
                     case News::ItemType::Blank:
@@ -299,7 +299,7 @@ public:
                         press = 0x20;
                 }
                 GfxFillRectInset(&dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
-                GfxDrawSprite(&dpi, ImageId(SPR_LOCATE), screenCoords);
+                GfxDrawSprite(dpi, ImageId(SPR_LOCATE), screenCoords);
             }
 
             y += itemHeight;

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -232,7 +232,7 @@ public:
                     case News::ItemType::PeepOnRide:
                     {
                         DrawPixelInfo cliped_dpi;
-                        if (!ClipDrawPixelInfo(&cliped_dpi, &dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
+                        if (!ClipDrawPixelInfo(cliped_dpi, dpi, screenCoords + ScreenCoordsXY{ 1, 1 }, 22, 22))
                         {
                             break;
                         }

--- a/src/openrct2-ui/windows/News.cpp
+++ b/src/openrct2-ui/windows/News.cpp
@@ -191,7 +191,7 @@ public:
 
             // Background
             GfxFillRectInset(
-                &dpi, { -1, y, 383, y + itemHeight - 1 }, colours[1],
+                dpi, { -1, y, 383, y + itemHeight - 1 }, colours[1],
                 (INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_GREY));
 
             // Date text
@@ -221,7 +221,7 @@ public:
                         press = INSET_RECT_FLAG_BORDER_INSET;
                     }
                 }
-                GfxFillRectInset(&dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
+                GfxFillRectInset(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
 
                 switch (newsItem.Type)
                 {
@@ -298,7 +298,7 @@ public:
                     if (i == _pressedNewsItemIndex && _pressedButtonIndex == 2)
                         press = 0x20;
                 }
-                GfxFillRectInset(&dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
+                GfxFillRectInset(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ 23, 23 } }, colours[2], press);
                 GfxDrawSprite(dpi, ImageId(SPR_LOCATE), screenCoords);
             }
 

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -242,7 +242,7 @@ private:
             }
 
             const auto& widget = widgets[widgetIndex];
-            GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget.left, widget.top });
+            GfxDrawSprite(*dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget.left, widget.top });
         }
     }
 

--- a/src/openrct2-ui/windows/NewsOptions.cpp
+++ b/src/openrct2-ui/windows/NewsOptions.cpp
@@ -204,7 +204,7 @@ public:
     void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
-        DrawTabImages(&dpi);
+        DrawTabImages(dpi);
     }
 
 private:
@@ -218,14 +218,14 @@ private:
         }
     }
 
-    void DrawTabImages(DrawPixelInfo* dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         DrawTabImage(dpi, NOTIFICATION_CATEGORY_PARK, SPR_TAB_PARK);
         DrawTabImage(dpi, NOTIFICATION_CATEGORY_RIDE, SPR_TAB_RIDE_0);
         DrawTabImage(dpi, NOTIFICATION_CATEGORY_GUEST, SPR_TAB_GUESTS_0);
     }
 
-    void DrawTabImage(DrawPixelInfo* dpi, int32_t p, int32_t spriteIndex)
+    void DrawTabImage(DrawPixelInfo& dpi, int32_t p, int32_t spriteIndex)
     {
         WidgetIndex widgetIndex = WIDX_FIRST_TAB + p;
 
@@ -242,7 +242,7 @@ private:
             }
 
             const auto& widget = widgets[widgetIndex];
-            GfxDrawSprite(*dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget.left, widget.top });
+            GfxDrawSprite(dpi, ImageId(spriteIndex), windowPos + ScreenCoordsXY{ widget.left, widget.top });
         }
     }
 

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -487,7 +487,7 @@ public:
 
     void OnDraw(DrawPixelInfo& dpi) override
     {
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
 
         // Draw explanatory message
         auto ft = Formatter();

--- a/src/openrct2-ui/windows/ObjectLoadError.cpp
+++ b/src/openrct2-ui/windows/ObjectLoadError.cpp
@@ -505,7 +505,7 @@ public:
     {
         auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
         GfxFillRect(
-            &dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
+            dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
         const int32_t listWidth = widgets[WIDX_SCROLL].width();
 
         for (int32_t i = 0; i < no_list_items; i++)
@@ -522,11 +522,11 @@ public:
                                                 { listWidth, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 } };
             // If hovering over item, change the color and fill the backdrop.
             if (i == selected_list_item)
-                GfxFillRect(&dpi, screenRect, ColourMapA[colours[1]].darker);
+                GfxFillRect(dpi, screenRect, ColourMapA[colours[1]].darker);
             else if (i == _highlightedIndex)
-                GfxFillRect(&dpi, screenRect, ColourMapA[colours[1]].mid_dark);
+                GfxFillRect(dpi, screenRect, ColourMapA[colours[1]].mid_dark);
             else if ((i & 1) != 0) // odd / even check
-                GfxFillRect(&dpi, screenRect, ColourMapA[colours[1]].light);
+                GfxFillRect(dpi, screenRect, ColourMapA[colours[1]].light);
 
             // Draw the actual object entry's name...
             screenCoords.x = NAME_COL_LEFT - 3;

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -555,15 +555,15 @@ public:
     void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
-        DrawTabImages(&dpi);
+        DrawTabImages(dpi);
 
         switch (page)
         {
             case WINDOW_OPTIONS_PAGE_DISPLAY:
-                DisplayDraw(&dpi);
+                DisplayDraw(dpi);
                 break;
             case WINDOW_OPTIONS_PAGE_ADVANCED:
-                AdvancedDraw(&dpi);
+                AdvancedDraw(dpi);
                 break;
             default:
                 break;
@@ -909,12 +909,12 @@ private:
         widgets[WIDX_DRAWING_ENGINE].text = DrawingEngineStringIds[EnumValue(gConfigGeneral.DrawingEngine)];
     }
 
-    void DisplayDraw(DrawPixelInfo* dpi)
+    void DisplayDraw(DrawPixelInfo& dpi)
     {
         auto ft = Formatter();
         ft.Add<int32_t>(static_cast<int32_t>(gConfigGeneral.WindowScale * 100));
         DrawTextBasic(
-            *dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_SCALE].left + 1, widgets[WIDX_SCALE].top + 1 },
+            dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_SCALE].left + 1, widgets[WIDX_SCALE].top + 1 },
             STR_WINDOW_COLOUR_2_COMMA2DP32, ft, { colours[1] });
     }
 #pragma endregion
@@ -1997,12 +1997,12 @@ private:
         widgets[WIDX_AUTOSAVE_FREQUENCY].text = AutosaveNames[gConfigGeneral.AutosaveFrequency];
     }
 
-    void AdvancedDraw(DrawPixelInfo* dpi)
+    void AdvancedDraw(DrawPixelInfo& dpi)
     {
         auto ft = Formatter();
         ft.Add<int32_t>(static_cast<int32_t>(gConfigGeneral.AutosaveAmount));
         DrawTextBasic(
-            *dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 },
+            dpi, windowPos + ScreenCoordsXY{ widgets[WIDX_AUTOSAVE_AMOUNT].left + 1, widgets[WIDX_AUTOSAVE_AMOUNT].top + 1 },
             STR_WINDOW_COLOUR_2_COMMA16, ft, { colours[1] });
 
         const auto normalisedPath = Platform::StrDecompToPrecomp(gConfigGeneral.RCT1Path);
@@ -2017,7 +2017,7 @@ private:
         uint32_t padding = widgetHeight > lineHeight ? (widgetHeight - lineHeight) / 2 : 0;
         ScreenCoordsXY screenCoords = { windowPos.x + pathWidget.left + 1,
                                         windowPos.y + pathWidget.top + static_cast<int32_t>(padding) };
-        DrawTextEllipsised(*dpi, screenCoords, 277, STR_STRING, ft, { colours[1] });
+        DrawTextEllipsised(dpi, screenCoords, 277, STR_STRING, ft, { colours[1] });
     }
 
     OpenRCT2String AdvancedTooltip(WidgetIndex widgetIndex, StringId fallback)
@@ -2068,7 +2068,7 @@ private:
             Dropdown::Flag::StayOpen, num_items, widget->width() - 3);
     }
 
-    void DrawTabImages(DrawPixelInfo* dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_DISPLAY, SPR_TAB_PAINT_0);
         DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_RENDERING, SPR_G2_TAB_TREE);
@@ -2079,7 +2079,7 @@ private:
         DrawTabImage(dpi, WINDOW_OPTIONS_PAGE_ADVANCED, SPR_TAB_WRENCH_0);
     }
 
-    void DrawTabImage(DrawPixelInfo* dpi, int32_t p, int32_t spriteIndex)
+    void DrawTabImage(DrawPixelInfo& dpi, int32_t p, int32_t spriteIndex)
     {
         WidgetIndex widgetIndex = WIDX_FIRST_TAB + p;
         Widget* widget = &widgets[widgetIndex];
@@ -2095,7 +2095,7 @@ private:
             }
 
             // Draw normal, enabled sprite.
-            GfxDrawSprite(*dpi, ImageId(spriteIndex), screenCoords);
+            GfxDrawSprite(dpi, ImageId(spriteIndex), screenCoords);
         }
         else
         {
@@ -2104,10 +2104,10 @@ private:
 
             // Draw greyed out (light border bottom right shadow)
             GfxDrawSpriteSolid(
-                dpi, ImageId(spriteIndex), screenCoords + ScreenCoordsXY{ 1, 1 }, ColourMapA[window_colour].lighter);
+                &dpi, ImageId(spriteIndex), screenCoords + ScreenCoordsXY{ 1, 1 }, ColourMapA[window_colour].lighter);
 
             // Draw greyed out (dark)
-            GfxDrawSpriteSolid(dpi, ImageId(spriteIndex), screenCoords, ColourMapA[window_colour].mid_light);
+            GfxDrawSpriteSolid(&dpi, ImageId(spriteIndex), screenCoords, ColourMapA[window_colour].mid_light);
         }
     }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -2095,7 +2095,7 @@ private:
             }
 
             // Draw normal, enabled sprite.
-            GfxDrawSprite(dpi, ImageId(spriteIndex), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(spriteIndex), screenCoords);
         }
         else
         {

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -700,7 +700,7 @@ private:
 
         // Graph border
         GfxFillRectInset(
-            &dpi,
+            dpi,
             { screenPos + ScreenCoordsXY{ widget->left + 4, widget->top + 15 },
               screenPos + ScreenCoordsXY{ widget->right - 4, widget->bottom - 4 } },
             colours[1], INSET_RECT_F_30);
@@ -715,7 +715,7 @@ private:
             DrawTextBasic(
                 dpi, screenPos + ScreenCoordsXY{ 10, 0 }, STR_GRAPH_AXIS_LABEL, ft, { FontStyle::Small, TextAlignment::RIGHT });
             GfxFillRectInset(
-                &dpi, { screenPos + ScreenCoordsXY{ 15, 5 }, screenPos + ScreenCoordsXY{ width - 32, 5 } }, colours[2],
+                dpi, { screenPos + ScreenCoordsXY{ 15, 5 }, screenPos + ScreenCoordsXY{ width - 32, 5 } }, colours[2],
                 INSET_RECT_FLAG_BORDER_INSET);
             screenPos.y += 20;
         }
@@ -772,7 +772,7 @@ private:
 
         // Graph border
         GfxFillRectInset(
-            &dpi,
+            dpi,
             { screenPos + ScreenCoordsXY{ widget->left + 4, widget->top + 15 },
               screenPos + ScreenCoordsXY{ widget->right - 4, widget->bottom - 4 } },
             colours[1], INSET_RECT_F_30);
@@ -787,7 +787,7 @@ private:
             DrawTextBasic(
                 dpi, screenPos + ScreenCoordsXY{ 10, 0 }, STR_GRAPH_AXIS_LABEL, ft, { FontStyle::Small, TextAlignment::RIGHT });
             GfxFillRectInset(
-                &dpi, { screenPos + ScreenCoordsXY{ 15, 5 }, screenPos + ScreenCoordsXY{ width - 32, 5 } }, colours[2],
+                dpi, { screenPos + ScreenCoordsXY{ 15, 5 }, screenPos + ScreenCoordsXY{ width - 32, 5 } }, colours[2],
                 INSET_RECT_FLAG_BORDER_INSET);
             screenPos.y += 20;
         }

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -595,7 +595,7 @@ private:
         {
             WindowDrawViewport(&dpi, *this);
             if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
-                GfxDrawSprite(&dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
+                GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
         }
 
         // Draw park closed / open label
@@ -1159,7 +1159,7 @@ private:
 
         for (const auto& award : GetAwards())
         {
-            GfxDrawSprite(&dpi, ImageId(_parkAwards[EnumValue(award.Type)].sprite), screenCoords);
+            GfxDrawSprite(dpi, ImageId(_parkAwards[EnumValue(award.Type)].sprite), screenCoords);
             DrawTextWrapped(dpi, screenCoords + ScreenCoordsXY{ 34, 6 }, 180, _parkAwards[EnumValue(award.Type)].text);
 
             screenCoords.y += 32;
@@ -1217,7 +1217,7 @@ private:
         if (!WidgetIsDisabled(*this, WIDX_TAB_1))
         {
             GfxDrawSprite(
-                &dpi, ImageId(SPR_TAB_PARK_ENTRANCE),
+                dpi, ImageId(SPR_TAB_PARK_ENTRANCE),
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
         }
 
@@ -1227,12 +1227,12 @@ private:
             ImageId spriteIdx(SPR_TAB_GRAPH_0);
             if (page == WINDOW_PARK_PAGE_RATING)
                 spriteIdx = spriteIdx.WithIndexOffset((frame_no / 8) % 8);
-            GfxDrawSprite(&dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
+            GfxDrawSprite(dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
             GfxDrawSprite(
-                &dpi, ImageId(SPR_RATING_HIGH),
+                dpi, ImageId(SPR_RATING_HIGH),
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left + 7, widgets[WIDX_TAB_2].top + 1 });
             GfxDrawSprite(
-                &dpi, ImageId(SPR_RATING_LOW),
+                dpi, ImageId(SPR_RATING_LOW),
                 windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left + 16, widgets[WIDX_TAB_2].top + 12 });
         }
 
@@ -1242,14 +1242,14 @@ private:
             ImageId spriteIdx(SPR_TAB_GRAPH_0);
             if (page == WINDOW_PARK_PAGE_GUESTS)
                 spriteIdx = spriteIdx.WithIndexOffset((frame_no / 8) % 8);
-            GfxDrawSprite(&dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
+            GfxDrawSprite(dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
 
             ImageId peepImage(GetPeepAnimation(PeepSpriteType::Normal).base_image + 1, COLOUR_BRIGHT_RED, COLOUR_TEAL);
             if (page == WINDOW_PARK_PAGE_GUESTS)
                 peepImage = peepImage.WithIndexOffset(_peepAnimationFrame & 0xFFFFFFFC);
 
             GfxDrawSprite(
-                &dpi, peepImage, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].midX(), widgets[WIDX_TAB_3].bottom - 9 });
+                dpi, peepImage, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].midX(), widgets[WIDX_TAB_3].bottom - 9 });
         }
 
         // Price tab
@@ -1258,7 +1258,7 @@ private:
             ImageId spriteIdx(SPR_TAB_ADMISSION_0);
             if (page == WINDOW_PARK_PAGE_PRICE)
                 spriteIdx = spriteIdx.WithIndexOffset((frame_no / 2) % 8);
-            GfxDrawSprite(&dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_4].left, widgets[WIDX_TAB_4].top });
+            GfxDrawSprite(dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_4].left, widgets[WIDX_TAB_4].top });
         }
 
         // Statistics tab
@@ -1267,7 +1267,7 @@ private:
             ImageId spriteIdx(SPR_TAB_STATS_0);
             if (page == WINDOW_PARK_PAGE_STATS)
                 spriteIdx = spriteIdx.WithIndexOffset((frame_no / 4) % 7);
-            GfxDrawSprite(&dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_5].left, widgets[WIDX_TAB_5].top });
+            GfxDrawSprite(dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_5].left, widgets[WIDX_TAB_5].top });
         }
 
         // Objective tab
@@ -1276,14 +1276,14 @@ private:
             ImageId spriteIdx(SPR_TAB_OBJECTIVE_0);
             if (page == WINDOW_PARK_PAGE_OBJECTIVE)
                 spriteIdx = spriteIdx.WithIndexOffset((frame_no / 4) % 16);
-            GfxDrawSprite(&dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_6].left, widgets[WIDX_TAB_6].top });
+            GfxDrawSprite(dpi, spriteIdx, windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_6].left, widgets[WIDX_TAB_6].top });
         }
 
         // Awards tab
         if (!WidgetIsDisabled(*this, WIDX_TAB_7))
         {
             GfxDrawSprite(
-                &dpi, ImageId(SPR_TAB_AWARDS), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_7].left, widgets[WIDX_TAB_7].top });
+                dpi, ImageId(SPR_TAB_AWARDS), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_7].left, widgets[WIDX_TAB_7].top });
         }
     }
 };

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -723,7 +723,7 @@ private:
         // Graph
         screenPos = windowPos + ScreenCoordsXY{ widget->left + 47, widget->top + 26 };
 
-        Graph::Draw(&dpi, gParkRatingHistory, 32, screenPos);
+        Graph::Draw(dpi, gParkRatingHistory, 32, screenPos);
     }
 
 #pragma endregion
@@ -808,7 +808,7 @@ private:
                 cappedHistory[i] = std::numeric_limits<uint8_t>::max();
             }
         }
-        Graph::Draw(&dpi, cappedHistory, static_cast<int32_t>(std::size(cappedHistory)), screenPos);
+        Graph::Draw(dpi, cappedHistory, static_cast<int32_t>(std::size(cappedHistory)), screenPos);
     }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Park.cpp
+++ b/src/openrct2-ui/windows/Park.cpp
@@ -593,7 +593,7 @@ private:
         // Draw viewport
         if (viewport != nullptr)
         {
-            WindowDrawViewport(&dpi, *this);
+            WindowDrawViewport(dpi, *this);
             if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
                 GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
         }

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -267,7 +267,7 @@ private:
         {
             widget = &this->widgets[WIDX_TAB_1];
             auto screenCoords = windowPos + ScreenCoordsXY{ widget->left, widget->top };
-            GfxDrawSprite(dpi, ImageId(SPR_PEEP_LARGE_FACE_NORMAL), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(SPR_PEEP_LARGE_FACE_NORMAL), screenCoords);
         }
 
         // Tab 2
@@ -282,7 +282,7 @@ private:
                 imageId += (frame_no / 2) & 7;
             }
 
-            GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(imageId), screenCoords);
         }
     }
 

--- a/src/openrct2-ui/windows/Player.cpp
+++ b/src/openrct2-ui/windows/Player.cpp
@@ -165,11 +165,11 @@ public:
         switch (page)
         {
             case WINDOW_PLAYER_PAGE_OVERVIEW:
-                OnDrawOverview(&dpi);
+                OnDrawOverview(dpi);
                 break;
 
             case WINDOW_PLAYER_PAGE_STATISTICS:
-                OnDrawStatistics(&dpi);
+                OnDrawStatistics(dpi);
                 break;
         }
     }
@@ -258,7 +258,7 @@ private:
         }
     }
 
-    void DrawTabImages(DrawPixelInfo* dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         Widget* widget;
 
@@ -267,7 +267,7 @@ private:
         {
             widget = &this->widgets[WIDX_TAB_1];
             auto screenCoords = windowPos + ScreenCoordsXY{ widget->left, widget->top };
-            GfxDrawSprite(*dpi, ImageId(SPR_PEEP_LARGE_FACE_NORMAL), screenCoords);
+            GfxDrawSprite(dpi, ImageId(SPR_PEEP_LARGE_FACE_NORMAL), screenCoords);
         }
 
         // Tab 2
@@ -282,7 +282,7 @@ private:
                 imageId += (frame_no / 2) & 7;
             }
 
-            GfxDrawSprite(*dpi, ImageId(imageId), screenCoords);
+            GfxDrawSprite(dpi, ImageId(imageId), screenCoords);
         }
     }
 
@@ -430,9 +430,9 @@ private:
         WidgetSetEnabled(*this, WIDX_KICK, canKick && !isOwnWindow && !isServer);
     }
 
-    void OnDrawOverview(DrawPixelInfo* dpi)
+    void OnDrawOverview(DrawPixelInfo& dpi)
     {
-        DrawWidgets(*dpi);
+        DrawWidgets(dpi);
         DrawTabImages(dpi);
 
         int32_t player = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
@@ -454,7 +454,7 @@ private:
             ft.Add<const char*>(_buffer.c_str());
 
             DrawTextEllipsised(
-                *dpi, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
+                dpi, windowPos + ScreenCoordsXY{ widget->midX() - 5, widget->top }, widget->width() - 8, STR_STRING, ft,
                 { TextAlignment::CENTRE });
         }
 
@@ -463,10 +463,10 @@ private:
 
         auto ft = Formatter();
         ft.Add<StringId>(STR_PING);
-        DrawTextBasic(*dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
+        DrawTextBasic(dpi, screenCoords, STR_WINDOW_COLOUR_2_STRINGID, ft);
         char ping[64];
         snprintf(ping, 64, "%d ms", NetworkGetPlayerPing(player));
-        GfxDrawString(*dpi, screenCoords + ScreenCoordsXY(30, 0), ping, { colours[2] });
+        GfxDrawString(dpi, screenCoords + ScreenCoordsXY(30, 0), ping, { colours[2] });
 
         // Draw last action
         screenCoords = windowPos + ScreenCoordsXY{ width / 2, height - 13 };
@@ -481,7 +481,7 @@ private:
         {
             ft.Add<StringId>(STR_ACTION_NA);
         }
-        DrawTextEllipsised(*dpi, screenCoords, updatedWidth, STR_LAST_ACTION_RAN, ft, { TextAlignment::CENTRE });
+        DrawTextEllipsised(dpi, screenCoords, updatedWidth, STR_LAST_ACTION_RAN, ft, { TextAlignment::CENTRE });
 
         if (viewport != nullptr && var_492 != -1)
         {
@@ -629,9 +629,9 @@ private:
         WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_2);
     }
 
-    void OnDrawStatistics(DrawPixelInfo* dpi)
+    void OnDrawStatistics(DrawPixelInfo& dpi)
     {
-        DrawWidgets(*dpi);
+        DrawWidgets(dpi);
         DrawTabImages(dpi);
 
         int32_t player = NetworkGetPlayerIndex(static_cast<uint8_t>(number));
@@ -646,13 +646,13 @@ private:
 
         auto ft = Formatter();
         ft.Add<uint32_t>(NetworkGetPlayerCommandsRan(player));
-        DrawTextBasic(*dpi, screenCoords, STR_COMMANDS_RAN, ft);
+        DrawTextBasic(dpi, screenCoords, STR_COMMANDS_RAN, ft);
 
         screenCoords.y += LIST_ROW_HEIGHT;
 
         ft = Formatter();
         ft.Add<uint32_t>(NetworkGetPlayerMoneySpent(player));
-        DrawTextBasic(*dpi, screenCoords, STR_MONEY_SPENT, ft);
+        DrawTextBasic(dpi, screenCoords, STR_MONEY_SPENT, ft);
     }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
+++ b/src/openrct2-ui/windows/RefurbishRidePrompt.cpp
@@ -75,7 +75,7 @@ public:
 
     void OnDraw(DrawPixelInfo& dpi) override
     {
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
 
         auto currentRide = GetRide(rideId);
         if (currentRide != nullptr)

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -608,7 +608,7 @@ static void WindowResearchDrawTabImage(DrawPixelInfo* dpi, WindowBase* w, int32_
         }
 
         GfxDrawSprite(
-            dpi, ImageId(spriteIndex),
+            *dpi, ImageId(spriteIndex),
             w->windowPos + ScreenCoordsXY{ w->widgets[widgetIndex].left, w->widgets[widgetIndex].top });
     }
 }

--- a/src/openrct2-ui/windows/Research.cpp
+++ b/src/openrct2-ui/windows/Research.cpp
@@ -104,14 +104,14 @@ static Widget *window_research_page_widgets[] = {
 static void WindowResearchDevelopmentMouseup(WindowBase *w, WidgetIndex widgetIndex);
 static void WindowResearchDevelopmentUpdate(WindowBase *w);
 static void WindowResearchDevelopmentInvalidate(WindowBase *w);
-static void WindowResearchDevelopmentPaint(WindowBase *w, DrawPixelInfo *dpi);
+static void WindowResearchDevelopmentPaint(WindowBase *w, DrawPixelInfo& dpi);
 
 static void WindowResearchFundingMouseup(WindowBase *w, WidgetIndex widgetIndex);
 static void WindowResearchFundingMousedown(WindowBase *w, WidgetIndex widgetIndex, Widget* widget);
 static void WindowResearchFundingDropdown(WindowBase *w, WidgetIndex widgetIndex, int32_t dropdownIndex);
 static void WindowResearchFundingUpdate(WindowBase *w);
 static void WindowResearchFundingInvalidate(WindowBase *w);
-static void WindowResearchFundingPaint(WindowBase *w, DrawPixelInfo *dpi);
+static void WindowResearchFundingPaint(WindowBase *w, DrawPixelInfo& dpi);
 
 //
 static WindowEventList window_research_development_events([](auto& events)
@@ -156,7 +156,7 @@ static constexpr const StringId ResearchStageNames[] = {
 
 static void WindowResearchSetPage(WindowBase* w, int32_t page);
 static void WindowResearchSetPressedTab(WindowBase* w);
-static void WindowResearchDrawTabImages(DrawPixelInfo* dpi, WindowBase* w);
+static void WindowResearchDrawTabImages(DrawPixelInfo& dpi, WindowBase* w);
 
 WindowBase* WindowResearchOpen()
 {
@@ -253,7 +253,7 @@ static void WindowResearchDevelopmentInvalidate(WindowBase* w)
  *
  *  rct2: 0x006B689B
  */
-static void WindowResearchDevelopmentPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowResearchDevelopmentPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowResearchDrawTabImages(dpi, w);
@@ -261,7 +261,7 @@ static void WindowResearchDevelopmentPaint(WindowBase* w, DrawPixelInfo* dpi)
     WindowResearchDevelopmentPagePaint(w, dpi, WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP);
 }
 
-void WindowResearchDevelopmentPagePaint(WindowBase* w, DrawPixelInfo* dpi, WidgetIndex baseWidgetIndex)
+void WindowResearchDevelopmentPagePaint(WindowBase* w, DrawPixelInfo& dpi, WidgetIndex baseWidgetIndex)
 {
     baseWidgetIndex = baseWidgetIndex - WIDX_CURRENTLY_IN_DEVELOPMENT_GROUP;
 
@@ -273,19 +273,19 @@ void WindowResearchDevelopmentPagePaint(WindowBase* w, DrawPixelInfo* dpi, Widge
         // Research type
         auto ft = Formatter();
         ft.Add<StringId>(STR_RESEARCH_UNKNOWN);
-        DrawTextWrapped(*dpi, screenCoords, 296, STR_RESEARCH_TYPE_LABEL, ft);
+        DrawTextWrapped(dpi, screenCoords, 296, STR_RESEARCH_TYPE_LABEL, ft);
         screenCoords.y += 25;
 
         // Progress
         ft = Formatter();
         ft.Add<StringId>(STR_RESEARCH_COMPLETED_AL);
-        DrawTextWrapped(*dpi, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, ft);
+        DrawTextWrapped(dpi, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, ft);
         screenCoords.y += 15;
 
         // Expected
         ft = Formatter();
         ft.Add<StringId>(STR_RESEARCH_STAGE_UNKNOWN);
-        DrawTextBasic(*dpi, screenCoords, STR_RESEARCH_EXPECTED_LABEL, ft);
+        DrawTextBasic(dpi, screenCoords, STR_RESEARCH_EXPECTED_LABEL, ft);
     }
     else
     {
@@ -322,13 +322,13 @@ void WindowResearchDevelopmentPagePaint(WindowBase* w, DrawPixelInfo* dpi, Widge
         {
             ft.Add<StringId>(gResearchNextItem->GetName());
         }
-        DrawTextWrapped(*dpi, screenCoords, 296, label, ft);
+        DrawTextWrapped(dpi, screenCoords, 296, label, ft);
         screenCoords.y += 25;
 
         // Progress
         ft = Formatter();
         ft.Add<StringId>(ResearchStageNames[gResearchProgressStage]);
-        DrawTextWrapped(*dpi, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, ft);
+        DrawTextWrapped(dpi, screenCoords, 296, STR_RESEARCH_PROGRESS_LABEL, ft);
         screenCoords.y += 15;
 
         // Expected
@@ -344,7 +344,7 @@ void WindowResearchDevelopmentPagePaint(WindowBase* w, DrawPixelInfo* dpi, Widge
         {
             ft.Add<StringId>(STR_RESEARCH_STAGE_UNKNOWN);
         }
-        DrawTextBasic(*dpi, screenCoords, STR_RESEARCH_EXPECTED_LABEL, ft);
+        DrawTextBasic(dpi, screenCoords, STR_RESEARCH_EXPECTED_LABEL, ft);
     }
 
     // Last development
@@ -379,7 +379,7 @@ void WindowResearchDevelopmentPagePaint(WindowBase* w, DrawPixelInfo* dpi, Widge
             }
         }
 
-        DrawTextWrapped(*dpi, screenCoords, 266, lastDevelopmentFormat, ft);
+        DrawTextWrapped(dpi, screenCoords, 266, lastDevelopmentFormat, ft);
     }
 }
 
@@ -528,7 +528,7 @@ static void WindowResearchFundingInvalidate(WindowBase* w)
  *
  *  rct2: 0x0069DAF0
  */
-static void WindowResearchFundingPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowResearchFundingPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowResearchDrawTabImages(dpi, w);
@@ -536,7 +536,7 @@ static void WindowResearchFundingPaint(WindowBase* w, DrawPixelInfo* dpi)
     WindowResearchFundingPagePaint(w, dpi, WIDX_RESEARCH_FUNDING);
 }
 
-void WindowResearchFundingPagePaint(WindowBase* w, DrawPixelInfo* dpi, WidgetIndex baseWidgetIndex)
+void WindowResearchFundingPagePaint(WindowBase* w, DrawPixelInfo& dpi, WidgetIndex baseWidgetIndex)
 {
     if (gParkFlags & PARK_FLAGS_NO_MONEY)
         return;
@@ -544,7 +544,7 @@ void WindowResearchFundingPagePaint(WindowBase* w, DrawPixelInfo* dpi, WidgetInd
     int32_t currentResearchLevel = gResearchFundingLevel;
     auto ft = Formatter();
     ft.Add<money64>(research_cost_table[currentResearchLevel]);
-    DrawTextBasic(*dpi, w->windowPos + ScreenCoordsXY{ 10, 77 }, STR_RESEARCH_COST_PER_MONTH, ft);
+    DrawTextBasic(dpi, w->windowPos + ScreenCoordsXY{ 10, 77 }, STR_RESEARCH_COST_PER_MONTH, ft);
 }
 
 #pragma endregion
@@ -593,7 +593,7 @@ static void WindowResearchSetPressedTab(WindowBase* w)
     w->pressed_widgets |= 1LL << (WIDX_TAB_1 + w->page);
 }
 
-static void WindowResearchDrawTabImage(DrawPixelInfo* dpi, WindowBase* w, int32_t page, int32_t spriteIndex)
+static void WindowResearchDrawTabImage(DrawPixelInfo& dpi, WindowBase* w, int32_t page, int32_t spriteIndex)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + page;
 
@@ -608,12 +608,12 @@ static void WindowResearchDrawTabImage(DrawPixelInfo* dpi, WindowBase* w, int32_
         }
 
         GfxDrawSprite(
-            *dpi, ImageId(spriteIndex),
+            dpi, ImageId(spriteIndex),
             w->windowPos + ScreenCoordsXY{ w->widgets[widgetIndex].left, w->widgets[widgetIndex].top });
     }
 }
 
-static void WindowResearchDrawTabImages(DrawPixelInfo* dpi, WindowBase* w)
+static void WindowResearchDrawTabImages(DrawPixelInfo& dpi, WindowBase* w)
 {
     WindowResearchDrawTabImage(dpi, w, WINDOW_RESEARCH_PAGE_DEVELOPMENT, SPR_TAB_FINANCES_RESEARCH_0);
     WindowResearchDrawTabImage(dpi, w, WINDOW_RESEARCH_PAGE_FUNDING, SPR_TAB_FINANCES_SUMMARY_0);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -937,7 +937,7 @@ static void WindowRideDrawTabVehicle(DrawPixelInfo& dpi, WindowBase* w)
         screenCoords += w->windowPos;
 
         DrawPixelInfo clipDPI;
-        if (!ClipDrawPixelInfo(&clipDPI, &dpi, screenCoords, width, height))
+        if (!ClipDrawPixelInfo(clipDPI, dpi, screenCoords, width, height))
         {
             return;
         }
@@ -4962,7 +4962,7 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo& dpi)
     if (entrancePreviewWidget.type != WindowWidgetType::Empty)
     {
         if (ClipDrawPixelInfo(
-                &clippedDpi, &dpi,
+                clippedDpi, dpi,
                 w->windowPos + ScreenCoordsXY{ entrancePreviewWidget.left + 1, entrancePreviewWidget.top + 1 },
                 entrancePreviewWidget.width(), entrancePreviewWidget.height()))
         {

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -439,7 +439,7 @@ static void WindowRideMainUpdate(WindowBase* w);
 static void WindowRideMainTextinput(WindowBase* w, WidgetIndex widgetIndex, const char* text);
 static void WindowRideMainViewportRotate(WindowBase* w);
 static void WindowRideMainInvalidate(WindowBase* w);
-static void WindowRideMainPaint(WindowBase* w, DrawPixelInfo* dpi);
+static void WindowRideMainPaint(WindowBase* w, DrawPixelInfo& dpi);
 static void WindowRideMainFollowRide(WindowBase* w);
 
 static void WindowRideVehicleMouseup(WindowBase* w, WidgetIndex widgetIndex);
@@ -449,8 +449,8 @@ static void WindowRideVehicleDropdown(WindowBase* w, WidgetIndex widgetIndex, in
 static void WindowRideVehicleUpdate(WindowBase* w);
 static OpenRCT2String WindowRideVehicleTooltip(WindowBase* const w, const WidgetIndex widgetIndex, StringId fallback);
 static void WindowRideVehicleInvalidate(WindowBase* w);
-static void WindowRideVehiclePaint(WindowBase* w, DrawPixelInfo* dpi);
-static void WindowRideVehicleScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32_t scrollIndex);
+static void WindowRideVehiclePaint(WindowBase* w, DrawPixelInfo& dpi);
+static void WindowRideVehicleScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32_t scrollIndex);
 
 static void WindowRideOperatingMouseup(WindowBase* w, WidgetIndex widgetIndex);
 static void WindowRideOperatingResize(WindowBase* w);
@@ -461,7 +461,7 @@ static void WindowRideOperatingDropdown(WindowBase* w, WidgetIndex widgetIndex, 
 static void WindowRideOperatingUpdate(WindowBase* w);
 static void WindowRideOperatingTextinput(WindowBase* w, WidgetIndex widgetIndex, const char* text);
 static void WindowRideOperatingInvalidate(WindowBase* w);
-static void WindowRideOperatingPaint(WindowBase* w, DrawPixelInfo* dpi);
+static void WindowRideOperatingPaint(WindowBase* w, DrawPixelInfo& dpi);
 
 static void WindowRideMaintenanceMouseup(WindowBase* w, WidgetIndex widgetIndex);
 static void WindowRideMaintenanceResize(WindowBase* w);
@@ -469,7 +469,7 @@ static void WindowRideMaintenanceMousedown(WindowBase* w, WidgetIndex widgetInde
 static void WindowRideMaintenanceDropdown(WindowBase* w, WidgetIndex widgetIndex, int32_t dropdownIndex);
 static void WindowRideMaintenanceUpdate(WindowBase* w);
 static void WindowRideMaintenanceInvalidate(WindowBase* w);
-static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo* dpi);
+static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo& dpi);
 
 static void WindowRideColourClose(WindowBase* w);
 static void WindowRideColourMouseup(WindowBase* w, WidgetIndex widgetIndex);
@@ -480,8 +480,8 @@ static void WindowRideColourUpdate(WindowBase* w);
 static void WindowRideColourTooldown(WindowBase* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
 static void WindowRideColourTooldrag(WindowBase* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
 static void WindowRideColourInvalidate(WindowBase* w);
-static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi);
-static void WindowRideColourScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32_t scrollIndex);
+static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo& dpi);
+static void WindowRideColourScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32_t scrollIndex);
 
 static void WindowRideMusicMouseup(WindowBase* w, WidgetIndex widgetIndex);
 static void WindowRideMusicResize(WindowBase* w);
@@ -489,7 +489,7 @@ static void WindowRideMusicMousedown(WindowBase* w, WidgetIndex widgetIndex, Wid
 static void WindowRideMusicDropdown(WindowBase* w, WidgetIndex widgetIndex, int32_t dropdownIndex);
 static void WindowRideMusicUpdate(WindowBase* w);
 static void WindowRideMusicInvalidate(WindowBase* w);
-static void WindowRideMusicPaint(WindowBase* w, DrawPixelInfo* dpi);
+static void WindowRideMusicPaint(WindowBase* w, DrawPixelInfo& dpi);
 
 static void WindowRideMeasurementsClose(WindowBase* w);
 static void WindowRideMeasurementsMouseup(WindowBase* w, WidgetIndex widgetIndex);
@@ -501,7 +501,7 @@ static void WindowRideMeasurementsTooldown(WindowBase* w, WidgetIndex widgetInde
 static void WindowRideMeasurementsTooldrag(WindowBase* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
 static void WindowRideMeasurementsToolabort(WindowBase* w, WidgetIndex widgetIndex);
 static void WindowRideMeasurementsInvalidate(WindowBase* w);
-static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi);
+static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo& dpi);
 
 static void WindowRideGraphsMouseup(WindowBase* w, WidgetIndex widgetIndex);
 static void WindowRideGraphsResize(WindowBase* w);
@@ -511,8 +511,8 @@ static void WindowRideGraphsScrollgetheight(WindowBase* w, int32_t scrollIndex, 
 static void WindowRideGraphs15(WindowBase* w, int32_t scrollIndex, int32_t scrollAreaType);
 static OpenRCT2String WindowRideGraphsTooltip(WindowBase* w, const WidgetIndex widgetIndex, const StringId fallback);
 static void WindowRideGraphsInvalidate(WindowBase* w);
-static void WindowRideGraphsPaint(WindowBase* w, DrawPixelInfo* dpi);
-static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32_t scrollIndex);
+static void WindowRideGraphsPaint(WindowBase* w, DrawPixelInfo& dpi);
+static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32_t scrollIndex);
 
 static void WindowRideIncomeMouseup(WindowBase* w, WidgetIndex widgetIndex);
 static void WindowRideIncomeResize(WindowBase* w);
@@ -520,14 +520,14 @@ static void WindowRideIncomeMousedown(WindowBase* w, WidgetIndex widgetIndex, Wi
 static void WindowRideIncomeUpdate(WindowBase* w);
 static void WindowRideIncomeTextinput(WindowBase* w, WidgetIndex widgetIndex, const char* text);
 static void WindowRideIncomeInvalidate(WindowBase* w);
-static void WindowRideIncomePaint(WindowBase* w, DrawPixelInfo* dpi);
+static void WindowRideIncomePaint(WindowBase* w, DrawPixelInfo& dpi);
 static bool WindowRideIncomeCanModifyPrimaryPrice(WindowBase* w);
 
 static void WindowRideCustomerMouseup(WindowBase* w, WidgetIndex widgetIndex);
 static void WindowRideCustomerResize(WindowBase* w);
 static void WindowRideCustomerUpdate(WindowBase* w);
 static void WindowRideCustomerInvalidate(WindowBase* w);
-static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi);
+static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo& dpi);
 
 static void WindowRideSetPage(WindowBase* w, int32_t page);
 
@@ -862,7 +862,7 @@ static const RideObjectEntry* VehicleDropdownRideType = nullptr;
 static bool VehicleDropdownExpanded = false;
 static std::vector<VehicleTypeLabel> VehicleDropdownData;
 
-static void WindowRideDrawTabImage(DrawPixelInfo* dpi, WindowBase* w, int32_t page, int32_t spriteIndex)
+static void WindowRideDrawTabImage(DrawPixelInfo& dpi, WindowBase* w, int32_t page, int32_t spriteIndex)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + page;
 
@@ -875,7 +875,7 @@ static void WindowRideDrawTabImage(DrawPixelInfo* dpi, WindowBase* w, int32_t pa
         }
 
         const auto& widget = w->widgets[widgetIndex];
-        GfxDrawSprite(*dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
+        GfxDrawSprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
     }
 }
 
@@ -883,7 +883,7 @@ static void WindowRideDrawTabImage(DrawPixelInfo* dpi, WindowBase* w, int32_t pa
  *
  *  rct2: 0x006B2E88
  */
-static void WindowRideDrawTabMain(DrawPixelInfo* dpi, WindowBase* w)
+static void WindowRideDrawTabMain(DrawPixelInfo& dpi, WindowBase* w)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_MAIN);
     if (!WidgetIsDisabled(*w, widgetIndex))
@@ -912,7 +912,7 @@ static void WindowRideDrawTabMain(DrawPixelInfo* dpi, WindowBase* w)
             }
 
             const auto& widget = w->widgets[widgetIndex];
-            GfxDrawSprite(*dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
+            GfxDrawSprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
         }
     }
 }
@@ -921,7 +921,7 @@ static void WindowRideDrawTabMain(DrawPixelInfo* dpi, WindowBase* w)
  *
  *  rct2: 0x006B2B68
  */
-static void WindowRideDrawTabVehicle(DrawPixelInfo* dpi, WindowBase* w)
+static void WindowRideDrawTabVehicle(DrawPixelInfo& dpi, WindowBase* w)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_VEHICLE);
     const auto& widget = w->widgets[widgetIndex];
@@ -937,7 +937,7 @@ static void WindowRideDrawTabVehicle(DrawPixelInfo* dpi, WindowBase* w)
         screenCoords += w->windowPos;
 
         DrawPixelInfo clipDPI;
-        if (!ClipDrawPixelInfo(&clipDPI, dpi, screenCoords, width, height))
+        if (!ClipDrawPixelInfo(&clipDPI, &dpi, screenCoords, width, height))
         {
             return;
         }
@@ -992,7 +992,7 @@ static void WindowRideDrawTabVehicle(DrawPixelInfo* dpi, WindowBase* w)
  *
  *  rct2: 0x006B2F42
  */
-static void WindowRideDrawTabCustomer(DrawPixelInfo* dpi, WindowBase* w)
+static void WindowRideDrawTabCustomer(DrawPixelInfo& dpi, WindowBase* w)
 {
     WidgetIndex widgetIndex = WIDX_TAB_1 + static_cast<int32_t>(WINDOW_RIDE_PAGE_CUSTOMER);
 
@@ -1006,7 +1006,7 @@ static void WindowRideDrawTabCustomer(DrawPixelInfo* dpi, WindowBase* w)
         spriteIndex += GetPeepAnimation(PeepSpriteType::Normal).base_image + 1;
 
         GfxDrawSprite(
-            *dpi, ImageId(spriteIndex, COLOUR_BRIGHT_RED, COLOUR_TEAL),
+            dpi, ImageId(spriteIndex, COLOUR_BRIGHT_RED, COLOUR_TEAL),
             w->windowPos + ScreenCoordsXY{ widget.midX(), widget.bottom - 6 });
     }
 }
@@ -1015,7 +1015,7 @@ static void WindowRideDrawTabCustomer(DrawPixelInfo* dpi, WindowBase* w)
  *
  *  rct2: 0x006B2B35
  */
-static void WindowRideDrawTabImages(DrawPixelInfo* dpi, WindowBase* w)
+static void WindowRideDrawTabImages(DrawPixelInfo& dpi, WindowBase* w)
 {
     WindowRideDrawTabVehicle(dpi, w);
     WindowRideDrawTabImage(dpi, w, WINDOW_RIDE_PAGE_OPERATING, SPR_TAB_GEARS_0);
@@ -2580,7 +2580,7 @@ static StringId WindowRideGetStatus(WindowBase* w, Formatter& ft)
  *
  *  rct2: 0x006AEE73
  */
-static void WindowRideMainPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowRideMainPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     Widget* widget;
 
@@ -2592,7 +2592,7 @@ static void WindowRideMainPaint(WindowBase* w, DrawPixelInfo* dpi)
     {
         WindowDrawViewport(dpi, *w);
         if (w->viewport->flags & VIEWPORT_FLAG_SOUND_ON)
-            GfxDrawSprite(*dpi, ImageId(SPR_HEARING_VIEWPORT), w->windowPos + ScreenCoordsXY{ 2, 2 });
+            GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), w->windowPos + ScreenCoordsXY{ 2, 2 });
     }
 
     // View dropdown
@@ -2621,7 +2621,7 @@ static void WindowRideMainPaint(WindowBase* w, DrawPixelInfo* dpi)
 
     widget = &window_ride_main_widgets[WIDX_VIEW];
     DrawTextBasic(
-        *dpi, { w->windowPos.x + (widget->left + widget->right - 11) / 2, w->windowPos.y + widget->top },
+        dpi, { w->windowPos.x + (widget->left + widget->right - 11) / 2, w->windowPos.y + widget->top },
         STR_WINDOW_COLOUR_2_STRINGID, ft, { TextAlignment::CENTRE });
 
     // Status
@@ -2629,7 +2629,7 @@ static void WindowRideMainPaint(WindowBase* w, DrawPixelInfo* dpi)
     widget = &window_ride_main_widgets[WIDX_STATUS];
     StringId rideStatus = WindowRideGetStatus(w, ft);
     DrawTextEllipsised(
-        *dpi, w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->top }, widget->width(), rideStatus, ft,
+        dpi, w->windowPos + ScreenCoordsXY{ (widget->left + widget->right) / 2, widget->top }, widget->width(), rideStatus, ft,
         { TextAlignment::CENTRE });
 }
 
@@ -2885,7 +2885,7 @@ static void WindowRideVehicleInvalidate(WindowBase* w)
  *
  *  rct2: 0x006B23DC
  */
-static void WindowRideVehiclePaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowRideVehiclePaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -2903,13 +2903,13 @@ static void WindowRideVehiclePaint(WindowBase* w, DrawPixelInfo* dpi)
     // Description
     auto ft = Formatter();
     ft.Add<StringId>(rideEntry->naming.Description);
-    screenCoords.y += DrawTextWrapped(*dpi, screenCoords, 300, STR_BLACK_STRING, ft, { TextAlignment::LEFT });
+    screenCoords.y += DrawTextWrapped(dpi, screenCoords, 300, STR_BLACK_STRING, ft, { TextAlignment::LEFT });
     screenCoords.y += 2;
 
     // Capacity
     ft = Formatter();
     ft.Add<StringId>(rideEntry->capacity);
-    DrawTextBasic(*dpi, screenCoords, STR_CAPACITY, ft);
+    DrawTextBasic(dpi, screenCoords, STR_CAPACITY, ft);
 
     // Excitement Factor
     if (rideEntry->excitement_multiplier != 0)
@@ -2919,7 +2919,7 @@ static void WindowRideVehiclePaint(WindowBase* w, DrawPixelInfo* dpi)
         ft = Formatter();
         ft.Add<int16_t>(abs(rideEntry->excitement_multiplier));
         StringId stringId = rideEntry->excitement_multiplier > 0 ? STR_EXCITEMENT_FACTOR : STR_EXCITEMENT_FACTOR_NEGATIVE;
-        DrawTextBasic(*dpi, screenCoords, stringId, ft);
+        DrawTextBasic(dpi, screenCoords, stringId, ft);
     }
 
     // Intensity Factor
@@ -2934,7 +2934,7 @@ static void WindowRideVehiclePaint(WindowBase* w, DrawPixelInfo* dpi)
         ft = Formatter();
         ft.Add<int16_t>(abs(rideEntry->intensity_multiplier));
         StringId stringId = rideEntry->intensity_multiplier > 0 ? STR_INTENSITY_FACTOR : STR_INTENSITY_FACTOR_NEGATIVE;
-        DrawTextBasic(*dpi, screenCoords, stringId, ft);
+        DrawTextBasic(dpi, screenCoords, stringId, ft);
 
         if (lineHeight != 10)
             screenCoords.x -= 150;
@@ -2948,7 +2948,7 @@ static void WindowRideVehiclePaint(WindowBase* w, DrawPixelInfo* dpi)
         ft = Formatter();
         ft.Add<int16_t>(abs(rideEntry->nausea_multiplier));
         StringId stringId = rideEntry->nausea_multiplier > 0 ? STR_NAUSEA_FACTOR : STR_NAUSEA_FACTOR_NEGATIVE;
-        DrawTextBasic(*dpi, screenCoords, stringId, ft);
+        DrawTextBasic(dpi, screenCoords, stringId, ft);
     }
 }
 
@@ -2963,7 +2963,7 @@ struct VehicleDrawInfo
  *
  *  rct2: 0x006B2502
  */
-static void WindowRideVehicleScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32_t scrollIndex)
+static void WindowRideVehicleScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32_t scrollIndex)
 {
     auto ride = GetRide(w->rideId);
     if (ride == nullptr)
@@ -2972,7 +2972,7 @@ static void WindowRideVehicleScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int3
     const auto* rideEntry = ride->GetRideEntry();
 
     // Background
-    GfxFillRect(dpi, { { dpi->x, dpi->y }, { dpi->x + dpi->width, dpi->y + dpi->height } }, PALETTE_INDEX_12);
+    GfxFillRect(&dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } }, PALETTE_INDEX_12);
 
     Widget* widget = &window_ride_vehicle_widgets[WIDX_VEHICLE_TRAINS_PREVIEW];
     int32_t startX = std::max(2, (widget->width() - ((ride->NumTrains - 1) * 36)) / 2 - 25);
@@ -3038,7 +3038,7 @@ static void WindowRideVehicleScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int3
 
         VehicleDrawInfo* current = nextSpriteToDraw;
         while (--current >= trainCarImages)
-            GfxDrawSprite(*dpi, current->imageId, { current->x, current->y });
+            GfxDrawSprite(dpi, current->imageId, { current->x, current->y });
 
         startX += 36;
     }
@@ -3721,7 +3721,7 @@ static void WindowRideOperatingInvalidate(WindowBase* w)
  *
  *  rct2: 0x006B1001
  */
-static void WindowRideOperatingPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowRideOperatingPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -3732,7 +3732,7 @@ static void WindowRideOperatingPaint(WindowBase* w, DrawPixelInfo* dpi)
 
     // Horizontal rule between mode settings and depart settings
     GfxFillRectInset(
-        dpi,
+        &dpi,
         { w->windowPos + ScreenCoordsXY{ window_ride_operating_widgets[WIDX_PAGE_BACKGROUND].left + 4, 103 },
           w->windowPos + ScreenCoordsXY{ window_ride_operating_widgets[WIDX_PAGE_BACKGROUND].right - 5, 104 } },
         w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
@@ -3743,7 +3743,7 @@ static void WindowRideOperatingPaint(WindowBase* w, DrawPixelInfo* dpi)
         auto ft = Formatter();
         ft.Add<uint16_t>(ride->num_block_brakes + ride->num_stations);
         DrawTextBasic(
-            *dpi, w->windowPos + ScreenCoordsXY{ 21, ride->mode == RideMode::PoweredLaunchBlockSectioned ? 89 : 61 },
+            dpi, w->windowPos + ScreenCoordsXY{ 21, ride->mode == RideMode::PoweredLaunchBlockSectioned ? 89 : 61 },
             STR_BLOCK_SECTIONS, ft, COLOUR_BLACK);
     }
 }
@@ -3784,9 +3784,9 @@ static void WindowRideLocateMechanic(WindowBase* w)
  *  rct2: 0x006B7D08
  */
 static void WindowRideMaintenanceDrawBar(
-    WindowBase* w, DrawPixelInfo* dpi, const ScreenCoordsXY& coords, int32_t value, int32_t colour)
+    WindowBase* w, DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t value, int32_t colour)
 {
-    GfxFillRectInset(dpi, { coords, coords + ScreenCoordsXY{ 149, 8 } }, w->colours[1], INSET_RECT_F_30);
+    GfxFillRectInset(&dpi, { coords, coords + ScreenCoordsXY{ 149, 8 } }, w->colours[1], INSET_RECT_F_30);
     if (colour & BAR_BLINK)
     {
         colour &= ~BAR_BLINK;
@@ -3797,7 +3797,7 @@ static void WindowRideMaintenanceDrawBar(
     value = ((186 * ((value * 2) & 0xFF)) >> 8) & 0xFF;
     if (value > 2)
     {
-        GfxFillRectInset(dpi, { coords + ScreenCoordsXY{ 2, 1 }, coords + ScreenCoordsXY{ value + 1, 7 } }, colour, 0);
+        GfxFillRectInset(&dpi, { coords + ScreenCoordsXY{ 2, 1 }, coords + ScreenCoordsXY{ value + 1, 7 } }, colour, 0);
     }
 }
 
@@ -4117,7 +4117,7 @@ static void WindowRideMaintenanceInvalidate(WindowBase* w)
  *
  *  rct2: 0x006B1877
  */
-static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -4130,12 +4130,12 @@ static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo* dpi)
     Widget* widget = &window_ride_maintenance_widgets[WIDX_LOCATE_MECHANIC];
     auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
     auto image = ImageId(SPR_MECHANIC, COLOUR_BLACK, gStaffMechanicColour);
-    GfxDrawSprite(*dpi, image, screenCoords);
+    GfxDrawSprite(dpi, image, screenCoords);
 
     // Inspection label
     widget = &window_ride_maintenance_widgets[WIDX_INSPECTION_INTERVAL];
     screenCoords = w->windowPos + ScreenCoordsXY{ 4, widget->top + 1 };
-    DrawTextBasic(*dpi, screenCoords, STR_INSPECTION);
+    DrawTextBasic(dpi, screenCoords, STR_INSPECTION);
 
     // Reliability
     widget = &window_ride_maintenance_widgets[WIDX_PAGE_BACKGROUND];
@@ -4144,7 +4144,7 @@ static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo* dpi)
     uint16_t reliability = ride->reliability_percentage;
     auto ft = Formatter();
     ft.Add<uint16_t>(reliability);
-    DrawTextBasic(*dpi, screenCoords, STR_RELIABILITY_LABEL_1757, ft);
+    DrawTextBasic(dpi, screenCoords, STR_RELIABILITY_LABEL_1757, ft);
     WindowRideMaintenanceDrawBar(
         w, dpi, screenCoords + ScreenCoordsXY{ 103, 0 }, std::max<int32_t>(10, reliability), COLOUR_BRIGHT_GREEN);
     screenCoords.y += 11;
@@ -4152,7 +4152,7 @@ static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo* dpi)
     uint16_t downTime = ride->downtime;
     ft = Formatter();
     ft.Add<uint16_t>(downTime);
-    DrawTextBasic(*dpi, screenCoords, STR_DOWN_TIME_LABEL_1889, ft);
+    DrawTextBasic(dpi, screenCoords, STR_DOWN_TIME_LABEL_1889, ft);
     WindowRideMaintenanceDrawBar(w, dpi, screenCoords + ScreenCoordsXY{ 103, 0 }, downTime, COLOUR_BRIGHT_RED);
     screenCoords.y += 26;
 
@@ -4167,7 +4167,7 @@ static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo* dpi)
 
     ft = Formatter();
     ft.Add<uint16_t>(ride->last_inspection);
-    DrawTextBasic(*dpi, screenCoords, stringId, ft);
+    DrawTextBasic(dpi, screenCoords, stringId, ft);
     screenCoords.y += 12;
 
     // Last / current breakdown
@@ -4177,7 +4177,7 @@ static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo* dpi)
     stringId = (ride->lifecycle_flags & RIDE_LIFECYCLE_BROKEN_DOWN) ? STR_CURRENT_BREAKDOWN : STR_LAST_BREAKDOWN;
     ft = Formatter();
     ft.Add<StringId>(RideBreakdownReasonNames[ride->breakdown_reason]);
-    DrawTextBasic(*dpi, screenCoords, stringId, ft);
+    DrawTextBasic(dpi, screenCoords, stringId, ft);
     screenCoords.y += 12;
 
     // Mechanic status
@@ -4215,7 +4215,7 @@ static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo* dpi)
         {
             if (stringId == STR_CALLING_MECHANIC || stringId == STR_NO_MECHANICS_ARE_HIRED_MESSAGE)
             {
-                DrawTextWrapped(*dpi, screenCoords, 280, stringId, {}, { TextAlignment::LEFT });
+                DrawTextWrapped(dpi, screenCoords, 280, stringId, {}, { TextAlignment::LEFT });
             }
             else
             {
@@ -4224,7 +4224,7 @@ static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo* dpi)
                 {
                     ft = Formatter();
                     staff->FormatNameTo(ft);
-                    DrawTextWrapped(*dpi, screenCoords, 280, stringId, ft, { TextAlignment::LEFT });
+                    DrawTextWrapped(dpi, screenCoords, 280, stringId, ft, { TextAlignment::LEFT });
                 }
             }
         }
@@ -4876,7 +4876,7 @@ static void WindowRideColourInvalidate(WindowBase* w)
  *
  *  rct2: 0x006AFF3E
  */
-static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     // TODO: This should use lists and identified sprites
     DrawPixelInfo clippedDpi;
@@ -4892,7 +4892,7 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
     const auto& trackPreviewWidget = window_ride_colour_widgets[WIDX_TRACK_PREVIEW];
     if (trackPreviewWidget.type != WindowWidgetType::Empty)
         GfxFillRect(
-            dpi,
+            &dpi,
             { { w->windowPos + ScreenCoordsXY{ trackPreviewWidget.left + 1, trackPreviewWidget.top + 1 } },
               { w->windowPos + ScreenCoordsXY{ trackPreviewWidget.right - 1, trackPreviewWidget.bottom - 1 } } },
             PALETTE_INDEX_12);
@@ -4909,7 +4909,7 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
         const auto& rtd = ride->GetRideTypeDescriptor();
         if (rtd.HasFlag(RIDE_TYPE_FLAG_IS_MAZE))
         {
-            GfxDrawSprite(*dpi, ImageId(MazeOptions[trackColour.supports].sprite), screenCoords);
+            GfxDrawSprite(dpi, ImageId(MazeOptions[trackColour.supports].sprite), screenCoords);
         }
         else
         {
@@ -4917,14 +4917,14 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
             int32_t spriteIndex = typeDescriptor.ColourPreview.Track;
             if (spriteIndex != 0)
             {
-                GfxDrawSprite(*dpi, ImageId(spriteIndex, trackColour.main, trackColour.additional), screenCoords);
+                GfxDrawSprite(dpi, ImageId(spriteIndex, trackColour.main, trackColour.additional), screenCoords);
             }
 
             // Supports
             spriteIndex = typeDescriptor.ColourPreview.Supports;
             if (spriteIndex != 0)
             {
-                GfxDrawSprite(*dpi, ImageId(spriteIndex, trackColour.supports), screenCoords);
+                GfxDrawSprite(dpi, ImageId(spriteIndex, trackColour.supports), screenCoords);
             }
         }
     }
@@ -4948,11 +4948,11 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
                 }
             }
 
-            GfxDrawSprite(*dpi, ImageId(GetShopItemDescriptor(shopItem).Image, spriteColour), screenCoords);
+            GfxDrawSprite(dpi, ImageId(GetShopItemDescriptor(shopItem).Image, spriteColour), screenCoords);
         }
         else
         {
-            GfxDrawSprite(*dpi, ImageId(GetShopItemDescriptor(shopItem).Image, ride->track_colour[0].main), screenCoords);
+            GfxDrawSprite(dpi, ImageId(GetShopItemDescriptor(shopItem).Image, ride->track_colour[0].main), screenCoords);
         }
     }
 
@@ -4962,7 +4962,7 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
     if (entrancePreviewWidget.type != WindowWidgetType::Empty)
     {
         if (ClipDrawPixelInfo(
-                &clippedDpi, dpi,
+                &clippedDpi, &dpi,
                 w->windowPos + ScreenCoordsXY{ entrancePreviewWidget.left + 1, entrancePreviewWidget.top + 1 },
                 entrancePreviewWidget.width(), entrancePreviewWidget.height()))
         {
@@ -4988,7 +4988,7 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
             }
         }
 
-        DrawTextEllipsised(*dpi, { w->windowPos.x + 3, w->windowPos.y + 103 }, 97, STR_STATION_STYLE, {});
+        DrawTextEllipsised(dpi, { w->windowPos.x + 3, w->windowPos.y + 103 }, 97, STR_STATION_STYLE, {});
     }
 }
 
@@ -4996,7 +4996,7 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
  *
  *  rct2: 0x006B0192
  */
-static void WindowRideColourScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32_t scrollIndex)
+static void WindowRideColourScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32_t scrollIndex)
 {
     auto ride = GetRide(w->rideId);
     if (ride == nullptr)
@@ -5010,7 +5010,7 @@ static void WindowRideColourScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32
     auto vehicleColour = RideGetVehicleColour(*ride, w->vehicleIndex);
 
     // Background colour
-    GfxFillRect(dpi, { { dpi->x, dpi->y }, { dpi->x + dpi->width - 1, dpi->y + dpi->height - 1 } }, PALETTE_INDEX_12);
+    GfxFillRect(&dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, PALETTE_INDEX_12);
 
     // ?
     auto screenCoords = ScreenCoordsXY{ vehiclePreviewWidget->width() / 2, vehiclePreviewWidget->height() - 15 };
@@ -5031,7 +5031,7 @@ static void WindowRideColourScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32
     imageIndex *= carEntry.base_num_frames;
     imageIndex += carEntry.base_image_id;
     auto imageId = ImageId(imageIndex, vehicleColour.Body, vehicleColour.Trim, vehicleColour.Tertiary);
-    GfxDrawSprite(*dpi, imageId, screenCoords);
+    GfxDrawSprite(dpi, imageId, screenCoords);
 }
 
 #pragma endregion
@@ -5259,7 +5259,7 @@ static void WindowRideMusicInvalidate(WindowBase* w)
  *
  *  rct2: 0x006B1ECC
  */
-static void WindowRideMusicPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowRideMusicPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -5639,7 +5639,7 @@ static void WindowRideMeasurementsInvalidate(WindowBase* w)
  *
  *  rct2: 0x006ACF07
  */
-static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -5649,12 +5649,12 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
         Widget* widget = &window_ride_measurements_widgets[WIDX_PAGE_BACKGROUND];
 
         ScreenCoordsXY widgetCoords(w->windowPos.x + widget->width() / 2, w->windowPos.y + widget->top + 40);
-        DrawTextWrapped(*dpi, widgetCoords, w->width - 8, STR_CLICK_ITEMS_OF_SCENERY_TO_SELECT, {}, { TextAlignment::CENTRE });
+        DrawTextWrapped(dpi, widgetCoords, w->width - 8, STR_CLICK_ITEMS_OF_SCENERY_TO_SELECT, {}, { TextAlignment::CENTRE });
 
         widgetCoords.x = w->windowPos.x + 4;
         widgetCoords.y = w->windowPos.y + window_ride_measurements_widgets[WIDX_SELECT_NEARBY_SCENERY].bottom + 17;
         GfxFillRectInset(
-            dpi, { widgetCoords, { w->windowPos.x + 312, widgetCoords.y + 1 } }, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
+            &dpi, { widgetCoords, { w->windowPos.x + 312, widgetCoords.y + 1 } }, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
     }
     else
     {
@@ -5674,7 +5674,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
             ft.Add<uint32_t>(ride->excitement);
             ft.Add<StringId>(ratingName);
             StringId stringId = !RideHasRatings(*ride) ? STR_EXCITEMENT_RATING_NOT_YET_AVAILABLE : STR_EXCITEMENT_RATING;
-            DrawTextBasic(*dpi, screenCoords, stringId, ft);
+            DrawTextBasic(dpi, screenCoords, stringId, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
 
             // Intensity
@@ -5689,7 +5689,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
             else if (ride->intensity >= RIDE_RATING(10, 00))
                 stringId = STR_INTENSITY_RATING_RED;
 
-            DrawTextBasic(*dpi, screenCoords, stringId, ft);
+            DrawTextBasic(dpi, screenCoords, stringId, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
 
             // Nausea
@@ -5698,12 +5698,12 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
             ft.Add<uint32_t>(ride->nausea);
             ft.Add<StringId>(ratingName);
             stringId = !RideHasRatings(*ride) ? STR_NAUSEA_RATING_NOT_YET_AVAILABLE : STR_NAUSEA_RATING;
-            DrawTextBasic(*dpi, screenCoords, stringId, ft);
+            DrawTextBasic(dpi, screenCoords, stringId, ft);
             screenCoords.y += 2 * LIST_ROW_HEIGHT;
 
             // Horizontal rule
             GfxFillRectInset(
-                dpi, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 303, -5 } }, w->colours[1],
+                &dpi, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 303, -5 } }, w->colours[1],
                 INSET_RECT_FLAG_BORDER_INSET);
 
             if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_NO_RAW_STATS))
@@ -5713,7 +5713,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
                     // Holes
                     ft = Formatter();
                     ft.Add<uint16_t>(ride->holes);
-                    DrawTextBasic(*dpi, screenCoords, STR_HOLES, ft);
+                    DrawTextBasic(dpi, screenCoords, STR_HOLES, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
                 }
                 else
@@ -5721,13 +5721,13 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
                     // Max speed
                     ft = Formatter();
                     ft.Add<int32_t>((ride->max_speed * 9) >> 18);
-                    DrawTextBasic(*dpi, screenCoords, STR_MAX_SPEED, ft);
+                    DrawTextBasic(dpi, screenCoords, STR_MAX_SPEED, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Average speed
                     ft = Formatter();
                     ft.Add<int32_t>((ride->average_speed * 9) >> 18);
-                    DrawTextBasic(*dpi, screenCoords, STR_AVERAGE_SPEED, ft);
+                    DrawTextBasic(dpi, screenCoords, STR_AVERAGE_SPEED, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Ride time
@@ -5764,7 +5764,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
                     ft.Add<uint16_t>(0);
                     ft.Add<uint16_t>(0);
                     ft.Add<uint16_t>(0);
-                    DrawTextEllipsised(*dpi, screenCoords, 308, STR_RIDE_TIME, ft);
+                    DrawTextEllipsised(dpi, screenCoords, 308, STR_RIDE_TIME, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
                 }
 
@@ -5803,7 +5803,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
                 ft.Add<uint16_t>(0);
                 ft.Add<uint16_t>(0);
                 ft.Add<uint16_t>(0);
-                DrawTextEllipsised(*dpi, screenCoords, 308, STR_RIDE_LENGTH, ft);
+                DrawTextEllipsised(dpi, screenCoords, 308, STR_RIDE_LENGTH, ft);
 
                 screenCoords.y += LIST_ROW_HEIGHT;
 
@@ -5814,7 +5814,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
 
                     ft = Formatter();
                     ft.Add<fixed16_2dp>(ride->max_positive_vertical_g);
-                    DrawTextBasic(*dpi, screenCoords, stringId, ft);
+                    DrawTextBasic(dpi, screenCoords, stringId, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Max. negative vertical G's
@@ -5822,20 +5822,20 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
                                                                                                : STR_MAX_NEGATIVE_VERTICAL_G;
                     ft = Formatter();
                     ft.Add<int32_t>(ride->max_negative_vertical_g);
-                    DrawTextBasic(*dpi, screenCoords, stringId, ft);
+                    DrawTextBasic(dpi, screenCoords, stringId, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Max lateral G's
                     stringId = ride->max_lateral_g > RIDE_G_FORCES_RED_LATERAL ? STR_MAX_LATERAL_G_RED : STR_MAX_LATERAL_G;
                     ft = Formatter();
                     ft.Add<fixed16_2dp>(ride->max_lateral_g);
-                    DrawTextBasic(*dpi, screenCoords, stringId, ft);
+                    DrawTextBasic(dpi, screenCoords, stringId, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Total 'air' time
                     ft = Formatter();
                     ft.Add<fixed32_2dp>(ride->total_air_time * 3);
-                    DrawTextBasic(*dpi, screenCoords, STR_TOTAL_AIR_TIME, ft);
+                    DrawTextBasic(dpi, screenCoords, STR_TOTAL_AIR_TIME, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
                 }
 
@@ -5845,14 +5845,14 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
                     auto drops = ride->drops & 0x3F;
                     ft = Formatter();
                     ft.Add<uint16_t>(drops);
-                    DrawTextBasic(*dpi, screenCoords, STR_DROPS, ft);
+                    DrawTextBasic(dpi, screenCoords, STR_DROPS, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
 
                     // Highest drop height
                     auto highestDropHeight = (ride->highest_drop_height * 3) / 4;
                     ft = Formatter();
                     ft.Add<int32_t>(highestDropHeight);
-                    DrawTextBasic(*dpi, screenCoords, STR_HIGHEST_DROP_HEIGHT, ft);
+                    DrawTextBasic(dpi, screenCoords, STR_HIGHEST_DROP_HEIGHT, ft);
                     screenCoords.y += LIST_ROW_HEIGHT;
                 }
 
@@ -5863,7 +5863,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
                     {
                         ft = Formatter();
                         ft.Add<uint16_t>(ride->inversions);
-                        DrawTextBasic(*dpi, screenCoords, STR_INVERSIONS, ft);
+                        DrawTextBasic(dpi, screenCoords, STR_INVERSIONS, ft);
                         screenCoords.y += LIST_ROW_HEIGHT;
                     }
                 }
@@ -5871,7 +5871,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo* dpi)
         }
         else
         {
-            DrawTextBasic(*dpi, screenCoords, STR_NO_TEST_RESULTS_YET);
+            DrawTextBasic(dpi, screenCoords, STR_NO_TEST_RESULTS_YET);
         }
     }
 }
@@ -6126,7 +6126,7 @@ static void WindowRideGraphsInvalidate(WindowBase* w)
  *
  *  rct2: 0x006AE4BC
  */
-static void WindowRideGraphsPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowRideGraphsPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     WindowDrawWidgets(*w, dpi);
     WindowRideDrawTabImages(dpi, w);
@@ -6136,9 +6136,9 @@ static void WindowRideGraphsPaint(WindowBase* w, DrawPixelInfo* dpi)
  *
  *  rct2: 0x006AE4C7
  */
-static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32_t scrollIndex)
+static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32_t scrollIndex)
 {
-    GfxClear(dpi, ColourMapA[COLOUR_SATURATED_GREEN].darker);
+    GfxClear(&dpi, ColourMapA[COLOUR_SATURATED_GREEN].darker);
 
     auto widget = &window_ride_graphs_widgets[WIDX_GRAPH];
     auto ride = GetRide(w->rideId);
@@ -6154,7 +6154,7 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32
         // No measurement message
         ScreenCoordsXY stringCoords(widget->width() / 2, widget->height() / 2 - 5);
         int32_t width = widget->width() - 2;
-        DrawTextWrapped(*dpi, stringCoords, width, message.str, message.args, { TextAlignment::CENTRE });
+        DrawTextWrapped(dpi, stringCoords, width, message.str, message.args, { TextAlignment::CENTRE });
         return;
     }
 
@@ -6163,17 +6163,17 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32
     const uint8_t darkColour = ColourMapA[COLOUR_SATURATED_GREEN].mid_dark;
 
     int32_t time = 0;
-    for (int32_t x = 0; x < dpi->x + dpi->width; x += 80)
+    for (int32_t x = 0; x < dpi.x + dpi.width; x += 80)
     {
-        if (x + 80 >= dpi->x)
+        if (x + 80 >= dpi.x)
         {
-            auto coord1 = ScreenCoordsXY{ x, dpi->y };
-            auto coord2 = ScreenCoordsXY{ x, dpi->y + dpi->height - 1 };
-            GfxFillRect(dpi, { coord1, coord2 }, lightColour);
-            GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 16, 0 }, coord2 + ScreenCoordsXY{ 16, 0 } }, darkColour);
-            GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 32, 0 }, coord2 + ScreenCoordsXY{ 32, 0 } }, darkColour);
-            GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 48, 0 }, coord2 + ScreenCoordsXY{ 48, 0 } }, darkColour);
-            GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 64, 0 }, coord2 + ScreenCoordsXY{ 64, 0 } }, darkColour);
+            auto coord1 = ScreenCoordsXY{ x, dpi.y };
+            auto coord2 = ScreenCoordsXY{ x, dpi.y + dpi.height - 1 };
+            GfxFillRect(&dpi, { coord1, coord2 }, lightColour);
+            GfxFillRect(&dpi, { coord1 + ScreenCoordsXY{ 16, 0 }, coord2 + ScreenCoordsXY{ 16, 0 } }, darkColour);
+            GfxFillRect(&dpi, { coord1 + ScreenCoordsXY{ 32, 0 }, coord2 + ScreenCoordsXY{ 32, 0 } }, darkColour);
+            GfxFillRect(&dpi, { coord1 + ScreenCoordsXY{ 48, 0 }, coord2 + ScreenCoordsXY{ 48, 0 } }, darkColour);
+            GfxFillRect(&dpi, { coord1 + ScreenCoordsXY{ 64, 0 }, coord2 + ScreenCoordsXY{ 64, 0 } }, darkColour);
         }
         time += 5;
     }
@@ -6195,7 +6195,7 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32
     {
         // Minor / major line
         int32_t colour = yUnit == 0 ? lightColour : darkColour;
-        GfxFillRect(dpi, { { dpi->x, y }, { dpi->x + dpi->width - 1, y } }, colour);
+        GfxFillRect(&dpi, { { dpi.x, y }, { dpi.x + dpi.width - 1, y } }, colour);
 
         int16_t scaled_yUnit = yUnit;
         // Scale modifier
@@ -6205,27 +6205,27 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32
         auto ft = Formatter();
         ft.Add<int16_t>(scaled_yUnit);
 
-        DrawTextBasic(*dpi, { w->scrolls[0].h_left + 1, y - 4 }, stringID, ft, { FontStyle::Small });
+        DrawTextBasic(dpi, { w->scrolls[0].h_left + 1, y - 4 }, stringID, ft, { FontStyle::Small });
     }
 
     // Time marks
     time = 0;
-    for (int32_t x = 0; x < dpi->x + dpi->width; x += 80)
+    for (int32_t x = 0; x < dpi.x + dpi.width; x += 80)
     {
         auto ft = Formatter();
         ft.Add<int32_t>(time);
-        if (x + 80 >= dpi->x)
-            DrawTextBasic(*dpi, { x + 2, 1 }, STR_RIDE_STATS_TIME, ft, { FontStyle::Small });
+        if (x + 80 >= dpi.x)
+            DrawTextBasic(dpi, { x + 2, 1 }, STR_RIDE_STATS_TIME, ft, { FontStyle::Small });
         time += 5;
     }
 
     // Plot
-    int32_t x = dpi->x;
+    int32_t x = dpi.x;
     int32_t firstPoint, secondPoint;
     // Uses the force limits (used to draw extreme G's in red on measurement tab) to determine if line should be drawn red.
     int32_t intensityThresholdPositive = 0;
     int32_t intensityThresholdNegative = 0;
-    for (int32_t width = 0; width < dpi->width; width++, x++)
+    for (int32_t width = 0; width < dpi.width; width++, x++)
     {
         if (x < 0 || x >= measurement->num_items - 1)
             continue;
@@ -6278,7 +6278,7 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32
         const bool previousMeasurement = x > measurement->current_item;
 
         // Draw the current line in grey.
-        GfxFillRect(dpi, { { x, firstPoint }, { x, secondPoint } }, previousMeasurement ? PALETTE_INDEX_17 : PALETTE_INDEX_21);
+        GfxFillRect(&dpi, { { x, firstPoint }, { x, secondPoint } }, previousMeasurement ? PALETTE_INDEX_17 : PALETTE_INDEX_21);
 
         // Draw red over extreme values (if supported by graph type).
         if (listType == GRAPH_VERTICAL || listType == GRAPH_LATERAL)
@@ -6290,7 +6290,7 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32
             {
                 const auto redLineTop = ScreenCoordsXY{ x, std::max(firstPoint, intensityThresholdNegative) };
                 const auto redLineBottom = ScreenCoordsXY{ x, std::max(secondPoint, intensityThresholdNegative) };
-                GfxFillRect(dpi, { redLineTop, redLineBottom }, redLineColour);
+                GfxFillRect(&dpi, { redLineTop, redLineBottom }, redLineColour);
             }
 
             // Line exceeds positive threshold (at top of graph).
@@ -6298,7 +6298,7 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32
             {
                 const auto redLineTop = ScreenCoordsXY{ x, std::min(firstPoint, intensityThresholdPositive) };
                 const auto redLineBottom = ScreenCoordsXY{ x, std::min(secondPoint, intensityThresholdPositive) };
-                GfxFillRect(dpi, { redLineTop, redLineBottom }, redLineColour);
+                GfxFillRect(&dpi, { redLineTop, redLineBottom }, redLineColour);
             }
         }
     }
@@ -6742,7 +6742,7 @@ static void WindowRideIncomeInvalidate(WindowBase* w)
  *
  *  rct2: 0x006ADCE5
  */
-static void WindowRideIncomePaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowRideIncomePaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     StringId stringId;
     money64 profit;
@@ -6780,7 +6780,7 @@ static void WindowRideIncomePaint(WindowBase* w, DrawPixelInfo* dpi)
         auto ft = Formatter();
         ft.Add<money64>(profit);
 
-        DrawTextBasic(*dpi, screenCoords, stringId, ft);
+        DrawTextBasic(dpi, screenCoords, stringId, ft);
     }
     screenCoords.y += 44;
 
@@ -6804,7 +6804,7 @@ static void WindowRideIncomePaint(WindowBase* w, DrawPixelInfo* dpi)
         auto ft = Formatter();
         ft.Add<money64>(profit);
 
-        DrawTextBasic(*dpi, screenCoords, stringId, ft);
+        DrawTextBasic(dpi, screenCoords, stringId, ft);
     }
     screenCoords.y += 18;
 
@@ -6814,7 +6814,7 @@ static void WindowRideIncomePaint(WindowBase* w, DrawPixelInfo* dpi)
         auto ft = Formatter();
         ft.Add<money64>(ride->income_per_hour);
 
-        DrawTextBasic(*dpi, screenCoords, STR_INCOME_PER_HOUR, ft);
+        DrawTextBasic(dpi, screenCoords, STR_INCOME_PER_HOUR, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
@@ -6823,7 +6823,7 @@ static void WindowRideIncomePaint(WindowBase* w, DrawPixelInfo* dpi)
     stringId = ride->upkeep_cost == MONEY64_UNDEFINED ? STR_RUNNING_COST_UNKNOWN : STR_RUNNING_COST_PER_HOUR;
     auto ft = Formatter();
     ft.Add<money64>(costPerHour);
-    DrawTextBasic(*dpi, screenCoords, stringId, ft);
+    DrawTextBasic(dpi, screenCoords, stringId, ft);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Profit per hour
@@ -6831,7 +6831,7 @@ static void WindowRideIncomePaint(WindowBase* w, DrawPixelInfo* dpi)
     {
         ft = Formatter();
         ft.Add<money64>(ride->profit);
-        DrawTextBasic(*dpi, screenCoords, STR_PROFIT_PER_HOUR, ft);
+        DrawTextBasic(dpi, screenCoords, STR_PROFIT_PER_HOUR, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
     screenCoords.y += 5;
@@ -6839,7 +6839,7 @@ static void WindowRideIncomePaint(WindowBase* w, DrawPixelInfo* dpi)
     // Total profit
     ft = Formatter();
     ft.Add<money64>(ride->total_profit);
-    DrawTextBasic(*dpi, screenCoords, STR_TOTAL_PROFIT, ft);
+    DrawTextBasic(dpi, screenCoords, STR_TOTAL_PROFIT, ft);
 }
 
 #pragma endregion
@@ -6969,7 +6969,7 @@ static void WindowRideCustomerInvalidate(WindowBase* w)
  *
  *  rct2: 0x006AD6CD
  */
-static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi)
+static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo& dpi)
 {
     ShopItem shopItem;
     int16_t popularity, satisfaction, queueTime;
@@ -6991,14 +6991,14 @@ static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi)
     {
         auto ft = Formatter();
         ft.Add<int16_t>(ride->num_riders);
-        DrawTextBasic(*dpi, screenCoords, STR_CUSTOMERS_ON_RIDE, ft);
+        DrawTextBasic(dpi, screenCoords, STR_CUSTOMERS_ON_RIDE, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
     // Customers per hour
     auto ft = Formatter();
     ft.Add<int32_t>(RideCustomersPerHour(*ride));
-    DrawTextBasic(*dpi, screenCoords, STR_CUSTOMERS_PER_HOUR, ft);
+    DrawTextBasic(dpi, screenCoords, STR_CUSTOMERS_PER_HOUR, ft);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Popularity
@@ -7014,7 +7014,7 @@ static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi)
     }
     ft = Formatter();
     ft.Add<int16_t>(popularity);
-    DrawTextBasic(*dpi, screenCoords, stringId, ft);
+    DrawTextBasic(dpi, screenCoords, stringId, ft);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Satisfaction
@@ -7030,7 +7030,7 @@ static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi)
     }
     ft = Formatter();
     ft.Add<int16_t>(satisfaction);
-    DrawTextBasic(*dpi, screenCoords, stringId, ft);
+    DrawTextBasic(dpi, screenCoords, stringId, ft);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Queue time
@@ -7040,7 +7040,7 @@ static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi)
         stringId = queueTime == 1 ? STR_QUEUE_TIME_MINUTE : STR_QUEUE_TIME_MINUTES;
         ft = Formatter();
         ft.Add<int32_t>(queueTime);
-        screenCoords.y += DrawTextWrapped(*dpi, screenCoords, 308, stringId, ft, { TextAlignment::LEFT });
+        screenCoords.y += DrawTextWrapped(dpi, screenCoords, 308, stringId, ft, { TextAlignment::LEFT });
         screenCoords.y += 5;
     }
 
@@ -7051,7 +7051,7 @@ static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi)
         ft = Formatter();
         ft.Add<StringId>(GetShopItemDescriptor(shopItem).Naming.Plural);
         ft.Add<uint32_t>(ride->no_primary_items_sold);
-        DrawTextBasic(*dpi, screenCoords, STR_ITEMS_SOLD, ft);
+        DrawTextBasic(dpi, screenCoords, STR_ITEMS_SOLD, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
@@ -7063,14 +7063,14 @@ static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi)
         ft = Formatter();
         ft.Add<StringId>(GetShopItemDescriptor(shopItem).Naming.Plural);
         ft.Add<uint32_t>(ride->no_secondary_items_sold);
-        DrawTextBasic(*dpi, screenCoords, STR_ITEMS_SOLD, ft);
+        DrawTextBasic(dpi, screenCoords, STR_ITEMS_SOLD, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
 
     // Total customers
     ft = Formatter();
     ft.Add<uint32_t>(ride->total_customers);
-    DrawTextBasic(*dpi, screenCoords, STR_TOTAL_CUSTOMERS, ft);
+    DrawTextBasic(dpi, screenCoords, STR_TOTAL_CUSTOMERS, ft);
     screenCoords.y += LIST_ROW_HEIGHT;
 
     // Guests favourite
@@ -7079,7 +7079,7 @@ static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi)
         ft = Formatter();
         ft.Add<uint32_t>(ride->guests_favourite);
         stringId = ride->guests_favourite == 1 ? STR_FAVOURITE_RIDE_OF_GUEST : STR_FAVOURITE_RIDE_OF_GUESTS;
-        DrawTextBasic(*dpi, screenCoords, stringId, ft);
+        DrawTextBasic(dpi, screenCoords, stringId, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
     }
     screenCoords.y += 2;
@@ -7090,7 +7090,7 @@ static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi)
     stringId = age == 0 ? STR_BUILT_THIS_YEAR : age == 1 ? STR_BUILT_LAST_YEAR : STR_BUILT_YEARS_AGO;
     ft = Formatter();
     ft.Add<int16_t>(age);
-    DrawTextBasic(*dpi, screenCoords, stringId, ft);
+    DrawTextBasic(dpi, screenCoords, stringId, ft);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -875,7 +875,7 @@ static void WindowRideDrawTabImage(DrawPixelInfo* dpi, WindowBase* w, int32_t pa
         }
 
         const auto& widget = w->widgets[widgetIndex];
-        GfxDrawSprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
+        GfxDrawSprite(*dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
     }
 }
 
@@ -912,7 +912,7 @@ static void WindowRideDrawTabMain(DrawPixelInfo* dpi, WindowBase* w)
             }
 
             const auto& widget = w->widgets[widgetIndex];
-            GfxDrawSprite(dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
+            GfxDrawSprite(*dpi, ImageId(spriteIndex), w->windowPos + ScreenCoordsXY{ widget.left, widget.top });
         }
     }
 }
@@ -984,7 +984,7 @@ static void WindowRideDrawTabVehicle(DrawPixelInfo* dpi, WindowBase* w)
         imageIndex *= carEntry.base_num_frames;
         imageIndex += carEntry.base_image_id;
         auto imageId = ImageId(imageIndex, vehicleColour.Body, vehicleColour.Trim, vehicleColour.Tertiary);
-        GfxDrawSprite(&clipDPI, imageId, screenCoords);
+        GfxDrawSprite(clipDPI, imageId, screenCoords);
     }
 }
 
@@ -1006,7 +1006,7 @@ static void WindowRideDrawTabCustomer(DrawPixelInfo* dpi, WindowBase* w)
         spriteIndex += GetPeepAnimation(PeepSpriteType::Normal).base_image + 1;
 
         GfxDrawSprite(
-            dpi, ImageId(spriteIndex, COLOUR_BRIGHT_RED, COLOUR_TEAL),
+            *dpi, ImageId(spriteIndex, COLOUR_BRIGHT_RED, COLOUR_TEAL),
             w->windowPos + ScreenCoordsXY{ widget.midX(), widget.bottom - 6 });
     }
 }
@@ -2592,7 +2592,7 @@ static void WindowRideMainPaint(WindowBase* w, DrawPixelInfo* dpi)
     {
         WindowDrawViewport(dpi, *w);
         if (w->viewport->flags & VIEWPORT_FLAG_SOUND_ON)
-            GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), w->windowPos + ScreenCoordsXY{ 2, 2 });
+            GfxDrawSprite(*dpi, ImageId(SPR_HEARING_VIEWPORT), w->windowPos + ScreenCoordsXY{ 2, 2 });
     }
 
     // View dropdown
@@ -3038,7 +3038,7 @@ static void WindowRideVehicleScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int3
 
         VehicleDrawInfo* current = nextSpriteToDraw;
         while (--current >= trainCarImages)
-            GfxDrawSprite(dpi, current->imageId, { current->x, current->y });
+            GfxDrawSprite(*dpi, current->imageId, { current->x, current->y });
 
         startX += 36;
     }
@@ -4130,7 +4130,7 @@ static void WindowRideMaintenancePaint(WindowBase* w, DrawPixelInfo* dpi)
     Widget* widget = &window_ride_maintenance_widgets[WIDX_LOCATE_MECHANIC];
     auto screenCoords = w->windowPos + ScreenCoordsXY{ widget->left, widget->top };
     auto image = ImageId(SPR_MECHANIC, COLOUR_BLACK, gStaffMechanicColour);
-    GfxDrawSprite(dpi, image, screenCoords);
+    GfxDrawSprite(*dpi, image, screenCoords);
 
     // Inspection label
     widget = &window_ride_maintenance_widgets[WIDX_INSPECTION_INTERVAL];
@@ -4909,7 +4909,7 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
         const auto& rtd = ride->GetRideTypeDescriptor();
         if (rtd.HasFlag(RIDE_TYPE_FLAG_IS_MAZE))
         {
-            GfxDrawSprite(dpi, ImageId(MazeOptions[trackColour.supports].sprite), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(MazeOptions[trackColour.supports].sprite), screenCoords);
         }
         else
         {
@@ -4917,14 +4917,14 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
             int32_t spriteIndex = typeDescriptor.ColourPreview.Track;
             if (spriteIndex != 0)
             {
-                GfxDrawSprite(dpi, ImageId(spriteIndex, trackColour.main, trackColour.additional), screenCoords);
+                GfxDrawSprite(*dpi, ImageId(spriteIndex, trackColour.main, trackColour.additional), screenCoords);
             }
 
             // Supports
             spriteIndex = typeDescriptor.ColourPreview.Supports;
             if (spriteIndex != 0)
             {
-                GfxDrawSprite(dpi, ImageId(spriteIndex, trackColour.supports), screenCoords);
+                GfxDrawSprite(*dpi, ImageId(spriteIndex, trackColour.supports), screenCoords);
             }
         }
     }
@@ -4948,11 +4948,11 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
                 }
             }
 
-            GfxDrawSprite(dpi, ImageId(GetShopItemDescriptor(shopItem).Image, spriteColour), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(GetShopItemDescriptor(shopItem).Image, spriteColour), screenCoords);
         }
         else
         {
-            GfxDrawSprite(dpi, ImageId(GetShopItemDescriptor(shopItem).Image, ride->track_colour[0].main), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(GetShopItemDescriptor(shopItem).Image, ride->track_colour[0].main), screenCoords);
         }
     }
 
@@ -4974,16 +4974,16 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo* dpi)
                 auto imageId = ImageId(stationObj->BaseImageId, trackColour.main, trackColour.additional);
 
                 // Back
-                GfxDrawSprite(&clippedDpi, imageId, { 34, 20 });
+                GfxDrawSprite(clippedDpi, imageId, { 34, 20 });
 
                 // Front
-                GfxDrawSprite(&clippedDpi, imageId.WithIndexOffset(4), { 34, 20 });
+                GfxDrawSprite(clippedDpi, imageId.WithIndexOffset(4), { 34, 20 });
 
                 // Glass
                 if (stationObj->Flags & STATION_OBJECT_FLAGS::IS_TRANSPARENT)
                 {
                     auto glassImageId = ImageId(stationObj->BaseImageId + 20).WithTransparency(trackColour.main);
-                    GfxDrawSprite(&clippedDpi, glassImageId, { 34, 20 });
+                    GfxDrawSprite(clippedDpi, glassImageId, { 34, 20 });
                 }
             }
         }
@@ -5031,7 +5031,7 @@ static void WindowRideColourScrollpaint(WindowBase* w, DrawPixelInfo* dpi, int32
     imageIndex *= carEntry.base_num_frames;
     imageIndex += carEntry.base_image_id;
     auto imageId = ImageId(imageIndex, vehicleColour.Body, vehicleColour.Trim, vehicleColour.Tertiary);
-    GfxDrawSprite(dpi, imageId, screenCoords);
+    GfxDrawSprite(*dpi, imageId, screenCoords);
 }
 
 #pragma endregion

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2972,7 +2972,7 @@ static void WindowRideVehicleScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int3
     const auto* rideEntry = ride->GetRideEntry();
 
     // Background
-    GfxFillRect(&dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } }, PALETTE_INDEX_12);
+    GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } }, PALETTE_INDEX_12);
 
     Widget* widget = &window_ride_vehicle_widgets[WIDX_VEHICLE_TRAINS_PREVIEW];
     int32_t startX = std::max(2, (widget->width() - ((ride->NumTrains - 1) * 36)) / 2 - 25);
@@ -3732,7 +3732,7 @@ static void WindowRideOperatingPaint(WindowBase* w, DrawPixelInfo& dpi)
 
     // Horizontal rule between mode settings and depart settings
     GfxFillRectInset(
-        &dpi,
+        dpi,
         { w->windowPos + ScreenCoordsXY{ window_ride_operating_widgets[WIDX_PAGE_BACKGROUND].left + 4, 103 },
           w->windowPos + ScreenCoordsXY{ window_ride_operating_widgets[WIDX_PAGE_BACKGROUND].right - 5, 104 } },
         w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
@@ -3786,7 +3786,7 @@ static void WindowRideLocateMechanic(WindowBase* w)
 static void WindowRideMaintenanceDrawBar(
     WindowBase* w, DrawPixelInfo& dpi, const ScreenCoordsXY& coords, int32_t value, int32_t colour)
 {
-    GfxFillRectInset(&dpi, { coords, coords + ScreenCoordsXY{ 149, 8 } }, w->colours[1], INSET_RECT_F_30);
+    GfxFillRectInset(dpi, { coords, coords + ScreenCoordsXY{ 149, 8 } }, w->colours[1], INSET_RECT_F_30);
     if (colour & BAR_BLINK)
     {
         colour &= ~BAR_BLINK;
@@ -3797,7 +3797,7 @@ static void WindowRideMaintenanceDrawBar(
     value = ((186 * ((value * 2) & 0xFF)) >> 8) & 0xFF;
     if (value > 2)
     {
-        GfxFillRectInset(&dpi, { coords + ScreenCoordsXY{ 2, 1 }, coords + ScreenCoordsXY{ value + 1, 7 } }, colour, 0);
+        GfxFillRectInset(dpi, { coords + ScreenCoordsXY{ 2, 1 }, coords + ScreenCoordsXY{ value + 1, 7 } }, colour, 0);
     }
 }
 
@@ -4892,7 +4892,7 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo& dpi)
     const auto& trackPreviewWidget = window_ride_colour_widgets[WIDX_TRACK_PREVIEW];
     if (trackPreviewWidget.type != WindowWidgetType::Empty)
         GfxFillRect(
-            &dpi,
+            dpi,
             { { w->windowPos + ScreenCoordsXY{ trackPreviewWidget.left + 1, trackPreviewWidget.top + 1 } },
               { w->windowPos + ScreenCoordsXY{ trackPreviewWidget.right - 1, trackPreviewWidget.bottom - 1 } } },
             PALETTE_INDEX_12);
@@ -5010,7 +5010,7 @@ static void WindowRideColourScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32
     auto vehicleColour = RideGetVehicleColour(*ride, w->vehicleIndex);
 
     // Background colour
-    GfxFillRect(&dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, PALETTE_INDEX_12);
+    GfxFillRect(dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, PALETTE_INDEX_12);
 
     // ?
     auto screenCoords = ScreenCoordsXY{ vehiclePreviewWidget->width() / 2, vehiclePreviewWidget->height() - 15 };
@@ -5654,7 +5654,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo& dpi)
         widgetCoords.x = w->windowPos.x + 4;
         widgetCoords.y = w->windowPos.y + window_ride_measurements_widgets[WIDX_SELECT_NEARBY_SCENERY].bottom + 17;
         GfxFillRectInset(
-            &dpi, { widgetCoords, { w->windowPos.x + 312, widgetCoords.y + 1 } }, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
+            dpi, { widgetCoords, { w->windowPos.x + 312, widgetCoords.y + 1 } }, w->colours[1], INSET_RECT_FLAG_BORDER_INSET);
     }
     else
     {
@@ -5703,7 +5703,7 @@ static void WindowRideMeasurementsPaint(WindowBase* w, DrawPixelInfo& dpi)
 
             // Horizontal rule
             GfxFillRectInset(
-                &dpi, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 303, -5 } }, w->colours[1],
+                dpi, { screenCoords - ScreenCoordsXY{ 0, 6 }, screenCoords + ScreenCoordsXY{ 303, -5 } }, w->colours[1],
                 INSET_RECT_FLAG_BORDER_INSET);
 
             if (!(ride->lifecycle_flags & RIDE_LIFECYCLE_NO_RAW_STATS))
@@ -6169,11 +6169,11 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32
         {
             auto coord1 = ScreenCoordsXY{ x, dpi.y };
             auto coord2 = ScreenCoordsXY{ x, dpi.y + dpi.height - 1 };
-            GfxFillRect(&dpi, { coord1, coord2 }, lightColour);
-            GfxFillRect(&dpi, { coord1 + ScreenCoordsXY{ 16, 0 }, coord2 + ScreenCoordsXY{ 16, 0 } }, darkColour);
-            GfxFillRect(&dpi, { coord1 + ScreenCoordsXY{ 32, 0 }, coord2 + ScreenCoordsXY{ 32, 0 } }, darkColour);
-            GfxFillRect(&dpi, { coord1 + ScreenCoordsXY{ 48, 0 }, coord2 + ScreenCoordsXY{ 48, 0 } }, darkColour);
-            GfxFillRect(&dpi, { coord1 + ScreenCoordsXY{ 64, 0 }, coord2 + ScreenCoordsXY{ 64, 0 } }, darkColour);
+            GfxFillRect(dpi, { coord1, coord2 }, lightColour);
+            GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 16, 0 }, coord2 + ScreenCoordsXY{ 16, 0 } }, darkColour);
+            GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 32, 0 }, coord2 + ScreenCoordsXY{ 32, 0 } }, darkColour);
+            GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 48, 0 }, coord2 + ScreenCoordsXY{ 48, 0 } }, darkColour);
+            GfxFillRect(dpi, { coord1 + ScreenCoordsXY{ 64, 0 }, coord2 + ScreenCoordsXY{ 64, 0 } }, darkColour);
         }
         time += 5;
     }
@@ -6195,7 +6195,7 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32
     {
         // Minor / major line
         int32_t colour = yUnit == 0 ? lightColour : darkColour;
-        GfxFillRect(&dpi, { { dpi.x, y }, { dpi.x + dpi.width - 1, y } }, colour);
+        GfxFillRect(dpi, { { dpi.x, y }, { dpi.x + dpi.width - 1, y } }, colour);
 
         int16_t scaled_yUnit = yUnit;
         // Scale modifier
@@ -6278,7 +6278,7 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32
         const bool previousMeasurement = x > measurement->current_item;
 
         // Draw the current line in grey.
-        GfxFillRect(&dpi, { { x, firstPoint }, { x, secondPoint } }, previousMeasurement ? PALETTE_INDEX_17 : PALETTE_INDEX_21);
+        GfxFillRect(dpi, { { x, firstPoint }, { x, secondPoint } }, previousMeasurement ? PALETTE_INDEX_17 : PALETTE_INDEX_21);
 
         // Draw red over extreme values (if supported by graph type).
         if (listType == GRAPH_VERTICAL || listType == GRAPH_LATERAL)
@@ -6290,7 +6290,7 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32
             {
                 const auto redLineTop = ScreenCoordsXY{ x, std::max(firstPoint, intensityThresholdNegative) };
                 const auto redLineBottom = ScreenCoordsXY{ x, std::max(secondPoint, intensityThresholdNegative) };
-                GfxFillRect(&dpi, { redLineTop, redLineBottom }, redLineColour);
+                GfxFillRect(dpi, { redLineTop, redLineBottom }, redLineColour);
             }
 
             // Line exceeds positive threshold (at top of graph).
@@ -6298,7 +6298,7 @@ static void WindowRideGraphsScrollpaint(WindowBase* w, DrawPixelInfo& dpi, int32
             {
                 const auto redLineTop = ScreenCoordsXY{ x, std::min(firstPoint, intensityThresholdPositive) };
                 const auto redLineBottom = ScreenCoordsXY{ x, std::min(secondPoint, intensityThresholdPositive) };
-                GfxFillRect(&dpi, { redLineTop, redLineBottom }, redLineColour);
+                GfxFillRect(dpi, { redLineTop, redLineBottom }, redLineColour);
             }
         }
     }

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -4962,8 +4962,7 @@ static void WindowRideColourPaint(WindowBase* w, DrawPixelInfo& dpi)
     if (entrancePreviewWidget.type != WindowWidgetType::Empty)
     {
         if (ClipDrawPixelInfo(
-                clippedDpi, dpi,
-                w->windowPos + ScreenCoordsXY{ entrancePreviewWidget.left + 1, entrancePreviewWidget.top + 1 },
+                clippedDpi, dpi, w->windowPos + ScreenCoordsXY{ entrancePreviewWidget.left + 1, entrancePreviewWidget.top + 1 },
                 entrancePreviewWidget.width(), entrancePreviewWidget.height()))
         {
             GfxClear(&clippedDpi, PALETTE_INDEX_12);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1519,7 +1519,7 @@ public:
         widgetHeight = widget->height() - 1;
         if (ClipDrawPixelInfo(&clipdpi, &dpi, screenCoords, widgetWidth, widgetHeight))
         {
-            DrawTrackPiece(&clipdpi, rideIndex, trackType, trackDirection, liftHillAndInvertedState, widgetWidth, widgetHeight);
+            DrawTrackPiece(clipdpi, rideIndex, trackType, trackDirection, liftHillAndInvertedState, widgetWidth, widgetHeight);
         }
 
         // Draw cost
@@ -2624,7 +2624,7 @@ private:
     }
 
     void DrawTrackPiece(
-        DrawPixelInfo* dpi, RideId rideIndex, int32_t trackType, int32_t trackDirection, int32_t liftHillAndInvertedState,
+        DrawPixelInfo& dpi, RideId rideIndex, int32_t trackType, int32_t trackDirection, int32_t liftHillAndInvertedState,
         int32_t widgetWidth, int32_t widgetHeight)
     {
         auto currentRide = GetRide(rideIndex);
@@ -2656,20 +2656,20 @@ private:
 
         const ScreenCoordsXY rotatedScreenCoords = Translate3DTo2DWithZ(GetCurrentRotation(), mapCoords);
 
-        dpi->x += rotatedScreenCoords.x - widgetWidth / 2;
-        dpi->y += rotatedScreenCoords.y - widgetHeight / 2 - 16;
+        dpi.x += rotatedScreenCoords.x - widgetWidth / 2;
+        dpi.y += rotatedScreenCoords.y - widgetHeight / 2 - 16;
 
         DrawTrackPieceHelper(dpi, rideIndex, trackType, trackDirection, liftHillAndInvertedState, { 4096, 4096 }, 1024);
     }
 
     void DrawTrackPieceHelper(
-        DrawPixelInfo* dpi, RideId rideIndex, int32_t trackType, int32_t trackDirection, int32_t liftHillAndInvertedState,
+        DrawPixelInfo& dpi, RideId rideIndex, int32_t trackType, int32_t trackDirection, int32_t liftHillAndInvertedState,
         const CoordsXY& originCoords, int32_t originZ)
     {
         TileElement tempSideTrackTileElement{ 0x80, 0x8F, 128, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         TileElement tempTrackTileElement{};
         TileElement* backupTileElementArrays[5]{};
-        PaintSession* session = PaintSessionAlloc(dpi, 0);
+        PaintSession* session = PaintSessionAlloc(&dpi, 0);
         trackDirection &= 3;
 
         auto currentRide = GetRide(rideIndex);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -2669,7 +2669,7 @@ private:
         TileElement tempSideTrackTileElement{ 0x80, 0x8F, 128, 128, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         TileElement tempTrackTileElement{};
         TileElement* backupTileElementArrays[5]{};
-        PaintSession* session = PaintSessionAlloc(&dpi, 0);
+        PaintSession* session = PaintSessionAlloc(dpi, 0);
         trackDirection &= 3;
 
         auto currentRide = GetRide(rideIndex);

--- a/src/openrct2-ui/windows/RideConstruction.cpp
+++ b/src/openrct2-ui/windows/RideConstruction.cpp
@@ -1517,7 +1517,7 @@ public:
         auto screenCoords = ScreenCoordsXY{ windowPos.x + widget->left + 1, windowPos.y + widget->top + 1 };
         widgetWidth = widget->width() - 1;
         widgetHeight = widget->height() - 1;
-        if (ClipDrawPixelInfo(&clipdpi, &dpi, screenCoords, widgetWidth, widgetHeight))
+        if (ClipDrawPixelInfo(clipdpi, dpi, screenCoords, widgetWidth, widgetHeight))
         {
             DrawTrackPiece(clipdpi, rideIndex, trackType, trackDirection, liftHillAndInvertedState, widgetWidth, widgetHeight);
         }

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -526,7 +526,7 @@ public:
     void OnScrollDraw(int32_t scrollIndex, DrawPixelInfo& dpi) override
     {
         auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
-        GfxFillRect(&dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width, dpi.height } }, ColourMapA[colours[1]].mid_light);
+        GfxFillRect(dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width, dpi.height } }, ColourMapA[colours[1]].mid_light);
 
         auto y = 0;
         for (size_t i = 0; i < _rideList.size(); i++)
@@ -535,7 +535,7 @@ public:
             if (i == static_cast<size_t>(selected_list_item))
             {
                 // Background highlight
-                GfxFilterRect(&dpi, { 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1 }, FilterPaletteID::PaletteDarken1);
+                GfxFilterRect(dpi, { 0, y, 800, y + SCROLLABLE_ROW_HEIGHT - 1 }, FilterPaletteID::PaletteDarken1);
                 format = (_quickDemolishMode ? STR_LIGHTPINK_STRINGID : STR_WINDOW_COLOUR_2_STRINGID);
             }
 

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -748,21 +748,21 @@ private:
         if (page == PAGE_RIDES)
             sprite_idx += frame_no / 4;
         GfxDrawSprite(
-            dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
+            *dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
 
         // Shops and stalls tab
         sprite_idx = SPR_TAB_SHOPS_AND_STALLS_0;
         if (page == PAGE_SHOPS_AND_STALLS)
             sprite_idx += frame_no / 4;
         GfxDrawSprite(
-            dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
+            *dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
 
         // Information kiosks and facilities tab
         sprite_idx = SPR_TAB_KIOSKS_AND_FACILITIES_0;
         if (page == PAGE_KIOSKS_AND_FACILITIES)
             sprite_idx += (frame_no / 4) % 8;
         GfxDrawSprite(
-            dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
+            *dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
     }
 
     /**

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -509,8 +509,8 @@ public:
      */
     void OnDraw(DrawPixelInfo& dpi) override
     {
-        WindowDrawWidgets(*this, &dpi);
-        DrawTabImages(&dpi);
+        WindowDrawWidgets(*this, dpi);
+        DrawTabImages(dpi);
 
         // Draw number of attractions on bottom
         auto ft = Formatter();
@@ -739,7 +739,7 @@ private:
      *
      *  rct2: 0x006B38EA
      */
-    void DrawTabImages(DrawPixelInfo* dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         int32_t sprite_idx;
 
@@ -748,21 +748,21 @@ private:
         if (page == PAGE_RIDES)
             sprite_idx += frame_no / 4;
         GfxDrawSprite(
-            *dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
+            dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_1].left, widgets[WIDX_TAB_1].top });
 
         // Shops and stalls tab
         sprite_idx = SPR_TAB_SHOPS_AND_STALLS_0;
         if (page == PAGE_SHOPS_AND_STALLS)
             sprite_idx += frame_no / 4;
         GfxDrawSprite(
-            *dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
+            dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_2].left, widgets[WIDX_TAB_2].top });
 
         // Information kiosks and facilities tab
         sprite_idx = SPR_TAB_KIOSKS_AND_FACILITIES_0;
         if (page == PAGE_KIOSKS_AND_FACILITIES)
             sprite_idx += (frame_no / 4) % 8;
         GfxDrawSprite(
-            *dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
+            dpi, ImageId(sprite_idx), windowPos + ScreenCoordsXY{ widgets[WIDX_TAB_3].left, widgets[WIDX_TAB_3].top });
     }
 
     /**

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -474,7 +474,7 @@ public:
                     if (isCompleted)
                     {
                         // Draw completion tick
-                        GfxDrawSprite(&dpi, ImageId(SPR_MENU_CHECKMARK), { widgets[WIDX_SCENARIOLIST].width() - 45, y + 1 });
+                        GfxDrawSprite(dpi, ImageId(SPR_MENU_CHECKMARK), { widgets[WIDX_SCENARIOLIST].width() - 45, y + 1 });
 
                         // Draw completion score
                         u8string completedByName = "???";

--- a/src/openrct2-ui/windows/ScenarioSelect.cpp
+++ b/src/openrct2-ui/windows/ScenarioSelect.cpp
@@ -448,7 +448,7 @@ public:
                     bool isHighlighted = highlighted_scenario == scenario;
                     if (isHighlighted)
                     {
-                        GfxFilterRect(&dpi, { 0, y, width, y + scenarioItemHeight - 1 }, FilterPaletteID::PaletteDarken1);
+                        GfxFilterRect(dpi, { 0, y, width, y + scenarioItemHeight - 1 }, FilterPaletteID::PaletteDarken1);
                     }
 
                     bool isCompleted = scenario->Highscore != nullptr;
@@ -521,21 +521,21 @@ private:
         int32_t lineY = y + 4;
         auto lightLineLeftTop1 = ScreenCoordsXY{ left, lineY };
         auto lightLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY };
-        GfxDrawLine(&dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
+        GfxDrawLine(dpi, { lightLineLeftTop1, lightLineRightBottom1 }, lightColour);
 
         auto lightLineLeftTop2 = ScreenCoordsXY{ strRight, lineY };
         auto lightLineRightBottom2 = ScreenCoordsXY{ right, lineY };
-        GfxDrawLine(&dpi, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
+        GfxDrawLine(dpi, { lightLineLeftTop2, lightLineRightBottom2 }, lightColour);
 
         // Draw dark horizontal rule
         lineY++;
         auto darkLineLeftTop1 = ScreenCoordsXY{ left, lineY };
         auto darkLineRightBottom1 = ScreenCoordsXY{ strLeft, lineY };
-        GfxDrawLine(&dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
+        GfxDrawLine(dpi, { darkLineLeftTop1, darkLineRightBottom1 }, darkColour);
 
         auto darkLineLeftTop2 = ScreenCoordsXY{ strRight, lineY };
         auto darkLineRightBottom2 = ScreenCoordsXY{ right, lineY };
-        GfxDrawLine(&dpi, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
+        GfxDrawLine(dpi, { darkLineLeftTop2, darkLineRightBottom2 }, darkColour);
     }
 
     void InitialiseListItems()

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1466,7 +1466,7 @@ private:
             if (_tabEntries[tabIndex].IsAll())
             {
                 auto imageId = ImageId(SPR_G2_INFINITY, FilterPaletteID::PaletteNull);
-                GfxDrawSprite(&dpi, imageId, offset + widgetCoordsXY + ScreenCoordsXY(2, 6));
+                GfxDrawSprite(dpi, imageId, offset + widgetCoordsXY + ScreenCoordsXY(2, 6));
             }
         }
     }
@@ -1477,8 +1477,8 @@ private:
         {
             auto bannerEntry = OpenRCT2::ObjectManager::GetObjectEntry<BannerSceneryEntry>(scenerySelection.EntryIndex);
             auto imageId = ImageId(bannerEntry->image + gWindowSceneryRotation * 2, gWindowSceneryPrimaryColour);
-            GfxDrawSprite(&dpi, imageId, { 33, 40 });
-            GfxDrawSprite(&dpi, imageId.WithIndexOffset(1), { 33, 40 });
+            GfxDrawSprite(dpi, imageId, { 33, 40 });
+            GfxDrawSprite(dpi, imageId.WithIndexOffset(1), { 33, 40 });
         }
         else if (scenerySelection.SceneryType == SCENERY_TYPE_LARGE)
         {
@@ -1490,7 +1490,7 @@ private:
                 imageId = imageId.WithSecondary(gWindowScenerySecondaryColour);
             if (sceneryEntry->flags & LARGE_SCENERY_FLAG_HAS_TERTIARY_COLOUR)
                 imageId = imageId.WithTertiary(gWindowSceneryTertiaryColour);
-            GfxDrawSprite(&dpi, imageId, { 33, 0 });
+            GfxDrawSprite(dpi, imageId, { 33, 0 });
         }
         else if (scenerySelection.SceneryType == SCENERY_TYPE_WALL)
         {
@@ -1504,10 +1504,10 @@ private:
                 {
                     imageId = imageId.WithSecondary(gWindowScenerySecondaryColour);
                 }
-                GfxDrawSprite(&dpi, imageId, { 47, spriteTop });
+                GfxDrawSprite(dpi, imageId, { 47, spriteTop });
 
                 auto glassImageId = ImageId(wallEntry->image + 6).WithTransparency(gWindowSceneryPrimaryColour);
-                GfxDrawSprite(&dpi, glassImageId, { 47, spriteTop });
+                GfxDrawSprite(dpi, glassImageId, { 47, spriteTop });
             }
             else
             {
@@ -1520,11 +1520,11 @@ private:
                         imageId = imageId.WithTertiary(gWindowSceneryTertiaryColour);
                     }
                 }
-                GfxDrawSprite(&dpi, imageId, { 47, spriteTop });
+                GfxDrawSprite(dpi, imageId, { 47, spriteTop });
 
                 if (wallEntry->flags & WALL_SCENERY_IS_DOOR)
                 {
-                    GfxDrawSprite(&dpi, imageId.WithIndexOffset(1), { 47, spriteTop });
+                    GfxDrawSprite(dpi, imageId.WithIndexOffset(1), { 47, spriteTop });
                 }
             }
         }
@@ -1532,7 +1532,7 @@ private:
         {
             auto* pathBitEntry = OpenRCT2::ObjectManager::GetObjectEntry<PathBitEntry>(scenerySelection.EntryIndex);
             auto imageId = ImageId(pathBitEntry->image);
-            GfxDrawSprite(&dpi, imageId, { 11, 16 });
+            GfxDrawSprite(dpi, imageId, { 11, 16 });
         }
         else
         {
@@ -1557,19 +1557,19 @@ private:
                 spriteTop -= 12;
             }
 
-            GfxDrawSprite(&dpi, imageId, { 32, spriteTop });
+            GfxDrawSprite(dpi, imageId, { 32, spriteTop });
 
             if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_HAS_GLASS))
             {
                 imageId = ImageId(sceneryEntry->image + 4 + gWindowSceneryRotation)
                               .WithTransparency(gWindowSceneryPrimaryColour);
-                GfxDrawSprite(&dpi, imageId, { 32, spriteTop });
+                GfxDrawSprite(dpi, imageId, { 32, spriteTop });
             }
 
             if (sceneryEntry->HasFlag(SMALL_SCENERY_FLAG_ANIMATED_FG))
             {
                 imageId = ImageId(sceneryEntry->image + 4 + gWindowSceneryRotation);
-                GfxDrawSprite(&dpi, imageId, { 32, spriteTop });
+                GfxDrawSprite(dpi, imageId, { 32, spriteTop });
             }
         }
     }

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1618,7 +1618,7 @@ private:
 
             DrawPixelInfo clipdpi;
             if (ClipDrawPixelInfo(
-                    &clipdpi, &dpi, topLeft + ScreenCoordsXY{ 1, 1 }, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2))
+                    clipdpi, dpi, topLeft + ScreenCoordsXY{ 1, 1 }, SCENERY_BUTTON_WIDTH - 2, SCENERY_BUTTON_HEIGHT - 2))
             {
                 DrawSceneryItem(clipdpi, currentSceneryGlobal);
             }

--- a/src/openrct2-ui/windows/Scenery.cpp
+++ b/src/openrct2-ui/windows/Scenery.cpp
@@ -1596,7 +1596,7 @@ private:
                 if (_selectedScenery == currentSceneryGlobal)
                 {
                     GfxFillRectInset(
-                        &dpi, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
+                        dpi, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
                         colours[1], INSET_RECT_FLAG_FILL_MID_LIGHT);
                 }
             }
@@ -1605,13 +1605,13 @@ private:
                 if (tabSelectedScenery == currentSceneryGlobal)
                 {
                     GfxFillRectInset(
-                        &dpi, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
+                        dpi, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
                         colours[1], (INSET_RECT_FLAG_BORDER_INSET | INSET_RECT_FLAG_FILL_MID_LIGHT));
                 }
                 else if (_selectedScenery == currentSceneryGlobal)
                 {
                     GfxFillRectInset(
-                        &dpi, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
+                        dpi, { topLeft, topLeft + ScreenCoordsXY{ SCENERY_BUTTON_WIDTH - 1, SCENERY_BUTTON_HEIGHT - 1 } },
                         colours[1], INSET_RECT_FLAG_FILL_MID_LIGHT);
                 }
             }

--- a/src/openrct2-ui/windows/SceneryScatter.cpp
+++ b/src/openrct2-ui/windows/SceneryScatter.cpp
@@ -178,7 +178,7 @@ public:
 
     void OnDraw(DrawPixelInfo& dpi) override
     {
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
 
         // Draw area as a number for tool sizes bigger than 7
         if (gWindowSceneryScatterSize > MAX_TOOL_SIZE_WITH_SPRITE)

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -406,14 +406,14 @@ public:
                 bool correctVersion = serverDetails.Version == NetworkGetVersion();
                 compatibilitySpriteId = correctVersion ? SPR_G2_RCT1_OPEN_BUTTON_2 : SPR_G2_RCT1_CLOSE_BUTTON_2;
             }
-            GfxDrawSprite(&dpi, ImageId(compatibilitySpriteId), { right, screenCoords.y + 1 });
+            GfxDrawSprite(dpi, ImageId(compatibilitySpriteId), { right, screenCoords.y + 1 });
             right -= 4;
 
             // Draw lock icon
             right -= 8;
             if (serverDetails.RequiresPassword)
             {
-                GfxDrawSprite(&dpi, ImageId(SPR_G2_LOCKED), { right, screenCoords.y + 4 });
+                GfxDrawSprite(dpi, ImageId(SPR_G2_LOCKED), { right, screenCoords.y + 4 });
             }
             right -= 6;
 

--- a/src/openrct2-ui/windows/ServerList.cpp
+++ b/src/openrct2-ui/windows/ServerList.cpp
@@ -350,8 +350,7 @@ public:
             if (highlighted)
             {
                 GfxFilterRect(
-                    &dpi, { 0, screenCoords.y, listWidgetWidth, screenCoords.y + ITEM_HEIGHT },
-                    FilterPaletteID::PaletteDarken1);
+                    dpi, { 0, screenCoords.y, listWidgetWidth, screenCoords.y + ITEM_HEIGHT }, FilterPaletteID::PaletteDarken1);
                 _version = serverDetails.Version;
             }
 

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -299,7 +299,7 @@ public:
     {
         auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
         GfxFillRect(
-            &dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
+            dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
 
         // TODO: the line below is a workaround for what is presumably a bug with dpi->width
         //       see https://github.com/OpenRCT2/OpenRCT2/issues/11238 for details
@@ -498,8 +498,8 @@ private:
     void DrawSeparator(DrawPixelInfo& dpi, int32_t y, int32_t scrollWidth)
     {
         const int32_t top = y + (SCROLLABLE_ROW_HEIGHT / 2) - 1;
-        GfxFillRect(&dpi, { { 0, top }, { scrollWidth, top } }, ColourMapA[colours[0]].mid_dark);
-        GfxFillRect(&dpi, { { 0, top + 1 }, { scrollWidth, top + 1 } }, ColourMapA[colours[0]].lightest);
+        GfxFillRect(dpi, { { 0, top }, { scrollWidth, top } }, ColourMapA[colours[0]].mid_dark);
+        GfxFillRect(dpi, { { 0, top + 1 }, { scrollWidth, top + 1 } }, ColourMapA[colours[0]].lightest);
     }
 
     void DrawItem(DrawPixelInfo& dpi, int32_t y, int32_t scrollWidth, const ShortcutStringPair& shortcut, bool isHighlighted)
@@ -508,7 +508,7 @@ private:
         if (isHighlighted)
         {
             format = STR_WINDOW_COLOUR_2_STRINGID;
-            GfxFilterRect(&dpi, { 0, y - 1, scrollWidth, y + (SCROLLABLE_ROW_HEIGHT - 2) }, FilterPaletteID::PaletteDarken1);
+            GfxFilterRect(dpi, { 0, y - 1, scrollWidth, y + (SCROLLABLE_ROW_HEIGHT - 2) }, FilterPaletteID::PaletteDarken1);
         }
 
         auto bindingOffset = (scrollWidth * 2) / 3;

--- a/src/openrct2-ui/windows/ShortcutKeys.cpp
+++ b/src/openrct2-ui/windows/ShortcutKeys.cpp
@@ -490,7 +490,7 @@ private:
                 }
 
                 const auto& widget = widgets[widgetIndex];
-                GfxDrawSprite(&dpi, ImageId(imageId), windowPos + ScreenCoordsXY{ widget.left, widget.top });
+                GfxDrawSprite(dpi, ImageId(imageId), windowPos + ScreenCoordsXY{ widget.left, widget.top });
             }
         }
     }

--- a/src/openrct2-ui/windows/Sign.cpp
+++ b/src/openrct2-ui/windows/Sign.cpp
@@ -293,7 +293,7 @@ public:
 
         if (viewport != nullptr)
         {
-            WindowDrawViewport(&dpi, *this);
+            WindowDrawViewport(dpi, *this);
         }
     }
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -553,7 +553,7 @@ private:
             widgetHeight++;
 
         DrawPixelInfo clip_dpi;
-        if (!ClipDrawPixelInfo(&clip_dpi, &dpi, screenCoords, widgetWidth, widgetHeight))
+        if (!ClipDrawPixelInfo(clip_dpi, dpi, screenCoords, widgetWidth, widgetHeight))
         {
             return;
         }

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -522,7 +522,7 @@ private:
 
             if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
             {
-                GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
+                GfxDrawSprite(*dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
             }
         }
 
@@ -580,7 +580,7 @@ private:
         }
         imageIndex += offset;
 
-        GfxDrawSprite(&clip_dpi, ImageId(imageIndex, staff->TshirtColour, staff->TrousersColour), screenCoords);
+        GfxDrawSprite(clip_dpi, ImageId(imageIndex, staff->TshirtColour, staff->TrousersColour), screenCoords);
     }
 
     void OverviewResize()
@@ -1215,7 +1215,7 @@ private:
             }
 
             // Draw normal, enabled sprite.
-            GfxDrawSprite(dpi, ImageId(baseImageId), screenCoords);
+            GfxDrawSprite(*dpi, ImageId(baseImageId), screenCoords);
         }
     }
 

--- a/src/openrct2-ui/windows/Staff.cpp
+++ b/src/openrct2-ui/windows/Staff.cpp
@@ -206,15 +206,15 @@ public:
     void OnDraw(DrawPixelInfo& dpi) override
     {
         DrawWidgets(dpi);
-        DrawTabImages(&dpi);
+        DrawTabImages(dpi);
 
         switch (page)
         {
             case WINDOW_STAFF_OVERVIEW:
-                OverviewDraw(&dpi);
+                OverviewDraw(dpi);
                 break;
             case WINDOW_STAFF_STATISTICS:
-                StatsDraw(&dpi);
+                StatsDraw(dpi);
                 break;
         }
     }
@@ -513,7 +513,7 @@ private:
         widgets[WIDX_FIRE].right = width - 2;
     }
 
-    void OverviewDraw(DrawPixelInfo* dpi)
+    void OverviewDraw(DrawPixelInfo& dpi)
     {
         // Draw the viewport no sound sprite
         if (viewport != nullptr)
@@ -522,7 +522,7 @@ private:
 
             if (viewport->flags & VIEWPORT_FLAG_SOUND_ON)
             {
-                GfxDrawSprite(*dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
+                GfxDrawSprite(dpi, ImageId(SPR_HEARING_VIEWPORT), windowPos + ScreenCoordsXY{ 2, 2 });
             }
         }
 
@@ -537,10 +537,10 @@ private:
         const auto& widget = widgets[WIDX_BTM_LABEL];
         auto screenPos = windowPos + ScreenCoordsXY{ widget.midX(), widget.top };
         int32_t widgetWidth = widget.width();
-        DrawTextEllipsised(*dpi, screenPos, widgetWidth, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
+        DrawTextEllipsised(dpi, screenPos, widgetWidth, STR_BLACK_STRING, ft, { TextAlignment::CENTRE });
     }
 
-    void DrawOverviewTabImage(DrawPixelInfo* dpi)
+    void DrawOverviewTabImage(DrawPixelInfo& dpi)
     {
         if (IsWidgetDisabled(WIDX_TAB_1))
             return;
@@ -553,7 +553,7 @@ private:
             widgetHeight++;
 
         DrawPixelInfo clip_dpi;
-        if (!ClipDrawPixelInfo(&clip_dpi, dpi, screenCoords, widgetWidth, widgetHeight))
+        if (!ClipDrawPixelInfo(&clip_dpi, &dpi, screenCoords, widgetWidth, widgetHeight))
         {
             return;
         }
@@ -914,7 +914,7 @@ private:
 #pragma endregion
 
 #pragma region Statistics tab events
-    void StatsDraw(DrawPixelInfo* dpi)
+    void StatsDraw(DrawPixelInfo& dpi)
     {
         auto staff = GetStaff();
         if (staff == nullptr)
@@ -928,13 +928,13 @@ private:
         {
             auto ft = Formatter();
             ft.Add<money64>(GetStaffWage(staff->AssignedStaffType));
-            DrawTextBasic(*dpi, screenCoords, STR_STAFF_STAT_WAGES, ft);
+            DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_WAGES, ft);
             screenCoords.y += LIST_ROW_HEIGHT;
         }
 
         auto ft = Formatter();
         ft.Add<int32_t>(staff->GetHireDate());
-        DrawTextBasic(*dpi, screenCoords, STR_STAFF_STAT_EMPLOYED_FOR, ft);
+        DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_EMPLOYED_FOR, ft);
         screenCoords.y += LIST_ROW_HEIGHT;
 
         switch (staff->AssignedStaffType)
@@ -942,37 +942,37 @@ private:
             case StaffType::Handyman:
                 ft = Formatter();
                 ft.Add<uint32_t>(staff->StaffLawnsMown);
-                DrawTextBasic(*dpi, screenCoords, STR_STAFF_STAT_LAWNS_MOWN, ft);
+                DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_LAWNS_MOWN, ft);
                 screenCoords.y += LIST_ROW_HEIGHT;
 
                 ft = Formatter();
                 ft.Add<uint32_t>(staff->StaffGardensWatered);
-                DrawTextBasic(*dpi, screenCoords, STR_STAFF_STAT_GARDENS_WATERED, ft);
+                DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_GARDENS_WATERED, ft);
                 screenCoords.y += LIST_ROW_HEIGHT;
 
                 ft = Formatter();
                 ft.Add<uint32_t>(staff->StaffLitterSwept);
-                DrawTextBasic(*dpi, screenCoords, STR_STAFF_STAT_LITTER_SWEPT, ft);
+                DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_LITTER_SWEPT, ft);
                 screenCoords.y += LIST_ROW_HEIGHT;
 
                 ft = Formatter();
                 ft.Add<uint32_t>(staff->StaffBinsEmptied);
-                DrawTextBasic(*dpi, screenCoords, STR_STAFF_STAT_BINS_EMPTIED, ft);
+                DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_BINS_EMPTIED, ft);
                 break;
             case StaffType::Mechanic:
                 ft = Formatter();
                 ft.Add<uint32_t>(staff->StaffRidesInspected);
-                DrawTextBasic(*dpi, screenCoords, STR_STAFF_STAT_RIDES_INSPECTED, ft);
+                DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_RIDES_INSPECTED, ft);
                 screenCoords.y += LIST_ROW_HEIGHT;
 
                 ft = Formatter();
                 ft.Add<uint32_t>(staff->StaffRidesFixed);
-                DrawTextBasic(*dpi, screenCoords, STR_STAFF_STAT_RIDES_FIXED, ft);
+                DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_RIDES_FIXED, ft);
                 break;
             case StaffType::Security:
                 ft = Formatter();
                 ft.Add<uint32_t>(staff->StaffVandalsStopped);
-                DrawTextBasic(*dpi, screenCoords, STR_STAFF_STAT_VANDALS_STOPPED, ft);
+                DrawTextBasic(dpi, screenCoords, STR_STAFF_STAT_VANDALS_STOPPED, ft);
                 break;
             case StaffType::Entertainer:
             case StaffType::Count:
@@ -1192,14 +1192,14 @@ private:
         WindowFollowSprite(*main, EntityId::FromUnderlying(number));
     }
 
-    void DrawTabImages(DrawPixelInfo* dpi)
+    void DrawTabImages(DrawPixelInfo& dpi)
     {
         DrawOverviewTabImage(dpi);
         DrawTabImage(dpi, WINDOW_STAFF_OPTIONS, SPR_TAB_STAFF_OPTIONS_0);
         DrawTabImage(dpi, WINDOW_STAFF_STATISTICS, SPR_TAB_STATS_0);
     }
 
-    void DrawTabImage(DrawPixelInfo* dpi, int32_t p, int32_t baseImageId)
+    void DrawTabImage(DrawPixelInfo& dpi, int32_t p, int32_t baseImageId)
     {
         WidgetIndex widgetIndex = WIDX_TAB_1 + p;
         Widget* widget = &widgets[widgetIndex];
@@ -1215,7 +1215,7 @@ private:
             }
 
             // Draw normal, enabled sprite.
-            GfxDrawSprite(*dpi, ImageId(baseImageId), screenCoords);
+            GfxDrawSprite(dpi, ImageId(baseImageId), screenCoords);
         }
     }
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -608,8 +608,8 @@ private:
         const auto& widget = widgets[widgetIndex];
         DrawPixelInfo clippedDpi;
         if (ClipDrawPixelInfo(
-                clippedDpi, dpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 },
-                widget.right - widget.left - 1, widget.bottom - widget.top - 1))
+                clippedDpi, dpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 }, widget.right - widget.left - 1,
+                widget.bottom - widget.top - 1))
         {
             auto imageId = (_selectedTab == 3 ? (_tabAnimationIndex & ~3) : 0);
             imageId += GetPeepAnimation(type).base_image + 1;

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -608,7 +608,7 @@ private:
         const auto& widget = widgets[widgetIndex];
         DrawPixelInfo clippedDpi;
         if (ClipDrawPixelInfo(
-                &clippedDpi, &dpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 },
+                clippedDpi, dpi, windowPos + ScreenCoordsXY{ widget.left + 1, widget.top + 1 },
                 widget.right - widget.left - 1, widget.bottom - widget.top - 1))
         {
             auto imageId = (_selectedTab == 3 ? (_tabAnimationIndex & ~3) : 0);

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -377,7 +377,7 @@ public:
     {
         auto dpiCoords = ScreenCoordsXY{ dpi.x, dpi.y };
         GfxFillRect(
-            &dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
+            dpi, { dpiCoords, dpiCoords + ScreenCoordsXY{ dpi.width - 1, dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
 
         // How much space do we have for the name and action columns? (Discount scroll area and icons.)
         const int32_t nonIconSpace = widgets[WIDX_STAFF_LIST_LIST].width() - 15 - 68;
@@ -405,7 +405,7 @@ public:
 
                 if (i == _highlightedIndex)
                 {
-                    GfxFilterRect(&dpi, { 0, y, 800, y + (SCROLLABLE_ROW_HEIGHT - 1) }, FilterPaletteID::PaletteDarken1);
+                    GfxFilterRect(dpi, { 0, y, 800, y + (SCROLLABLE_ROW_HEIGHT - 1) }, FilterPaletteID::PaletteDarken1);
                     format = (_quickFireMode ? STR_LIGHTPINK_STRINGID : STR_WINDOW_COLOUR_2_STRINGID);
                 }
 

--- a/src/openrct2-ui/windows/StaffList.cpp
+++ b/src/openrct2-ui/windows/StaffList.cpp
@@ -420,7 +420,7 @@ public:
                 // True if a patrol path is set for the worker
                 if (peep->HasPatrolArea())
                 {
-                    GfxDrawSprite(&dpi, ImageId(SPR_STAFF_PATROL_PATH), { nameColumnSize + 5, y });
+                    GfxDrawSprite(dpi, ImageId(SPR_STAFF_PATROL_PATH), { nameColumnSize + 5, y });
                 }
 
                 auto staffOrderIcon_x = nameColumnSize + 20;
@@ -433,7 +433,7 @@ public:
                     {
                         if (staffOrders & 1)
                         {
-                            GfxDrawSprite(&dpi, ImageId(staffOrderSprite), { staffOrderIcon_x, y });
+                            GfxDrawSprite(dpi, ImageId(staffOrderSprite), { staffOrderIcon_x, y });
                         }
                         staffOrders = staffOrders >> 1;
                         staffOrderIcon_x += 9;
@@ -443,7 +443,7 @@ public:
                 }
                 else
                 {
-                    GfxDrawSprite(&dpi, ImageId(GetEntertainerCostumeSprite(peep->SpriteType)), { staffOrderIcon_x, y });
+                    GfxDrawSprite(dpi, ImageId(GetEntertainerCostumeSprite(peep->SpriteType)), { staffOrderIcon_x, y });
                 }
             }
 
@@ -599,7 +599,7 @@ private:
         auto imageId = (_selectedTab == tabIndex ? (_tabAnimationIndex & ~3) : 0);
         imageId += GetPeepAnimation(type).base_image + 1;
         GfxDrawSprite(
-            &dpi, ImageId(imageId, colour), windowPos + ScreenCoordsXY{ (widget.left + widget.right) / 2, widget.bottom - 6 });
+            dpi, ImageId(imageId, colour), windowPos + ScreenCoordsXY{ (widget.left + widget.right) / 2, widget.bottom - 6 });
     }
 
     void DrawTabImage(DrawPixelInfo& dpi, int32_t tabIndex, PeepSpriteType type) const
@@ -613,7 +613,7 @@ private:
         {
             auto imageId = (_selectedTab == 3 ? (_tabAnimationIndex & ~3) : 0);
             imageId += GetPeepAnimation(type).base_image + 1;
-            GfxDrawSprite(&clippedDpi, ImageId(imageId), { 15, 23 });
+            GfxDrawSprite(clippedDpi, ImageId(imageId), { 15, 23 });
         }
     }
 

--- a/src/openrct2-ui/windows/TextInput.cpp
+++ b/src/openrct2-ui/windows/TextInput.cpp
@@ -228,7 +228,7 @@ public:
             u8string_view{ _buffer.data(), _buffer.size() }, WW - (24 + 13), FontStyle::Medium, &wrappedString, &no_lines);
 
         GfxFillRectInset(
-            &dpi, { { windowPos.x + 10, screenCoords.y }, { windowPos.x + WW - 10, screenCoords.y + 10 * (no_lines + 1) + 3 } },
+            dpi, { { windowPos.x + 10, screenCoords.y }, { windowPos.x + WW - 10, screenCoords.y + 10 * (no_lines + 1) + 3 } },
             colours[1], INSET_RECT_F_60);
 
         screenCoords.y += 1;
@@ -270,7 +270,7 @@ public:
                     uint8_t colour = ColourMapA[colours[1]].mid_light;
                     // TODO: palette index addition
                     GfxFillRect(
-                        &dpi, { { cursorX, screenCoords.y + 9 }, { cursorX + textWidth, screenCoords.y + 9 } }, colour + 5);
+                        dpi, { { cursorX, screenCoords.y + 9 }, { cursorX + textWidth, screenCoords.y + 9 } }, colour + 5);
                 }
 
                 cur_drawn++;
@@ -322,9 +322,9 @@ private:
         int height = 10;
 
         GfxFillRect(
-            &dpi, { screenCoords - ScreenCoordsXY{ 1, 1 }, screenCoords + ScreenCoordsXY{ width + 1, height + 1 } },
+            dpi, { screenCoords - ScreenCoordsXY{ 1, 1 }, screenCoords + ScreenCoordsXY{ width + 1, height + 1 } },
             PALETTE_INDEX_12);
-        GfxFillRect(&dpi, { screenCoords, screenCoords + ScreenCoordsXY{ width, height } }, PALETTE_INDEX_0);
+        GfxFillRect(dpi, { screenCoords, screenCoords + ScreenCoordsXY{ width, height } }, PALETTE_INDEX_0);
         GfxDrawString(dpi, screenCoords, static_cast<const char*>(gTextInput->ImeBuffer), { COLOUR_DARK_GREEN });
     }
 

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -447,8 +447,8 @@ public:
     void OnDraw(DrawPixelInfo& dpi) override
     {
         // Widgets
-        WindowDrawWidgets(*this, &dpi);
-        WindowThemesDrawTabImages(&dpi);
+        WindowDrawWidgets(*this, dpi);
+        WindowThemesDrawTabImages(dpi);
 
         if (_selected_tab == WINDOW_THEMES_TAB_SETTINGS)
         {
@@ -868,7 +868,7 @@ public:
         return 0;
     }
 
-    void WindowThemesDrawTabImages(DrawPixelInfo* dpi)
+    void WindowThemesDrawTabImages(DrawPixelInfo& dpi)
     {
         for (int32_t i = 0; i < WINDOW_THEMES_TAB_COUNT; i++)
         {
@@ -876,7 +876,7 @@ public:
             if (_selected_tab == i)
                 sprite_idx += frame_no / window_themes_tab_animation_divisor[_selected_tab];
             GfxDrawSprite(
-                *dpi, ImageId(sprite_idx),
+                dpi, ImageId(sprite_idx),
                 windowPos
                     + ScreenCoordsXY{ widgets[WIDX_THEMES_SETTINGS_TAB + i].left, widgets[WIDX_THEMES_SETTINGS_TAB + i].top });
         }

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -815,7 +815,7 @@ public:
                     const bool isPressed = (i == _colour_index_1 && j == _colour_index_2);
                     auto image = ImageId(
                         isPressed ? SPR_PALETTE_BTN_PRESSED : SPR_PALETTE_BTN, colour & ~COLOUR_FLAG_TRANSLUCENT);
-                    GfxDrawSprite(&dpi, image, { _button_offset_x + 12 * j, screenCoords.y + _button_offset_y });
+                    GfxDrawSprite(dpi, image, { _button_offset_x + 12 * j, screenCoords.y + _button_offset_y });
 
                     ScreenCoordsXY topLeft{ _button_offset_x + 12 * j, screenCoords.y + _check_offset_y };
                     ScreenCoordsXY bottomRight{ _button_offset_x + 12 * j + 9, screenCoords.y + _check_offset_y + 10 };
@@ -876,7 +876,7 @@ public:
             if (_selected_tab == i)
                 sprite_idx += frame_no / window_themes_tab_animation_divisor[_selected_tab];
             GfxDrawSprite(
-                dpi, ImageId(sprite_idx),
+                *dpi, ImageId(sprite_idx),
                 windowPos
                     + ScreenCoordsXY{ widgets[WIDX_THEMES_SETTINGS_TAB + i].left, widgets[WIDX_THEMES_SETTINGS_TAB + i].top });
         }

--- a/src/openrct2-ui/windows/Themes.cpp
+++ b/src/openrct2-ui/windows/Themes.cpp
@@ -792,16 +792,16 @@ public:
                     {
                         TranslucentWindowPalette windowPalette = TranslucentWindowPalettes[BASE_COLOUR(colour)];
 
-                        GfxFilterRect(&dpi, { leftTop, rightBottom }, windowPalette.highlight);
-                        GfxFilterRect(&dpi, { leftTop + yPixelOffset, rightBottom + yPixelOffset }, windowPalette.shadow);
+                        GfxFilterRect(dpi, { leftTop, rightBottom }, windowPalette.highlight);
+                        GfxFilterRect(dpi, { leftTop + yPixelOffset, rightBottom + yPixelOffset }, windowPalette.shadow);
                     }
                     else
                     {
                         colour = ColourMapA[colours[1]].mid_dark;
-                        GfxFillRect(&dpi, { leftTop, rightBottom }, colour);
+                        GfxFillRect(dpi, { leftTop, rightBottom }, colour);
 
                         colour = ColourMapA[colours[1]].lightest;
-                        GfxFillRect(&dpi, { leftTop + yPixelOffset, rightBottom + yPixelOffset }, colour);
+                        GfxFillRect(dpi, { leftTop + yPixelOffset, rightBottom + yPixelOffset }, colour);
                     }
                 }
 
@@ -819,7 +819,7 @@ public:
 
                     ScreenCoordsXY topLeft{ _button_offset_x + 12 * j, screenCoords.y + _check_offset_y };
                     ScreenCoordsXY bottomRight{ _button_offset_x + 12 * j + 9, screenCoords.y + _check_offset_y + 10 };
-                    GfxFillRectInset(&dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_E0);
+                    GfxFillRectInset(dpi, { topLeft, bottomRight }, colours[1], INSET_RECT_F_E0);
                     if (colour & COLOUR_FLAG_TRANSLUCENT)
                     {
                         GfxDrawString(

--- a/src/openrct2-ui/windows/TileInspector.cpp
+++ b/src/openrct2-ui/windows/TileInspector.cpp
@@ -1540,7 +1540,7 @@ public:
     {
         const int32_t listWidth = widgets[WIDX_LIST].width();
         GfxFillRect(
-            &dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
+            dpi, { { dpi.x, dpi.y }, { dpi.x + dpi.width - 1, dpi.y + dpi.height - 1 } }, ColourMapA[colours[1]].mid_light);
 
         // Show usage hint when nothing is selected
         if (!_tileSelected)
@@ -1573,12 +1573,12 @@ public:
             // Draw row background colour
             auto fillRectangle = ScreenRect{ { 0, screenCoords.y }, { listWidth, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 } };
             if (selectedRow)
-                GfxFillRect(&dpi, fillRectangle, ColourMapA[colours[1]].mid_dark);
+                GfxFillRect(dpi, fillRectangle, ColourMapA[colours[1]].mid_dark);
             else if (hoveredRow)
-                GfxFillRect(&dpi, fillRectangle, ColourMapA[colours[1]].mid_dark | 0x1000000);
+                GfxFillRect(dpi, fillRectangle, ColourMapA[colours[1]].mid_dark | 0x1000000);
             // Zebra stripes
             else if (((windowTileInspectorElementCount - i) & 1) == 0)
-                GfxFillRect(&dpi, fillRectangle, ColourMapA[colours[1]].light | 0x1000000);
+                GfxFillRect(dpi, fillRectangle, ColourMapA[colours[1]].light | 0x1000000);
 
             const StringId stringFormat = (selectedRow || hoveredRow) ? STR_WHITE_STRING : STR_WINDOW_COLOUR_2_STRINGID;
             auto checkboxFormatter = Formatter();
@@ -1586,7 +1586,7 @@ public:
             checkboxFormatter.Add<char*>(CheckBoxMarkString);
 
             // Draw checkbox and check if visible
-            GfxFillRectInset(&dpi, { { 2, screenCoords.y }, { 15, screenCoords.y + 11 } }, colours[1], INSET_RECT_F_E0);
+            GfxFillRectInset(dpi, { { 2, screenCoords.y }, { 15, screenCoords.y + 11 } }, colours[1], INSET_RECT_F_E0);
             if (!tileElement->IsInvisible())
             {
                 auto eyeFormatter = Formatter();

--- a/src/openrct2-ui/windows/TitleLogo.cpp
+++ b/src/openrct2-ui/windows/TitleLogo.cpp
@@ -60,8 +60,8 @@ public:
     void OnDraw(DrawPixelInfo& dpi) override
     {
         auto screenCoords = windowPos + ScreenCoordsXY{ 2, 2 };
-        GfxDrawSprite(&dpi, ImageId(SPR_G2_LOGO), screenCoords);
-        GfxDrawSprite(&dpi, ImageId(SPR_G2_TITLE), screenCoords + ScreenCoordsXY{ 104, 18 });
+        GfxDrawSprite(dpi, ImageId(SPR_G2_LOGO), screenCoords);
+        GfxDrawSprite(dpi, ImageId(SPR_G2_TITLE), screenCoords + ScreenCoordsXY{ 104, 18 });
     }
 };
 

--- a/src/openrct2-ui/windows/TitleMenu.cpp
+++ b/src/openrct2-ui/windows/TitleMenu.cpp
@@ -269,7 +269,7 @@ public:
 
     void OnDraw(DrawPixelInfo& dpi) override
     {
-        GfxFilterRect(&dpi, _filterRect, FilterPaletteID::Palette51);
+        GfxFilterRect(dpi, _filterRect, FilterPaletteID::Palette51);
         DrawWidgets(dpi);
     }
 };

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -82,14 +82,14 @@ public:
         int32_t bottom = windowPos.y + height - 1;
 
         // Background
-        GfxFilterRect(&dpi, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, FilterPaletteID::Palette45);
-        GfxFilterRect(&dpi, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, FilterPaletteID::PaletteGlassLightOrange);
+        GfxFilterRect(dpi, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, FilterPaletteID::Palette45);
+        GfxFilterRect(dpi, { { left + 1, top + 1 }, { right - 1, bottom - 1 } }, FilterPaletteID::PaletteGlassLightOrange);
 
         // Sides
-        GfxFilterRect(&dpi, { { left + 0, top + 2 }, { left + 0, bottom - 2 } }, FilterPaletteID::PaletteDarken3);
-        GfxFilterRect(&dpi, { { right + 0, top + 2 }, { right + 0, bottom - 2 } }, FilterPaletteID::PaletteDarken3);
-        GfxFilterRect(&dpi, { { left + 2, bottom + 0 }, { right - 2, bottom + 0 } }, FilterPaletteID::PaletteDarken3);
-        GfxFilterRect(&dpi, { { left + 2, top + 0 }, { right - 2, top + 0 } }, FilterPaletteID::PaletteDarken3);
+        GfxFilterRect(dpi, { { left + 0, top + 2 }, { left + 0, bottom - 2 } }, FilterPaletteID::PaletteDarken3);
+        GfxFilterRect(dpi, { { right + 0, top + 2 }, { right + 0, bottom - 2 } }, FilterPaletteID::PaletteDarken3);
+        GfxFilterRect(dpi, { { left + 2, bottom + 0 }, { right - 2, bottom + 0 } }, FilterPaletteID::PaletteDarken3);
+        GfxFilterRect(dpi, { { left + 2, top + 0 }, { right - 2, top + 0 } }, FilterPaletteID::PaletteDarken3);
 
         // Corners
         GfxFilterPixel(&dpi, { left + 1, top + 1 }, FilterPaletteID::PaletteDarken3);

--- a/src/openrct2-ui/windows/Tooltip.cpp
+++ b/src/openrct2-ui/windows/Tooltip.cpp
@@ -92,10 +92,10 @@ public:
         GfxFilterRect(dpi, { { left + 2, top + 0 }, { right - 2, top + 0 } }, FilterPaletteID::PaletteDarken3);
 
         // Corners
-        GfxFilterPixel(&dpi, { left + 1, top + 1 }, FilterPaletteID::PaletteDarken3);
-        GfxFilterPixel(&dpi, { right - 1, top + 1 }, FilterPaletteID::PaletteDarken3);
-        GfxFilterPixel(&dpi, { left + 1, bottom - 1 }, FilterPaletteID::PaletteDarken3);
-        GfxFilterPixel(&dpi, { right - 1, bottom - 1 }, FilterPaletteID::PaletteDarken3);
+        GfxFilterPixel(dpi, { left + 1, top + 1 }, FilterPaletteID::PaletteDarken3);
+        GfxFilterPixel(dpi, { right - 1, top + 1 }, FilterPaletteID::PaletteDarken3);
+        GfxFilterPixel(dpi, { left + 1, bottom - 1 }, FilterPaletteID::PaletteDarken3);
+        GfxFilterPixel(dpi, { right - 1, bottom - 1 }, FilterPaletteID::PaletteDarken3);
 
         // Text
         left = windowPos.x + ((width + 1) / 2) - 1;

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -3190,7 +3190,7 @@ public:
             imgId = SPR_TOOLBAR_STAFF;
             if (WidgetIsPressed(*this, WIDX_STAFF))
                 imgId++;
-            GfxDrawSprite(&dpi, ImageId(imgId, gStaffHandymanColour, gStaffMechanicColour), screenPos);
+            GfxDrawSprite(dpi, ImageId(imgId, gStaffHandymanColour, gStaffMechanicColour), screenPos);
         }
 
         // Draw fast forward button
@@ -3199,15 +3199,15 @@ public:
             screenPos = { windowPos.x + widgets[WIDX_FASTFORWARD].left + 0, windowPos.y + widgets[WIDX_FASTFORWARD].top + 0 };
             if (WidgetIsPressed(*this, WIDX_FASTFORWARD))
                 screenPos.y++;
-            GfxDrawSprite(&dpi, ImageId(SPR_G2_FASTFORWARD), screenPos + ScreenCoordsXY{ 6, 3 });
+            GfxDrawSprite(dpi, ImageId(SPR_G2_FASTFORWARD), screenPos + ScreenCoordsXY{ 6, 3 });
 
             for (int32_t i = 0; i < gGameSpeed && gGameSpeed <= 4; i++)
             {
-                GfxDrawSprite(&dpi, ImageId(SPR_G2_SPEED_ARROW), screenPos + ScreenCoordsXY{ 5 + i * 5, 15 });
+                GfxDrawSprite(dpi, ImageId(SPR_G2_SPEED_ARROW), screenPos + ScreenCoordsXY{ 5 + i * 5, 15 });
             }
             for (int32_t i = 0; i < 3 && i < gGameSpeed - 4 && gGameSpeed >= 5; i++)
             {
-                GfxDrawSprite(&dpi, ImageId(SPR_G2_HYPER_ARROW), screenPos + ScreenCoordsXY{ 5 + i * 6, 15 });
+                GfxDrawSprite(dpi, ImageId(SPR_G2_HYPER_ARROW), screenPos + ScreenCoordsXY{ 5 + i * 6, 15 });
             }
         }
 
@@ -3217,7 +3217,7 @@ public:
             screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_CHEATS].left - 1, widgets[WIDX_CHEATS].top - 1 };
             if (WidgetIsPressed(*this, WIDX_CHEATS))
                 screenPos.y++;
-            GfxDrawSprite(&dpi, ImageId(SPR_G2_SANDBOX), screenPos);
+            GfxDrawSprite(dpi, ImageId(SPR_G2_SANDBOX), screenPos);
 
             // Draw an overlay if clearance checks are disabled
             if (gCheatsDisableClearanceChecks)
@@ -3234,7 +3234,7 @@ public:
             screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_CHAT].left, widgets[WIDX_CHAT].top - 2 };
             if (WidgetIsPressed(*this, WIDX_CHAT))
                 screenPos.y++;
-            GfxDrawSprite(&dpi, ImageId(SPR_G2_CHAT), screenPos);
+            GfxDrawSprite(dpi, ImageId(SPR_G2_CHAT), screenPos);
         }
 
         // Draw debug button
@@ -3243,7 +3243,7 @@ public:
             screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_DEBUG].left, widgets[WIDX_DEBUG].top - 1 };
             if (WidgetIsPressed(*this, WIDX_DEBUG))
                 screenPos.y++;
-            GfxDrawSprite(&dpi, ImageId(SPR_TAB_GEARS_0), screenPos);
+            GfxDrawSprite(dpi, ImageId(SPR_TAB_GEARS_0), screenPos);
         }
 
         // Draw research button
@@ -3252,7 +3252,7 @@ public:
             screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_RESEARCH].left - 1, widgets[WIDX_RESEARCH].top };
             if (WidgetIsPressed(*this, WIDX_RESEARCH))
                 screenPos.y++;
-            GfxDrawSprite(&dpi, ImageId(SPR_TAB_FINANCES_RESEARCH_0), screenPos);
+            GfxDrawSprite(dpi, ImageId(SPR_TAB_FINANCES_RESEARCH_0), screenPos);
         }
 
         // Draw finances button
@@ -3261,7 +3261,7 @@ public:
             screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_FINANCES].left + 3, widgets[WIDX_FINANCES].top + 1 };
             if (WidgetIsPressed(*this, WIDX_FINANCES))
                 screenPos.y++;
-            GfxDrawSprite(&dpi, ImageId(SPR_FINANCE), screenPos);
+            GfxDrawSprite(dpi, ImageId(SPR_FINANCE), screenPos);
         }
 
         // Draw news button
@@ -3270,7 +3270,7 @@ public:
             screenPos = windowPos + ScreenCoordsXY{ widgets[WIDX_NEWS].left + 3, widgets[WIDX_NEWS].top + 0 };
             if (WidgetIsPressed(*this, WIDX_NEWS))
                 screenPos.y++;
-            GfxDrawSprite(&dpi, ImageId(SPR_G2_TAB_NEWS), screenPos);
+            GfxDrawSprite(dpi, ImageId(SPR_G2_TAB_NEWS), screenPos);
         }
 
         // Draw network button
@@ -3282,7 +3282,7 @@ public:
 
             // Draw (de)sync icon.
             imgId = (NetworkIsDesynchronised() ? SPR_G2_MULTIPLAYER_DESYNC : SPR_G2_MULTIPLAYER_SYNC);
-            GfxDrawSprite(&dpi, ImageId(imgId), screenPos + ScreenCoordsXY{ 3, 11 });
+            GfxDrawSprite(dpi, ImageId(imgId), screenPos + ScreenCoordsXY{ 3, 11 });
 
             // Draw number of players.
             auto ft = Formatter();

--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -3180,7 +3180,7 @@ public:
     {
         int32_t imgId;
 
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
 
         ScreenCoordsXY screenPos{};
         // Draw staff button image (setting masks to the staff colours)

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -300,7 +300,7 @@ public:
             g1temp.height = TRACK_MINI_PREVIEW_HEIGHT;
             GfxSetG1Element(SPR_TEMP, &g1temp);
             DrawingEngineInvalidateImage(SPR_TEMP);
-            GfxDrawSprite(&clippedDpi, ImageId(SPR_TEMP, NOT_TRANSLUCENT(this->colours[0])), { 0, 0 });
+            GfxDrawSprite(clippedDpi, ImageId(SPR_TEMP, NOT_TRANSLUCENT(this->colours[0])), { 0, 0 });
         }
 
         // Price

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -288,7 +288,7 @@ public:
     {
         auto ft = Formatter::Common();
         ft.Add<char*>(_trackDesign->name.c_str());
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
 
         // Draw mini tile preview
         DrawPixelInfo clippedDpi;

--- a/src/openrct2-ui/windows/TrackDesignPlace.cpp
+++ b/src/openrct2-ui/windows/TrackDesignPlace.cpp
@@ -292,7 +292,7 @@ public:
 
         // Draw mini tile preview
         DrawPixelInfo clippedDpi;
-        if (ClipDrawPixelInfo(&clippedDpi, &dpi, this->windowPos + ScreenCoordsXY{ 4, 18 }, 168, 78))
+        if (ClipDrawPixelInfo(clippedDpi, dpi, this->windowPos + ScreenCoordsXY{ 4, 18 }, 168, 78))
         {
             G1Element g1temp = {};
             g1temp.offset = _miniPreview.data();

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -502,7 +502,7 @@ public:
         g1temp.flags = G1_FLAG_HAS_TRANSPARENCY;
         GfxSetG1Element(SPR_TEMP, &g1temp);
         DrawingEngineInvalidateImage(SPR_TEMP);
-        GfxDrawSprite(&dpi, ImageId(SPR_TEMP), trackPreview);
+        GfxDrawSprite(dpi, ImageId(SPR_TEMP), trackPreview);
 
         screenPos.y = windowPos.y + tdWidget.bottom - 12;
 

--- a/src/openrct2-ui/windows/TrackList.cpp
+++ b/src/openrct2-ui/windows/TrackList.cpp
@@ -473,7 +473,7 @@ public:
         }
 
         auto screenPos = windowPos + ScreenCoordsXY{ tdWidget.left + 1, tdWidget.top + 1 };
-        GfxFillRect(&dpi, { screenPos, screenPos + ScreenCoordsXY{ 369, 216 } }, colour); // TODO Check dpi
+        GfxFillRect(dpi, { screenPos, screenPos + ScreenCoordsXY{ 369, 216 } }, colour); // TODO Check dpi
 
         if (_loadedTrackDesignIndex != trackIndex)
         {
@@ -689,7 +689,7 @@ public:
             {
                 // Highlight
                 GfxFilterRect(
-                    &dpi, { screenCoords, { width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 } },
+                    dpi, { screenCoords, { width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 } },
                     FilterPaletteID::PaletteDarken1);
                 stringId = STR_WINDOW_COLOUR_2_STRINGID;
             }
@@ -714,7 +714,7 @@ public:
                 {
                     // Highlight
                     GfxFilterRect(
-                        &dpi, { screenCoords, { width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 } },
+                        dpi, { screenCoords, { width, screenCoords.y + SCROLLABLE_ROW_HEIGHT - 1 } },
                         FilterPaletteID::PaletteDarken1);
                     stringId = STR_WINDOW_COLOUR_2_STRINGID;
                 }

--- a/src/openrct2-ui/windows/Transparency.cpp
+++ b/src/openrct2-ui/windows/Transparency.cpp
@@ -152,7 +152,7 @@ public:
         const auto& widget = widgets[WIDX_HIDE_STAFF];
         auto screenCoords = windowPos + ScreenCoordsXY{ widget.left, widget.top };
         auto image = ImageId(SPR_MECHANIC, COLOUR_BLACK, gStaffMechanicColour);
-        GfxDrawSprite(&dpi, image, screenCoords);
+        GfxDrawSprite(dpi, image, screenCoords);
     }
 
 private:

--- a/src/openrct2-ui/windows/ViewClipping.cpp
+++ b/src/openrct2-ui/windows/ViewClipping.cpp
@@ -274,7 +274,7 @@ public:
 
     void OnDraw(DrawPixelInfo& dpi) override
     {
-        WindowDrawWidgets(*this, &dpi);
+        WindowDrawWidgets(*this, dpi);
 
         // Clip height value
         auto screenCoords = this->windowPos + ScreenCoordsXY{ 8, this->widgets[WIDX_CLIP_HEIGHT_VALUE].top };

--- a/src/openrct2-ui/windows/Viewport.cpp
+++ b/src/openrct2-ui/windows/Viewport.cpp
@@ -156,7 +156,7 @@ public:
 
         // Draw viewport
         if (viewport != nullptr)
-            WindowDrawViewport(&dpi, *this);
+            WindowDrawViewport(dpi, *this);
     }
 
     void OnResize() override

--- a/src/openrct2-ui/windows/Window.h
+++ b/src/openrct2-ui/windows/Window.h
@@ -120,8 +120,8 @@ WindowBase* WindowMapOpen();
 void WindowMapReset();
 
 WindowBase* WindowResearchOpen();
-void WindowResearchDevelopmentPagePaint(WindowBase* w, DrawPixelInfo* dpi, WidgetIndex baseWidgetIndex);
-void WindowResearchFundingPagePaint(WindowBase* w, DrawPixelInfo* dpi, WidgetIndex baseWidgetIndex);
+void WindowResearchDevelopmentPagePaint(WindowBase* w, DrawPixelInfo& dpi, WidgetIndex baseWidgetIndex);
+void WindowResearchFundingPagePaint(WindowBase* w, DrawPixelInfo& dpi, WidgetIndex baseWidgetIndex);
 
 WindowBase* WindowNewRideOpen();
 WindowBase* WindowNewRideOpenResearch();

--- a/src/openrct2/Intro.cpp
+++ b/src/openrct2/Intro.cpp
@@ -185,7 +185,7 @@ void IntroDraw(DrawPixelInfo& dpi)
 
             // Draw a white rectangle for the logo background (gives a bit of white margin)
             GfxFillRect(
-                &dpi,
+                dpi,
                 { { (screenWidth / 2) - 320 + 50, _introStateCounter + 50 },
                   { (screenWidth / 2) - 320 + 50 + 540, _introStateCounter + 50 + 425 } },
                 BORDER_COLOUR_PUBLISHER);

--- a/src/openrct2/Intro.cpp
+++ b/src/openrct2/Intro.cpp
@@ -38,7 +38,7 @@ static bool _chainLiftFinished;
 static void ScreenIntroProcessMouseInput();
 static void ScreenIntroProcessKeyboardInput();
 static void ScreenIntroSkipPart();
-static void ScreenIntroDrawLogo(DrawPixelInfo* dpi);
+static void ScreenIntroDrawLogo(DrawPixelInfo& dpi);
 
 // rct2: 0x0068E966
 void IntroUpdate()
@@ -168,7 +168,7 @@ void IntroUpdate()
     }
 }
 
-void IntroDraw(DrawPixelInfo* dpi)
+void IntroDraw(DrawPixelInfo& dpi)
 {
     int32_t screenWidth = ContextGetWidth();
 
@@ -178,34 +178,34 @@ void IntroDraw(DrawPixelInfo* dpi)
         case IntroState::Disclaimer2:
             break;
         case IntroState::PublisherBegin:
-            GfxClear(dpi, BACKROUND_COLOUR_DARK);
+            GfxClear(&dpi, BACKROUND_COLOUR_DARK);
             break;
         case IntroState::PublisherScroll:
-            GfxClear(dpi, BACKROUND_COLOUR_DARK);
+            GfxClear(&dpi, BACKROUND_COLOUR_DARK);
 
             // Draw a white rectangle for the logo background (gives a bit of white margin)
             GfxFillRect(
-                dpi,
+                &dpi,
                 { { (screenWidth / 2) - 320 + 50, _introStateCounter + 50 },
                   { (screenWidth / 2) - 320 + 50 + 540, _introStateCounter + 50 + 425 } },
                 BORDER_COLOUR_PUBLISHER);
 
             // Draw Infogrames logo
-            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_INFOGRAMES_00), { (screenWidth / 2) - 320 + 69, _introStateCounter + 69 });
-            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_INFOGRAMES_10), { (screenWidth / 2) - 320 + 319, _introStateCounter + 69 });
-            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_INFOGRAMES_01), { (screenWidth / 2) - 320 + 69, _introStateCounter + 319 });
-            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_INFOGRAMES_11), { (screenWidth / 2) - 320 + 319, _introStateCounter + 319 });
+            GfxDrawSprite(dpi, ImageId(SPR_INTRO_INFOGRAMES_00), { (screenWidth / 2) - 320 + 69, _introStateCounter + 69 });
+            GfxDrawSprite(dpi, ImageId(SPR_INTRO_INFOGRAMES_10), { (screenWidth / 2) - 320 + 319, _introStateCounter + 69 });
+            GfxDrawSprite(dpi, ImageId(SPR_INTRO_INFOGRAMES_01), { (screenWidth / 2) - 320 + 69, _introStateCounter + 319 });
+            GfxDrawSprite(dpi, ImageId(SPR_INTRO_INFOGRAMES_11), { (screenWidth / 2) - 320 + 319, _introStateCounter + 319 });
             break;
         case IntroState::DeveloperBegin:
-            GfxClear(dpi, BACKROUND_COLOUR_DARK);
+            GfxClear(&dpi, BACKROUND_COLOUR_DARK);
             GfxTransposePalette(PALETTE_G1_IDX_DEVELOPER, 255);
             break;
         case IntroState::DeveloperScroll:
-            GfxClear(dpi, BACKROUND_COLOUR_DARK);
+            GfxClear(&dpi, BACKROUND_COLOUR_DARK);
 
             // Draw Chris Sawyer logo
-            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_00), { (screenWidth / 2) - 320 + 70, _introStateCounter });
-            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_10), { (screenWidth / 2) - 320 + 320, _introStateCounter });
+            GfxDrawSprite(dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_00), { (screenWidth / 2) - 320 + 70, _introStateCounter });
+            GfxDrawSprite(dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_10), { (screenWidth / 2) - 320 + 320, _introStateCounter });
             break;
         case IntroState::LogoFadeIn:
             if (_introStateCounter <= 0xFF00)
@@ -233,7 +233,7 @@ void IntroDraw(DrawPixelInfo* dpi)
             ScreenIntroDrawLogo(dpi);
             break;
         case IntroState::Clear:
-            GfxClear(dpi, BACKROUND_COLOUR_DARK);
+            GfxClear(&dpi, BACKROUND_COLOUR_DARK);
             break;
         default:
             break;
@@ -280,7 +280,7 @@ static void ScreenIntroSkipPart()
     }
 }
 
-static void ScreenIntroDrawLogo(DrawPixelInfo* dpi)
+static void ScreenIntroDrawLogo(DrawPixelInfo& dpi)
 {
     int32_t screenWidth = ContextGetWidth();
     int32_t imageWidth = 640;
@@ -293,11 +293,11 @@ static void ScreenIntroDrawLogo(DrawPixelInfo* dpi)
     DrawingEngineInvalidateImage(SPR_INTRO_LOGO_11);
     DrawingEngineInvalidateImage(SPR_INTRO_LOGO_21);
 
-    GfxClear(dpi, BACKROUND_COLOUR_LOGO);
-    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_00), { imageX + 0, 0 });
-    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_10), { imageX + 220, 0 });
-    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_20), { imageX + 440, 0 });
-    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_01), { imageX + 0, 240 });
-    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_11), { imageX + 220, 240 });
-    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_21), { imageX + 440, 240 });
+    GfxClear(&dpi, BACKROUND_COLOUR_LOGO);
+    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_00), { imageX + 0, 0 });
+    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_10), { imageX + 220, 0 });
+    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_20), { imageX + 440, 0 });
+    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_01), { imageX + 0, 240 });
+    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_11), { imageX + 220, 240 });
+    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_21), { imageX + 440, 240 });
 }

--- a/src/openrct2/Intro.cpp
+++ b/src/openrct2/Intro.cpp
@@ -191,10 +191,10 @@ void IntroDraw(DrawPixelInfo* dpi)
                 BORDER_COLOUR_PUBLISHER);
 
             // Draw Infogrames logo
-            GfxDrawSprite(dpi, ImageId(SPR_INTRO_INFOGRAMES_00), { (screenWidth / 2) - 320 + 69, _introStateCounter + 69 });
-            GfxDrawSprite(dpi, ImageId(SPR_INTRO_INFOGRAMES_10), { (screenWidth / 2) - 320 + 319, _introStateCounter + 69 });
-            GfxDrawSprite(dpi, ImageId(SPR_INTRO_INFOGRAMES_01), { (screenWidth / 2) - 320 + 69, _introStateCounter + 319 });
-            GfxDrawSprite(dpi, ImageId(SPR_INTRO_INFOGRAMES_11), { (screenWidth / 2) - 320 + 319, _introStateCounter + 319 });
+            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_INFOGRAMES_00), { (screenWidth / 2) - 320 + 69, _introStateCounter + 69 });
+            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_INFOGRAMES_10), { (screenWidth / 2) - 320 + 319, _introStateCounter + 69 });
+            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_INFOGRAMES_01), { (screenWidth / 2) - 320 + 69, _introStateCounter + 319 });
+            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_INFOGRAMES_11), { (screenWidth / 2) - 320 + 319, _introStateCounter + 319 });
             break;
         case IntroState::DeveloperBegin:
             GfxClear(dpi, BACKROUND_COLOUR_DARK);
@@ -204,8 +204,8 @@ void IntroDraw(DrawPixelInfo* dpi)
             GfxClear(dpi, BACKROUND_COLOUR_DARK);
 
             // Draw Chris Sawyer logo
-            GfxDrawSprite(dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_00), { (screenWidth / 2) - 320 + 70, _introStateCounter });
-            GfxDrawSprite(dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_10), { (screenWidth / 2) - 320 + 320, _introStateCounter });
+            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_00), { (screenWidth / 2) - 320 + 70, _introStateCounter });
+            GfxDrawSprite(*dpi, ImageId(SPR_INTRO_CHRIS_SAWYER_10), { (screenWidth / 2) - 320 + 320, _introStateCounter });
             break;
         case IntroState::LogoFadeIn:
             if (_introStateCounter <= 0xFF00)
@@ -294,10 +294,10 @@ static void ScreenIntroDrawLogo(DrawPixelInfo* dpi)
     DrawingEngineInvalidateImage(SPR_INTRO_LOGO_21);
 
     GfxClear(dpi, BACKROUND_COLOUR_LOGO);
-    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_00), { imageX + 0, 0 });
-    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_10), { imageX + 220, 0 });
-    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_20), { imageX + 440, 0 });
-    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_01), { imageX + 0, 240 });
-    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_11), { imageX + 220, 240 });
-    GfxDrawSprite(dpi, ImageId(SPR_INTRO_LOGO_21), { imageX + 440, 240 });
+    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_00), { imageX + 0, 0 });
+    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_10), { imageX + 220, 0 });
+    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_20), { imageX + 440, 0 });
+    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_01), { imageX + 0, 240 });
+    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_11), { imageX + 220, 240 });
+    GfxDrawSprite(*dpi, ImageId(SPR_INTRO_LOGO_21), { imageX + 440, 240 });
 }

--- a/src/openrct2/Intro.h
+++ b/src/openrct2/Intro.h
@@ -32,4 +32,4 @@ enum class IntroState : uint8_t
 extern IntroState gIntroState;
 
 void IntroUpdate();
-void IntroDraw(DrawPixelInfo* dpi);
+void IntroDraw(DrawPixelInfo& dpi);

--- a/src/openrct2/command_line/BenchSpriteSort.cpp
+++ b/src/openrct2/command_line/BenchSpriteSort.cpp
@@ -122,7 +122,7 @@ static std::vector<RecordedPaintSession> extract_paint_session(std::string_view 
         dpi.bits = static_cast<uint8_t*>(malloc(dpi.width * dpi.height));
 
         LOG_INFO("Obtaining sprite data...");
-        ViewportRender(&dpi, &viewport, { { 0, 0 }, { viewport.width, viewport.height } }, &sessions);
+        ViewportRender(dpi, &viewport, { { 0, 0 }, { viewport.width, viewport.height } }, &sessions);
 
         free(dpi.bits);
         DrawingEngineDispose();

--- a/src/openrct2/drawing/Drawing.String.cpp
+++ b/src/openrct2/drawing/Drawing.String.cpp
@@ -768,7 +768,7 @@ static void TTFProcessFormatCode(DrawPixelInfo& dpi, const FmtString::Token& tok
             {
                 if (!(info->flags & TEXT_DRAW_FLAG_NO_DRAW))
                 {
-                    GfxDrawSprite(&dpi, imageId, { info->x, info->y });
+                    GfxDrawSprite(dpi, imageId, { info->x, info->y });
                 }
                 info->x += g1->width;
             }

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -735,7 +735,7 @@ void MaskInit()
 
 void GfxFilterPixel(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, FilterPaletteID palette)
 {
-    GfxFilterRect(dpi, { coords, coords }, palette);
+    GfxFilterRect(*dpi, { coords, coords }, palette);
 }
 
 /**

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -895,7 +895,7 @@ void GfxDrawPickedUpPeep(DrawPixelInfo* dpi)
 {
     if (gPickupPeepImage.HasValue())
     {
-        GfxDrawSprite(dpi, gPickupPeepImage, { gPickupPeepX, gPickupPeepY });
+        GfxDrawSprite(*dpi, gPickupPeepImage, { gPickupPeepX, gPickupPeepY });
     }
 }
 

--- a/src/openrct2/drawing/Drawing.cpp
+++ b/src/openrct2/drawing/Drawing.cpp
@@ -733,9 +733,9 @@ void MaskInit()
     }
 }
 
-void GfxFilterPixel(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, FilterPaletteID palette)
+void GfxFilterPixel(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, FilterPaletteID palette)
 {
-    GfxFilterRect(*dpi, { coords, coords }, palette);
+    GfxFilterRect(dpi, { coords, coords }, palette);
 }
 
 /**
@@ -825,49 +825,49 @@ void GfxInvalidateScreen()
  * height (dx)
  * drawpixelinfo (edi)
  */
-bool ClipDrawPixelInfo(DrawPixelInfo* dst, DrawPixelInfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height)
+bool ClipDrawPixelInfo(DrawPixelInfo& dst, DrawPixelInfo& src, const ScreenCoordsXY& coords, int32_t width, int32_t height)
 {
     int32_t right = coords.x + width;
     int32_t bottom = coords.y + height;
 
-    *dst = *src;
-    dst->zoom_level = ZoomLevel{ 0 };
+    dst = src;
+    dst.zoom_level = ZoomLevel{ 0 };
 
-    if (coords.x > dst->x)
+    if (coords.x > dst.x)
     {
-        uint16_t clippedFromLeft = coords.x - dst->x;
-        dst->width -= clippedFromLeft;
-        dst->x = coords.x;
-        dst->pitch += clippedFromLeft;
-        dst->bits += clippedFromLeft;
+        uint16_t clippedFromLeft = coords.x - dst.x;
+        dst.width -= clippedFromLeft;
+        dst.x = coords.x;
+        dst.pitch += clippedFromLeft;
+        dst.bits += clippedFromLeft;
     }
 
-    int32_t stickOutWidth = dst->x + dst->width - right;
+    int32_t stickOutWidth = dst.x + dst.width - right;
     if (stickOutWidth > 0)
     {
-        dst->width -= stickOutWidth;
-        dst->pitch += stickOutWidth;
+        dst.width -= stickOutWidth;
+        dst.pitch += stickOutWidth;
     }
 
-    if (coords.y > dst->y)
+    if (coords.y > dst.y)
     {
-        uint16_t clippedFromTop = coords.y - dst->y;
-        dst->height -= clippedFromTop;
-        dst->y = coords.y;
-        uint32_t bitsPlus = (dst->pitch + dst->width) * clippedFromTop;
-        dst->bits += bitsPlus;
+        uint16_t clippedFromTop = coords.y - dst.y;
+        dst.height -= clippedFromTop;
+        dst.y = coords.y;
+        uint32_t bitsPlus = (dst.pitch + dst.width) * clippedFromTop;
+        dst.bits += bitsPlus;
     }
 
-    int32_t bp = dst->y + dst->height - bottom;
+    int32_t bp = dst.y + dst.height - bottom;
     if (bp > 0)
     {
-        dst->height -= bp;
+        dst.height -= bp;
     }
 
-    if (dst->width > 0 && dst->height > 0)
+    if (dst.width > 0 && dst.height > 0)
     {
-        dst->x -= coords.x;
-        dst->y -= coords.y;
+        dst.x -= coords.x;
+        dst.y -= coords.y;
         return true;
     }
 
@@ -891,11 +891,11 @@ void GfxInvalidatePickedUpPeep()
     }
 }
 
-void GfxDrawPickedUpPeep(DrawPixelInfo* dpi)
+void GfxDrawPickedUpPeep(DrawPixelInfo& dpi)
 {
     if (gPickupPeepImage.HasValue())
     {
-        GfxDrawSprite(*dpi, gPickupPeepImage, { gPickupPeepX, gPickupPeepY });
+        GfxDrawSprite(dpi, gPickupPeepImage, { gPickupPeepX, gPickupPeepY });
     }
 }
 

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -518,7 +518,7 @@ void GfxDrawPickedUpPeep(DrawPixelInfo* dpi);
 
 // line
 void GfxDrawLine(DrawPixelInfo* dpi, const ScreenLine& line, int32_t colour);
-void GfxDrawLineSoftware(DrawPixelInfo* dpi, const ScreenLine& line, int32_t colour);
+void GfxDrawLineSoftware(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour);
 void GfxDrawDashedLine(
     DrawPixelInfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);
 
@@ -547,11 +547,11 @@ void FASTCALL GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const Screen
 void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
 void FASTCALL GfxDrawSpriteRawMasked(
     DrawPixelInfo* dpi, const ScreenCoordsXY& coords, const ImageId maskImage, const ImageId colourImage);
-void FASTCALL GfxDrawSpriteSoftware(DrawPixelInfo* dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
+void FASTCALL GfxDrawSpriteSoftware(DrawPixelInfo& dpi, const ImageId imageId, const ScreenCoordsXY& spriteCoords);
 void FASTCALL GfxDrawSpritePaletteSetSoftware(
-    DrawPixelInfo* dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
+    DrawPixelInfo& dpi, const ImageId imageId, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
 void FASTCALL GfxDrawSpriteRawMaskedSoftware(
-    DrawPixelInfo* dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage);
+    DrawPixelInfo& dpi, const ScreenCoordsXY& scrCoords, const ImageId maskImage, const ImageId colourImage);
 
 // string
 void GfxDrawString(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, const_utf8string buffer, TextPaint textPaint = {});

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -517,15 +517,15 @@ void GfxInvalidatePickedUpPeep();
 void GfxDrawPickedUpPeep(DrawPixelInfo* dpi);
 
 // line
-void GfxDrawLine(DrawPixelInfo* dpi, const ScreenLine& line, int32_t colour);
+void GfxDrawLine(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour);
 void GfxDrawLineSoftware(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour);
 void GfxDrawDashedLine(
-    DrawPixelInfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);
+    DrawPixelInfo& dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color);
 
 // rect
-void GfxFillRect(DrawPixelInfo* dpi, const ScreenRect& rect, int32_t colour);
-void GfxFillRectInset(DrawPixelInfo* dpi, const ScreenRect& rect, int32_t colour, uint8_t flags);
-void GfxFilterRect(DrawPixelInfo* dpi, const ScreenRect& rect, FilterPaletteID palette);
+void GfxFillRect(DrawPixelInfo& dpi, const ScreenRect& rect, int32_t colour);
+void GfxFillRectInset(DrawPixelInfo& dpi, const ScreenRect& rect, int32_t colour, uint8_t flags);
+void GfxFilterRect(DrawPixelInfo& dpi, const ScreenRect& rect, FilterPaletteID palette);
 
 // sprite
 bool GfxLoadG1(const OpenRCT2::IPlatformEnvironment& env);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -502,7 +502,7 @@ extern int32_t gPickupPeepY;
 
 extern bool gTinyFontAntiAliased;
 
-bool ClipDrawPixelInfo(DrawPixelInfo* dst, DrawPixelInfo* src, const ScreenCoordsXY& coords, int32_t width, int32_t height);
+bool ClipDrawPixelInfo(DrawPixelInfo& dst, DrawPixelInfo& src, const ScreenCoordsXY& coords, int32_t width, int32_t height);
 void GfxSetDirtyBlocks(const ScreenRect& rect);
 void GfxInvalidateScreen();
 
@@ -512,9 +512,9 @@ void LoadPalette();
 
 // other
 void GfxClear(DrawPixelInfo* dpi, uint8_t paletteIndex);
-void GfxFilterPixel(DrawPixelInfo* dpi, const ScreenCoordsXY& coords, FilterPaletteID palette);
+void GfxFilterPixel(DrawPixelInfo& dpi, const ScreenCoordsXY& coords, FilterPaletteID palette);
 void GfxInvalidatePickedUpPeep();
-void GfxDrawPickedUpPeep(DrawPixelInfo* dpi);
+void GfxDrawPickedUpPeep(DrawPixelInfo& dpi);
 
 // line
 void GfxDrawLine(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour);

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -542,7 +542,7 @@ bool IsCsgLoaded();
 void FASTCALL GfxSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL GfxBmpSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
 void FASTCALL GfxRleSpriteToBuffer(DrawPixelInfo& dpi, const DrawSpriteArgs& args);
-void FASTCALL GfxDrawSprite(DrawPixelInfo* dpi, const ImageId image_id, const ScreenCoordsXY& coords);
+void FASTCALL GfxDrawSprite(DrawPixelInfo& dpi, const ImageId image_id, const ScreenCoordsXY& coords);
 void FASTCALL GfxDrawGlyph(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, const PaletteMap& paletteMap);
 void FASTCALL GfxDrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, const ScreenCoordsXY& coords, uint8_t colour);
 void FASTCALL GfxDrawSpriteRawMasked(

--- a/src/openrct2/drawing/IDrawingEngine.h
+++ b/src/openrct2/drawing/IDrawingEngine.h
@@ -92,7 +92,7 @@ namespace OpenRCT2::Drawing
     {
         virtual ~IWeatherDrawer() = default;
         virtual void Draw(
-            DrawPixelInfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+            DrawPixelInfo& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
             const uint8_t* weatherpattern) abstract;
     };
 } // namespace OpenRCT2::Drawing

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -180,11 +180,11 @@ void LightFXInit()
     CalcRescaleLightHalf(_bakedLightTexture_spot_0, _bakedLightTexture_spot_1, 32, 32);
 }
 
-void LightFXUpdateBuffers(DrawPixelInfo* info)
+void LightFXUpdateBuffers(DrawPixelInfo& info)
 {
-    _light_rendered_buffer_front = realloc(_light_rendered_buffer_front, info->width * info->height);
-    _light_rendered_buffer_back = realloc(_light_rendered_buffer_back, info->width * info->height);
-    _pixelInfo = *info;
+    _light_rendered_buffer_front = realloc(_light_rendered_buffer_front, info.width * info.height);
+    _light_rendered_buffer_back = realloc(_light_rendered_buffer_back, info.width * info.height);
+    _pixelInfo = info;
 }
 
 void LightFXPrepareLightList()

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -305,7 +305,7 @@ void LightFXPrepareLightList()
                     dpi.zoom_level = _current_view_zoom_front;
                     dpi.width = 1;
 
-                    PaintSession* session = PaintSessionAlloc(&dpi, w->viewport->flags);
+                    PaintSession* session = PaintSessionAlloc(dpi, w->viewport->flags);
                     PaintSessionGenerate(*session);
                     PaintSessionArrange(*session);
                     auto info = SetInteractionInfoFromPaintSession(session, w->viewport->flags, ViewportInteractionItemAll);

--- a/src/openrct2/drawing/LightFX.h
+++ b/src/openrct2/drawing/LightFX.h
@@ -48,7 +48,7 @@ bool LightFXForVehiclesIsAvailable();
 
 void LightFXInit();
 
-void LightFXUpdateBuffers(DrawPixelInfo*);
+void LightFXUpdateBuffers(DrawPixelInfo&);
 
 void LightFXPrepareLightList();
 void LightFXSwapBuffers();

--- a/src/openrct2/drawing/Line.cpp
+++ b/src/openrct2/drawing/Line.cpp
@@ -16,14 +16,14 @@
  * Draws a horizontal line of specified colour to a buffer.
  *  rct2: 0x0068474C
  */
-static void GfxDrawLineOnBuffer(DrawPixelInfo* dpi, char colour, const ScreenCoordsXY& coords, int32_t no_pixels)
+static void GfxDrawLineOnBuffer(DrawPixelInfo& dpi, char colour, const ScreenCoordsXY& coords, int32_t no_pixels)
 {
-    ScreenCoordsXY offset{ coords.x - dpi->x, coords.y - dpi->y };
+    ScreenCoordsXY offset{ coords.x - dpi.x, coords.y - dpi.y };
 
     // Check to make sure point is in the y range
     if (offset.y < 0)
         return;
-    if (offset.y >= dpi->height)
+    if (offset.y >= dpi.height)
         return;
     // Check to make sure we are drawing at least a pixel
     if (!no_pixels)
@@ -41,18 +41,18 @@ static void GfxDrawLineOnBuffer(DrawPixelInfo* dpi, char colour, const ScreenCoo
     }
 
     // Ensure that the end point of the line is within range
-    if (offset.x + no_pixels - dpi->width > 0)
+    if (offset.x + no_pixels - dpi.width > 0)
     {
         // If the end point has any pixels outside range
         // cut them off. If there are now no pixels return.
-        no_pixels -= offset.x + no_pixels - dpi->width;
+        no_pixels -= offset.x + no_pixels - dpi.width;
         if (no_pixels <= 0)
             return;
     }
 
     // Get the buffer we are drawing to and move to the first coordinate.
-    uint8_t* bits_pointer = dpi->bits
-        + offset.y * (static_cast<int64_t>(static_cast<int64_t>(dpi->pitch) + static_cast<int64_t>(dpi->width))) + offset.x;
+    uint8_t* bits_pointer = dpi.bits
+        + offset.y * (static_cast<int64_t>(static_cast<int64_t>(dpi.pitch) + static_cast<int64_t>(dpi.width))) + offset.x;
 
     // Draw the line to the specified colour
     for (; no_pixels > 0; --no_pixels, ++bits_pointer)
@@ -72,29 +72,29 @@ static void GfxDrawLineOnBuffer(DrawPixelInfo* dpi, char colour, const ScreenCoo
  * colour (ebp)
  */
 
-void GfxDrawLineSoftware(DrawPixelInfo* dpi, const ScreenLine& line, int32_t colour)
+void GfxDrawLineSoftware(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour)
 {
     int32_t x1 = line.GetX1();
     int32_t x2 = line.GetX2();
     int32_t y1 = line.GetY1();
     int32_t y2 = line.GetY2();
     // Check to make sure the line is within the drawing area
-    if ((x1 < dpi->x) && (x2 < dpi->x))
+    if ((x1 < dpi.x) && (x2 < dpi.x))
     {
         return;
     }
 
-    if ((y1 < dpi->y) && (y2 < dpi->y))
+    if ((y1 < dpi.y) && (y2 < dpi.y))
     {
         return;
     }
 
-    if ((x1 > (dpi->x + dpi->width)) && (x2 > (dpi->x + dpi->width)))
+    if ((x1 > (dpi.x + dpi.width)) && (x2 > (dpi.x + dpi.width)))
     {
         return;
     }
 
-    if ((y1 > (dpi->y + dpi->height)) && (y2 > (dpi->y + dpi->height)))
+    if ((y1 > (dpi.y + dpi.height)) && (y2 > (dpi.y + dpi.height)))
     {
         return;
     }

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -170,42 +170,42 @@ void GfxClear(DrawPixelInfo* dpi, uint8_t paletteIndex)
     }
 }
 
-void GfxFillRect(DrawPixelInfo* dpi, const ScreenRect& rect, int32_t colour)
+void GfxFillRect(DrawPixelInfo& dpi, const ScreenRect& rect, int32_t colour)
 {
-    auto drawingEngine = dpi->DrawingEngine;
+    auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->FillRect(dpi, colour, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
+        dc->FillRect(&dpi, colour, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
     }
 }
 
-void GfxFilterRect(DrawPixelInfo* dpi, const ScreenRect& rect, FilterPaletteID palette)
+void GfxFilterRect(DrawPixelInfo& dpi, const ScreenRect& rect, FilterPaletteID palette)
 {
-    auto drawingEngine = dpi->DrawingEngine;
+    auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->FilterRect(dpi, palette, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
+        dc->FilterRect(&dpi, palette, rect.GetLeft(), rect.GetTop(), rect.GetRight(), rect.GetBottom());
     }
 }
 
-void GfxDrawLine(DrawPixelInfo* dpi, const ScreenLine& line, int32_t colour)
+void GfxDrawLine(DrawPixelInfo& dpi, const ScreenLine& line, int32_t colour)
 {
-    auto drawingEngine = dpi->DrawingEngine;
+    auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->DrawLine(dpi, colour, line);
+        dc->DrawLine(&dpi, colour, line);
     }
 }
 
 void GfxDrawDashedLine(
-    DrawPixelInfo* dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
+    DrawPixelInfo& dpi, const ScreenLine& screenLine, const int32_t dashedLineSegmentLength, const int32_t color)
 {
     assert(dashedLineSegmentLength > 0);
 
-    const auto drawingEngine = dpi->DrawingEngine;
+    const auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         constexpr int32_t precisionFactor = 1000;
@@ -228,7 +228,7 @@ void GfxDrawDashedLine(
         {
             x = screenLine.GetX1() + dxPrecise * i * 2 / precisionFactor;
             y = screenLine.GetY1() + dyPrecise * i * 2 / precisionFactor;
-            dc->DrawLine(dpi, color, { { x, y }, { x + dxPrecise / precisionFactor, y + dyPrecise / precisionFactor } });
+            dc->DrawLine(&dpi, color, { { x, y }, { x + dxPrecise / precisionFactor, y + dyPrecise / precisionFactor } });
         }
     }
 }

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -233,13 +233,13 @@ void GfxDrawDashedLine(
     }
 }
 
-void FASTCALL GfxDrawSprite(DrawPixelInfo* dpi, const ImageId imageId, const ScreenCoordsXY& coords)
+void FASTCALL GfxDrawSprite(DrawPixelInfo& dpi, const ImageId imageId, const ScreenCoordsXY& coords)
 {
-    auto drawingEngine = dpi->DrawingEngine;
+    auto drawingEngine = dpi.DrawingEngine;
     if (drawingEngine != nullptr)
     {
         IDrawingContext* dc = drawingEngine->GetDrawingContext();
-        dc->DrawSprite(dpi, imageId, coords.x, coords.y);
+        dc->DrawSprite(&dpi, imageId, coords.x, coords.y);
     }
 }
 

--- a/src/openrct2/drawing/NewDrawing.cpp
+++ b/src/openrct2/drawing/NewDrawing.cpp
@@ -115,11 +115,11 @@ void DrawingEngineDispose()
     }
 }
 
-DrawPixelInfo* DrawingEngineGetDpi()
+DrawPixelInfo& DrawingEngineGetDpi()
 {
     auto context = GetContext();
     auto drawingEngine = context->GetDrawingEngine();
-    return drawingEngine->GetDrawingPixelInfo();
+    return *(drawingEngine->GetDrawingPixelInfo());
 }
 
 bool DrawingEngineHasDirtyOptimisations()

--- a/src/openrct2/drawing/NewDrawing.h
+++ b/src/openrct2/drawing/NewDrawing.h
@@ -25,7 +25,7 @@ void DrawingEngineSetPalette(const GamePalette& colours);
 void DrawingEngineCopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy);
 void DrawingEngineDispose();
 
-DrawPixelInfo* DrawingEngineGetDpi();
+DrawPixelInfo& DrawingEngineGetDpi();
 bool DrawingEngineHasDirtyOptimisations();
 void DrawingEngineInvalidateImage(uint32_t image);
 void DrawingEngineSetVSync(bool vsync);

--- a/src/openrct2/drawing/Rect.cpp
+++ b/src/openrct2/drawing/Rect.cpp
@@ -24,7 +24,7 @@
  * colour (ebp)
  * flags (si)
  */
-void GfxFillRectInset(DrawPixelInfo* dpi, const ScreenRect& rect, int32_t colour, uint8_t flags)
+void GfxFillRectInset(DrawPixelInfo& dpi, const ScreenRect& rect, int32_t colour, uint8_t flags)
 {
     const auto leftTop = ScreenCoordsXY{ rect.GetLeft(), rect.GetTop() };
     const auto leftBottom = ScreenCoordsXY{ rect.GetLeft(), rect.GetBottom() };

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -58,7 +58,7 @@ static void ScrollingTextInitialiseCharacterBitmaps(uint32_t glyphStart, uint16_
     for (int32_t i = 0; i < count; i++)
     {
         std::fill_n(drawingSurface, sizeof(drawingSurface), 0x00);
-        GfxDrawSpriteSoftware(&dpi, ImageId(glyphStart + (EnumValue(FontStyle::Tiny) * count) + i), { -1, 0 });
+        GfxDrawSpriteSoftware(dpi, ImageId(glyphStart + (EnumValue(FontStyle::Tiny) * count) + i), { -1, 0 });
 
         for (int32_t x = 0; x < 8; x++)
         {

--- a/src/openrct2/drawing/ScrollingText.cpp
+++ b/src/openrct2/drawing/ScrollingText.cpp
@@ -1440,9 +1440,7 @@ ImageId ScrollingTextSetup(
 
     assert(scrollingMode < MAX_SCROLLING_TEXT_MODES);
 
-    DrawPixelInfo* dpi = &session.DPI;
-
-    if (dpi->zoom_level > ZoomLevel{ 0 })
+    if (session.DPI.zoom_level > ZoomLevel{ 0 })
         return ImageId(SPR_SCROLLING_TEXT_DEFAULT);
 
     _drawSCrollNextIndex++;

--- a/src/openrct2/drawing/Text.cpp
+++ b/src/openrct2/drawing/Text.cpp
@@ -98,12 +98,12 @@ void DrawText(
     if (paint.UnderlineText == TextUnderline::On)
     {
         GfxFillRect(
-            &dpi, { { alignedCoords + ScreenCoordsXY{ 0, 11 } }, { alignedCoords + ScreenCoordsXY{ width, 11 } } },
+            dpi, { { alignedCoords + ScreenCoordsXY{ 0, 11 } }, { alignedCoords + ScreenCoordsXY{ width, 11 } } },
             gTextPalette[1]);
         if (gTextPalette[2] != 0)
         {
             GfxFillRect(
-                &dpi, { { alignedCoords + ScreenCoordsXY{ 1, 12 } }, { alignedCoords + ScreenCoordsXY{ width + 1, 12 } } },
+                dpi, { { alignedCoords + ScreenCoordsXY{ 1, 12 } }, { alignedCoords + ScreenCoordsXY{ width + 1, 12 } } },
                 gTextPalette[2]);
         }
     }

--- a/src/openrct2/drawing/Weather.cpp
+++ b/src/openrct2/drawing/Weather.cpp
@@ -23,13 +23,13 @@ using namespace OpenRCT2;
 using namespace OpenRCT2::Drawing;
 
 static void DrawLightRain(
-    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawHeavyRain(
-    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawLightSnow(
-    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 static void DrawHeavySnow(
-    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
+    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height);
 
 /**
  *
@@ -51,7 +51,7 @@ const DrawWeatherFunc DrawSnowFunctions[] = {
  *
  *  rct2: 0x00684218
  */
-void DrawWeather(DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer)
+void DrawWeather(DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer)
 {
     if (gConfigGeneral.RenderWeatherEffects)
     {
@@ -81,7 +81,7 @@ void DrawWeather(DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer)
  *  rct2: 0x00684114
  */
 static void DrawLightRain(
-    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     int32_t x_start = -static_cast<int32_t>(gCurrentTicks) + 8;
     int32_t y_start = (gCurrentTicks * 3) + 7;
@@ -103,7 +103,7 @@ static void DrawLightRain(
  *  rct2: 0x0068416D
  */
 static void DrawHeavyRain(
-    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     int32_t x_start = -static_cast<int32_t>(gCurrentTicks);
     int32_t y_start = gCurrentTicks * 5;
@@ -135,7 +135,7 @@ static void DrawHeavyRain(
 }
 
 static void DrawLightSnow(
-    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     const uint32_t t = gCurrentTicks / 2;
     const int32_t negT = -static_cast<int32_t>(t);
@@ -157,7 +157,7 @@ static void DrawLightSnow(
 }
 
 static void DrawHeavySnow(
-    DrawPixelInfo* dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
+    DrawPixelInfo& dpi, IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width, int32_t height)
 {
     int32_t x_start = -static_cast<int32_t>(gCurrentTicks * 3) + 1;
     int32_t y_start = gCurrentTicks + 23;

--- a/src/openrct2/drawing/Weather.h
+++ b/src/openrct2/drawing/Weather.h
@@ -37,4 +37,4 @@ static constexpr const uint8_t SnowPattern[] =
 
 // clang-format on
 
-void DrawWeather(DrawPixelInfo* dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer);
+void DrawWeather(DrawPixelInfo& dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer);

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -340,7 +340,7 @@ void X8DrawingEngine::ConfigureBits(uint32_t width, uint32_t height, uint32_t pi
 
     if (LightFXIsAvailable())
     {
-        LightFXUpdateBuffers(dpi);
+        LightFXUpdateBuffers(*dpi);
     }
 }
 
@@ -704,18 +704,18 @@ void X8DrawingContext::FilterRect(
 
 void X8DrawingContext::DrawLine(DrawPixelInfo* dpi, uint32_t colour, const ScreenLine& line)
 {
-    GfxDrawLineSoftware(dpi, line, colour);
+    GfxDrawLineSoftware(*dpi, line, colour);
 }
 
 void X8DrawingContext::DrawSprite(DrawPixelInfo* dpi, const ImageId imageId, int32_t x, int32_t y)
 {
-    GfxDrawSpriteSoftware(dpi, imageId, { x, y });
+    GfxDrawSpriteSoftware(*dpi, imageId, { x, y });
 }
 
 void X8DrawingContext::DrawSpriteRawMasked(
     DrawPixelInfo* dpi, int32_t x, int32_t y, const ImageId maskImage, const ImageId colourImage)
 {
-    GfxDrawSpriteRawMaskedSoftware(dpi, { x, y }, maskImage, colourImage);
+    GfxDrawSpriteRawMaskedSoftware(*dpi, { x, y }, maskImage, colourImage);
 }
 
 void X8DrawingContext::DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, uint8_t colour)
@@ -725,10 +725,10 @@ void X8DrawingContext::DrawSpriteSolid(DrawPixelInfo* dpi, const ImageId image, 
     palette[0] = 0;
 
     const auto spriteCoords = ScreenCoordsXY{ x, y };
-    GfxDrawSpritePaletteSetSoftware(dpi, ImageId(image.GetIndex(), 0), spriteCoords, PaletteMap(palette));
+    GfxDrawSpritePaletteSetSoftware(*dpi, ImageId(image.GetIndex(), 0), spriteCoords, PaletteMap(palette));
 }
 
 void X8DrawingContext::DrawGlyph(DrawPixelInfo* dpi, const ImageId image, int32_t x, int32_t y, const PaletteMap& paletteMap)
 {
-    GfxDrawSpritePaletteSetSoftware(dpi, image, { x, y }, paletteMap);
+    GfxDrawSpritePaletteSetSoftware(*dpi, image, { x, y }, paletteMap);
 }

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -44,7 +44,7 @@ X8WeatherDrawer::~X8WeatherDrawer()
 }
 
 void X8WeatherDrawer::Draw(
-    DrawPixelInfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+    DrawPixelInfo& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
     const uint8_t* weatherpattern)
 {
     const uint8_t* pattern = weatherpattern;
@@ -54,10 +54,10 @@ void X8WeatherDrawer::Draw(
     uint8_t patternStartXOffset = xStart % patternXSpace;
     uint8_t patternStartYOffset = yStart % patternYSpace;
 
-    uint32_t pixelOffset = (dpi->pitch + dpi->width) * y + x;
+    uint32_t pixelOffset = (dpi.pitch + dpi.width) * y + x;
     uint8_t patternYPos = patternStartYOffset % patternYSpace;
 
-    uint8_t* screenBits = dpi->bits;
+    uint8_t* screenBits = dpi.bits;
 
     // Stores the colours of changed pixels
     WeatherPixel* newPixels = &_weatherPixels[_weatherPixelsCount];
@@ -86,7 +86,7 @@ void X8WeatherDrawer::Draw(
             }
         }
 
-        pixelOffset += dpi->pitch + dpi->width;
+        pixelOffset += dpi.pitch + dpi.width;
         patternYPos++;
         patternYPos %= patternYSpace;
     }
@@ -214,7 +214,7 @@ void X8DrawingEngine::PaintWindows()
 
 void X8DrawingEngine::PaintWeather()
 {
-    DrawWeather(&_bitsDPI, &_weatherDrawer);
+    DrawWeather(_bitsDPI, &_weatherDrawer);
 }
 
 void X8DrawingEngine::CopyRect(int32_t x, int32_t y, int32_t width, int32_t height, int32_t dx, int32_t dy)

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -259,7 +259,7 @@ void X8DrawingEngine::CopyRect(int32_t x, int32_t y, int32_t width, int32_t heig
 
 std::string X8DrawingEngine::Screenshot()
 {
-    return ScreenshotDumpPNG(&_bitsDPI);
+    return ScreenshotDumpPNG(_bitsDPI);
 }
 
 IDrawingContext* X8DrawingEngine::GetDrawingContext()

--- a/src/openrct2/drawing/X8DrawingEngine.cpp
+++ b/src/openrct2/drawing/X8DrawingEngine.cpp
@@ -437,7 +437,7 @@ void X8DrawingEngine::DrawDirtyBlocks(uint32_t x, uint32_t y, uint32_t columns, 
 
     // Draw region
     OnDrawDirtyBlock(x, y, columns, rows);
-    WindowDrawAll(&_bitsDPI, left, top, right, bottom);
+    WindowDrawAll(_bitsDPI, left, top, right, bottom);
 }
 
 #ifdef __WARN_SUGGEST_FINAL_METHODS__

--- a/src/openrct2/drawing/X8DrawingEngine.h
+++ b/src/openrct2/drawing/X8DrawingEngine.h
@@ -56,7 +56,7 @@ namespace OpenRCT2
             X8WeatherDrawer();
             ~X8WeatherDrawer();
             void Draw(
-                DrawPixelInfo* dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
+                DrawPixelInfo& dpi, int32_t x, int32_t y, int32_t width, int32_t height, int32_t xStart, int32_t yStart,
                 const uint8_t* weatherpattern) override;
             void Restore(DrawPixelInfo* dpi);
         };

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -2801,8 +2801,7 @@ void Peep::Paint(PaintSession& session, int32_t imageDirection) const
         }
     }
 
-    DrawPixelInfo* dpi = &session.DPI;
-    if (dpi->zoom_level > ZoomLevel{ 2 })
+    if (session.DPI.zoom_level > ZoomLevel{ 2 })
     {
         return;
     }

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -42,7 +42,7 @@ static TextInputSession* _chatTextInputSession;
 static const u8string& ChatGetHistory(size_t index);
 static uint32_t ChatHistoryGetTime(size_t index);
 static void ChatClearInput();
-static int32_t ChatHistoryDrawString(DrawPixelInfo* dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width);
+static int32_t ChatHistoryDrawString(DrawPixelInfo& dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width);
 
 bool ChatAvailable()
 {
@@ -86,7 +86,7 @@ void ChatUpdate()
     _chatCaretTicks = (_chatCaretTicks + 1) % 30;
 }
 
-void ChatDraw(DrawPixelInfo* dpi, uint8_t chatBackgroundColor)
+void ChatDraw(DrawPixelInfo& dpi, uint8_t chatBackgroundColor)
 {
     thread_local std::string lineBuffer;
 
@@ -140,16 +140,16 @@ void ChatDraw(DrawPixelInfo* dpi, uint8_t chatBackgroundColor)
         GfxSetDirtyBlocks(
             { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } }); // Background area + Textbox
         GfxFilterRect(
-            dpi, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } },
+            &dpi, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } },
             FilterPaletteID::Palette51); // Opaque grey background
         GfxFillRectInset(
-            dpi, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } }, chatBackgroundColor,
+            &dpi, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } }, chatBackgroundColor,
             INSET_RECT_FLAG_FILL_NONE);
         GfxFillRectInset(
-            dpi, { topLeft + ScreenCoordsXY{ 1, -4 }, bottomRight - ScreenCoordsXY{ 1, inputLineHeight + 6 } },
+            &dpi, { topLeft + ScreenCoordsXY{ 1, -4 }, bottomRight - ScreenCoordsXY{ 1, inputLineHeight + 6 } },
             chatBackgroundColor, INSET_RECT_FLAG_BORDER_INSET);
         GfxFillRectInset(
-            dpi, { bottomLeft + ScreenCoordsXY{ 1, -inputLineHeight - 5 }, bottomRight + ScreenCoordsXY{ -1, 4 } },
+            &dpi, { bottomLeft + ScreenCoordsXY{ 1, -inputLineHeight - 5 }, bottomRight + ScreenCoordsXY{ -1, 4 } },
             chatBackgroundColor,
             INSET_RECT_FLAG_BORDER_INSET); // Textbox
     }
@@ -193,7 +193,7 @@ void ChatDraw(DrawPixelInfo* dpi, uint8_t chatBackgroundColor)
         auto ft = Formatter();
         ft.Add<const char*>(lineCh);
         inputLineHeight = DrawTextWrapped(
-            *dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, _chatWidth - 10, STR_STRING, ft, { TEXT_COLOUR_255 });
+            dpi, screenCoords + ScreenCoordsXY{ 0, 3 }, _chatWidth - 10, STR_STRING, ft, { TEXT_COLOUR_255 });
         GfxSetDirtyBlocks({ screenCoords, { screenCoords + ScreenCoordsXY{ _chatWidth, inputLineHeight + 15 } } });
 
         // TODO: Show caret if the input text has multiple lines
@@ -203,7 +203,7 @@ void ChatDraw(DrawPixelInfo* dpi, uint8_t chatBackgroundColor)
             int32_t caretX = screenCoords.x + GfxGetStringWidth(lineBuffer, FontStyle::Medium);
             int32_t caretY = screenCoords.y + 14;
 
-            GfxFillRect(dpi, { { caretX, caretY }, { caretX + 6, caretY + 1 } }, PALETTE_INDEX_56);
+            GfxFillRect(&dpi, { { caretX, caretY }, { caretX + 6, caretY + 1 } }, PALETTE_INDEX_56);
         }
     }
 }
@@ -272,7 +272,7 @@ static void ChatClearInput()
 
 // This method is the same as gfx_draw_string_left_wrapped.
 // But this adjusts the initial Y coordinate depending of the number of lines.
-static int32_t ChatHistoryDrawString(DrawPixelInfo* dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width)
+static int32_t ChatHistoryDrawString(DrawPixelInfo& dpi, const char* text, const ScreenCoordsXY& screenCoords, int32_t width)
 {
     int32_t numLines;
     u8string wrappedString;
@@ -289,7 +289,7 @@ static int32_t ChatHistoryDrawString(DrawPixelInfo* dpi, const char* text, const
     int32_t lineY = screenCoords.y;
     for (int32_t line = 0; line <= numLines; ++line)
     {
-        GfxDrawString(*dpi, { screenCoords.x, lineY - (numLines * lineHeight) }, bufferPtr, { TEXT_COLOUR_254 });
+        GfxDrawString(dpi, { screenCoords.x, lineY - (numLines * lineHeight) }, bufferPtr, { TEXT_COLOUR_254 });
         bufferPtr = GetStringEnd(bufferPtr) + 1;
         lineY += lineHeight;
     }

--- a/src/openrct2/interface/Chat.cpp
+++ b/src/openrct2/interface/Chat.cpp
@@ -140,16 +140,16 @@ void ChatDraw(DrawPixelInfo& dpi, uint8_t chatBackgroundColor)
         GfxSetDirtyBlocks(
             { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } }); // Background area + Textbox
         GfxFilterRect(
-            &dpi, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } },
+            dpi, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } },
             FilterPaletteID::Palette51); // Opaque grey background
         GfxFillRectInset(
-            &dpi, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } }, chatBackgroundColor,
+            dpi, { topLeft - ScreenCoordsXY{ 0, 5 }, bottomRight + ScreenCoordsXY{ 0, 5 } }, chatBackgroundColor,
             INSET_RECT_FLAG_FILL_NONE);
         GfxFillRectInset(
-            &dpi, { topLeft + ScreenCoordsXY{ 1, -4 }, bottomRight - ScreenCoordsXY{ 1, inputLineHeight + 6 } },
+            dpi, { topLeft + ScreenCoordsXY{ 1, -4 }, bottomRight - ScreenCoordsXY{ 1, inputLineHeight + 6 } },
             chatBackgroundColor, INSET_RECT_FLAG_BORDER_INSET);
         GfxFillRectInset(
-            &dpi, { bottomLeft + ScreenCoordsXY{ 1, -inputLineHeight - 5 }, bottomRight + ScreenCoordsXY{ -1, 4 } },
+            dpi, { bottomLeft + ScreenCoordsXY{ 1, -inputLineHeight - 5 }, bottomRight + ScreenCoordsXY{ -1, 4 } },
             chatBackgroundColor,
             INSET_RECT_FLAG_BORDER_INSET); // Textbox
     }
@@ -203,7 +203,7 @@ void ChatDraw(DrawPixelInfo& dpi, uint8_t chatBackgroundColor)
             int32_t caretX = screenCoords.x + GfxGetStringWidth(lineBuffer, FontStyle::Medium);
             int32_t caretY = screenCoords.y + 14;
 
-            GfxFillRect(&dpi, { { caretX, caretY }, { caretX + 6, caretY + 1 } }, PALETTE_INDEX_56);
+            GfxFillRect(dpi, { { caretX, caretY }, { caretX + 6, caretY + 1 } }, PALETTE_INDEX_56);
         }
     }
 }

--- a/src/openrct2/interface/Chat.h
+++ b/src/openrct2/interface/Chat.h
@@ -38,7 +38,7 @@ void ChatToggle();
 
 void ChatInit();
 void ChatUpdate();
-void ChatDraw(DrawPixelInfo* dpi, uint8_t chatBackgroundColour);
+void ChatDraw(DrawPixelInfo& dpi, uint8_t chatBackgroundColour);
 
 void ChatAddHistory(std::string_view s);
 void ChatInput(ChatInput input);

--- a/src/openrct2/interface/Screenshot.cpp
+++ b/src/openrct2/interface/Screenshot.cpp
@@ -51,17 +51,17 @@ extern uint8_t gClipHeight;
 
 uint8_t gScreenshotCountdown = 0;
 
-static bool WriteDpiToFile(std::string_view path, const DrawPixelInfo* dpi, const GamePalette& palette)
+static bool WriteDpiToFile(std::string_view path, const DrawPixelInfo& dpi, const GamePalette& palette)
 {
-    auto const pixels8 = dpi->bits;
-    auto const pixelsLen = (dpi->width + dpi->pitch) * dpi->height;
+    auto const pixels8 = dpi.bits;
+    auto const pixelsLen = (dpi.width + dpi.pitch) * dpi.height;
     try
     {
         Image image;
-        image.Width = dpi->width;
-        image.Height = dpi->height;
+        image.Width = dpi.width;
+        image.Height = dpi.height;
         image.Depth = 8;
-        image.Stride = dpi->width + dpi->pitch;
+        image.Stride = dpi.width + dpi.pitch;
         image.Palette = std::make_unique<GamePalette>(palette);
         image.Pixels = std::vector<uint8_t>(pixels8, pixels8 + pixelsLen);
         Imaging::WriteToFile(path, image, IMAGE_FORMAT::PNG);
@@ -164,7 +164,7 @@ static std::optional<std::string> ScreenshotGetNextPath()
     return std::nullopt;
 };
 
-std::string ScreenshotDumpPNG(DrawPixelInfo* dpi)
+std::string ScreenshotDumpPNG(DrawPixelInfo& dpi)
 {
     // Get a free screenshot path
     auto path = ScreenshotGetNextPath();
@@ -336,7 +336,7 @@ static void RenderViewport(IDrawingEngine* drawingEngine, const Viewport& viewpo
         drawingEngine = tempDrawingEngine.get();
     }
     dpi.DrawingEngine = drawingEngine;
-    ViewportRender(&dpi, &viewport, { { 0, 0 }, { viewport.width, viewport.height } });
+    ViewportRender(dpi, &viewport, { { 0, 0 }, { viewport.width, viewport.height } });
 }
 
 void ScreenshotGiant()
@@ -372,7 +372,7 @@ void ScreenshotGiant()
         dpi = CreateDPI(viewport);
 
         RenderViewport(nullptr, viewport, dpi);
-        WriteDpiToFile(path.value(), &dpi, gPalette);
+        WriteDpiToFile(path.value(), dpi, gPalette);
 
         // Show user that screenshot saved successfully
         const auto filename = Path::GetFileName(path.value());
@@ -690,7 +690,7 @@ int32_t CommandLineForScreenshot(const char** argv, int32_t argc, ScreenshotOpti
         dpi = CreateDPI(viewport);
 
         RenderViewport(nullptr, viewport, dpi);
-        WriteDpiToFile(outputPath, &dpi, gPalette);
+        WriteDpiToFile(outputPath, dpi, gPalette);
     }
     catch (const std::exception& e)
     {
@@ -786,7 +786,7 @@ void CaptureImage(const CaptureOptions& options)
     auto outputPath = ResolveFilenameForCapture(options.Filename);
     auto dpi = CreateDPI(viewport);
     RenderViewport(nullptr, viewport, dpi);
-    WriteDpiToFile(outputPath, &dpi, gPalette);
+    WriteDpiToFile(outputPath, dpi, gPalette);
     ReleaseDPI(dpi);
 
     gCurrentRotation = backupRotation;

--- a/src/openrct2/interface/Screenshot.h
+++ b/src/openrct2/interface/Screenshot.h
@@ -54,7 +54,7 @@ struct CaptureOptions
 
 void ScreenshotCheck();
 std::string ScreenshotDump();
-std::string ScreenshotDumpPNG(DrawPixelInfo* dpi);
+std::string ScreenshotDumpPNG(DrawPixelInfo& dpi);
 std::string ScreenshotDumpPNG32bpp(int32_t width, int32_t height, const void* pixels);
 
 void ScreenshotGiant();

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -370,14 +370,14 @@ static void ViewportRedrawAfterShift(DrawPixelInfo* dpi, WindowBase* window, Vie
             {
                 // draw left
                 auto _right = viewport->pos.x + coords.x;
-                WindowDrawAll(dpi, left, top, _right, bottom);
+                WindowDrawAll(*dpi, left, top, _right, bottom);
                 left += coords.x;
             }
             else if (coords.x < 0)
             {
                 // draw right
                 auto _left = viewport->pos.x + viewport->width + coords.x;
-                WindowDrawAll(dpi, _left, top, right, bottom);
+                WindowDrawAll(*dpi, _left, top, right, bottom);
                 right += coords.x;
             }
 
@@ -385,19 +385,19 @@ static void ViewportRedrawAfterShift(DrawPixelInfo* dpi, WindowBase* window, Vie
             {
                 // draw top
                 bottom = viewport->pos.y + coords.y;
-                WindowDrawAll(dpi, left, top, right, bottom);
+                WindowDrawAll(*dpi, left, top, right, bottom);
             }
             else if (coords.y < 0)
             {
                 // draw bottom
                 top = viewport->pos.y + viewport->height + coords.y;
-                WindowDrawAll(dpi, left, top, right, bottom);
+                WindowDrawAll(*dpi, left, top, right, bottom);
             }
         }
         else
         {
             // redraw whole viewport
-            WindowDrawAll(dpi, left, top, right, bottom);
+            WindowDrawAll(*dpi, left, top, right, bottom);
         }
     }
 }
@@ -443,7 +443,7 @@ static void ViewportShiftPixels(DrawPixelInfo* dpi, WindowBase* window, Viewport
         if (top >= bottom)
             continue;
 
-        WindowDrawAll(dpi, left, top, right, bottom);
+        WindowDrawAll(*dpi, left, top, right, bottom);
     }
 
     ViewportRedrawAfterShift(dpi, window, viewport, { x_diff, y_diff });
@@ -480,7 +480,7 @@ static void ViewportMove(const ScreenCoordsXY& coords, WindowBase* w, Viewport* 
         if (DrawingEngineHasDirtyOptimisations())
         {
             DrawPixelInfo* dpi = DrawingEngineGetDpi();
-            WindowDrawAll(dpi, left, top, right, bottom);
+            WindowDrawAll(*dpi, left, top, right, bottom);
             return;
         }
     }

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -479,8 +479,8 @@ static void ViewportMove(const ScreenCoordsXY& coords, WindowBase* w, Viewport* 
 
         if (DrawingEngineHasDirtyOptimisations())
         {
-            DrawPixelInfo* dpi = DrawingEngineGetDpi();
-            WindowDrawAll(*dpi, left, top, right, bottom);
+            DrawPixelInfo& dpi = DrawingEngineGetDpi();
+            WindowDrawAll(dpi, left, top, right, bottom);
             return;
         }
     }
@@ -531,8 +531,8 @@ static void ViewportMove(const ScreenCoordsXY& coords, WindowBase* w, Viewport* 
 
     if (DrawingEngineHasDirtyOptimisations())
     {
-        DrawPixelInfo* dpi = DrawingEngineGetDpi();
-        ViewportShiftPixels(*dpi, w, viewport, x_diff, y_diff);
+        DrawPixelInfo& dpi = DrawingEngineGetDpi();
+        ViewportShiftPixels(dpi, w, viewport, x_diff, y_diff);
     }
 
     *viewport = view_copy;

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -945,7 +945,7 @@ static void ViewportPaintColumn(PaintSession& session)
 
     if (session.PSStringHead != nullptr)
     {
-        PaintDrawMoneyStructs(&session.DPI, session.PSStringHead);
+        PaintDrawMoneyStructs(session.DPI, session.PSStringHead);
     }
 }
 
@@ -1031,7 +1031,7 @@ void ViewportPaint(
     // Generate and sort columns.
     for (x = alignedX; x < rightBorder; x += 32, index++)
     {
-        PaintSession* session = PaintSessionAlloc(&dpi1, viewFlags);
+        PaintSession* session = PaintSessionAlloc(dpi1, viewFlags);
         _paintColumns.push_back(session);
 
         DrawPixelInfo& dpi2 = session->DPI;
@@ -1921,7 +1921,7 @@ InteractionInfo GetMapCoordinatesFromPosWindow(WindowBase* window, const ScreenC
         dpi.zoom_level = myviewport->zoom;
         dpi.width = 1;
 
-        PaintSession* session = PaintSessionAlloc(&dpi, myviewport->flags);
+        PaintSession* session = PaintSessionAlloc(dpi, myviewport->flags);
         PaintSessionGenerate(*session);
         PaintSessionArrange(*session);
         info = SetInteractionInfoFromPaintSession(session, myviewport->flags, flags & 0xFFFF);

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1104,7 +1104,7 @@ static void ViewportPaintWeatherGloom(DrawPixelInfo& dpi)
         auto y = dpi.y;
         auto w = zoomLevel.ApplyInversedTo(dpi.width) - 1;
         auto h = zoomLevel.ApplyInversedTo(dpi.height) - 1;
-        GfxFilterRect(&dpi, ScreenRect(x, y, x + w, y + h), paletteId);
+        GfxFilterRect(dpi, ScreenRect(x, y, x + w, y + h), paletteId);
     }
 }
 

--- a/src/openrct2/interface/Viewport.h
+++ b/src/openrct2/interface/Viewport.h
@@ -131,10 +131,10 @@ void ViewportUpdateSmartFollowGuest(WindowBase* window, const Guest* peep);
 void ViewportUpdateSmartFollowStaff(WindowBase* window, const Staff* peep);
 void ViewportUpdateSmartFollowVehicle(WindowBase* window);
 void ViewportRender(
-    DrawPixelInfo* dpi, const Viewport* viewport, const ScreenRect& screenRect,
+    DrawPixelInfo& dpi, const Viewport* viewport, const ScreenRect& screenRect,
     std::vector<RecordedPaintSession>* sessions = nullptr);
 void ViewportPaint(
-    const Viewport* viewport, DrawPixelInfo* dpi, const ScreenRect& screenRect,
+    const Viewport* viewport, DrawPixelInfo& dpi, const ScreenRect& screenRect,
     std::vector<RecordedPaintSession>* sessions = nullptr);
 
 CoordsXYZ ViewportAdjustForMapHeight(const ScreenCoordsXY& startCoords);

--- a/src/openrct2/interface/Widget.h
+++ b/src/openrct2/interface/Widget.h
@@ -163,7 +163,7 @@ constexpr Widget MakeDropdownButtonWidget(
 }
 
 void WidgetScrollUpdateThumbs(WindowBase& w, WidgetIndex widget_index);
-void WidgetDraw(DrawPixelInfo* dpi, WindowBase& w, WidgetIndex widgetIndex);
+void WidgetDraw(DrawPixelInfo& dpi, WindowBase& w, WidgetIndex widgetIndex);
 
 bool WidgetIsDisabled(const WindowBase& w, WidgetIndex widgetIndex);
 bool WidgetIsHoldable(const WindowBase& w, WidgetIndex widgetIndex);

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -1278,7 +1278,7 @@ static void WindowDrawSingle(DrawPixelInfo* dpi, WindowBase& w, int32_t left, in
  */
 void WindowDrawViewport(DrawPixelInfo& dpi, WindowBase& w)
 {
-    ViewportRender(&dpi, w.viewport, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } });
+    ViewportRender(dpi, w.viewport, { { dpi.x, dpi.y }, { dpi.x + dpi.width, dpi.y + dpi.height } });
 }
 
 void WindowSetPosition(WindowBase& w, const ScreenCoordsXY& screenCoords)

--- a/src/openrct2/interface/Window.cpp
+++ b/src/openrct2/interface/Window.cpp
@@ -85,7 +85,7 @@ namespace WindowCloseFlags
 } // namespace WindowCloseFlags
 
 static void WindowDrawCore(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
-static void WindowDrawSingle(DrawPixelInfo* dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+static void WindowDrawSingle(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
 
 std::list<std::shared_ptr<WindowBase>>::iterator WindowGetIterator(const WindowBase* w)
 {
@@ -1203,56 +1203,55 @@ static void WindowDrawCore(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int3
         auto* v = (*it).get();
         if ((&w == v || (v->flags & WF_TRANSPARENT)) && WindowIsVisible(*v))
         {
-            WindowDrawSingle(&dpi, *v, left, top, right, bottom);
+            WindowDrawSingle(dpi, *v, left, top, right, bottom);
         }
     }
 }
 
-static void WindowDrawSingle(DrawPixelInfo* dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
+static void WindowDrawSingle(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom)
 {
     // Copy dpi so we can crop it
-    DrawPixelInfo copy = *dpi;
-    dpi = &copy;
+    DrawPixelInfo copy = dpi;
 
     // Clamp left to 0
-    int32_t overflow = left - dpi->x;
+    int32_t overflow = left - copy.x;
     if (overflow > 0)
     {
-        dpi->x += overflow;
-        dpi->width -= overflow;
-        if (dpi->width <= 0)
+        copy.x += overflow;
+        copy.width -= overflow;
+        if (copy.width <= 0)
             return;
-        dpi->pitch += overflow;
-        dpi->bits += overflow;
+        copy.pitch += overflow;
+        copy.bits += overflow;
     }
 
     // Clamp width to right
-    overflow = dpi->x + dpi->width - right;
+    overflow = copy.x + copy.width - right;
     if (overflow > 0)
     {
-        dpi->width -= overflow;
-        if (dpi->width <= 0)
+        copy.width -= overflow;
+        if (copy.width <= 0)
             return;
-        dpi->pitch += overflow;
+        copy.pitch += overflow;
     }
 
     // Clamp top to 0
-    overflow = top - dpi->y;
+    overflow = top - copy.y;
     if (overflow > 0)
     {
-        dpi->y += overflow;
-        dpi->height -= overflow;
-        if (dpi->height <= 0)
+        copy.y += overflow;
+        copy.height -= overflow;
+        if (copy.height <= 0)
             return;
-        dpi->bits += (dpi->width + dpi->pitch) * overflow;
+        copy.bits += (copy.width + copy.pitch) * overflow;
     }
 
     // Clamp height to bottom
-    overflow = dpi->y + dpi->height - bottom;
+    overflow = copy.y + copy.height - bottom;
     if (overflow > 0)
     {
-        dpi->height -= overflow;
-        if (dpi->height <= 0)
+        copy.height -= overflow;
+        if (copy.height <= 0)
             return;
     }
 
@@ -1266,7 +1265,7 @@ static void WindowDrawSingle(DrawPixelInfo* dpi, WindowBase& w, int32_t left, in
     gCurrentWindowColours[2] = NOT_TRANSLUCENT(w.colours[2]);
     gCurrentWindowColours[3] = NOT_TRANSLUCENT(w.colours[3]);
 
-    WindowEventPaintCall(&w, *dpi);
+    WindowEventPaintCall(&w, copy);
 }
 
 /**

--- a/src/openrct2/interface/Window.h
+++ b/src/openrct2/interface/Window.h
@@ -247,8 +247,8 @@ struct WindowEventList
     void (*cursor)(struct WindowBase*, WidgetIndex, const ScreenCoordsXY&, CursorID*){};
     void (*moved)(struct WindowBase*, const ScreenCoordsXY&){};
     void (*invalidate)(struct WindowBase*){};
-    void (*paint)(struct WindowBase*, DrawPixelInfo*){};
-    void (*scroll_paint)(struct WindowBase*, DrawPixelInfo*, int32_t){};
+    void (*paint)(struct WindowBase*, DrawPixelInfo&){};
+    void (*scroll_paint)(struct WindowBase*, DrawPixelInfo&, int32_t){};
 
     typedef void (*fnEventInitializer)(WindowEventList&);
     WindowEventList(fnEventInitializer fn)
@@ -662,10 +662,10 @@ void WindowZoomIn(WindowBase& w, bool atCursor);
 void WindowZoomOut(WindowBase& w, bool atCursor);
 void MainWindowZoom(bool zoomIn, bool atCursor);
 
-void WindowDrawAll(DrawPixelInfo* dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
-void WindowDraw(DrawPixelInfo* dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
-void WindowDrawWidgets(WindowBase& w, DrawPixelInfo* dpi);
-void WindowDrawViewport(DrawPixelInfo* dpi, WindowBase& w);
+void WindowDrawAll(DrawPixelInfo& dpi, int32_t left, int32_t top, int32_t right, int32_t bottom);
+void WindowDraw(DrawPixelInfo& dpi, WindowBase& w, int32_t left, int32_t top, int32_t right, int32_t bottom);
+void WindowDrawWidgets(WindowBase& w, DrawPixelInfo& dpi);
+void WindowDrawViewport(DrawPixelInfo& dpi, WindowBase& w);
 
 void WindowSetPosition(WindowBase& w, const ScreenCoordsXY& screenCoords);
 void WindowMovePosition(WindowBase& w, const ScreenCoordsXY& screenCoords);
@@ -713,8 +713,8 @@ OpenRCT2String WindowEventTooltipCall(WindowBase* w, const WidgetIndex widgetInd
 CursorID WindowEventCursorCall(WindowBase* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
 void WindowEventMovedCall(WindowBase* w, const ScreenCoordsXY& screenCoords);
 void WindowEventInvalidateCall(WindowBase* w);
-void WindowEventPaintCall(WindowBase* w, DrawPixelInfo* dpi);
-void WindowEventScrollPaintCall(WindowBase* w, DrawPixelInfo* dpi, int32_t scrollIndex);
+void WindowEventPaintCall(WindowBase* w, DrawPixelInfo& dpi);
+void WindowEventScrollPaintCall(WindowBase* w, DrawPixelInfo& dpi, int32_t scrollIndex);
 
 void InvalidateAllWindowsAfterInput();
 void TextinputCancel();

--- a/src/openrct2/object/BannerObject.cpp
+++ b/src/openrct2/object/BannerObject.cpp
@@ -81,8 +81,8 @@ void BannerObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height
     auto image0 = ImageId(_legacyType.image, COLOUR_BORDEAUX_RED);
     auto image1 = ImageId(_legacyType.image + 1, COLOUR_BORDEAUX_RED);
 
-    GfxDrawSprite(&dpi, image0, screenCoords + ScreenCoordsXY{ -12, 8 });
-    GfxDrawSprite(&dpi, image1, screenCoords + ScreenCoordsXY{ -12, 8 });
+    GfxDrawSprite(dpi, image0, screenCoords + ScreenCoordsXY{ -12, 8 });
+    GfxDrawSprite(dpi, image1, screenCoords + ScreenCoordsXY{ -12, 8 });
 }
 
 void BannerObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/EntranceObject.cpp
+++ b/src/openrct2/object/EntranceObject.cpp
@@ -46,9 +46,9 @@ void EntranceObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t heig
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 
-    GfxDrawSprite(&dpi, ImageId(_legacyType.image_id + 1), screenCoords + ScreenCoordsXY{ -32, 14 });
-    GfxDrawSprite(&dpi, ImageId(_legacyType.image_id + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
-    GfxDrawSprite(&dpi, ImageId(_legacyType.image_id + 2), screenCoords + ScreenCoordsXY{ 32, 44 });
+    GfxDrawSprite(dpi, ImageId(_legacyType.image_id + 1), screenCoords + ScreenCoordsXY{ -32, 14 });
+    GfxDrawSprite(dpi, ImageId(_legacyType.image_id + 0), screenCoords + ScreenCoordsXY{ 0, 28 });
+    GfxDrawSprite(dpi, ImageId(_legacyType.image_id + 2), screenCoords + ScreenCoordsXY{ 32, 44 });
 }
 
 void EntranceObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/FootpathItemObject.cpp
+++ b/src/openrct2/object/FootpathItemObject.cpp
@@ -83,7 +83,7 @@ void FootpathItemObject::Unload()
 void FootpathItemObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
-    GfxDrawSprite(&dpi, ImageId(_legacyType.image), screenCoords - ScreenCoordsXY{ 22, 24 });
+    GfxDrawSprite(dpi, ImageId(_legacyType.image), screenCoords - ScreenCoordsXY{ 22, 24 });
 }
 
 static PathBitDrawType ParseDrawType(const std::string& s)

--- a/src/openrct2/object/FootpathObject.cpp
+++ b/src/openrct2/object/FootpathObject.cpp
@@ -72,8 +72,8 @@ void FootpathObject::Unload()
 void FootpathObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
-    GfxDrawSprite(&dpi, ImageId(_pathSurfaceDescriptor.PreviewImage), screenCoords - ScreenCoordsXY{ 49, 17 });
-    GfxDrawSprite(&dpi, ImageId(_queueSurfaceDescriptor.PreviewImage), screenCoords + ScreenCoordsXY{ 4, -17 });
+    GfxDrawSprite(dpi, ImageId(_pathSurfaceDescriptor.PreviewImage), screenCoords - ScreenCoordsXY{ 49, 17 });
+    GfxDrawSprite(dpi, ImageId(_queueSurfaceDescriptor.PreviewImage), screenCoords + ScreenCoordsXY{ 4, -17 });
 }
 
 void FootpathObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/FootpathRailingsObject.cpp
+++ b/src/openrct2/object/FootpathRailingsObject.cpp
@@ -61,20 +61,20 @@ void FootpathRailingsObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int3
         for (int i = 0; i < 2; i++)
         {
             auto h = i * 16;
-            GfxDrawSprite(&dpi, img, { x - 8, y + 8 + h });
-            GfxDrawSprite(&dpi, img, { x + 8, y + 16 + h });
+            GfxDrawSprite(dpi, img, { x - 8, y + 8 + h });
+            GfxDrawSprite(dpi, img, { x + 8, y + 16 + h });
         }
 
-        GfxDrawSprite(&dpi, helper.WithIndex(BridgeImageId + 5), { x, y - 17 });
-        GfxDrawSprite(&dpi, ImageId(RailingsImageId + 1), { x + 4, y - 14 });
-        GfxDrawSprite(&dpi, ImageId(RailingsImageId + 1), { x + 27, y - 2 });
+        GfxDrawSprite(dpi, helper.WithIndex(BridgeImageId + 5), { x, y - 17 });
+        GfxDrawSprite(dpi, ImageId(RailingsImageId + 1), { x + 4, y - 14 });
+        GfxDrawSprite(dpi, ImageId(RailingsImageId + 1), { x + 27, y - 2 });
     }
     else
     {
-        GfxDrawSprite(&dpi, helper.WithIndex(BridgeImageId + 22), { x + 0, y + 16 });
-        GfxDrawSprite(&dpi, helper.WithIndex(BridgeImageId + 49), { x, y - 17 });
-        GfxDrawSprite(&dpi, ImageId(RailingsImageId + 1), { x + 4, y - 14 });
-        GfxDrawSprite(&dpi, ImageId(RailingsImageId + 1), { x + 27, y - 3 });
+        GfxDrawSprite(dpi, helper.WithIndex(BridgeImageId + 22), { x + 0, y + 16 });
+        GfxDrawSprite(dpi, helper.WithIndex(BridgeImageId + 49), { x, y - 17 });
+        GfxDrawSprite(dpi, ImageId(RailingsImageId + 1), { x + 4, y - 14 });
+        GfxDrawSprite(dpi, ImageId(RailingsImageId + 1), { x + 27, y - 3 });
     }
 }
 

--- a/src/openrct2/object/FootpathSurfaceObject.cpp
+++ b/src/openrct2/object/FootpathSurfaceObject.cpp
@@ -46,9 +46,9 @@ void FootpathSurfaceObject::Unload()
 void FootpathSurfaceObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const
 {
     auto screenCoords = ScreenCoordsXY{ width / 2 - 16, height / 2 };
-    GfxDrawSprite(&dpi, ImageId(BaseImageId + 3), screenCoords);
-    GfxDrawSprite(&dpi, ImageId(BaseImageId + 16), { screenCoords.x + 32, screenCoords.y - 16 });
-    GfxDrawSprite(&dpi, ImageId(BaseImageId + 8), { screenCoords.x + 32, screenCoords.y + 16 });
+    GfxDrawSprite(dpi, ImageId(BaseImageId + 3), screenCoords);
+    GfxDrawSprite(dpi, ImageId(BaseImageId + 16), { screenCoords.x + 32, screenCoords.y - 16 });
+    GfxDrawSprite(dpi, ImageId(BaseImageId + 8), { screenCoords.x + 32, screenCoords.y + 16 });
 }
 
 void FootpathSurfaceObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/LargeSceneryObject.cpp
+++ b/src/openrct2/object/LargeSceneryObject.cpp
@@ -155,7 +155,7 @@ void LargeSceneryObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t 
     if (_legacyType.flags & LARGE_SCENERY_FLAG_HAS_TERTIARY_COLOUR)
         image = image.WithTertiary(COLOUR_DARK_BROWN);
 
-    GfxDrawSprite(&dpi, image, screenCoords);
+    GfxDrawSprite(dpi, image, screenCoords);
 }
 
 std::vector<LargeSceneryTile> LargeSceneryObject::ReadTiles(OpenRCT2::IStream* stream)

--- a/src/openrct2/object/MusicObject.cpp
+++ b/src/openrct2/object/MusicObject.cpp
@@ -93,7 +93,7 @@ void MusicObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height)
     int32_t x = width / 2;
     int32_t y = height / 2;
     if (_hasPreview)
-        GfxDrawSprite(&dpi, ImageId(_previewImageId), { 0, 0 });
+        GfxDrawSprite(dpi, ImageId(_previewImageId), { 0, 0 });
     else
         DrawTextBasic(dpi, { x, y }, STR_WINDOW_NO_IMAGE, {}, { TextAlignment::CENTRE });
 }

--- a/src/openrct2/object/RideObject.cpp
+++ b/src/openrct2/object/RideObject.cpp
@@ -346,7 +346,7 @@ void RideObject::DrawPreview(DrawPixelInfo& dpi, [[maybe_unused]] int32_t width,
         imageId++;
     }
 
-    GfxDrawSprite(&dpi, ImageId(imageId), { 0, 0 });
+    GfxDrawSprite(dpi, ImageId(imageId), { 0, 0 });
 }
 
 std::string RideObject::GetDescription() const

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -76,7 +76,7 @@ void SceneryGroupObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t 
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 
     const auto imageId = ImageId(_legacyType.image + 1, COLOUR_DARK_GREEN);
-    GfxDrawSprite(&dpi, imageId, screenCoords - ScreenCoordsXY{ 15, 14 });
+    GfxDrawSprite(dpi, imageId, screenCoords - ScreenCoordsXY{ 15, 14 });
 }
 
 static std::optional<uint8_t> GetSceneryType(const ObjectType type)

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -119,12 +119,12 @@ void SmallSceneryObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t 
         screenCoords.y -= 12;
     }
 
-    GfxDrawSprite(&dpi, imageId, screenCoords);
+    GfxDrawSprite(dpi, imageId, screenCoords);
 
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_GLASS))
     {
         imageId = ImageId(_legacyType.image + 4).WithTransparency(COLOUR_BORDEAUX_RED);
-        GfxDrawSprite(&dpi, imageId, screenCoords);
+        GfxDrawSprite(dpi, imageId, screenCoords);
     }
 
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_ANIMATED_FG))
@@ -134,7 +134,7 @@ void SmallSceneryObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t 
         {
             imageId = imageId.WithSecondary(COLOUR_YELLOW);
         }
-        GfxDrawSprite(&dpi, imageId, screenCoords);
+        GfxDrawSprite(dpi, imageId, screenCoords);
     }
 }
 

--- a/src/openrct2/object/StationObject.cpp
+++ b/src/openrct2/object/StationObject.cpp
@@ -64,16 +64,16 @@ void StationObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t heigh
         imageId = imageId.WithSecondary(colour1);
     }
 
-    GfxDrawSprite(&dpi, imageId, screenCoords);
+    GfxDrawSprite(dpi, imageId, screenCoords);
     if (Flags & STATION_OBJECT_FLAGS::IS_TRANSPARENT)
     {
-        GfxDrawSprite(&dpi, tImageId, screenCoords);
+        GfxDrawSprite(dpi, tImageId, screenCoords);
     }
 
-    GfxDrawSprite(&dpi, imageId.WithIndexOffset(4), screenCoords);
+    GfxDrawSprite(dpi, imageId.WithIndexOffset(4), screenCoords);
     if (Flags & STATION_OBJECT_FLAGS::IS_TRANSPARENT)
     {
-        GfxDrawSprite(&dpi, tImageId.WithIndexOffset(4), screenCoords);
+        GfxDrawSprite(dpi, tImageId.WithIndexOffset(4), screenCoords);
     }
 }
 

--- a/src/openrct2/object/TerrainEdgeObject.cpp
+++ b/src/openrct2/object/TerrainEdgeObject.cpp
@@ -43,8 +43,8 @@ void TerrainEdgeObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t h
     auto screenCoords = ScreenCoordsXY{ width / 2, height / 2 };
 
     auto imageId = ImageId(BaseImageId + 5);
-    GfxDrawSprite(&dpi, imageId, screenCoords + ScreenCoordsXY{ 8, -8 });
-    GfxDrawSprite(&dpi, imageId, screenCoords + ScreenCoordsXY{ 8, 8 });
+    GfxDrawSprite(dpi, imageId, screenCoords + ScreenCoordsXY{ 8, -8 });
+    GfxDrawSprite(dpi, imageId, screenCoords + ScreenCoordsXY{ 8, 8 });
 }
 
 void TerrainEdgeObject::ReadJson(IReadObjectContext* context, json_t& root)

--- a/src/openrct2/object/TerrainSurfaceObject.cpp
+++ b/src/openrct2/object/TerrainSurfaceObject.cpp
@@ -70,7 +70,7 @@ void TerrainSurfaceObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_
         }
         for (int32_t j = 0; j < 4; j++)
         {
-            GfxDrawSprite(&dpi, imageId, screenCoords);
+            GfxDrawSprite(dpi, imageId, screenCoords);
             screenCoords.x += 64;
         }
         screenCoords.y += 16;

--- a/src/openrct2/object/WallObject.cpp
+++ b/src/openrct2/object/WallObject.cpp
@@ -81,16 +81,16 @@ void WallObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) 
         imageId = imageId.WithSecondary(COLOUR_YELLOW);
     }
 
-    GfxDrawSprite(&dpi, imageId, screenCoords);
+    GfxDrawSprite(dpi, imageId, screenCoords);
 
     if (_legacyType.flags & WALL_SCENERY_HAS_GLASS)
     {
         auto glassImageId = imageId.WithTransparency(COLOUR_BORDEAUX_RED).WithIndexOffset(6);
-        GfxDrawSprite(&dpi, glassImageId, screenCoords);
+        GfxDrawSprite(dpi, glassImageId, screenCoords);
     }
     else if (_legacyType.flags & WALL_SCENERY_IS_DOOR)
     {
-        GfxDrawSprite(&dpi, imageId.WithIndexOffset(1), screenCoords);
+        GfxDrawSprite(dpi, imageId.WithIndexOffset(1), screenCoords);
     }
 }
 

--- a/src/openrct2/paint/Paint.Entity.cpp
+++ b/src/openrct2/paint/Paint.Entity.cpp
@@ -47,8 +47,7 @@ void EntityPaintSetup(PaintSession& session, const CoordsXY& pos)
         return;
     }
 
-    DrawPixelInfo* dpi = &session.DPI;
-    if (dpi->zoom_level > ZoomLevel{ 2 })
+    if (session.DPI.zoom_level > ZoomLevel{ 2 })
     {
         return;
     }
@@ -95,10 +94,8 @@ void EntityPaintSetup(PaintSession& session, const CoordsXY& pos)
             }
         }
 
-        dpi = &session.DPI;
-
-        if (dpi->y + dpi->height <= spr->SpriteData.SpriteRect.GetTop() || spr->SpriteData.SpriteRect.GetBottom() <= dpi->y
-            || dpi->x + dpi->width <= spr->SpriteData.SpriteRect.GetLeft() || spr->SpriteData.SpriteRect.GetRight() <= dpi->x)
+        if (session.DPI.y + session.DPI.height <= spr->SpriteData.SpriteRect.GetTop() || spr->SpriteData.SpriteRect.GetBottom() <= session.DPI.y
+            || session.DPI.x + session.DPI.width <= spr->SpriteData.SpriteRect.GetLeft() || spr->SpriteData.SpriteRect.GetRight() <= session.DPI.x)
         {
             continue;
         }

--- a/src/openrct2/paint/Paint.Entity.cpp
+++ b/src/openrct2/paint/Paint.Entity.cpp
@@ -94,8 +94,10 @@ void EntityPaintSetup(PaintSession& session, const CoordsXY& pos)
             }
         }
 
-        if (session.DPI.y + session.DPI.height <= spr->SpriteData.SpriteRect.GetTop() || spr->SpriteData.SpriteRect.GetBottom() <= session.DPI.y
-            || session.DPI.x + session.DPI.width <= spr->SpriteData.SpriteRect.GetLeft() || spr->SpriteData.SpriteRect.GetRight() <= session.DPI.x)
+        if (session.DPI.y + session.DPI.height <= spr->SpriteData.SpriteRect.GetTop()
+            || spr->SpriteData.SpriteRect.GetBottom() <= session.DPI.y
+            || session.DPI.x + session.DPI.width <= spr->SpriteData.SpriteRect.GetLeft()
+            || spr->SpriteData.SpriteRect.GetRight() <= session.DPI.x)
         {
             continue;
         }

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -624,28 +624,28 @@ static void PaintPSImageWithBoundingBoxes(DrawPixelInfo& dpi, PaintStruct* ps, I
     const auto screenCoordBackBottom = Translate3DTo2DWithZ(rotation, backBottom);
 
     // bottom square
-    GfxDrawLine(&dpi, { screenCoordFrontBottom, screenCoordLeftBottom }, colour);
-    GfxDrawLine(&dpi, { screenCoordBackBottom, screenCoordLeftBottom }, colour);
-    GfxDrawLine(&dpi, { screenCoordBackBottom, screenCoordRightBottom }, colour);
-    GfxDrawLine(&dpi, { screenCoordFrontBottom, screenCoordRightBottom }, colour);
+    GfxDrawLine(dpi, { screenCoordFrontBottom, screenCoordLeftBottom }, colour);
+    GfxDrawLine(dpi, { screenCoordBackBottom, screenCoordLeftBottom }, colour);
+    GfxDrawLine(dpi, { screenCoordBackBottom, screenCoordRightBottom }, colour);
+    GfxDrawLine(dpi, { screenCoordFrontBottom, screenCoordRightBottom }, colour);
 
     // vertical back + sides
-    GfxDrawLine(&dpi, { screenCoordBackTop, screenCoordBackBottom }, colour);
-    GfxDrawLine(&dpi, { screenCoordLeftTop, screenCoordLeftBottom }, colour);
-    GfxDrawLine(&dpi, { screenCoordRightTop, screenCoordRightBottom }, colour);
+    GfxDrawLine(dpi, { screenCoordBackTop, screenCoordBackBottom }, colour);
+    GfxDrawLine(dpi, { screenCoordLeftTop, screenCoordLeftBottom }, colour);
+    GfxDrawLine(dpi, { screenCoordRightTop, screenCoordRightBottom }, colour);
 
     // top square back
-    GfxDrawLine(&dpi, { screenCoordBackTop, screenCoordLeftTop }, colour);
-    GfxDrawLine(&dpi, { screenCoordBackTop, screenCoordRightTop }, colour);
+    GfxDrawLine(dpi, { screenCoordBackTop, screenCoordLeftTop }, colour);
+    GfxDrawLine(dpi, { screenCoordBackTop, screenCoordRightTop }, colour);
 
     GfxDrawSprite(dpi, imageId, { x, y });
 
     // vertical front
-    GfxDrawLine(&dpi, { screenCoordFrontTop, screenCoordFrontBottom }, colour);
+    GfxDrawLine(dpi, { screenCoordFrontTop, screenCoordFrontBottom }, colour);
 
     // top square
-    GfxDrawLine(&dpi, { screenCoordFrontTop, screenCoordLeftTop }, colour);
-    GfxDrawLine(&dpi, { screenCoordFrontTop, screenCoordRightTop }, colour);
+    GfxDrawLine(dpi, { screenCoordFrontTop, screenCoordLeftTop }, colour);
+    GfxDrawLine(dpi, { screenCoordFrontTop, screenCoordRightTop }, colour);
 }
 
 static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uint32_t viewFlags)

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -509,7 +509,7 @@ static void PaintDrawStruct(PaintSession& session, PaintStruct* ps)
     }
     else
     {
-        GfxDrawSprite(dpi, imageId, { x, y });
+        GfxDrawSprite(*dpi, imageId, { x, y });
     }
 
     if (ps->children != nullptr)
@@ -559,7 +559,7 @@ static void PaintAttachedPS(DrawPixelInfo* dpi, PaintStruct* ps, uint32_t viewFl
         }
         else
         {
-            GfxDrawSprite(dpi, imageId, screenCoords);
+            GfxDrawSprite(*dpi, imageId, screenCoords);
         }
     }
 }
@@ -640,7 +640,7 @@ static void PaintPSImageWithBoundingBoxes(DrawPixelInfo* dpi, PaintStruct* ps, I
     GfxDrawLine(dpi, { screenCoordBackTop, screenCoordLeftTop }, colour);
     GfxDrawLine(dpi, { screenCoordBackTop, screenCoordRightTop }, colour);
 
-    GfxDrawSprite(dpi, imageId, { x, y });
+    GfxDrawSprite(*dpi, imageId, { x, y });
 
     // vertical front
     GfxDrawLine(dpi, { screenCoordFrontTop, screenCoordFrontBottom }, colour);

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -55,8 +55,8 @@ bool gShowDirtyVisuals;
 bool gPaintBoundingBoxes;
 bool gPaintBlockedTiles;
 
-static void PaintAttachedPS(DrawPixelInfo* dpi, PaintStruct* ps, uint32_t viewFlags);
-static void PaintPSImageWithBoundingBoxes(DrawPixelInfo* dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y);
+static void PaintAttachedPS(DrawPixelInfo& dpi, PaintStruct* ps, uint32_t viewFlags);
+static void PaintPSImageWithBoundingBoxes(DrawPixelInfo& dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y);
 static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uint32_t viewFlags);
 
 static int32_t RemapPositionToQuadrant(const PaintStruct& ps, uint8_t rotation)
@@ -483,18 +483,16 @@ void PaintSessionArrange(PaintSessionCore& session)
 
 static void PaintDrawStruct(PaintSession& session, PaintStruct* ps)
 {
-    DrawPixelInfo* dpi = &session.DPI;
-
     auto x = ps->x;
     auto y = ps->y;
 
     if (ps->sprite_type == ViewportInteractionItem::Entity)
     {
-        if (dpi->zoom_level >= ZoomLevel{ 1 })
+        if (session.DPI.zoom_level >= ZoomLevel{ 1 })
         {
             x = Floor2(x, 2);
             y = Floor2(y, 2);
-            if (dpi->zoom_level >= ZoomLevel{ 2 })
+            if (session.DPI.zoom_level >= ZoomLevel{ 2 })
             {
                 x = Floor2(x, 4);
                 y = Floor2(y, 4);
@@ -503,13 +501,13 @@ static void PaintDrawStruct(PaintSession& session, PaintStruct* ps)
     }
 
     auto imageId = PaintPSColourifyImage(ps, ps->image_id, session.ViewFlags);
-    if (gPaintBoundingBoxes && dpi->zoom_level == ZoomLevel{ 0 })
+    if (gPaintBoundingBoxes && session.DPI.zoom_level == ZoomLevel{ 0 })
     {
-        PaintPSImageWithBoundingBoxes(dpi, ps, imageId, x, y);
+        PaintPSImageWithBoundingBoxes(session.DPI, ps, imageId, x, y);
     }
     else
     {
-        GfxDrawSprite(*dpi, imageId, { x, y });
+        GfxDrawSprite(session.DPI, imageId, { x, y });
     }
 
     if (ps->children != nullptr)
@@ -518,7 +516,7 @@ static void PaintDrawStruct(PaintSession& session, PaintStruct* ps)
     }
     else
     {
-        PaintAttachedPS(dpi, ps, session.ViewFlags);
+        PaintAttachedPS(session.DPI, ps, session.ViewFlags);
     }
 }
 
@@ -545,7 +543,7 @@ void PaintDrawStructs(PaintSession& session)
  *  rct2: 0x00688596
  *  Part of 0x688485
  */
-static void PaintAttachedPS(DrawPixelInfo* dpi, PaintStruct* ps, uint32_t viewFlags)
+static void PaintAttachedPS(DrawPixelInfo& dpi, PaintStruct* ps, uint32_t viewFlags)
 {
     AttachedPaintStruct* attached_ps = ps->attached_ps;
     for (; attached_ps != nullptr; attached_ps = attached_ps->next)
@@ -555,16 +553,16 @@ static void PaintAttachedPS(DrawPixelInfo* dpi, PaintStruct* ps, uint32_t viewFl
         auto imageId = PaintPSColourifyImage(ps, attached_ps->image_id, viewFlags);
         if (attached_ps->IsMasked)
         {
-            GfxDrawSpriteRawMasked(dpi, screenCoords, imageId, attached_ps->ColourImageId);
+            GfxDrawSpriteRawMasked(&dpi, screenCoords, imageId, attached_ps->ColourImageId);
         }
         else
         {
-            GfxDrawSprite(*dpi, imageId, screenCoords);
+            GfxDrawSprite(dpi, imageId, screenCoords);
         }
     }
 }
 
-static void PaintPSImageWithBoundingBoxes(DrawPixelInfo* dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y)
+static void PaintPSImageWithBoundingBoxes(DrawPixelInfo& dpi, PaintStruct* ps, ImageId imageId, int32_t x, int32_t y)
 {
     const uint8_t colour = BoundBoxDebugColours[EnumValue(ps->sprite_type)];
     const uint8_t rotation = GetCurrentRotation();
@@ -626,28 +624,28 @@ static void PaintPSImageWithBoundingBoxes(DrawPixelInfo* dpi, PaintStruct* ps, I
     const auto screenCoordBackBottom = Translate3DTo2DWithZ(rotation, backBottom);
 
     // bottom square
-    GfxDrawLine(dpi, { screenCoordFrontBottom, screenCoordLeftBottom }, colour);
-    GfxDrawLine(dpi, { screenCoordBackBottom, screenCoordLeftBottom }, colour);
-    GfxDrawLine(dpi, { screenCoordBackBottom, screenCoordRightBottom }, colour);
-    GfxDrawLine(dpi, { screenCoordFrontBottom, screenCoordRightBottom }, colour);
+    GfxDrawLine(&dpi, { screenCoordFrontBottom, screenCoordLeftBottom }, colour);
+    GfxDrawLine(&dpi, { screenCoordBackBottom, screenCoordLeftBottom }, colour);
+    GfxDrawLine(&dpi, { screenCoordBackBottom, screenCoordRightBottom }, colour);
+    GfxDrawLine(&dpi, { screenCoordFrontBottom, screenCoordRightBottom }, colour);
 
     // vertical back + sides
-    GfxDrawLine(dpi, { screenCoordBackTop, screenCoordBackBottom }, colour);
-    GfxDrawLine(dpi, { screenCoordLeftTop, screenCoordLeftBottom }, colour);
-    GfxDrawLine(dpi, { screenCoordRightTop, screenCoordRightBottom }, colour);
+    GfxDrawLine(&dpi, { screenCoordBackTop, screenCoordBackBottom }, colour);
+    GfxDrawLine(&dpi, { screenCoordLeftTop, screenCoordLeftBottom }, colour);
+    GfxDrawLine(&dpi, { screenCoordRightTop, screenCoordRightBottom }, colour);
 
     // top square back
-    GfxDrawLine(dpi, { screenCoordBackTop, screenCoordLeftTop }, colour);
-    GfxDrawLine(dpi, { screenCoordBackTop, screenCoordRightTop }, colour);
+    GfxDrawLine(&dpi, { screenCoordBackTop, screenCoordLeftTop }, colour);
+    GfxDrawLine(&dpi, { screenCoordBackTop, screenCoordRightTop }, colour);
 
-    GfxDrawSprite(*dpi, imageId, { x, y });
+    GfxDrawSprite(dpi, imageId, { x, y });
 
     // vertical front
-    GfxDrawLine(dpi, { screenCoordFrontTop, screenCoordFrontBottom }, colour);
+    GfxDrawLine(&dpi, { screenCoordFrontTop, screenCoordFrontBottom }, colour);
 
     // top square
-    GfxDrawLine(dpi, { screenCoordFrontTop, screenCoordLeftTop }, colour);
-    GfxDrawLine(dpi, { screenCoordFrontTop, screenCoordRightTop }, colour);
+    GfxDrawLine(&dpi, { screenCoordFrontTop, screenCoordLeftTop }, colour);
+    GfxDrawLine(&dpi, { screenCoordFrontTop, screenCoordRightTop }, colour);
 }
 
 static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uint32_t viewFlags)
@@ -664,7 +662,7 @@ static ImageId PaintPSColourifyImage(const PaintStruct* ps, ImageId imageId, uin
     }
 }
 
-PaintSession* PaintSessionAlloc(DrawPixelInfo* dpi, uint32_t viewFlags)
+PaintSession* PaintSessionAlloc(DrawPixelInfo& dpi, uint32_t viewFlags)
 {
     return GetContext()->GetPainter()->CreateSession(dpi, viewFlags);
 }
@@ -877,7 +875,7 @@ void PaintFloatingMoneyEffect(
  *
  *  rct2: 0x006860C3
  */
-void PaintDrawMoneyStructs(DrawPixelInfo* dpi, PaintStringStruct* ps)
+void PaintDrawMoneyStructs(DrawPixelInfo& dpi, PaintStringStruct* ps)
 {
     do
     {
@@ -893,7 +891,7 @@ void PaintDrawMoneyStructs(DrawPixelInfo* dpi, PaintStringStruct* ps)
         }
 
         GfxDrawStringWithYOffsets(
-            *dpi, buffer, COLOUR_BLACK, { ps->x, ps->y }, reinterpret_cast<int8_t*>(ps->y_offsets), forceSpriteFont,
+            dpi, buffer, COLOUR_BLACK, { ps->x, ps->y }, reinterpret_cast<int8_t*>(ps->y_offsets), forceSpriteFont,
             FontStyle::Medium);
     } while ((ps = ps->next) != nullptr);
 }

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -344,9 +344,9 @@ void PaintFloatingMoneyEffect(
     PaintSession& session, money64 amount, StringId string_id, int32_t y, int32_t z, int8_t y_offsets[], int32_t offset_x,
     uint32_t rotation);
 
-PaintSession* PaintSessionAlloc(DrawPixelInfo* dpi, uint32_t viewFlags);
+PaintSession* PaintSessionAlloc(DrawPixelInfo& dpi, uint32_t viewFlags);
 void PaintSessionFree(PaintSession* session);
 void PaintSessionGenerate(PaintSession& session);
 void PaintSessionArrange(PaintSessionCore& session);
 void PaintDrawStructs(PaintSession& session);
-void PaintDrawMoneyStructs(DrawPixelInfo* dpi, PaintStringStruct* ps);
+void PaintDrawMoneyStructs(DrawPixelInfo& dpi, PaintStringStruct* ps);

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -43,7 +43,7 @@ void Painter::Paint(IDrawingEngine& de)
     auto dpi = de.GetDrawingPixelInfo();
     if (gIntroState != IntroState::None)
     {
-        IntroDraw(dpi);
+        IntroDraw(*dpi);
     }
     else
     {

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -50,11 +50,11 @@ void Painter::Paint(IDrawingEngine& de)
         de.PaintWindows();
 
         UpdatePaletteEffects();
-        _uiContext->Draw(dpi);
+        _uiContext->Draw(*dpi);
 
         if ((gScreenFlags & SCREEN_FLAGS_TITLE_DEMO) && !TitleShouldHideVersionInfo())
         {
-            DrawOpenRCT2(dpi, { 0, _uiContext->GetHeight() - 20 });
+            DrawOpenRCT2(*dpi, { 0, _uiContext->GetHeight() - 20 });
         }
 
         GfxDrawPickedUpPeep(dpi);

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -57,7 +57,7 @@ void Painter::Paint(IDrawingEngine& de)
             DrawOpenRCT2(*dpi, { 0, _uiContext->GetHeight() - 20 });
         }
 
-        GfxDrawPickedUpPeep(dpi);
+        GfxDrawPickedUpPeep(*dpi);
         GfxInvalidatePickedUpPeep();
 
         de.PaintWeather();

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -74,16 +74,16 @@ void Painter::Paint(IDrawingEngine& de)
         text = "Normalising...";
 
     if (text != nullptr)
-        PaintReplayNotice(dpi, text);
+        PaintReplayNotice(*dpi, text);
 
     if (gConfigGeneral.ShowFPS)
     {
-        PaintFPS(dpi);
+        PaintFPS(*dpi);
     }
     gCurrentDrawCount++;
 }
 
-void Painter::PaintReplayNotice(DrawPixelInfo* dpi, const char* text)
+void Painter::PaintReplayNotice(DrawPixelInfo& dpi, const char* text)
 {
     ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, _uiContext->GetHeight() - 44);
 
@@ -94,13 +94,13 @@ void Painter::PaintReplayNotice(DrawPixelInfo* dpi, const char* text)
     screenCoords.x = screenCoords.x - stringWidth;
 
     if (((gCurrentTicks >> 1) & 0xF) > 4)
-        GfxDrawString(*dpi, screenCoords, buffer, { COLOUR_SATURATED_RED });
+        GfxDrawString(dpi, screenCoords, buffer, { COLOUR_SATURATED_RED });
 
     // Make area dirty so the text doesn't get drawn over the last
     GfxSetDirtyBlocks({ screenCoords, screenCoords + ScreenCoordsXY{ stringWidth, 16 } });
 }
 
-void Painter::PaintFPS(DrawPixelInfo* dpi)
+void Painter::PaintFPS(DrawPixelInfo& dpi)
 {
     ScreenCoordsXY screenCoords(_uiContext->GetWidth() / 2, 2);
 
@@ -112,10 +112,10 @@ void Painter::PaintFPS(DrawPixelInfo* dpi)
     // Draw Text
     int32_t stringWidth = GfxGetStringWidth(buffer, FontStyle::Medium);
     screenCoords.x = screenCoords.x - (stringWidth / 2);
-    GfxDrawString(*dpi, screenCoords, buffer);
+    GfxDrawString(dpi, screenCoords, buffer);
 
     // Make area dirty so the text doesn't get drawn over the last
-    GfxSetDirtyBlocks({ { screenCoords - ScreenCoordsXY{ 16, 4 } }, { dpi->lastStringPos.x + 16, 16 } });
+    GfxSetDirtyBlocks({ { screenCoords - ScreenCoordsXY{ 16, 4 } }, { dpi.lastStringPos.x + 16, 16 } });
 }
 
 void Painter::MeasureFPS()
@@ -131,7 +131,7 @@ void Painter::MeasureFPS()
     _lastSecond = currentTime;
 }
 
-PaintSession* Painter::CreateSession(DrawPixelInfo* dpi, uint32_t viewFlags)
+PaintSession* Painter::CreateSession(DrawPixelInfo& dpi, uint32_t viewFlags)
 {
     PROFILED_FUNCTION();
 
@@ -152,7 +152,7 @@ PaintSession* Painter::CreateSession(DrawPixelInfo* dpi, uint32_t viewFlags)
         session = _paintSessionPool.back().get();
     }
 
-    session->DPI = *dpi;
+    session->DPI = dpi;
     session->ViewFlags = viewFlags;
     session->QuadrantBackIndex = std::numeric_limits<uint32_t>::max();
     session->QuadrantFrontIndex = 0;

--- a/src/openrct2/paint/Painter.h
+++ b/src/openrct2/paint/Painter.h
@@ -47,13 +47,13 @@ namespace OpenRCT2
             explicit Painter(const std::shared_ptr<Ui::IUiContext>& uiContext);
             void Paint(Drawing::IDrawingEngine& de);
 
-            PaintSession* CreateSession(DrawPixelInfo* dpi, uint32_t viewFlags);
+            PaintSession* CreateSession(DrawPixelInfo& dpi, uint32_t viewFlags);
             void ReleaseSession(PaintSession* session);
             ~Painter();
 
         private:
-            void PaintReplayNotice(DrawPixelInfo* dpi, const char* text);
-            void PaintFPS(DrawPixelInfo* dpi);
+            void PaintReplayNotice(DrawPixelInfo& dpi, const char* text);
+            void PaintFPS(DrawPixelInfo& dpi);
             void MeasureFPS();
         };
     } // namespace Paint

--- a/src/openrct2/paint/tile_element/Paint.Path.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Path.cpp
@@ -274,9 +274,9 @@ static void PathBitBenchesPaint(
 
 /* rct2: 0x006A6008 */
 static void PathBitJumpingFountainsPaint(
-    PaintSession& session, const PathBitEntry& pathBitEntry, int32_t height, ImageId imageTemplate, DrawPixelInfo* dpi)
+    PaintSession& session, const PathBitEntry& pathBitEntry, int32_t height, ImageId imageTemplate, DrawPixelInfo& dpi)
 {
-    if (dpi->zoom_level > ZoomLevel{ 0 })
+    if (dpi.zoom_level > ZoomLevel{ 0 })
         return;
 
     auto imageId = imageTemplate.WithIndex(pathBitEntry.image);
@@ -781,9 +781,7 @@ static void Sub6A3F61(
     // Probably drawing benches etc.
     PROFILED_FUNCTION();
 
-    DrawPixelInfo* dpi = &session.DPI;
-
-    if (dpi->zoom_level <= ZoomLevel{ 1 })
+    if (session.DPI.zoom_level <= ZoomLevel{ 1 })
     {
         if (!gTrackDesignSaveMode)
         {
@@ -826,7 +824,7 @@ static void Sub6A3F61(
                                 sceneryImageTemplate);
                             break;
                         case PathBitDrawType::JumpingFountain:
-                            PathBitJumpingFountainsPaint(session, *pathAddEntry, height, sceneryImageTemplate, dpi);
+                            PathBitJumpingFountainsPaint(session, *pathAddEntry, height, sceneryImageTemplate, session.DPI);
                             break;
                     }
 

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1023,12 +1023,11 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
 {
     PROFILED_FUNCTION();
 
-    DrawPixelInfo* dpi = &session.DPI;
     session.InteractionType = ViewportInteractionItem::Terrain;
     session.Flags |= PaintSessionFlags::PassedSurface;
     session.Surface = &tileElement;
 
-    const auto zoomLevel = dpi->zoom_level;
+    const auto zoomLevel = session.DPI.zoom_level;
     const uint8_t rotation = session.CurrentRotation;
     const auto terrain_type = tileElement.GetSurfaceStyle();
     const uint8_t surfaceShape = ViewportSurfacePaintSetupGetRelativeSlope(tileElement, rotation);

--- a/src/openrct2/paint/tile_element/Paint.TileElement.cpp
+++ b/src/openrct2/paint/tile_element/Paint.TileElement.cpp
@@ -94,12 +94,11 @@ static void BlankTilesPaint(PaintSession& session, int32_t x, int32_t y)
     dx -= 16;
     int32_t bx = dx + 32;
 
-    DrawPixelInfo* dpi = &session.DPI;
-    if (bx <= dpi->y)
+    if (bx <= session.DPI.y)
         return;
     dx -= 20;
-    dx -= dpi->height;
-    if (dx >= dpi->y)
+    dx -= session.DPI.height;
+    if (dx >= session.DPI.y)
         return;
 
     session.SpritePosition.x = x;
@@ -119,7 +118,6 @@ static void PaintTileElementBase(PaintSession& session, const CoordsXY& origCoor
     PROFILED_FUNCTION();
 
     CoordsXY coords = origCoords;
-    DrawPixelInfo* dpi = &session.DPI;
 
     if ((session.ViewFlags & VIEWPORT_FLAG_CLIP_VIEW))
     {
@@ -184,7 +182,7 @@ static void PaintTileElementBase(PaintSession& session, const CoordsXY& origCoor
         PaintAddImageAsParent(session, imageId, { 0, 0, arrowZ }, { { 0, 0, arrowZ + 18 }, { 32, 32, -1 } });
     }
 
-    if (screenMinY + 52 <= dpi->y)
+    if (screenMinY + 52 <= session.DPI.y)
         return;
 
     const TileElement* element = tile_element; // push tile_element
@@ -208,7 +206,7 @@ static void PaintTileElementBase(PaintSession& session, const CoordsXY& origCoor
         max_height = std::max(max_height, VirtualFloorGetHeight());
     }
 
-    if (screenMinY - (max_height + 32) >= dpi->y + dpi->height)
+    if (screenMinY - (max_height + 32) >= session.DPI.y + session.DPI.height)
         return;
 
     session.SpritePosition.x = coords.x;

--- a/src/openrct2/ride/CarEntry.cpp
+++ b/src/openrct2/ride/CarEntry.cpp
@@ -60,7 +60,7 @@ void CarEntrySetImageMaxSizes(CarEntry& carEntry, int32_t numImages)
 
     for (int32_t i = 0; i < numImages; ++i)
     {
-        GfxDrawSpriteSoftware(&dpi, ImageId(carEntry.base_image_id + i), { 0, 0 });
+        GfxDrawSpriteSoftware(dpi, ImageId(carEntry.base_image_id + i), { 0, 0 });
     }
     int32_t spriteWidth = -1;
     for (int32_t i = 99; i != 0; --i)

--- a/src/openrct2/ride/TrackDesign.cpp
+++ b/src/openrct2/ride/TrackDesign.cpp
@@ -2172,7 +2172,7 @@ void TrackDesignDrawPreview(TrackDesign* td6, uint8_t* pixels)
         gCurrentRotation = i;
 
         view.viewPos = Translate3DTo2DWithZ(i, centre) - offset;
-        ViewportPaint(&view, &dpi, { view.viewPos, view.viewPos + ScreenCoordsXY{ size_x, size_y } });
+        ViewportPaint(&view, dpi, { view.viewPos, view.viewPos + ScreenCoordsXY{ size_x, size_y } });
 
         dpi.bits += TRACK_PREVIEW_IMAGE_SIZE;
     }

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -1190,8 +1190,7 @@ void VehicleVisualMiniGolfPlayer(
         return;
     }
 
-    DrawPixelInfo* edi = &session.DPI;
-    if (edi->zoom_level >= ZoomLevel{ 2 })
+    if (session.DPI.zoom_level >= ZoomLevel{ 2 })
     {
         return;
     }
@@ -1227,8 +1226,7 @@ void VehicleVisualMiniGolfBall(
         return;
     }
 
-    DrawPixelInfo* edi = &session.DPI;
-    if (edi->zoom_level >= ZoomLevel{ 1 })
+    if (session.DPI.zoom_level >= ZoomLevel{ 1 })
     {
         return;
     }

--- a/src/openrct2/ride/gentle/SpiralSlide.cpp
+++ b/src/openrct2/ride/gentle/SpiralSlide.cpp
@@ -134,8 +134,7 @@ static void SpiralSlidePaintTileFront(
         PaintAddImageAsParent(session, imageId, { 16, 16, height }, { { 8, 0, height + 3 }, { 8, 16, 108 } });
     }
 
-    DrawPixelInfo* dpi = &session.DPI;
-    if (dpi->zoom_level <= ZoomLevel{ 0 } && ride.slide_in_use != 0)
+    if (session.DPI.zoom_level <= ZoomLevel{ 0 } && ride.slide_in_use != 0)
     {
         uint8_t slide_progress = ride.spiral_slide_progress;
         if (slide_progress != 0)

--- a/src/openrct2/title/TitleScreen.cpp
+++ b/src/openrct2/title/TitleScreen.cpp
@@ -440,7 +440,7 @@ bool TitleIsPreviewingSequence()
     return false;
 }
 
-void DrawOpenRCT2(DrawPixelInfo* dpi, const ScreenCoordsXY& screenCoords)
+void DrawOpenRCT2(DrawPixelInfo& dpi, const ScreenCoordsXY& screenCoords)
 {
     thread_local std::string buffer;
     buffer.clear();
@@ -448,7 +448,7 @@ void DrawOpenRCT2(DrawPixelInfo* dpi, const ScreenCoordsXY& screenCoords)
 
     // Write name and version information
     buffer += gVersionInfoFull;
-    GfxDrawString(*dpi, screenCoords + ScreenCoordsXY(5, 5 - 13), buffer.c_str(), { COLOUR_BLACK });
+    GfxDrawString(dpi, screenCoords + ScreenCoordsXY(5, 5 - 13), buffer.c_str(), { COLOUR_BLACK });
 
     // Invalidate screen area
     int16_t width = static_cast<int16_t>(GfxGetStringWidth(buffer, FontStyle::Medium));
@@ -461,5 +461,5 @@ void DrawOpenRCT2(DrawPixelInfo* dpi, const ScreenCoordsXY& screenCoords)
     buffer.append(" (");
     buffer.append(OPENRCT2_ARCHITECTURE);
     buffer.append(")");
-    GfxDrawString(*dpi, screenCoords + ScreenCoordsXY(5, 5), buffer.c_str(), { COLOUR_BLACK });
+    GfxDrawString(dpi, screenCoords + ScreenCoordsXY(5, 5), buffer.c_str(), { COLOUR_BLACK });
 }

--- a/src/openrct2/title/TitleScreen.h
+++ b/src/openrct2/title/TitleScreen.h
@@ -65,4 +65,4 @@ size_t TitleGetCurrentSequence();
 bool TitlePreviewSequence(size_t value);
 void TitleStopPreviewingSequence();
 bool TitleIsPreviewingSequence();
-void DrawOpenRCT2(DrawPixelInfo* dpi, const ScreenCoordsXY& screenCoords);
+void DrawOpenRCT2(DrawPixelInfo& dpi, const ScreenCoordsXY& screenCoords);

--- a/src/openrct2/ui/DummyUiContext.cpp
+++ b/src/openrct2/ui/DummyUiContext.cpp
@@ -31,7 +31,7 @@ namespace OpenRCT2::Ui
         void Tick() override
         {
         }
-        void Draw(DrawPixelInfo* /*dpi*/) override
+        void Draw(DrawPixelInfo& /*dpi*/) override
         {
         }
 
@@ -173,7 +173,7 @@ namespace OpenRCT2::Ui
         {
             return std::make_shared<X8DrawingEngineFactory>();
         }
-        void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, DrawPixelInfo* dpi, DrawWeatherFunc drawFunc) override
+        void DrawWeatherAnimation(IWeatherDrawer* weatherDrawer, DrawPixelInfo& dpi, DrawWeatherFunc drawFunc) override
         {
         }
 

--- a/src/openrct2/ui/UiContext.h
+++ b/src/openrct2/ui/UiContext.h
@@ -29,7 +29,7 @@ namespace OpenRCT2
         struct IDrawingEngineFactory;
         struct IWeatherDrawer;
         using DrawWeatherFunc = void (*)(
-            DrawPixelInfo* dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width,
+            DrawPixelInfo& dpi, OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, int32_t left, int32_t top, int32_t width,
             int32_t height);
     } // namespace Drawing
 
@@ -101,7 +101,7 @@ namespace OpenRCT2
 
             virtual void Initialise() abstract;
             virtual void Tick() abstract;
-            virtual void Draw(DrawPixelInfo* dpi) abstract;
+            virtual void Draw(DrawPixelInfo& dpi) abstract;
 
             // Window
             virtual void CreateWindow() abstract;
@@ -149,7 +149,7 @@ namespace OpenRCT2
             // Drawing
             [[nodiscard]] virtual std::shared_ptr<Drawing::IDrawingEngineFactory> GetDrawingEngineFactory() abstract;
             virtual void DrawWeatherAnimation(
-                OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, DrawPixelInfo* dpi,
+                OpenRCT2::Drawing::IWeatherDrawer* weatherDrawer, DrawPixelInfo& dpi,
                 OpenRCT2::Drawing::DrawWeatherFunc drawFunc) abstract;
 
             // Text input


### PR DESCRIPTION
This refactors most of the places where DrawPixelInfo was passed as a pointer. The only places left out are the drawing engines, as I couldn’t get those working (they kept crashing on software rendering mode). Some else might perhaps want to take a look at those.

Blocked by https://github.com/OpenRCT2/OpenRCT2/pull/19693