### PR TITLE
Fix #19825: Repainting small scenery objects is broken

### DIFF
--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1100,7 +1100,7 @@ namespace OpenRCT2
                                     }
                                 }
                                 else if (
-                                    it.element->GetType() == TileElementType::SmallScenery && os.GetHeader().TargetVersion < 22)
+                                    it.element->GetType() == TileElementType::SmallScenery && os.GetHeader().TargetVersion < 23)
                                 {
                                     auto* sceneryElement = it.element->AsSmallScenery();
                                     // Previous formats stored the needs supports flag in the primary colour

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -9,7 +9,7 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 22;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 23;
 
     // The minimum version that is forwards compatible with the current version.
     constexpr uint32_t PARK_FILE_MIN_VERSION = 22;

--- a/src/openrct2/world/SmallScenery.cpp
+++ b/src/openrct2/world/SmallScenery.cpp
@@ -97,19 +97,19 @@ colour_t SmallSceneryElement::GetTertiaryColour() const
 void SmallSceneryElement::SetPrimaryColour(colour_t newColour)
 {
     assert(newColour < COLOUR_COUNT);
-    Colour[0] |= newColour;
+    Colour[0] = newColour;
 }
 
 void SmallSceneryElement::SetSecondaryColour(colour_t newColour)
 {
     assert(newColour < COLOUR_COUNT);
-    Colour[1] |= newColour;
+    Colour[1] = newColour;
 }
 
 void SmallSceneryElement::SetTertiaryColour(colour_t newColour)
 {
     assert(newColour < COLOUR_COUNT);
-    Colour[2] |= newColour;
+    Colour[2] = newColour;
 }
 
 bool SmallSceneryElement::NeedsSupports() const


### PR DESCRIPTION
Fix #19825

An oversight in #19759 broke repainting for small scenery, causing the resulting color to be incorrect. Replacing the |= in the small scenery set color functions with = fixes this.

The park version and version in the related conversion logic is also bumped once more, as otherwise parks that were converted to v22 prior to this fix would retain the bit for the old support flag in the color property, which would cause issues for #19446.