### PR TITLE
Refactor tile access

### DIFF
--- a/src/openrct2/Game.cpp
+++ b/src/openrct2/Game.cpp
@@ -414,7 +414,7 @@ void GameFixSaveVars()
     {
         for (int32_t x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
         {
-            auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
 
             if (surfaceElement == nullptr)
             {

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -367,7 +367,7 @@ void CheatSetAction::SetGrassLength(int32_t length) const
     {
         for (int32_t x = 0; x < gMapSize.x; x++)
         {
-            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
             if (surfaceElement == nullptr)
                 continue;
 

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -2907,6 +2907,7 @@ static PeepThoughtType PeepAssessSurroundings(int16_t centre_x, int16_t centre_y
     uint16_t nearby_music = 0;
     uint16_t num_rubbish = 0;
 
+    // TODO: Refactor this to step as tiles, 160 units is 5 tiles.
     int16_t initial_x = std::max(centre_x - 160, 0);
     int16_t initial_y = std::max(centre_y - 160, 0);
     int16_t final_x = std::min(centre_x + 160, MAXIMUM_MAP_SIZE_BIG);
@@ -2916,7 +2917,7 @@ static PeepThoughtType PeepAssessSurroundings(int16_t centre_x, int16_t centre_y
     {
         for (int16_t y = initial_y; y < final_y; y += COORDS_XY_STEP)
         {
-            for (auto* tileElement : TileElementsView({ x, y }))
+            for (auto* tileElement : TileElementsView(CoordsXY{ x, y }))
             {
                 if (tileElement->IsGhost())
                 {

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -6381,7 +6381,7 @@ static bool PeepFindRideToLookAt(Peep* peep, uint8_t edge, RideId* rideToView, u
 
     uint16_t x = peep->NextLoc.x + CoordsDirectionDelta[edge].x;
     uint16_t y = peep->NextLoc.y + CoordsDirectionDelta[edge].y;
-    if (!MapIsLocationValid({ x, y }))
+    if (!MapIsLocationValid(CoordsXY{ x, y }))
     {
         return false;
     }
@@ -6498,7 +6498,7 @@ static bool PeepFindRideToLookAt(Peep* peep, uint8_t edge, RideId* rideToView, u
 
     x += CoordsDirectionDelta[edge].x;
     y += CoordsDirectionDelta[edge].y;
-    if (!MapIsLocationValid({ x, y }))
+    if (!MapIsLocationValid(CoordsXY{ x, y }))
     {
         return false;
     }
@@ -6615,7 +6615,7 @@ static bool PeepFindRideToLookAt(Peep* peep, uint8_t edge, RideId* rideToView, u
 
     x += CoordsDirectionDelta[edge].x;
     y += CoordsDirectionDelta[edge].y;
-    if (!MapIsLocationValid({ x, y }))
+    if (!MapIsLocationValid(CoordsXY{ x, y }))
     {
         return false;
     }

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -628,7 +628,7 @@ GameActions::Result Peep::Place(const TileCoordsXYZ& location, bool apply)
     TileElement* tileElement = reinterpret_cast<TileElement*>(pathElement);
     if (pathElement == nullptr)
     {
-        tileElement = reinterpret_cast<TileElement*>(MapGetSurfaceElementAt(location.ToCoordsXYZ()));
+        tileElement = reinterpret_cast<TileElement*>(MapGetSurfaceElementAt(location));
     }
     if (tileElement == nullptr)
     {

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -650,7 +650,7 @@ namespace RCT2
             if (String::Equals(_s6.ScenarioFilename, "Infernal Views.SC6", true)
                 || String::Equals(_s6.ScenarioFilename, "infernal views.sea", true))
             {
-                auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ 45, 62 }.ToCoordsXY());
+                auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ 45, 62 });
 
                 surfaceElement->SetWaterHeight(96);
             }
@@ -659,7 +659,7 @@ namespace RCT2
                 || String::Equals(_s6.ScenarioFilename, "six flags holland.sea", true))
 
             {
-                auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ 126, 73 }.ToCoordsXY());
+                auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ 126, 73 });
 
                 surfaceElement->SetWaterHeight(96);
             }

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -174,7 +174,7 @@ std::vector<TileElement> GetReorganisedTileElementsWithoutGhosts()
             auto oldSize = newElements.size();
 
             // Add all non-ghost elements
-            const auto* element = MapGetFirstElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+            const auto* element = MapGetFirstElementAt(TileCoordsXY{ x, y });
             if (element != nullptr)
             {
                 do
@@ -373,7 +373,7 @@ TileElement* MapGetNthElementAt(const CoordsXY& coords, int32_t n)
 
 TileElement* MapGetFirstTileElementWithBaseHeightBetween(const TileCoordsXYRangedZ& loc, TileElementType type)
 {
-    TileElement* tileElement = MapGetFirstElementAt(loc.ToCoordsXY());
+    TileElement* tileElement = MapGetFirstElementAt(loc);
     if (tileElement == nullptr)
         return nullptr;
     do

--- a/src/openrct2/world/Map.cpp
+++ b/src/openrct2/world/Map.cpp
@@ -397,11 +397,16 @@ void MapSetTileElement(const TileCoordsXY& tilePos, TileElement* elements)
     _tileIndex.SetTile(tilePos, elements);
 }
 
-SurfaceElement* MapGetSurfaceElementAt(const CoordsXY& coords)
+SurfaceElement* MapGetSurfaceElementAt(const TileCoordsXY& coords)
 {
     auto view = TileElementsView<SurfaceElement>(coords);
 
     return *view.begin();
+}
+
+SurfaceElement* MapGetSurfaceElementAt(const CoordsXY& coords)
+{
+    return MapGetSurfaceElementAt(TileCoordsXY{ coords });
 }
 
 PathElement* MapGetPathElementAt(const TileCoordsXYZ& loc)
@@ -465,7 +470,7 @@ void MapCountRemainingLandRights()
     {
         for (int32_t x = 0; x < gMapSize.x; x++)
         {
-            auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto* surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
             // Surface elements are sometimes hacked out to save some space for other map elements
             if (surfaceElement == nullptr)
             {
@@ -1475,8 +1480,8 @@ void MapExtendBoundarySurfaceY()
     auto y = gMapSize.y - 2;
     for (auto x = 0; x < MAXIMUM_MAP_SIZE_TECHNICAL; x++)
     {
-        auto existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y - 1 }.ToCoordsXY());
-        auto newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+        auto existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y - 1 });
+        auto newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
 
         if (existingTileElement != nullptr && newTileElement != nullptr)
         {
@@ -1495,8 +1500,8 @@ void MapExtendBoundarySurfaceX()
     auto x = gMapSize.x - 2;
     for (auto y = 0; y < MAXIMUM_MAP_SIZE_TECHNICAL; y++)
     {
-        auto existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x - 1, y }.ToCoordsXY());
-        auto newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+        auto existingTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x - 1, y });
+        auto newTileElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
         if (existingTileElement != nullptr && newTileElement != nullptr)
         {
             MapExtendBoundarySurfaceExtendTile(*existingTileElement, *newTileElement);
@@ -2285,7 +2290,7 @@ void FixLandOwnershipTilesWithOwnership(std::initializer_list<TileCoordsXY> tile
 {
     for (const TileCoordsXY* tile = tiles.begin(); tile != tiles.end(); ++tile)
     {
-        auto surfaceElement = MapGetSurfaceElementAt(tile->ToCoordsXY());
+        auto surfaceElement = MapGetSurfaceElementAt(*tile);
         if (surfaceElement != nullptr)
         {
             if (doNotDowngrade && surfaceElement->GetOwnership() == OWNERSHIP_OWNED)

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -168,6 +168,7 @@ TileElement* MapGetFirstTileElementWithBaseHeightBetween(const TileCoordsXYRange
 void MapSetTileElement(const TileCoordsXY& tilePos, TileElement* elements);
 int32_t MapHeightFromSlope(const CoordsXY& coords, int32_t slopeDirection, bool isSloped);
 BannerElement* MapGetBannerElementAt(const CoordsXYZ& bannerPos, uint8_t direction);
+SurfaceElement* MapGetSurfaceElementAt(const TileCoordsXY& coords);
 SurfaceElement* MapGetSurfaceElementAt(const CoordsXY& coords);
 PathElement* MapGetPathElementAt(const TileCoordsXYZ& loc);
 WallElement* MapGetWallElementAt(const CoordsXYZD& wallCoords);

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -136,7 +136,7 @@ void MapGenGenerateBlank(MapGenSettings* settings)
             }
         }
     }
-    
+
     MapGenSetWaterLevel(settings->water_level);
 }
 

--- a/src/openrct2/world/MapGen.cpp
+++ b/src/openrct2/world/MapGen.cpp
@@ -126,7 +126,7 @@ void MapGenGenerateBlank(MapGenSettings* settings)
     {
         for (x = 1; x < settings->mapSize.x - 1; x++)
         {
-            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
             if (surfaceElement != nullptr)
             {
                 surfaceElement->SetSurfaceStyle(settings->floor);
@@ -136,7 +136,7 @@ void MapGenGenerateBlank(MapGenSettings* settings)
             }
         }
     }
-
+    
     MapGenSetWaterLevel(settings->water_level);
 }
 
@@ -190,7 +190,7 @@ void MapGenGenerate(MapGenSettings* settings)
     {
         for (auto x = 1; x < mapSize.x - 1; x++)
         {
-            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
             if (surfaceElement != nullptr)
             {
                 surfaceElement->SetSurfaceStyle(floorTextureId);
@@ -240,7 +240,7 @@ void MapGenGenerate(MapGenSettings* settings)
     {
         for (auto x = 1; x < mapSize.x - 1; x++)
         {
-            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
 
             if (surfaceElement != nullptr && surfaceElement->BaseHeight < waterLevel + 6)
                 surfaceElement->SetSurfaceStyle(beachTextureId);
@@ -419,7 +419,7 @@ static void MapGenSetWaterLevel(int32_t waterLevel)
     {
         for (int32_t x = 1; x < gMapSize.x - 1; x++)
         {
-            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
             if (surfaceElement != nullptr && surfaceElement->BaseHeight < waterLevel)
                 surfaceElement->SetWaterHeight(waterLevel * COORDS_Z_STEP);
         }
@@ -480,7 +480,7 @@ static void MapGenSetHeight(MapGenSettings* settings)
 
             uint8_t baseHeight = (q00 + q01 + q10 + q11) / 4;
 
-            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
             if (surfaceElement == nullptr)
                 continue;
             surfaceElement->BaseHeight = std::max(2, baseHeight * 2);
@@ -847,7 +847,7 @@ void MapGenGenerateFromHeightmap(MapGenSettings* settings)
         {
             // The x and y axis are flipped in the world, so this uses y for x and x for y.
             auto tileCoords = MapgenHeightmapCoordToTileCoordsXY(x, y);
-            auto* const surfaceElement = MapGetSurfaceElementAt(tileCoords.ToCoordsXY());
+            auto* const surfaceElement = MapGetSurfaceElementAt(tileCoords);
             if (surfaceElement == nullptr)
                 continue;
 

--- a/src/openrct2/world/MapHelpers.cpp
+++ b/src/openrct2/world/MapHelpers.cpp
@@ -16,7 +16,7 @@
 
 static uint8_t GetBaseHeightOrZero(int32_t x, int32_t y)
 {
-    auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+    auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
     return surfaceElement != nullptr ? surfaceElement->BaseHeight : 0;
 }
 
@@ -31,7 +31,7 @@ int32_t MapSmooth(int32_t l, int32_t t, int32_t r, int32_t b)
     {
         for (x = l; x < r; x++)
         {
-            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y }.ToCoordsXY());
+            auto surfaceElement = MapGetSurfaceElementAt(TileCoordsXY{ x, y });
             if (surfaceElement == nullptr)
                 continue;
             surfaceElement->SetSlope(TILE_ELEMENT_SLOPE_FLAT);
@@ -146,36 +146,36 @@ int32_t MapSmooth(int32_t l, int32_t t, int32_t r, int32_t b)
             {
                 uint8_t slope = surfaceElement->GetSlope();
                 // Corners
-                auto surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x + 1, y + 1 }.ToCoordsXY());
+                auto surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x + 1, y + 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->BaseHeight > surfaceElement->BaseHeight)
                     slope |= TILE_ELEMENT_SLOPE_N_CORNER_UP;
 
-                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x - 1, y + 1 }.ToCoordsXY());
+                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x - 1, y + 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->BaseHeight > surfaceElement->BaseHeight)
                     slope |= TILE_ELEMENT_SLOPE_W_CORNER_UP;
 
-                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x + 1, y - 1 }.ToCoordsXY());
+                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x + 1, y - 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->BaseHeight > surfaceElement->BaseHeight)
                     slope |= TILE_ELEMENT_SLOPE_E_CORNER_UP;
 
-                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x - 1, y - 1 }.ToCoordsXY());
+                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x - 1, y - 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->BaseHeight > surfaceElement->BaseHeight)
                     slope |= TILE_ELEMENT_SLOPE_S_CORNER_UP;
 
                 // Sides
-                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x + 1, y + 0 }.ToCoordsXY());
+                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x + 1, y + 0 });
                 if (surfaceElement2 != nullptr && surfaceElement2->BaseHeight > surfaceElement->BaseHeight)
                     slope |= TILE_ELEMENT_SLOPE_NE_SIDE_UP;
 
-                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x - 1, y + 0 }.ToCoordsXY());
+                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x - 1, y + 0 });
                 if (surfaceElement2 != nullptr && surfaceElement2->BaseHeight > surfaceElement->BaseHeight)
                     slope |= TILE_ELEMENT_SLOPE_SW_SIDE_UP;
 
-                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x + 0, y - 1 }.ToCoordsXY());
+                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x + 0, y - 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->BaseHeight > surfaceElement->BaseHeight)
                     slope |= TILE_ELEMENT_SLOPE_SE_SIDE_UP;
 
-                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x + 0, y + 1 }.ToCoordsXY());
+                surfaceElement2 = MapGetSurfaceElementAt(TileCoordsXY{ x + 0, y + 1 });
                 if (surfaceElement2 != nullptr && surfaceElement2->BaseHeight > surfaceElement->BaseHeight)
                     slope |= TILE_ELEMENT_SLOPE_NW_SIDE_UP;
 
@@ -200,7 +200,7 @@ int32_t MapSmooth(int32_t l, int32_t t, int32_t r, int32_t b)
  */
 int32_t TileSmooth(const TileCoordsXY& tileCoords)
 {
-    auto* const surfaceElement = MapGetSurfaceElementAt(tileCoords.ToCoordsXY());
+    auto* const surfaceElement = MapGetSurfaceElementAt(tileCoords);
     if (surfaceElement == nullptr)
         return 0;
 
@@ -241,8 +241,7 @@ int32_t TileSmooth(const TileCoordsXY& tileCoords)
                 continue;
 
             // Get neighbour height. If the element is not valid (outside of map) assume the same height
-            auto* neighbourSurfaceElement = MapGetSurfaceElementAt(
-                (tileCoords + TileCoordsXY{ x_offset, y_offset }).ToCoordsXY());
+            auto* neighbourSurfaceElement = MapGetSurfaceElementAt(tileCoords + TileCoordsXY{ x_offset, y_offset });
             neighbourHeightOffset.baseheight[index] = neighbourSurfaceElement != nullptr ? neighbourSurfaceElement->BaseHeight
                                                                                          : surfaceElement->BaseHeight;
 

--- a/src/openrct2/world/TileElementsView.h
+++ b/src/openrct2/world/TileElementsView.h
@@ -41,7 +41,7 @@ namespace OpenRCT2
 
     template<typename T = TileElement> class TileElementsView
     {
-        const CoordsXY _loc;
+        const TileCoordsXY _loc;
 
     public:
         struct Iterator
@@ -104,6 +104,11 @@ namespace OpenRCT2
             using iterator_category = std::forward_iterator_tag;
         };
 
+        TileElementsView(const TileCoordsXY& loc)
+            : _loc(loc)
+        {
+        }
+        
         TileElementsView(const CoordsXY& loc)
             : _loc(loc)
         {

--- a/src/openrct2/world/TileElementsView.h
+++ b/src/openrct2/world/TileElementsView.h
@@ -108,7 +108,7 @@ namespace OpenRCT2
             : _loc(loc)
         {
         }
-        
+
         TileElementsView(const CoordsXY& loc)
             : _loc(loc)
         {


### PR DESCRIPTION
This further reduces how often we convert from CoordsXY back to TileCoordsXY whenever a tile element has to be accessed.