### PR TITLE
Disable marketing tab when marketing is prohibited

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#19547] Add large sloped turns to hybrid coaster and single rail coaster.
 - Feature: [OpenMusic#25] Added Prehistoric ride music style.
 - Improved: [#18490] Reduce guests walking through trains on level crossing next to station.
+- Improved: [#18996] When marketing campaigns are disabled, disable the Marketing tab in the Finances window.
 - Improved: [#19764] Miscellaneous scenery tab now grouped next to the all-scenery tab.
 - Fix: [#12598] Number of holes is not set correctly when saving track designs.
 - Fix: [#18895] Responding mechanic blocked at level crossing.

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -225,10 +225,32 @@ class FinancesWindow final : public Window
 {
 private:
     uint32_t _lastPaintedMonth;
+    bool _marketingTabDisabled = false;
+    void _hideMarketingTabIfDisabled()
+    {
+        _marketingTabDisabled = (gParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
+        if (_marketingTabDisabled)
+        {
+            for (auto w : _windowFinancesPageWidgets)
+            {
+                w[WIDX_TAB_5].type = WindowWidgetType::Empty;
+                w[WIDX_TAB_6] = MakeTab({ 127, 17 }, STR_FINANCES_RESEARCH_TIP);
+            }
+        }
+        else
+        {
+            for (auto w : _windowFinancesPageWidgets)
+            {
+                w[WIDX_TAB_5] = MakeTab({ 127, 17 }, STR_FINANCES_SHOW_MARKETING_TAB_TIP);
+                w[WIDX_TAB_6] = MakeTab({ 158, 17 }, STR_FINANCES_RESEARCH_TIP);
+            }
+        }
+    }
 
 public:
     void OnOpen() override
     {
+        _hideMarketingTabIfDisabled();
         SetPage(WINDOW_FINANCES_PAGE_SUMMARY);
         _lastPaintedMonth = std::numeric_limits<uint32_t>::max();
         ResearchUpdateUncompletedTypes();
@@ -438,6 +460,9 @@ public:
 
     void SetPage(int32_t p)
     {
+        if ((p == WIDX_TAB_5) && _marketingTabDisabled)
+            return;
+
         page = p;
         frame_no = 0;
 
@@ -1024,7 +1049,8 @@ public:
         DrawTabImage(dpi, WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH, SPR_TAB_FINANCES_FINANCIAL_GRAPH_0);
         DrawTabImage(dpi, WINDOW_FINANCES_PAGE_VALUE_GRAPH, SPR_TAB_FINANCES_VALUE_GRAPH_0);
         DrawTabImage(dpi, WINDOW_FINANCES_PAGE_PROFIT_GRAPH, SPR_TAB_FINANCES_PROFIT_GRAPH_0);
-        DrawTabImage(dpi, WINDOW_FINANCES_PAGE_MARKETING, SPR_TAB_FINANCES_MARKETING_0);
+        if (!_marketingTabDisabled)
+            DrawTabImage(dpi, WINDOW_FINANCES_PAGE_MARKETING, SPR_TAB_FINANCES_MARKETING_0);
         DrawTabImage(dpi, WINDOW_FINANCES_PAGE_RESEARCH, SPR_TAB_FINANCES_RESEARCH_0);
     }
 };

--- a/src/openrct2-ui/windows/Finances.cpp
+++ b/src/openrct2-ui/windows/Finances.cpp
@@ -225,32 +225,15 @@ class FinancesWindow final : public Window
 {
 private:
     uint32_t _lastPaintedMonth;
-    bool _marketingTabDisabled = false;
-    void _hideMarketingTabIfDisabled()
+
+    void SetDisabledTabs()
     {
-        _marketingTabDisabled = (gParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN);
-        if (_marketingTabDisabled)
-        {
-            for (auto w : _windowFinancesPageWidgets)
-            {
-                w[WIDX_TAB_5].type = WindowWidgetType::Empty;
-                w[WIDX_TAB_6] = MakeTab({ 127, 17 }, STR_FINANCES_RESEARCH_TIP);
-            }
-        }
-        else
-        {
-            for (auto w : _windowFinancesPageWidgets)
-            {
-                w[WIDX_TAB_5] = MakeTab({ 127, 17 }, STR_FINANCES_SHOW_MARKETING_TAB_TIP);
-                w[WIDX_TAB_6] = MakeTab({ 158, 17 }, STR_FINANCES_RESEARCH_TIP);
-            }
-        }
+        disabled_widgets = (gParkFlags & PARK_FLAGS_FORBID_MARKETING_CAMPAIGN) ? (1uLL << WIDX_TAB_5) : 0;
     }
 
 public:
     void OnOpen() override
     {
-        _hideMarketingTabIfDisabled();
         SetPage(WINDOW_FINANCES_PAGE_SUMMARY);
         _lastPaintedMonth = std::numeric_limits<uint32_t>::max();
         ResearchUpdateUncompletedTypes();
@@ -321,7 +304,7 @@ public:
             WindowInitScrollWidgets(*this);
         }
 
-        disabled_widgets = 0;
+        WindowAlignTabs(this, WIDX_TAB_1, WIDX_TAB_6);
 
         for (auto i = 0; i < WINDOW_FINANCES_PAGE_COUNT; i++)
             SetWidgetPressed(WIDX_TAB_1 + i, false);
@@ -460,17 +443,15 @@ public:
 
     void SetPage(int32_t p)
     {
-        if ((p == WIDX_TAB_5) && _marketingTabDisabled)
-            return;
-
         page = p;
         frame_no = 0;
 
         hold_down_widgets = _windowFinancesPageHoldDownWidgets[p];
         pressed_widgets = 0;
         widgets = _windowFinancesPageWidgets[p];
-
+        SetDisabledTabs();
         Invalidate();
+
         if (p == WINDOW_FINANCES_PAGE_RESEARCH)
         {
             width = WW_RESEARCH;
@@ -1049,8 +1030,7 @@ public:
         DrawTabImage(dpi, WINDOW_FINANCES_PAGE_FINANCIAL_GRAPH, SPR_TAB_FINANCES_FINANCIAL_GRAPH_0);
         DrawTabImage(dpi, WINDOW_FINANCES_PAGE_VALUE_GRAPH, SPR_TAB_FINANCES_VALUE_GRAPH_0);
         DrawTabImage(dpi, WINDOW_FINANCES_PAGE_PROFIT_GRAPH, SPR_TAB_FINANCES_PROFIT_GRAPH_0);
-        if (!_marketingTabDisabled)
-            DrawTabImage(dpi, WINDOW_FINANCES_PAGE_MARKETING, SPR_TAB_FINANCES_MARKETING_0);
+        DrawTabImage(dpi, WINDOW_FINANCES_PAGE_MARKETING, SPR_TAB_FINANCES_MARKETING_0);
         DrawTabImage(dpi, WINDOW_FINANCES_PAGE_RESEARCH, SPR_TAB_FINANCES_RESEARCH_0);
     }
 };


### PR DESCRIPTION
Fix #18996

When a scenario has marketing campaigns disabled, the marketing tab is hidden. If the user later uses cheats to enable marketing campaigns, the tab is restored.

The user needs to close and reopen the finance window for tab visibility changes to apply.