### PR TITLE
Fix highlight path issues not hide wall element

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -105,6 +105,7 @@ The following people are not part of the development team, but have been contrib
 * Andrew Arnold (fidwell) - Added window support for more scenery groups.
 * Josh Trzebiatowski (trzejos) - Ride and scenery filtering
 * (kyphii) - Extended color selection
+* Phumdol Lookthipnapha (beam41) - Misc.
 
 ## Bug fixes
 * (KirilAngelov)

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [OpenMusic#25] Added Prehistoric ride music style.
 - Improved: [#18490] Reduce guests walking through trains on level crossing next to station.
 - Improved: [#19764] Miscellaneous scenery tab now grouped next to the all-scenery tab.
+- Improved: [#19830] “Highlight path issues” will now hide wall elements.
 - Fix: [#12598] Number of holes is not set correctly when saving track designs.
 - Fix: [#18895] Responding mechanic blocked at level crossing.
 - Fix: [#19231] Crash due to null pointer to previously deleted banner in tile copy/paste functionality

--- a/src/openrct2/paint/tile_element/Paint.Wall.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Wall.cpp
@@ -302,6 +302,11 @@ void PaintWall(PaintSession& session, uint8_t direction, int32_t height, const W
 {
     PROFILED_FUNCTION();
 
+    if (session.ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES)
+    {
+        return;
+    }
+
     auto* wallEntry = wallElement.GetEntry();
     if (wallEntry == nullptr)
     {
@@ -327,7 +332,7 @@ void PaintWall(PaintSession& session, uint8_t direction, int32_t height, const W
     PaintUtilSetGeneralSupportHeight(session, 8 * wallElement.ClearanceHeight, 0x20);
 
     auto isGhost = false;
-    if (gTrackDesignSaveMode || (session.ViewFlags & VIEWPORT_FLAG_HIGHLIGHT_PATH_ISSUES))
+    if (gTrackDesignSaveMode)
     {
         if (!TrackDesignSaveContainsTileElement(reinterpret_cast<const TileElement*>(&wallElement)))
         {


### PR DESCRIPTION
I don't know why highlight path issues doesn't hide wall piece, but it obstructs path inside building. So, I think it should be hidden.

![285330_20230405164324_1](https://user-images.githubusercontent.com/1791353/230047828-e477a181-0035-4921-8258-74ecd84d6bc3.png)
![Crazy Castle 2023-04-05 16-45-56](https://user-images.githubusercontent.com/1791353/230047881-031c23af-41f9-4570-813b-85582aacb5d3.png)
