### PR TITLE
Add clang-based tests coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,7 @@ jobs:
           cd bin
           llvm-profdata merge -sparse openrct2-coverage*profraw -o openrct2.profdata
           llvm-cov export -instr-profile=openrct2.profdata ./OpenRCT2Tests > coverage.json
+          llvm-cov report ./OpenRCT2Tests -instr-profile=openrct2.profdata
           xz -1v openrct2.profdata
           xz -1v coverage.json
       - name: Upload artifacts (CI)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
     name: Windows (${{ matrix.platform_name }}) using mingw
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:8-mingw
+    container: openrct2/openrct2-build:11-mingw
     strategy:
       fail-fast: false
       matrix:
@@ -262,19 +262,19 @@ jobs:
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -fno-var-tracking-assignments" -DWITH_TESTS=off -DDISABLE_FLAC=ON -DDISABLE_VORBIS=ON
           - platform: x86_64
             distro: focal
-            image: openrct2/openrct2-build:8-focal
+            image: openrct2/openrct2-build:11-focal
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g1 -gz" -DWITH_TESTS=off
           - platform: x86_64
             distro: jammy
-            image: openrct2/openrct2-build:8-jammy
+            image: openrct2/openrct2-build:11-jammy
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -fno-var-tracking-assignments"
           - platform: x86_64
             distro: bullseye
-            image: openrct2/openrct2-build:8-bullseye
+            image: openrct2/openrct2-build:11-bullseye
             build_flags: -DCMAKE_POSITION_INDEPENDENT_CODE=on -DCMAKE_CXX_FLAGS="-g -gz -fno-var-tracking-assignments" -DWITH_TESTS=off
           - platform: i686
             distro: focal
-            image: openrct2/openrct2-build:8-focal32
+            image: openrct2/openrct2-build:11-focal32
             build_flags: -DFORCE32=ON -DENABLE_SCRIPTING=OFF -DCMAKE_CXX_FLAGS="-m32 -g1 -gz" -DWITH_TESTS=off
     steps:
       - name: Checkout
@@ -312,7 +312,7 @@ jobs:
     name: Linux (x86_64, AppImage)
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:8-focal
+    container: openrct2/openrct2-build:11-focal
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -370,7 +370,7 @@ jobs:
     name: Linux (Debug, [http, network, flac, vorbis OpenGL] disabled) using clang
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:8-jammy
+    container: openrct2/openrct2-build:11-jammy
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -386,7 +386,7 @@ jobs:
     name: Android
     runs-on: ubuntu-latest
     needs: check-code-formatting
-    container: openrct2/openrct2-build:8-android
+    container: openrct2/openrct2-build:11-android
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,7 @@ jobs:
           llvm-cov report ./OpenRCT2Tests -instr-profile=openrct2.profdata
           xz -1v openrct2.profdata
           xz -1v coverage.json
+          xz -1v OpenRCT2Tests
       - name: Upload artifacts (CI)
         uses: actions/upload-artifact@v3
         with:
@@ -415,6 +416,7 @@ jobs:
           path: |
             bin/*profdata*
             bin/coverage.json*
+            bin/OpenRCT2Tests.xz
           if-no-files-found: error
   android:
     name: Android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,39 @@ jobs:
         uses: ammaraskar/gcc-problem-matcher@master
       - name: Build OpenRCT2
         run: . scripts/setenv && build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DDISABLE_NETWORK=ON -DDISABLE_HTTP=ON -DDISABLE_FLAC=ON -DDISABLE_VORBIS=ON -DDISABLE_OPENGL=ON
+  linux-clang-tests:
+    name: Linux (Debug) using clang, coverage enabled
+    runs-on: ubuntu-latest
+    needs: check-code-formatting
+    container: openrct2/openrct2-build:11-jammy
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: linux-clang
+      - name: Install GCC problem matcher
+        uses: ammaraskar/gcc-problem-matcher@master
+      - name: Build OpenRCT2
+        run: . scripts/setenv && build -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping" -DWITH_TESTS=on
+      - name: Run Tests
+        run: . scripts/setenv -q && LLVM_PROFILE_FILE="openrct2-coverage-%p.profraw" run-tests
+      - name: Process coverage information
+        run: |
+          cd bin
+          llvm-profdata merge -sparse openrct2-coverage*profraw -o openrct2.profdata
+          llvm-cov export -instr-profile=openrct2.profdata ./OpenRCT2Tests > coverage.json
+          xz -1v openrct2.profdata
+          xz -1v coverage.json
+      - name: Upload artifacts (CI)
+        uses: actions/upload-artifact@v3
+        with:
+          name: OpenRCT2-${{ runner.os }}-coverage
+          path: |
+            bin/*profdata*
+            bin/coverage.json*
+          if-no-files-found: error
   android:
     name: Android
     runs-on: ubuntu-latest

--- a/src/openrct2/scripting/Plugin.cpp
+++ b/src/openrct2/scripting/Plugin.cpp
@@ -123,7 +123,15 @@ void Plugin::ThrowIfStopping() const
 
 void Plugin::Unload()
 {
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105937, fixed in GCC13
+#    if defined(__GNUC__) && !defined(__clang__)
+#        pragma GCC diagnostic push
+#        pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#    endif
     _metadata.Main = {};
+#    if defined(__GNUC__) && !defined(__clang__)
+#        pragma GCC diagnostic pop
+#    endif
     _hasLoaded = false;
 }
 


### PR DESCRIPTION
This adds new job compiling clang with tests enabled, collects coverage information and uploads it as an artifact for offline processing.

Requested by @ZehMatt 