### PR TITLE
Make audio source release status atomic

### DIFF
--- a/src/openrct2-ui/audio/SDLAudioSource.h
+++ b/src/openrct2-ui/audio/SDLAudioSource.h
@@ -11,6 +11,7 @@
 
 #include "AudioFormat.h"
 
+#include <atomic>
 #include <SDL.h>
 #include <memory>
 #include <openrct2/audio/AudioSource.h>
@@ -28,7 +29,7 @@ namespace OpenRCT2::Audio
     class SDLAudioSource : public IAudioSource
     {
     private:
-        bool _released{};
+        std::atomic<bool> _released{};
 
     public:
         void Release() override;

--- a/src/openrct2-ui/audio/SDLAudioSource.h
+++ b/src/openrct2-ui/audio/SDLAudioSource.h
@@ -11,8 +11,8 @@
 
 #include "AudioFormat.h"
 
-#include <atomic>
 #include <SDL.h>
+#include <atomic>
 #include <memory>
 #include <openrct2/audio/AudioSource.h>
 #include <vector>


### PR DESCRIPTION
As audio sources get released from a callback done in a thread separate from main, the released status needs to be atomic.