### PR TITLE
Fix #19817: merry-go-round doesn't have a vehicle until opened

### DIFF
--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -92,7 +92,10 @@ static void PaintCarousel(
     auto imageId = imageTemplate.WithIndex(rideEntry->Cars[0].base_image_id + imageOffset);
     PaintAddImageAsParent(session, imageId, offset, bb);
 
-    PaintRiders(session, ride, *rideEntry, *vehicle, rotationOffset, offset, bb);
+    if (vehicle != nullptr && vehicle->num_peeps > 0)
+    {
+        PaintRiders(session, ride, *rideEntry, *vehicle, rotationOffset, offset, bb);
+    }
 
     session.CurrentlyDrawnEntity = nullptr;
     session.InteractionType = ViewportInteractionItem::Ride;


### PR DESCRIPTION
Merry-go-round doesn't receive its vehicle until it gets tested/opened, but tries painting non-existent guests anyway, leading to reference binding to nullptr.