### PR TITLE
Fix Looping Coaster trains clipping through steep quarter turns down

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#19296] Crash due to a race condition for parallel object loading.
 - Fix: [#19756] Crash with title sequences containing no commands.
 - Fix: [#19767] No message when path is not connected to ride exit and is therefore unreachable for mechanics.
+- Fix: [#19854] Looping Coaster trains clipping through steep quarter turns down.
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
+++ b/src/openrct2/ride/coaster/LoopingRollerCoaster.cpp
@@ -4436,7 +4436,7 @@ static void LoopingRCTrackLeftQuarterTurn160DegUp(
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15346), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 2, 2, height + 75 }, { 28, 28, 1 } });
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -4497,7 +4497,7 @@ static void LoopingRCTrackRightQuarterTurn160DegUp(
                 { { 2, 2, height }, { 28, 28, 3 } });
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(15339), { 0, 0, height },
-                { { 2, 2, height + 99 }, { 28, 28, 1 } });
+                { { 2, 2, height + 75 }, { 28, 28, 1 } });
             break;
     }
     TrackPaintUtilRightQuarterTurn1TileTunnel(session, direction, height, -8, TUNNEL_1, +56, TUNNEL_2);


### PR DESCRIPTION
Noticed this specific instance of Looping Coaster clipping in Marcel's latest video, couldn't resist fixing it.

**Before (right turn):**
![Before right](https://user-images.githubusercontent.com/30838294/230459826-9d405668-fa80-4516-8209-c069c67190fc.gif)

**After (right turn):**
![After right](https://user-images.githubusercontent.com/30838294/230459854-e2608b12-f6e5-4f12-a905-601837d6c4e3.gif)

**Before (left turn):**
![Before left](https://user-images.githubusercontent.com/30838294/230459871-bf460d7b-1864-48b9-8442-06db64bac767.gif)

**After (left turn):**
![After left](https://user-images.githubusercontent.com/30838294/230459897-3e88fa3b-f3ad-4d1d-8de0-7170c33b4d16.gif)
