### PR TITLE
Fix #19848: Hint OpenGL driver by default

### DIFF
--- a/src/openrct2-ui/UiContext.cpp
+++ b/src/openrct2-ui/UiContext.cpp
@@ -115,6 +115,7 @@ public:
         , _shortcutManager(env)
     {
         LogSDLVersion();
+        SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
         if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0)
         {
             SDLException::Throw("SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK)");


### PR DESCRIPTION
The failure message in #19848 reads:
> Failed to create screen texture: CreateTexture(D3DPOOL_DEFAULT): INVALIDCALL

According to a bug report at
https://discourse.libsdl.org/t/sdl2-0-10-textures-disappearing-renderer-causing-error-when-resizing-window-with-a-render-target-texture/26598/3 and us using OpenGL, we should set this hint.