### PR TITLE
Fix 19853: Landscaping tool not indicating corners when choosing where to raise or lower land

### DIFF
--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -192,10 +192,14 @@ enum class FilterPaletteID : int32_t
 
     PaletteWater = COLOUR_COUNT,
 
-    Palette34 = PaletteWater + 2,
+    PaletteLandMarker,
+    Palette34,
 
-    Palette44 = Palette34 + 10, // Construction marker
-    Palette45,                  // Decolourise + lighten
+    PaletteWaterMarker = Palette34 + 4,
+    PaletteQuarterMarker,
+
+    Palette44 = PaletteQuarterMarker + 5, // Construction marker
+    Palette45, // Decolourise + lighten
     Palette46,
 
     PaletteDarken3,

--- a/src/openrct2/drawing/Drawing.h
+++ b/src/openrct2/drawing/Drawing.h
@@ -199,7 +199,7 @@ enum class FilterPaletteID : int32_t
     PaletteQuarterMarker,
 
     Palette44 = PaletteQuarterMarker + 5, // Construction marker
-    Palette45, // Decolourise + lighten
+    Palette45,                            // Decolourise + lighten
     Palette46,
 
     PaletteDarken3,

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1221,7 +1221,8 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
                 // Walls
                 // Loc661089:
                 const auto fpId = static_cast<FilterPaletteID>(
-                    (((mapSelectionType - 9) + rotation) & 3) + static_cast<uint32_t>(FilterPaletteID::PaletteLandMarker));
+                    (((mapSelectionType - MAP_SELECT_TYPE_EDGE_0 + 1) + rotation) & 3)
+                    + static_cast<uint32_t>(FilterPaletteID::PaletteLandMarker));
                 const auto image_id = ImageId(SPR_TERRAIN_SELECTION_EDGE + Byte97B444[surfaceShape], fpId);
                 PaintAttachToPreviousPS(session, image_id, 0, 0);
             }

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1220,7 +1220,8 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
             {
                 // Walls
                 // Loc661089:
-                const auto fpId = static_cast<FilterPaletteID>((((mapSelectionType - 9) + rotation) & 3) + 0x21);
+                const auto fpId = static_cast<FilterPaletteID>(
+                    (((mapSelectionType - 9) + rotation) & 3) + static_cast<uint32_t>(FilterPaletteID::PaletteLandMarker));
                 const auto image_id = ImageId(SPR_TERRAIN_SELECTION_EDGE + Byte97B444[surfaceShape], fpId);
                 PaintAttachToPreviousPS(session, image_id, 0, 0);
             }
@@ -1229,7 +1230,8 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
                 // Loc661051:(no jump)
                 // Selection split into four quarter segments
                 const auto fpId = static_cast<FilterPaletteID>(
-                    (((mapSelectionType - MAP_SELECT_TYPE_QUARTER_0) + rotation) & 3) + 0x27);
+                    (((mapSelectionType - MAP_SELECT_TYPE_QUARTER_0) + rotation) & 3)
+                    + static_cast<uint32_t>(FilterPaletteID::PaletteQuarterMarker));
                 const auto image_id = ImageId(SPR_TERRAIN_SELECTION_QUARTER + Byte97B444[surfaceShape], fpId);
                 PaintAttachToPreviousPS(session, image_id, 0, 0);
             }
@@ -1242,7 +1244,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
                     eax = (mapSelectionType + rotation) & 3;
                 }
 
-                const auto fpId = static_cast<FilterPaletteID>(eax + 0x21);
+                const auto fpId = static_cast<FilterPaletteID>(eax + static_cast<uint32_t>(FilterPaletteID::PaletteLandMarker));
                 const auto image_id = ImageId(SPR_TERRAIN_SELECTION_CORNER + Byte97B444[surfaceShape], fpId);
                 PaintAttachToPreviousPS(session, image_id, 0, 0);
             }
@@ -1251,7 +1253,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
                 // The water tool should draw its grid _on_ the water, rather than on the surface under water.
                 auto [local_height, local_surfaceShape] = SurfaceGetHeightAboveWater(tileElement, height, surfaceShape);
 
-                const auto fpId = static_cast<FilterPaletteID>(38);
+                const auto fpId = FilterPaletteID::PaletteWaterMarker;
                 const auto image_id = ImageId(SPR_TERRAIN_SELECTION_CORNER + Byte97B444[local_surfaceShape], fpId);
 
                 PaintStruct* backup = session.LastPS;


### PR DESCRIPTION
Fix #19853