### PR TITLE
Fix #19801: Cannot resize load/save window anymore

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -11,6 +11,7 @@
 - Fix: [#19296] Crash due to a race condition for parallel object loading.
 - Fix: [#19756] Crash with title sequences containing no commands.
 - Fix: [#19767] No message when path is not connected to ride exit and is therefore unreachable for mechanics.
+- Fix: [#19801] The in-game load/save window cannot be resized anymore.
 - Fix: [#19854] Looping Coaster trains clipping through steep quarter turns down.
 
 0.4.4 (2023-03-28)

--- a/src/openrct2-ui/windows/LoadSave.cpp
+++ b/src/openrct2-ui/windows/LoadSave.cpp
@@ -496,11 +496,6 @@ public:
     {
         widgets = window_loadsave_widgets;
 
-        min_width = WW;
-        min_height = WH / 2;
-        max_width = WW * 2;
-        max_height = WH * 2;
-
         const auto uiContext = OpenRCT2::GetContext()->GetUiContext();
         if (!uiContext->HasFilePicker())
         {
@@ -697,6 +692,10 @@ public:
 public:
     void OnOpen() override
     {
+        min_width = WW;
+        min_height = WH / 2;
+        max_width = WW * 2;
+        max_height = WH * 2;
     }
 
     void OnClose() override
@@ -730,7 +729,7 @@ public:
         window_loadsave_widgets[WIDX_SORT_NAME].left = 4;
         window_loadsave_widgets[WIDX_SORT_NAME].right = window_loadsave_widgets[WIDX_SORT_DATE].left - 1;
 
-        window_loadsave_widgets[WIDX_SCROLL].right = width - 4;
+        window_loadsave_widgets[WIDX_SCROLL].right = width - 5;
         window_loadsave_widgets[WIDX_SCROLL].bottom = height - 30;
 
         window_loadsave_widgets[WIDX_BROWSE].top = height - 24;
@@ -787,11 +786,6 @@ public:
         DrawTextBasic(
             dpi, windowPos + ScreenCoordsXY{ sort_date_widget.left + 5, sort_date_widget.top + 1 }, STR_DATE, ft,
             { COLOUR_GREY });
-    }
-
-    OpenRCT2String OnTooltip(WidgetIndex widgetIndex, StringId fallback) override
-    {
-        return { fallback, {} };
     }
 
     void OnMouseUp(WidgetIndex widgetIndex) override


### PR DESCRIPTION
The main issue was that the min/max sizes of the window were set in the constructor, then being overwritten by the `WindowCreate` function. That function calls the `OnOpen` function, which can be used to set them properly.

The other two changes are just minor cleanups; a pixel difference in padding on the right side, and an overriden function that's identical to the base.