### PR TITLE
Move sprite related info into its own structure

### DIFF
--- a/src/openrct2-ui/interface/ViewportInteraction.cpp
+++ b/src/openrct2-ui/interface/ViewportInteraction.cpp
@@ -725,8 +725,9 @@ PeepDistance GetClosestPeep(const ScreenCoordsXY& viewportCoords, const int32_t 
         if (peep->x == LOCATION_NULL)
             continue;
 
-        auto distance = abs(((peep->SpriteRect.GetLeft() + peep->SpriteRect.GetRight()) / 2) - viewportCoords.x)
-            + abs(((peep->SpriteRect.GetTop() + peep->SpriteRect.GetBottom()) / 2) - viewportCoords.y);
+        auto distance = abs(((peep->SpriteData.SpriteRect.GetLeft() + peep->SpriteData.SpriteRect.GetRight()) / 2)
+                            - viewportCoords.x)
+            + abs(((peep->SpriteData.SpriteRect.GetTop() + peep->SpriteData.SpriteRect.GetBottom()) / 2) - viewportCoords.y);
         if (distance > maxDistance)
             continue;
 

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -253,7 +253,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(SpriteBase, sprite_right);
         COMPARE_FIELD(SpriteBase, sprite_bottom);
         */
-        COMPARE_FIELD(EntityBase, SpriteData.Direction);
+        COMPARE_FIELD(EntityBase, Orientation);
     }
 
     void CompareSpriteDataPeep(const Peep& spriteBase, const Peep& spriteCmp, GameStateSpriteChange& changeData) const

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -253,7 +253,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(SpriteBase, sprite_right);
         COMPARE_FIELD(SpriteBase, sprite_bottom);
         */
-        COMPARE_FIELD(EntityBase, SpriteData.sprite_direction);
+        COMPARE_FIELD(EntityBase, SpriteData.Direction);
     }
 
     void CompareSpriteDataPeep(const Peep& spriteBase, const Peep& spriteCmp, GameStateSpriteChange& changeData) const

--- a/src/openrct2/GameStateSnapshots.cpp
+++ b/src/openrct2/GameStateSnapshots.cpp
@@ -253,7 +253,7 @@ struct GameStateSnapshots final : public IGameStateSnapshots
         COMPARE_FIELD(SpriteBase, sprite_right);
         COMPARE_FIELD(SpriteBase, sprite_bottom);
         */
-        COMPARE_FIELD(EntityBase, sprite_direction);
+        COMPARE_FIELD(EntityBase, SpriteData.sprite_direction);
     }
 
     void CompareSpriteDataPeep(const Peep& spriteBase, const Peep& spriteCmp, GameStateSpriteChange& changeData) const

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -172,9 +172,9 @@ GameActions::Result StaffHireNewAction::QueryExecute(bool execute) const
         newPeep->SpriteType = spriteType;
 
         const SpriteBounds* spriteBounds = &GetSpriteBounds(spriteType);
-        newPeep->sprite_width = spriteBounds->sprite_width;
-        newPeep->sprite_height_negative = spriteBounds->sprite_height_negative;
-        newPeep->sprite_height_positive = spriteBounds->sprite_height_positive;
+        newPeep->SpriteData.sprite_width = spriteBounds->sprite_width;
+        newPeep->SpriteData.sprite_height_negative = spriteBounds->sprite_height_negative;
+        newPeep->SpriteData.sprite_height_positive = spriteBounds->sprite_height_positive;
 
         if (_autoPosition)
         {

--- a/src/openrct2/actions/StaffHireNewAction.cpp
+++ b/src/openrct2/actions/StaffHireNewAction.cpp
@@ -172,9 +172,9 @@ GameActions::Result StaffHireNewAction::QueryExecute(bool execute) const
         newPeep->SpriteType = spriteType;
 
         const SpriteBounds* spriteBounds = &GetSpriteBounds(spriteType);
-        newPeep->SpriteData.sprite_width = spriteBounds->sprite_width;
-        newPeep->SpriteData.sprite_height_negative = spriteBounds->sprite_height_negative;
-        newPeep->SpriteData.sprite_height_positive = spriteBounds->sprite_height_positive;
+        newPeep->SpriteData.Width = spriteBounds->sprite_width;
+        newPeep->SpriteData.HeightMin = spriteBounds->sprite_height_negative;
+        newPeep->SpriteData.HeightMax = spriteBounds->sprite_height_positive;
 
         if (_autoPosition)
         {

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -710,8 +710,8 @@ void LightFxAddLightsMagicVehicle_MineTrainCoaster(const Vehicle* vehicle)
 {
     if (vehicle == vehicle->TrainHead())
     {
-        int16_t place_x = vehicle->x - offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
-        int16_t place_y = vehicle->y - offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
+        int16_t place_x = vehicle->x - offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
+        int16_t place_y = vehicle->y - offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 0, { place_x, place_y, vehicle->z }, LightType::Spot3);
     }
 }
@@ -730,11 +730,11 @@ void LightFxAddLightsMagicVehicle_BoatHire(const Vehicle* vehicle)
     }
     int16_t place_x = vehicle_draw->x;
     int16_t place_y = vehicle_draw->y;
-    place_x -= offsetLookup[(vehicle_draw->SpriteData.sprite_direction + 0) % 32];
-    place_y -= offsetLookup[(vehicle_draw->SpriteData.sprite_direction + 8) % 32];
+    place_x -= offsetLookup[(vehicle_draw->SpriteData.Direction + 0) % 32];
+    place_y -= offsetLookup[(vehicle_draw->SpriteData.Direction + 8) % 32];
     LightFXAdd3DLight(*vehicle, 0, { place_x, place_y, vehicle_draw->z }, LightType::Spot2);
-    place_x -= offsetLookup[(vehicle_draw->SpriteData.sprite_direction + 0) % 32];
-    place_y -= offsetLookup[(vehicle_draw->SpriteData.sprite_direction + 8) % 32];
+    place_x -= offsetLookup[(vehicle_draw->SpriteData.Direction + 0) % 32];
+    place_y -= offsetLookup[(vehicle_draw->SpriteData.Direction + 8) % 32];
     LightFXAdd3DLight(*vehicle, 1, { place_x, place_y, vehicle_draw->z }, LightType::Spot2);
 }
 void LightFxAddLightsMagicVehicle_Monorail(const Vehicle* vehicle)
@@ -744,20 +744,20 @@ void LightFxAddLightsMagicVehicle_Monorail(const Vehicle* vehicle)
     int16_t place_y = vehicle->y;
     if (vehicle == vehicle->TrainHead())
     {
-        place_x -= offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
-        place_y -= offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
+        place_x -= offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
+        place_y -= offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 1, { place_x, place_y, vehicle->z + 10 }, LightType::Lantern3);
-        place_x -= offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 3;
-        place_y -= offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 3;
+        place_x -= offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 3;
+        place_y -= offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 3;
         LightFXAdd3DLight(*vehicle, 2, { place_x, place_y, vehicle->z + 2 }, LightType::Lantern3);
     }
     if (vehicle == vehicle->TrainTail())
     {
-        place_x += offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
-        place_y += offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
+        place_x += offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
+        place_y += offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 3, { place_x, place_y, vehicle->z + 10 }, LightType::Lantern3);
-        place_x += offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
-        place_y += offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
+        place_x += offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
+        place_y += offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 4, { place_x, place_y, vehicle->z + 2 }, LightType::Lantern3);
     }
 }
@@ -765,11 +765,11 @@ void LightFxAddLightsMagicVehicle_MiniatureRailway(const Vehicle* vehicle)
 {
     if (vehicle == vehicle->TrainHead())
     {
-        int16_t place_x = vehicle->x - offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
-        int16_t place_y = vehicle->y - offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
+        int16_t place_x = vehicle->x - offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
+        int16_t place_y = vehicle->y - offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 1, { place_x, place_y, vehicle->z + 10 }, LightType::Lantern3);
-        place_x -= offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
-        place_y -= offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
+        place_x -= offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
+        place_y -= offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 2, { place_x, place_y, vehicle->z + 2 }, LightType::Lantern3);
     }
     else

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -710,8 +710,8 @@ void LightFxAddLightsMagicVehicle_MineTrainCoaster(const Vehicle* vehicle)
 {
     if (vehicle == vehicle->TrainHead())
     {
-        int16_t place_x = vehicle->x - offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
-        int16_t place_y = vehicle->y - offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
+        int16_t place_x = vehicle->x - offsetLookup[(vehicle->Orientation + 0) % 32] * 2;
+        int16_t place_y = vehicle->y - offsetLookup[(vehicle->Orientation + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 0, { place_x, place_y, vehicle->z }, LightType::Spot3);
     }
 }
@@ -730,11 +730,11 @@ void LightFxAddLightsMagicVehicle_BoatHire(const Vehicle* vehicle)
     }
     int16_t place_x = vehicle_draw->x;
     int16_t place_y = vehicle_draw->y;
-    place_x -= offsetLookup[(vehicle_draw->SpriteData.Direction + 0) % 32];
-    place_y -= offsetLookup[(vehicle_draw->SpriteData.Direction + 8) % 32];
+    place_x -= offsetLookup[(vehicle_draw->Orientation + 0) % 32];
+    place_y -= offsetLookup[(vehicle_draw->Orientation + 8) % 32];
     LightFXAdd3DLight(*vehicle, 0, { place_x, place_y, vehicle_draw->z }, LightType::Spot2);
-    place_x -= offsetLookup[(vehicle_draw->SpriteData.Direction + 0) % 32];
-    place_y -= offsetLookup[(vehicle_draw->SpriteData.Direction + 8) % 32];
+    place_x -= offsetLookup[(vehicle_draw->Orientation + 0) % 32];
+    place_y -= offsetLookup[(vehicle_draw->Orientation + 8) % 32];
     LightFXAdd3DLight(*vehicle, 1, { place_x, place_y, vehicle_draw->z }, LightType::Spot2);
 }
 void LightFxAddLightsMagicVehicle_Monorail(const Vehicle* vehicle)
@@ -744,20 +744,20 @@ void LightFxAddLightsMagicVehicle_Monorail(const Vehicle* vehicle)
     int16_t place_y = vehicle->y;
     if (vehicle == vehicle->TrainHead())
     {
-        place_x -= offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
-        place_y -= offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
+        place_x -= offsetLookup[(vehicle->Orientation + 0) % 32] * 2;
+        place_y -= offsetLookup[(vehicle->Orientation + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 1, { place_x, place_y, vehicle->z + 10 }, LightType::Lantern3);
-        place_x -= offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 3;
-        place_y -= offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 3;
+        place_x -= offsetLookup[(vehicle->Orientation + 0) % 32] * 3;
+        place_y -= offsetLookup[(vehicle->Orientation + 8) % 32] * 3;
         LightFXAdd3DLight(*vehicle, 2, { place_x, place_y, vehicle->z + 2 }, LightType::Lantern3);
     }
     if (vehicle == vehicle->TrainTail())
     {
-        place_x += offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
-        place_y += offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
+        place_x += offsetLookup[(vehicle->Orientation + 0) % 32] * 2;
+        place_y += offsetLookup[(vehicle->Orientation + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 3, { place_x, place_y, vehicle->z + 10 }, LightType::Lantern3);
-        place_x += offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
-        place_y += offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
+        place_x += offsetLookup[(vehicle->Orientation + 0) % 32] * 2;
+        place_y += offsetLookup[(vehicle->Orientation + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 4, { place_x, place_y, vehicle->z + 2 }, LightType::Lantern3);
     }
 }
@@ -765,11 +765,11 @@ void LightFxAddLightsMagicVehicle_MiniatureRailway(const Vehicle* vehicle)
 {
     if (vehicle == vehicle->TrainHead())
     {
-        int16_t place_x = vehicle->x - offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
-        int16_t place_y = vehicle->y - offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
+        int16_t place_x = vehicle->x - offsetLookup[(vehicle->Orientation + 0) % 32] * 2;
+        int16_t place_y = vehicle->y - offsetLookup[(vehicle->Orientation + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 1, { place_x, place_y, vehicle->z + 10 }, LightType::Lantern3);
-        place_x -= offsetLookup[(vehicle->SpriteData.Direction + 0) % 32] * 2;
-        place_y -= offsetLookup[(vehicle->SpriteData.Direction + 8) % 32] * 2;
+        place_x -= offsetLookup[(vehicle->Orientation + 0) % 32] * 2;
+        place_y -= offsetLookup[(vehicle->Orientation + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 2, { place_x, place_y, vehicle->z + 2 }, LightType::Lantern3);
     }
     else

--- a/src/openrct2/drawing/LightFX.cpp
+++ b/src/openrct2/drawing/LightFX.cpp
@@ -710,8 +710,8 @@ void LightFxAddLightsMagicVehicle_MineTrainCoaster(const Vehicle* vehicle)
 {
     if (vehicle == vehicle->TrainHead())
     {
-        int16_t place_x = vehicle->x - offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-        int16_t place_y = vehicle->y - offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+        int16_t place_x = vehicle->x - offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
+        int16_t place_y = vehicle->y - offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 0, { place_x, place_y, vehicle->z }, LightType::Spot3);
     }
 }
@@ -730,11 +730,11 @@ void LightFxAddLightsMagicVehicle_BoatHire(const Vehicle* vehicle)
     }
     int16_t place_x = vehicle_draw->x;
     int16_t place_y = vehicle_draw->y;
-    place_x -= offsetLookup[(vehicle_draw->sprite_direction + 0) % 32];
-    place_y -= offsetLookup[(vehicle_draw->sprite_direction + 8) % 32];
+    place_x -= offsetLookup[(vehicle_draw->SpriteData.sprite_direction + 0) % 32];
+    place_y -= offsetLookup[(vehicle_draw->SpriteData.sprite_direction + 8) % 32];
     LightFXAdd3DLight(*vehicle, 0, { place_x, place_y, vehicle_draw->z }, LightType::Spot2);
-    place_x -= offsetLookup[(vehicle_draw->sprite_direction + 0) % 32];
-    place_y -= offsetLookup[(vehicle_draw->sprite_direction + 8) % 32];
+    place_x -= offsetLookup[(vehicle_draw->SpriteData.sprite_direction + 0) % 32];
+    place_y -= offsetLookup[(vehicle_draw->SpriteData.sprite_direction + 8) % 32];
     LightFXAdd3DLight(*vehicle, 1, { place_x, place_y, vehicle_draw->z }, LightType::Spot2);
 }
 void LightFxAddLightsMagicVehicle_Monorail(const Vehicle* vehicle)
@@ -744,20 +744,20 @@ void LightFxAddLightsMagicVehicle_Monorail(const Vehicle* vehicle)
     int16_t place_y = vehicle->y;
     if (vehicle == vehicle->TrainHead())
     {
-        place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-        place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+        place_x -= offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
+        place_y -= offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 1, { place_x, place_y, vehicle->z + 10 }, LightType::Lantern3);
-        place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 3;
-        place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 3;
+        place_x -= offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 3;
+        place_y -= offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 3;
         LightFXAdd3DLight(*vehicle, 2, { place_x, place_y, vehicle->z + 2 }, LightType::Lantern3);
     }
     if (vehicle == vehicle->TrainTail())
     {
-        place_x += offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-        place_y += offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+        place_x += offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
+        place_y += offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 3, { place_x, place_y, vehicle->z + 10 }, LightType::Lantern3);
-        place_x += offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-        place_y += offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+        place_x += offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
+        place_y += offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 4, { place_x, place_y, vehicle->z + 2 }, LightType::Lantern3);
     }
 }
@@ -765,11 +765,11 @@ void LightFxAddLightsMagicVehicle_MiniatureRailway(const Vehicle* vehicle)
 {
     if (vehicle == vehicle->TrainHead())
     {
-        int16_t place_x = vehicle->x - offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-        int16_t place_y = vehicle->y - offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+        int16_t place_x = vehicle->x - offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
+        int16_t place_y = vehicle->y - offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 1, { place_x, place_y, vehicle->z + 10 }, LightType::Lantern3);
-        place_x -= offsetLookup[(vehicle->sprite_direction + 0) % 32] * 2;
-        place_y -= offsetLookup[(vehicle->sprite_direction + 8) % 32] * 2;
+        place_x -= offsetLookup[(vehicle->SpriteData.sprite_direction + 0) % 32] * 2;
+        place_y -= offsetLookup[(vehicle->SpriteData.sprite_direction + 8) % 32] * 2;
         LightFXAdd3DLight(*vehicle, 2, { place_x, place_y, vehicle->z + 2 }, LightType::Lantern3);
     }
     else

--- a/src/openrct2/entity/Balloon.cpp
+++ b/src/openrct2/entity/Balloon.cpp
@@ -90,9 +90,9 @@ void Balloon::Create(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped)
     if (balloon == nullptr)
         return;
 
-    balloon->sprite_width = 13;
-    balloon->sprite_height_negative = 22;
-    balloon->sprite_height_positive = 11;
+    balloon->SpriteData.sprite_width = 13;
+    balloon->SpriteData.sprite_height_negative = 22;
+    balloon->SpriteData.sprite_height_positive = 11;
     balloon->MoveTo(balloonPos);
     balloon->time_to_move = 0;
     balloon->frame = 0;

--- a/src/openrct2/entity/Balloon.cpp
+++ b/src/openrct2/entity/Balloon.cpp
@@ -90,9 +90,9 @@ void Balloon::Create(const CoordsXYZ& balloonPos, int32_t colour, bool isPopped)
     if (balloon == nullptr)
         return;
 
-    balloon->SpriteData.sprite_width = 13;
-    balloon->SpriteData.sprite_height_negative = 22;
-    balloon->SpriteData.sprite_height_positive = 11;
+    balloon->SpriteData.Width = 13;
+    balloon->SpriteData.HeightMin = 22;
+    balloon->SpriteData.HeightMax = 11;
     balloon->MoveTo(balloonPos);
     balloon->time_to_move = 0;
     balloon->frame = 0;

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -99,7 +99,7 @@ void Duck::UpdateFlyToWater()
 
     Invalidate();
     int32_t manhattanDistance = abs(target_x - x) + abs(target_y - y);
-    int32_t direction = sprite_direction >> 3;
+    int32_t direction = SpriteData.sprite_direction >> 3;
     auto destination = CoordsXYZ{ CoordsXY{ x, y } + DuckMoveOffset[direction], 0 };
     int32_t manhattanDistanceN = abs(target_x - destination.x) + abs(target_y - destination.y);
 
@@ -195,10 +195,10 @@ void Duck::UpdateSwim()
                 if ((randomNumber & 0xFFFF) <= 0xAAA)
                 {
                     randomNumber >>= 16;
-                    sprite_direction = randomNumber & 0x18;
+                    SpriteData.sprite_direction = randomNumber & 0x18;
                 }
 
-                int32_t direction = sprite_direction >> 3;
+                int32_t direction = SpriteData.sprite_direction >> 3;
                 auto destination = CoordsXYZ{ CoordsXY{ x, y } + DuckMoveOffset[direction], 0 };
                 landZ = TileElementHeight(destination);
                 waterZ = TileElementWaterHeight(destination);
@@ -256,7 +256,7 @@ void Duck::UpdateFlyAway()
 
         Invalidate();
 
-        int32_t direction = sprite_direction >> 3;
+        int32_t direction = SpriteData.sprite_direction >> 3;
         auto destination = CoordsXYZ{ x + (DuckMoveOffset[direction].x * 2), y + (DuckMoveOffset[direction].y * 2),
                                       std::min<int32_t>(z + 2, 496) };
         if (MapIsLocationValid(destination))
@@ -294,9 +294,9 @@ void Duck::Create(const CoordsXY& pos)
     targetPos.x += offsetXY;
     targetPos.y += offsetXY;
 
-    duck->sprite_width = 9;
-    duck->sprite_height_negative = 12;
-    duck->sprite_height_positive = 9;
+    duck->SpriteData.sprite_width = 9;
+    duck->SpriteData.sprite_height_negative = 12;
+    duck->SpriteData.sprite_height_positive = 9;
     duck->target_x = targetPos.x;
     duck->target_y = targetPos.y;
     uint8_t direction = ScenarioRand() & 3;
@@ -315,7 +315,7 @@ void Duck::Create(const CoordsXY& pos)
             targetPos.y = GetMapSizeMaxXY().y - (ScenarioRand() & 0x3F);
             break;
     }
-    duck->sprite_direction = direction << 3;
+    duck->SpriteData.sprite_direction = direction << 3;
     duck->MoveTo({ targetPos.x, targetPos.y, 496 });
     duck->state = Duck::DuckState::FlyToWater;
     duck->frame = 0;

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -99,7 +99,7 @@ void Duck::UpdateFlyToWater()
 
     Invalidate();
     int32_t manhattanDistance = abs(target_x - x) + abs(target_y - y);
-    int32_t direction = SpriteData.Direction >> 3;
+    int32_t direction = Orientation >> 3;
     auto destination = CoordsXYZ{ CoordsXY{ x, y } + DuckMoveOffset[direction], 0 };
     int32_t manhattanDistanceN = abs(target_x - destination.x) + abs(target_y - destination.y);
 
@@ -195,10 +195,10 @@ void Duck::UpdateSwim()
                 if ((randomNumber & 0xFFFF) <= 0xAAA)
                 {
                     randomNumber >>= 16;
-                    SpriteData.Direction = randomNumber & 0x18;
+                    Orientation = randomNumber & 0x18;
                 }
 
-                int32_t direction = SpriteData.Direction >> 3;
+                int32_t direction = Orientation >> 3;
                 auto destination = CoordsXYZ{ CoordsXY{ x, y } + DuckMoveOffset[direction], 0 };
                 landZ = TileElementHeight(destination);
                 waterZ = TileElementWaterHeight(destination);
@@ -256,7 +256,7 @@ void Duck::UpdateFlyAway()
 
         Invalidate();
 
-        int32_t direction = SpriteData.Direction >> 3;
+        int32_t direction = Orientation >> 3;
         auto destination = CoordsXYZ{ x + (DuckMoveOffset[direction].x * 2), y + (DuckMoveOffset[direction].y * 2),
                                       std::min<int32_t>(z + 2, 496) };
         if (MapIsLocationValid(destination))
@@ -315,7 +315,7 @@ void Duck::Create(const CoordsXY& pos)
             targetPos.y = GetMapSizeMaxXY().y - (ScenarioRand() & 0x3F);
             break;
     }
-    duck->SpriteData.Direction = direction << 3;
+    duck->Orientation = direction << 3;
     duck->MoveTo({ targetPos.x, targetPos.y, 496 });
     duck->state = Duck::DuckState::FlyToWater;
     duck->frame = 0;

--- a/src/openrct2/entity/Duck.cpp
+++ b/src/openrct2/entity/Duck.cpp
@@ -99,7 +99,7 @@ void Duck::UpdateFlyToWater()
 
     Invalidate();
     int32_t manhattanDistance = abs(target_x - x) + abs(target_y - y);
-    int32_t direction = SpriteData.sprite_direction >> 3;
+    int32_t direction = SpriteData.Direction >> 3;
     auto destination = CoordsXYZ{ CoordsXY{ x, y } + DuckMoveOffset[direction], 0 };
     int32_t manhattanDistanceN = abs(target_x - destination.x) + abs(target_y - destination.y);
 
@@ -195,10 +195,10 @@ void Duck::UpdateSwim()
                 if ((randomNumber & 0xFFFF) <= 0xAAA)
                 {
                     randomNumber >>= 16;
-                    SpriteData.sprite_direction = randomNumber & 0x18;
+                    SpriteData.Direction = randomNumber & 0x18;
                 }
 
-                int32_t direction = SpriteData.sprite_direction >> 3;
+                int32_t direction = SpriteData.Direction >> 3;
                 auto destination = CoordsXYZ{ CoordsXY{ x, y } + DuckMoveOffset[direction], 0 };
                 landZ = TileElementHeight(destination);
                 waterZ = TileElementWaterHeight(destination);
@@ -256,7 +256,7 @@ void Duck::UpdateFlyAway()
 
         Invalidate();
 
-        int32_t direction = SpriteData.sprite_direction >> 3;
+        int32_t direction = SpriteData.Direction >> 3;
         auto destination = CoordsXYZ{ x + (DuckMoveOffset[direction].x * 2), y + (DuckMoveOffset[direction].y * 2),
                                       std::min<int32_t>(z + 2, 496) };
         if (MapIsLocationValid(destination))
@@ -294,9 +294,9 @@ void Duck::Create(const CoordsXY& pos)
     targetPos.x += offsetXY;
     targetPos.y += offsetXY;
 
-    duck->SpriteData.sprite_width = 9;
-    duck->SpriteData.sprite_height_negative = 12;
-    duck->SpriteData.sprite_height_positive = 9;
+    duck->SpriteData.Width = 9;
+    duck->SpriteData.HeightMin = 12;
+    duck->SpriteData.HeightMax = 9;
     duck->target_x = targetPos.x;
     duck->target_y = targetPos.y;
     uint8_t direction = ScenarioRand() & 3;
@@ -315,7 +315,7 @@ void Duck::Create(const CoordsXY& pos)
             targetPos.y = GetMapSizeMaxXY().y - (ScenarioRand() & 0x3F);
             break;
     }
-    duck->SpriteData.sprite_direction = direction << 3;
+    duck->SpriteData.Direction = direction << 3;
     duck->MoveTo({ targetPos.x, targetPos.y, 496 });
     duck->state = Duck::DuckState::FlyToWater;
     duck->frame = 0;

--- a/src/openrct2/entity/EntityBase.cpp
+++ b/src/openrct2/entity/EntityBase.cpp
@@ -64,7 +64,7 @@ void EntityBase::Invalidate()
             break;
     }
 
-    ViewportsInvalidate(SpriteRect, maxZoom);
+    ViewportsInvalidate(SpriteData.SpriteRect, maxZoom);
 }
 
 void EntityBase::Serialise(DataSerialiser& stream)
@@ -74,7 +74,7 @@ void EntityBase::Serialise(DataSerialiser& stream)
     stream << x;
     stream << y;
     stream << z;
-    stream << sprite_direction;
+    stream << SpriteData.sprite_direction;
 }
 
 // Exists only for signature

--- a/src/openrct2/entity/EntityBase.cpp
+++ b/src/openrct2/entity/EntityBase.cpp
@@ -74,7 +74,7 @@ void EntityBase::Serialise(DataSerialiser& stream)
     stream << x;
     stream << y;
     stream << z;
-    stream << SpriteData.Direction;
+    stream << Orientation;
 }
 
 // Exists only for signature

--- a/src/openrct2/entity/EntityBase.cpp
+++ b/src/openrct2/entity/EntityBase.cpp
@@ -74,7 +74,7 @@ void EntityBase::Serialise(DataSerialiser& stream)
     stream << x;
     stream << y;
     stream << z;
-    stream << SpriteData.sprite_direction;
+    stream << SpriteData.Direction;
 }
 
 // Exists only for signature

--- a/src/openrct2/entity/EntityBase.h
+++ b/src/openrct2/entity/EntityBase.h
@@ -26,15 +26,13 @@ enum class EntityType : uint8_t
 struct EntitySpriteData
 {
     // Width from centre of sprite to edge
-    uint8_t sprite_width;
+    uint8_t Width;
     // Height from centre of sprite to bottom
-    uint8_t sprite_height_negative;
+    uint8_t HeightMin;
     // Height from centre of sprite to top
-    uint8_t sprite_height_positive;
+    uint8_t HeightMax;
     // Screen Coordinates of sprite
     ScreenRect SpriteRect;
-
-    uint8_t sprite_direction;
 };
 
 struct EntityBase
@@ -45,6 +43,7 @@ struct EntityBase
     int32_t y;
     int32_t z;
     EntitySpriteData SpriteData;
+    uint8_t Direction;
 
     /**
      * Moves a sprite to a new location, invalidates the current position if valid

--- a/src/openrct2/entity/EntityBase.h
+++ b/src/openrct2/entity/EntityBase.h
@@ -23,13 +23,8 @@ enum class EntityType : uint8_t
     Null = 255
 };
 
-struct EntityBase
+struct EntitySpriteData
 {
-    EntityType Type;
-    EntityId Id;
-    int32_t x;
-    int32_t y;
-    int32_t z;
     // Width from centre of sprite to edge
     uint8_t sprite_width;
     // Height from centre of sprite to bottom
@@ -40,6 +35,16 @@ struct EntityBase
     ScreenRect SpriteRect;
 
     uint8_t sprite_direction;
+};
+
+struct EntityBase
+{
+    EntityType Type;
+    EntityId Id;
+    int32_t x;
+    int32_t y;
+    int32_t z;
+    EntitySpriteData SpriteData;
 
     /**
      * Moves a sprite to a new location, invalidates the current position if valid

--- a/src/openrct2/entity/EntityBase.h
+++ b/src/openrct2/entity/EntityBase.h
@@ -43,7 +43,8 @@ struct EntityBase
     int32_t y;
     int32_t z;
     EntitySpriteData SpriteData;
-    uint8_t Direction;
+    // Used as direction or rotation depending on the entity.
+    uint8_t Orientation;
 
     /**
      * Moves a sprite to a new location, invalidates the current position if valid

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -323,10 +323,10 @@ static void PrepareNewEntity(EntityBase* base, const EntityType type)
     base->x = LOCATION_NULL;
     base->y = LOCATION_NULL;
     base->z = 0;
-    base->sprite_width = 0x10;
-    base->sprite_height_negative = 0x14;
-    base->sprite_height_positive = 0x8;
-    base->SpriteRect = {};
+    base->SpriteData.sprite_width = 0x10;
+    base->SpriteData.sprite_height_negative = 0x14;
+    base->SpriteData.sprite_height_positive = 0x8;
+    base->SpriteData.SpriteRect = {};
 
     EntitySpatialInsert(base, { LOCATION_NULL, 0 });
 }
@@ -478,9 +478,9 @@ void EntitySetCoordinates(const CoordsXYZ& entityPos, EntityBase* entity)
 {
     auto screenCoords = Translate3DTo2DWithZ(GetCurrentRotation(), entityPos);
 
-    entity->SpriteRect = ScreenRect(
-        screenCoords - ScreenCoordsXY{ entity->sprite_width, entity->sprite_height_negative },
-        screenCoords + ScreenCoordsXY{ entity->sprite_width, entity->sprite_height_positive });
+    entity->SpriteData.SpriteRect = ScreenRect(
+        screenCoords - ScreenCoordsXY{ entity->SpriteData.sprite_width, entity->SpriteData.sprite_height_negative },
+        screenCoords + ScreenCoordsXY{ entity->SpriteData.sprite_width, entity->SpriteData.sprite_height_positive });
     entity->SetLocation(entityPos);
 }
 

--- a/src/openrct2/entity/EntityRegistry.cpp
+++ b/src/openrct2/entity/EntityRegistry.cpp
@@ -323,9 +323,9 @@ static void PrepareNewEntity(EntityBase* base, const EntityType type)
     base->x = LOCATION_NULL;
     base->y = LOCATION_NULL;
     base->z = 0;
-    base->SpriteData.sprite_width = 0x10;
-    base->SpriteData.sprite_height_negative = 0x14;
-    base->SpriteData.sprite_height_positive = 0x8;
+    base->SpriteData.Width = 0x10;
+    base->SpriteData.HeightMin = 0x14;
+    base->SpriteData.HeightMax = 0x8;
     base->SpriteData.SpriteRect = {};
 
     EntitySpatialInsert(base, { LOCATION_NULL, 0 });
@@ -479,8 +479,8 @@ void EntitySetCoordinates(const CoordsXYZ& entityPos, EntityBase* entity)
     auto screenCoords = Translate3DTo2DWithZ(GetCurrentRotation(), entityPos);
 
     entity->SpriteData.SpriteRect = ScreenRect(
-        screenCoords - ScreenCoordsXY{ entity->SpriteData.sprite_width, entity->SpriteData.sprite_height_negative },
-        screenCoords + ScreenCoordsXY{ entity->SpriteData.sprite_width, entity->SpriteData.sprite_height_positive });
+        screenCoords - ScreenCoordsXY{ entity->SpriteData.Width, entity->SpriteData.HeightMin },
+        screenCoords + ScreenCoordsXY{ entity->SpriteData.Width, entity->SpriteData.HeightMax });
     entity->SetLocation(entityPos);
 }
 

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -142,7 +142,7 @@ void JumpingFountain::Create(
     {
         jumpingFountain->Iteration = iteration;
         jumpingFountain->FountainFlags = newFlags;
-        jumpingFountain->SpriteData.Direction = direction << 3;
+        jumpingFountain->Orientation = direction << 3;
         jumpingFountain->SpriteData.Width = 33;
         jumpingFountain->SpriteData.HeightMin = 36;
         jumpingFountain->SpriteData.HeightMax = 12;
@@ -204,7 +204,7 @@ JumpingFountainType JumpingFountain::GetType() const
 void JumpingFountain::AdvanceAnimation()
 {
     const JumpingFountainType newType = GetType();
-    const int32_t direction = (SpriteData.Direction >> 3) & 7;
+    const int32_t direction = (Orientation >> 3) & 7;
     const CoordsXY newLoc = CoordsXY{ x, y } + CoordsDirectionDelta[direction];
 
     int32_t availableDirections = 0;
@@ -278,7 +278,7 @@ bool JumpingFountain::IsJumpingFountain(const JumpingFountainType newType, const
 
 void JumpingFountain::GoToEdge(const CoordsXYZ& newLoc, const int32_t availableDirections) const
 {
-    int32_t direction = (SpriteData.Direction >> 3) << 1;
+    int32_t direction = (Orientation >> 3) << 1;
     if (availableDirections & (1 << direction))
     {
         CreateNext(newLoc, direction);
@@ -318,7 +318,7 @@ void JumpingFountain::Bounce(const CoordsXYZ& newLoc, const int32_t availableDir
     Iteration++;
     if (Iteration < 8)
     {
-        int32_t direction = ((SpriteData.Direction >> 3) ^ 2) << 1;
+        int32_t direction = ((Orientation >> 3) ^ 2) << 1;
         if (availableDirections & (1 << direction))
         {
             CreateNext(newLoc, direction);
@@ -339,7 +339,7 @@ void JumpingFountain::Split(const CoordsXYZ& newLoc, int32_t availableDirections
     if (Iteration < 3)
     {
         const auto newType = GetType();
-        int32_t direction = ((SpriteData.Direction >> 3) ^ 2) << 1;
+        int32_t direction = ((Orientation >> 3) ^ 2) << 1;
         availableDirections &= ~(1 << direction);
         availableDirections &= ~(1 << (direction + 1));
 
@@ -417,7 +417,7 @@ void JumpingFountain::Paint(PaintSession& session, int32_t imageDirection) const
     // Fountain is firing anti clockwise
     bool reversed = (FountainFlags & FOUNTAIN_FLAG::DIRECTION);
     // Fountain rotation
-    bool rotated = (SpriteData.Direction / 16) & 1;
+    bool rotated = (Orientation / 16) & 1;
     bool isAntiClockwise = (imageDirection / 2) & 1; // Clockwise or Anti-clockwise
 
     // These cancel each other out

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -142,10 +142,10 @@ void JumpingFountain::Create(
     {
         jumpingFountain->Iteration = iteration;
         jumpingFountain->FountainFlags = newFlags;
-        jumpingFountain->SpriteData.sprite_direction = direction << 3;
-        jumpingFountain->SpriteData.sprite_width = 33;
-        jumpingFountain->SpriteData.sprite_height_negative = 36;
-        jumpingFountain->SpriteData.sprite_height_positive = 12;
+        jumpingFountain->SpriteData.Direction = direction << 3;
+        jumpingFountain->SpriteData.Width = 33;
+        jumpingFountain->SpriteData.HeightMin = 36;
+        jumpingFountain->SpriteData.HeightMax = 12;
         jumpingFountain->MoveTo(newLoc);
         jumpingFountain->FountainType = newType;
         jumpingFountain->NumTicksAlive = 0;
@@ -204,7 +204,7 @@ JumpingFountainType JumpingFountain::GetType() const
 void JumpingFountain::AdvanceAnimation()
 {
     const JumpingFountainType newType = GetType();
-    const int32_t direction = (SpriteData.sprite_direction >> 3) & 7;
+    const int32_t direction = (SpriteData.Direction >> 3) & 7;
     const CoordsXY newLoc = CoordsXY{ x, y } + CoordsDirectionDelta[direction];
 
     int32_t availableDirections = 0;
@@ -278,7 +278,7 @@ bool JumpingFountain::IsJumpingFountain(const JumpingFountainType newType, const
 
 void JumpingFountain::GoToEdge(const CoordsXYZ& newLoc, const int32_t availableDirections) const
 {
-    int32_t direction = (SpriteData.sprite_direction >> 3) << 1;
+    int32_t direction = (SpriteData.Direction >> 3) << 1;
     if (availableDirections & (1 << direction))
     {
         CreateNext(newLoc, direction);
@@ -318,7 +318,7 @@ void JumpingFountain::Bounce(const CoordsXYZ& newLoc, const int32_t availableDir
     Iteration++;
     if (Iteration < 8)
     {
-        int32_t direction = ((SpriteData.sprite_direction >> 3) ^ 2) << 1;
+        int32_t direction = ((SpriteData.Direction >> 3) ^ 2) << 1;
         if (availableDirections & (1 << direction))
         {
             CreateNext(newLoc, direction);
@@ -339,7 +339,7 @@ void JumpingFountain::Split(const CoordsXYZ& newLoc, int32_t availableDirections
     if (Iteration < 3)
     {
         const auto newType = GetType();
-        int32_t direction = ((SpriteData.sprite_direction >> 3) ^ 2) << 1;
+        int32_t direction = ((SpriteData.Direction >> 3) ^ 2) << 1;
         availableDirections &= ~(1 << direction);
         availableDirections &= ~(1 << (direction + 1));
 
@@ -417,7 +417,7 @@ void JumpingFountain::Paint(PaintSession& session, int32_t imageDirection) const
     // Fountain is firing anti clockwise
     bool reversed = (FountainFlags & FOUNTAIN_FLAG::DIRECTION);
     // Fountain rotation
-    bool rotated = (SpriteData.sprite_direction / 16) & 1;
+    bool rotated = (SpriteData.Direction / 16) & 1;
     bool isAntiClockwise = (imageDirection / 2) & 1; // Clockwise or Anti-clockwise
 
     // These cancel each other out

--- a/src/openrct2/entity/Fountain.cpp
+++ b/src/openrct2/entity/Fountain.cpp
@@ -142,10 +142,10 @@ void JumpingFountain::Create(
     {
         jumpingFountain->Iteration = iteration;
         jumpingFountain->FountainFlags = newFlags;
-        jumpingFountain->sprite_direction = direction << 3;
-        jumpingFountain->sprite_width = 33;
-        jumpingFountain->sprite_height_negative = 36;
-        jumpingFountain->sprite_height_positive = 12;
+        jumpingFountain->SpriteData.sprite_direction = direction << 3;
+        jumpingFountain->SpriteData.sprite_width = 33;
+        jumpingFountain->SpriteData.sprite_height_negative = 36;
+        jumpingFountain->SpriteData.sprite_height_positive = 12;
         jumpingFountain->MoveTo(newLoc);
         jumpingFountain->FountainType = newType;
         jumpingFountain->NumTicksAlive = 0;
@@ -204,7 +204,7 @@ JumpingFountainType JumpingFountain::GetType() const
 void JumpingFountain::AdvanceAnimation()
 {
     const JumpingFountainType newType = GetType();
-    const int32_t direction = (sprite_direction >> 3) & 7;
+    const int32_t direction = (SpriteData.sprite_direction >> 3) & 7;
     const CoordsXY newLoc = CoordsXY{ x, y } + CoordsDirectionDelta[direction];
 
     int32_t availableDirections = 0;
@@ -278,7 +278,7 @@ bool JumpingFountain::IsJumpingFountain(const JumpingFountainType newType, const
 
 void JumpingFountain::GoToEdge(const CoordsXYZ& newLoc, const int32_t availableDirections) const
 {
-    int32_t direction = (sprite_direction >> 3) << 1;
+    int32_t direction = (SpriteData.sprite_direction >> 3) << 1;
     if (availableDirections & (1 << direction))
     {
         CreateNext(newLoc, direction);
@@ -318,7 +318,7 @@ void JumpingFountain::Bounce(const CoordsXYZ& newLoc, const int32_t availableDir
     Iteration++;
     if (Iteration < 8)
     {
-        int32_t direction = ((sprite_direction >> 3) ^ 2) << 1;
+        int32_t direction = ((SpriteData.sprite_direction >> 3) ^ 2) << 1;
         if (availableDirections & (1 << direction))
         {
             CreateNext(newLoc, direction);
@@ -339,7 +339,7 @@ void JumpingFountain::Split(const CoordsXYZ& newLoc, int32_t availableDirections
     if (Iteration < 3)
     {
         const auto newType = GetType();
-        int32_t direction = ((sprite_direction >> 3) ^ 2) << 1;
+        int32_t direction = ((SpriteData.sprite_direction >> 3) ^ 2) << 1;
         availableDirections &= ~(1 << direction);
         availableDirections &= ~(1 << (direction + 1));
 
@@ -417,7 +417,7 @@ void JumpingFountain::Paint(PaintSession& session, int32_t imageDirection) const
     // Fountain is firing anti clockwise
     bool reversed = (FountainFlags & FOUNTAIN_FLAG::DIRECTION);
     // Fountain rotation
-    bool rotated = (sprite_direction / 16) & 1;
+    bool rotated = (SpriteData.sprite_direction / 16) & 1;
     bool isAntiClockwise = (imageDirection / 2) & 1; // Clockwise or Anti-clockwise
 
     // These cancel each other out

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -500,8 +500,8 @@ void Guest::GivePassingPeepsPizza(Guest* passingPeep)
 
     passingPeep->GiveItem(ShopItem::Pizza);
 
-    int32_t peepDirection = (SpriteData.sprite_direction >> 3) ^ 2;
-    int32_t otherPeepOppositeDirection = passingPeep->SpriteData.sprite_direction >> 3;
+    int32_t peepDirection = (SpriteData.Direction >> 3) ^ 2;
+    int32_t otherPeepOppositeDirection = passingPeep->SpriteData.Direction >> 3;
     if (peepDirection == otherPeepOppositeDirection)
     {
         if (passingPeep->IsActionInterruptable())
@@ -1258,7 +1258,7 @@ void Guest::UpdateSitting()
 
         MoveTo(loc);
 
-        SpriteData.sprite_direction = ((Var37 + 2) & 3) * 8;
+        SpriteData.Direction = ((Var37 + 2) & 3) * 8;
         Action = PeepActionType::Idle;
         NextActionSpriteType = PeepActionSpriteType::SittingIdle;
         SwitchNextActionSpriteType();
@@ -3345,7 +3345,7 @@ void Guest::UpdateBuying()
             }
             WindowInvalidateByNumber(WindowClass::Peep, Id);
         }
-        SpriteData.sprite_direction ^= 0x10;
+        SpriteData.Direction ^= 0x10;
 
         auto destination = CoordsXY{ 16, 16 } + NextLoc;
         SetDestination(destination);
@@ -3456,7 +3456,7 @@ void Guest::UpdateRideAtEntrance()
         else
         {
             DestinationTolerance = 0;
-            SpriteData.sprite_direction ^= (1 << 4);
+            SpriteData.Direction ^= (1 << 4);
             Invalidate();
         }
     }
@@ -3748,7 +3748,7 @@ void Guest::UpdateRideAdvanceThroughEntrance()
     }
 
     auto destination = GetDestination();
-    switch (vehicle->SpriteData.sprite_direction / 8)
+    switch (vehicle->SpriteData.Direction / 8)
     {
         case 0:
             destination.x = vehicle->x - load_position;
@@ -3818,7 +3818,7 @@ static void PeepGoToRideExit(Peep* peep, const Ride& ride, int16_t x, int16_t y,
 
     peep->SetDestination({ x, y }, 2);
 
-    peep->SpriteData.sprite_direction = exit_direction * 8;
+    peep->SpriteData.Direction = exit_direction * 8;
     peep->RideSubState = PeepRideSubState::ApproachExit;
 }
 
@@ -4200,7 +4200,7 @@ void Guest::UpdateRideLeaveVehicle()
 
                 if (carEntry->flags & (CAR_ENTRY_FLAG_CHAIRLIFT | CAR_ENTRY_FLAG_GO_KART))
                 {
-                    specialDirection = ((vehicle->SpriteData.sprite_direction + 3) / 8) + 1;
+                    specialDirection = ((vehicle->SpriteData.Direction + 3) / 8) + 1;
                     specialDirection &= 3;
 
                     if (vehicle->TrackSubposition == VehicleTrackSubposition::GoKartsRightLane)
@@ -4235,7 +4235,7 @@ void Guest::UpdateRideLeaveVehicle()
         {
             int8_t loadPosition = carEntry->peep_loading_positions[CurrentSeat];
 
-            switch (vehicle->SpriteData.sprite_direction / 8)
+            switch (vehicle->SpriteData.Direction / 8)
             {
                 case 0:
                     platformLocation.x -= loadPosition;
@@ -4758,7 +4758,7 @@ void Guest::UpdateRideOnSpiralSlide()
 
                 MoveTo({ newLocation, z });
 
-                SpriteData.sprite_direction = (Var37 & 0xC) * 2;
+                SpriteData.Direction = (Var37 & 0xC) * 2;
 
                 Var37++;
                 return;
@@ -5665,7 +5665,7 @@ void Guest::UpdateQueuing()
     if (Happiness <= 65 && (0xFFFF & ScenarioRand()) < 2184)
     {
         // Give up queueing for the ride
-        SpriteData.sprite_direction ^= (1 << 4);
+        SpriteData.Direction ^= (1 << 4);
         Invalidate();
         RemoveFromQueue();
         SetState(PeepState::One);
@@ -5757,7 +5757,7 @@ void Guest::UpdateWatching()
 
         SetDestination(GetLocation());
 
-        SpriteData.sprite_direction = (Var37 & 3) * 8;
+        SpriteData.Direction = (Var37 & 3) * 8;
 
         Action = PeepActionType::Idle;
         NextActionSpriteType = PeepActionSpriteType::WatchRide;
@@ -7076,10 +7076,10 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
     peep->FavouriteRideRating = 0;
 
     const SpriteBounds* spriteBounds = &GetSpriteBounds(peep->SpriteType, peep->ActionSpriteType);
-    peep->SpriteData.sprite_width = spriteBounds->sprite_width;
-    peep->SpriteData.sprite_height_negative = spriteBounds->sprite_height_negative;
-    peep->SpriteData.sprite_height_positive = spriteBounds->sprite_height_positive;
-    peep->SpriteData.sprite_direction = 0;
+    peep->SpriteData.Width = spriteBounds->sprite_width;
+    peep->SpriteData.HeightMin = spriteBounds->sprite_height_negative;
+    peep->SpriteData.HeightMax = spriteBounds->sprite_height_positive;
+    peep->SpriteData.Direction = 0;
 
     peep->MoveTo(coords);
     peep->Mass = (ScenarioRand() & 0x1F) + 45;

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -500,8 +500,8 @@ void Guest::GivePassingPeepsPizza(Guest* passingPeep)
 
     passingPeep->GiveItem(ShopItem::Pizza);
 
-    int32_t peepDirection = (SpriteData.Direction >> 3) ^ 2;
-    int32_t otherPeepOppositeDirection = passingPeep->SpriteData.Direction >> 3;
+    int32_t peepDirection = (Orientation >> 3) ^ 2;
+    int32_t otherPeepOppositeDirection = passingPeep->Orientation >> 3;
     if (peepDirection == otherPeepOppositeDirection)
     {
         if (passingPeep->IsActionInterruptable())
@@ -1258,7 +1258,7 @@ void Guest::UpdateSitting()
 
         MoveTo(loc);
 
-        SpriteData.Direction = ((Var37 + 2) & 3) * 8;
+        Orientation = ((Var37 + 2) & 3) * 8;
         Action = PeepActionType::Idle;
         NextActionSpriteType = PeepActionSpriteType::SittingIdle;
         SwitchNextActionSpriteType();
@@ -3345,7 +3345,7 @@ void Guest::UpdateBuying()
             }
             WindowInvalidateByNumber(WindowClass::Peep, Id);
         }
-        SpriteData.Direction ^= 0x10;
+        Orientation ^= 0x10;
 
         auto destination = CoordsXY{ 16, 16 } + NextLoc;
         SetDestination(destination);
@@ -3456,7 +3456,7 @@ void Guest::UpdateRideAtEntrance()
         else
         {
             DestinationTolerance = 0;
-            SpriteData.Direction ^= (1 << 4);
+            Orientation ^= (1 << 4);
             Invalidate();
         }
     }
@@ -3748,7 +3748,7 @@ void Guest::UpdateRideAdvanceThroughEntrance()
     }
 
     auto destination = GetDestination();
-    switch (vehicle->SpriteData.Direction / 8)
+    switch (vehicle->Orientation / 8)
     {
         case 0:
             destination.x = vehicle->x - load_position;
@@ -3818,7 +3818,7 @@ static void PeepGoToRideExit(Peep* peep, const Ride& ride, int16_t x, int16_t y,
 
     peep->SetDestination({ x, y }, 2);
 
-    peep->SpriteData.Direction = exit_direction * 8;
+    peep->Orientation = exit_direction * 8;
     peep->RideSubState = PeepRideSubState::ApproachExit;
 }
 
@@ -4200,7 +4200,7 @@ void Guest::UpdateRideLeaveVehicle()
 
                 if (carEntry->flags & (CAR_ENTRY_FLAG_CHAIRLIFT | CAR_ENTRY_FLAG_GO_KART))
                 {
-                    specialDirection = ((vehicle->SpriteData.Direction + 3) / 8) + 1;
+                    specialDirection = ((vehicle->Orientation + 3) / 8) + 1;
                     specialDirection &= 3;
 
                     if (vehicle->TrackSubposition == VehicleTrackSubposition::GoKartsRightLane)
@@ -4235,7 +4235,7 @@ void Guest::UpdateRideLeaveVehicle()
         {
             int8_t loadPosition = carEntry->peep_loading_positions[CurrentSeat];
 
-            switch (vehicle->SpriteData.Direction / 8)
+            switch (vehicle->Orientation / 8)
             {
                 case 0:
                     platformLocation.x -= loadPosition;
@@ -4758,7 +4758,7 @@ void Guest::UpdateRideOnSpiralSlide()
 
                 MoveTo({ newLocation, z });
 
-                SpriteData.Direction = (Var37 & 0xC) * 2;
+                Orientation = (Var37 & 0xC) * 2;
 
                 Var37++;
                 return;
@@ -5665,7 +5665,7 @@ void Guest::UpdateQueuing()
     if (Happiness <= 65 && (0xFFFF & ScenarioRand()) < 2184)
     {
         // Give up queueing for the ride
-        SpriteData.Direction ^= (1 << 4);
+        Orientation ^= (1 << 4);
         Invalidate();
         RemoveFromQueue();
         SetState(PeepState::One);
@@ -5757,7 +5757,7 @@ void Guest::UpdateWatching()
 
         SetDestination(GetLocation());
 
-        SpriteData.Direction = (Var37 & 3) * 8;
+        Orientation = (Var37 & 3) * 8;
 
         Action = PeepActionType::Idle;
         NextActionSpriteType = PeepActionSpriteType::WatchRide;
@@ -7079,7 +7079,7 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
     peep->SpriteData.Width = spriteBounds->sprite_width;
     peep->SpriteData.HeightMin = spriteBounds->sprite_height_negative;
     peep->SpriteData.HeightMax = spriteBounds->sprite_height_positive;
-    peep->SpriteData.Direction = 0;
+    peep->Orientation = 0;
 
     peep->MoveTo(coords);
     peep->Mass = (ScenarioRand() & 0x1F) + 45;

--- a/src/openrct2/entity/Guest.cpp
+++ b/src/openrct2/entity/Guest.cpp
@@ -500,8 +500,8 @@ void Guest::GivePassingPeepsPizza(Guest* passingPeep)
 
     passingPeep->GiveItem(ShopItem::Pizza);
 
-    int32_t peepDirection = (sprite_direction >> 3) ^ 2;
-    int32_t otherPeepOppositeDirection = passingPeep->sprite_direction >> 3;
+    int32_t peepDirection = (SpriteData.sprite_direction >> 3) ^ 2;
+    int32_t otherPeepOppositeDirection = passingPeep->SpriteData.sprite_direction >> 3;
     if (peepDirection == otherPeepOppositeDirection)
     {
         if (passingPeep->IsActionInterruptable())
@@ -1258,7 +1258,7 @@ void Guest::UpdateSitting()
 
         MoveTo(loc);
 
-        sprite_direction = ((Var37 + 2) & 3) * 8;
+        SpriteData.sprite_direction = ((Var37 + 2) & 3) * 8;
         Action = PeepActionType::Idle;
         NextActionSpriteType = PeepActionSpriteType::SittingIdle;
         SwitchNextActionSpriteType();
@@ -3345,7 +3345,7 @@ void Guest::UpdateBuying()
             }
             WindowInvalidateByNumber(WindowClass::Peep, Id);
         }
-        sprite_direction ^= 0x10;
+        SpriteData.sprite_direction ^= 0x10;
 
         auto destination = CoordsXY{ 16, 16 } + NextLoc;
         SetDestination(destination);
@@ -3456,7 +3456,7 @@ void Guest::UpdateRideAtEntrance()
         else
         {
             DestinationTolerance = 0;
-            sprite_direction ^= (1 << 4);
+            SpriteData.sprite_direction ^= (1 << 4);
             Invalidate();
         }
     }
@@ -3748,7 +3748,7 @@ void Guest::UpdateRideAdvanceThroughEntrance()
     }
 
     auto destination = GetDestination();
-    switch (vehicle->sprite_direction / 8)
+    switch (vehicle->SpriteData.sprite_direction / 8)
     {
         case 0:
             destination.x = vehicle->x - load_position;
@@ -3818,7 +3818,7 @@ static void PeepGoToRideExit(Peep* peep, const Ride& ride, int16_t x, int16_t y,
 
     peep->SetDestination({ x, y }, 2);
 
-    peep->sprite_direction = exit_direction * 8;
+    peep->SpriteData.sprite_direction = exit_direction * 8;
     peep->RideSubState = PeepRideSubState::ApproachExit;
 }
 
@@ -4200,7 +4200,7 @@ void Guest::UpdateRideLeaveVehicle()
 
                 if (carEntry->flags & (CAR_ENTRY_FLAG_CHAIRLIFT | CAR_ENTRY_FLAG_GO_KART))
                 {
-                    specialDirection = ((vehicle->sprite_direction + 3) / 8) + 1;
+                    specialDirection = ((vehicle->SpriteData.sprite_direction + 3) / 8) + 1;
                     specialDirection &= 3;
 
                     if (vehicle->TrackSubposition == VehicleTrackSubposition::GoKartsRightLane)
@@ -4235,7 +4235,7 @@ void Guest::UpdateRideLeaveVehicle()
         {
             int8_t loadPosition = carEntry->peep_loading_positions[CurrentSeat];
 
-            switch (vehicle->sprite_direction / 8)
+            switch (vehicle->SpriteData.sprite_direction / 8)
             {
                 case 0:
                     platformLocation.x -= loadPosition;
@@ -4758,7 +4758,7 @@ void Guest::UpdateRideOnSpiralSlide()
 
                 MoveTo({ newLocation, z });
 
-                sprite_direction = (Var37 & 0xC) * 2;
+                SpriteData.sprite_direction = (Var37 & 0xC) * 2;
 
                 Var37++;
                 return;
@@ -5665,7 +5665,7 @@ void Guest::UpdateQueuing()
     if (Happiness <= 65 && (0xFFFF & ScenarioRand()) < 2184)
     {
         // Give up queueing for the ride
-        sprite_direction ^= (1 << 4);
+        SpriteData.sprite_direction ^= (1 << 4);
         Invalidate();
         RemoveFromQueue();
         SetState(PeepState::One);
@@ -5757,7 +5757,7 @@ void Guest::UpdateWatching()
 
         SetDestination(GetLocation());
 
-        sprite_direction = (Var37 & 3) * 8;
+        SpriteData.sprite_direction = (Var37 & 3) * 8;
 
         Action = PeepActionType::Idle;
         NextActionSpriteType = PeepActionSpriteType::WatchRide;
@@ -7076,12 +7076,12 @@ Guest* Guest::Generate(const CoordsXYZ& coords)
     peep->FavouriteRideRating = 0;
 
     const SpriteBounds* spriteBounds = &GetSpriteBounds(peep->SpriteType, peep->ActionSpriteType);
-    peep->sprite_width = spriteBounds->sprite_width;
-    peep->sprite_height_negative = spriteBounds->sprite_height_negative;
-    peep->sprite_height_positive = spriteBounds->sprite_height_positive;
+    peep->SpriteData.sprite_width = spriteBounds->sprite_width;
+    peep->SpriteData.sprite_height_negative = spriteBounds->sprite_height_negative;
+    peep->SpriteData.sprite_height_positive = spriteBounds->sprite_height_positive;
+    peep->SpriteData.sprite_direction = 0;
 
     peep->MoveTo(coords);
-    peep->sprite_direction = 0;
     peep->Mass = (ScenarioRand() & 0x1F) + 45;
     peep->PathCheckOptimisation = 0;
     peep->InteractionRideIndex = RideId::GetNull();

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -80,10 +80,10 @@ void Litter::Create(const CoordsXYZD& litterPos, Type type)
     if (litter == nullptr)
         return;
 
-    litter->sprite_direction = offsetLitterPos.direction;
-    litter->sprite_width = 6;
-    litter->sprite_height_negative = 6;
-    litter->sprite_height_positive = 3;
+    litter->SpriteData.sprite_direction = offsetLitterPos.direction;
+    litter->SpriteData.sprite_width = 6;
+    litter->SpriteData.sprite_height_negative = 6;
+    litter->SpriteData.sprite_height_positive = 3;
     litter->SubType = type;
     litter->MoveTo(offsetLitterPos);
     litter->creationTick = gCurrentTicks;

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -80,10 +80,10 @@ void Litter::Create(const CoordsXYZD& litterPos, Type type)
     if (litter == nullptr)
         return;
 
-    litter->SpriteData.sprite_direction = offsetLitterPos.direction;
-    litter->SpriteData.sprite_width = 6;
-    litter->SpriteData.sprite_height_negative = 6;
-    litter->SpriteData.sprite_height_positive = 3;
+    litter->SpriteData.Direction = offsetLitterPos.direction;
+    litter->SpriteData.Width = 6;
+    litter->SpriteData.HeightMin = 6;
+    litter->SpriteData.HeightMax = 3;
     litter->SubType = type;
     litter->MoveTo(offsetLitterPos);
     litter->creationTick = gCurrentTicks;

--- a/src/openrct2/entity/Litter.cpp
+++ b/src/openrct2/entity/Litter.cpp
@@ -80,7 +80,7 @@ void Litter::Create(const CoordsXYZD& litterPos, Type type)
     if (litter == nullptr)
         return;
 
-    litter->SpriteData.Direction = offsetLitterPos.direction;
+    litter->Orientation = offsetLitterPos.direction;
     litter->SpriteData.Width = 6;
     litter->SpriteData.HeightMin = 6;
     litter->SpriteData.HeightMax = 3;

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -49,9 +49,9 @@ void MoneyEffect::CreateAt(money64 value, const CoordsXYZ& effectPos, bool guest
 
     moneyEffect->Value = value;
     moneyEffect->GuestPurchase = (guestPurchase ? 1 : 0);
-    moneyEffect->sprite_width = 64;
-    moneyEffect->sprite_height_negative = 20;
-    moneyEffect->sprite_height_positive = 30;
+    moneyEffect->SpriteData.sprite_width = 64;
+    moneyEffect->SpriteData.sprite_height_negative = 20;
+    moneyEffect->SpriteData.sprite_height_positive = 30;
     moneyEffect->MoveTo(effectPos);
     moneyEffect->NumMovements = 0;
     moneyEffect->MoveDelay = 0;

--- a/src/openrct2/entity/MoneyEffect.cpp
+++ b/src/openrct2/entity/MoneyEffect.cpp
@@ -49,9 +49,9 @@ void MoneyEffect::CreateAt(money64 value, const CoordsXYZ& effectPos, bool guest
 
     moneyEffect->Value = value;
     moneyEffect->GuestPurchase = (guestPurchase ? 1 : 0);
-    moneyEffect->SpriteData.sprite_width = 64;
-    moneyEffect->SpriteData.sprite_height_negative = 20;
-    moneyEffect->SpriteData.sprite_height_positive = 30;
+    moneyEffect->SpriteData.Width = 64;
+    moneyEffect->SpriteData.HeightMin = 20;
+    moneyEffect->SpriteData.HeightMax = 30;
     moneyEffect->MoveTo(effectPos);
     moneyEffect->NumMovements = 0;
     moneyEffect->MoveDelay = 0;

--- a/src/openrct2/entity/Particle.cpp
+++ b/src/openrct2/entity/Particle.cpp
@@ -58,9 +58,9 @@ void VehicleCrashParticle::Create(VehicleColour& colours, const CoordsXYZ& vehic
     {
         sprite->colour[0] = colours.Body;
         sprite->colour[1] = colours.Trim;
-        sprite->sprite_width = 8;
-        sprite->sprite_height_negative = 8;
-        sprite->sprite_height_positive = 8;
+        sprite->SpriteData.sprite_width = 8;
+        sprite->SpriteData.sprite_height_negative = 8;
+        sprite->SpriteData.sprite_height_positive = 8;
         sprite->MoveTo(vehiclePos);
 
         sprite->frame = (ScenarioRand() & 0xFF) * 12;
@@ -175,9 +175,9 @@ void CrashSplashParticle::Create(const CoordsXYZ& splashPos)
     auto* sprite = CreateEntity<CrashSplashParticle>();
     if (sprite != nullptr)
     {
-        sprite->sprite_width = 33;
-        sprite->sprite_height_negative = 51;
-        sprite->sprite_height_positive = 16;
+        sprite->SpriteData.sprite_width = 33;
+        sprite->SpriteData.sprite_height_negative = 51;
+        sprite->SpriteData.sprite_height_positive = 16;
         sprite->MoveTo(splashPos + CoordsXYZ{ 0, 0, 3 });
         sprite->frame = 0;
     }
@@ -225,9 +225,9 @@ void SteamParticle::Create(const CoordsXYZ& coords)
         if (steam == nullptr)
             return;
 
-        steam->sprite_width = 20;
-        steam->sprite_height_negative = 18;
-        steam->sprite_height_positive = 16;
+        steam->SpriteData.sprite_width = 20;
+        steam->SpriteData.sprite_height_negative = 18;
+        steam->SpriteData.sprite_height_positive = 16;
         steam->frame = 256;
         steam->time_to_move = 0;
         steam->MoveTo(coords);
@@ -280,9 +280,9 @@ void ExplosionCloud::Create(const CoordsXYZ& cloudPos)
     auto* entity = CreateEntity<ExplosionCloud>();
     if (entity != nullptr)
     {
-        entity->sprite_width = 44;
-        entity->sprite_height_negative = 32;
-        entity->sprite_height_positive = 34;
+        entity->SpriteData.sprite_width = 44;
+        entity->SpriteData.sprite_height_negative = 32;
+        entity->SpriteData.sprite_height_positive = 34;
         entity->MoveTo(cloudPos + CoordsXYZ{ 0, 0, 4 });
         entity->frame = 0;
     }
@@ -325,9 +325,9 @@ void ExplosionFlare::Create(const CoordsXYZ& flarePos)
     auto* entity = CreateEntity<ExplosionFlare>();
     if (entity != nullptr)
     {
-        entity->sprite_width = 25;
-        entity->sprite_height_negative = 85;
-        entity->sprite_height_positive = 8;
+        entity->SpriteData.sprite_width = 25;
+        entity->SpriteData.sprite_height_negative = 85;
+        entity->SpriteData.sprite_height_positive = 8;
         entity->MoveTo(flarePos + CoordsXYZ{ 0, 0, 4 });
         entity->frame = 0;
     }

--- a/src/openrct2/entity/Particle.cpp
+++ b/src/openrct2/entity/Particle.cpp
@@ -58,9 +58,9 @@ void VehicleCrashParticle::Create(VehicleColour& colours, const CoordsXYZ& vehic
     {
         sprite->colour[0] = colours.Body;
         sprite->colour[1] = colours.Trim;
-        sprite->SpriteData.sprite_width = 8;
-        sprite->SpriteData.sprite_height_negative = 8;
-        sprite->SpriteData.sprite_height_positive = 8;
+        sprite->SpriteData.Width = 8;
+        sprite->SpriteData.HeightMin = 8;
+        sprite->SpriteData.HeightMax = 8;
         sprite->MoveTo(vehiclePos);
 
         sprite->frame = (ScenarioRand() & 0xFF) * 12;
@@ -175,9 +175,9 @@ void CrashSplashParticle::Create(const CoordsXYZ& splashPos)
     auto* sprite = CreateEntity<CrashSplashParticle>();
     if (sprite != nullptr)
     {
-        sprite->SpriteData.sprite_width = 33;
-        sprite->SpriteData.sprite_height_negative = 51;
-        sprite->SpriteData.sprite_height_positive = 16;
+        sprite->SpriteData.Width = 33;
+        sprite->SpriteData.HeightMin = 51;
+        sprite->SpriteData.HeightMax = 16;
         sprite->MoveTo(splashPos + CoordsXYZ{ 0, 0, 3 });
         sprite->frame = 0;
     }
@@ -225,9 +225,9 @@ void SteamParticle::Create(const CoordsXYZ& coords)
         if (steam == nullptr)
             return;
 
-        steam->SpriteData.sprite_width = 20;
-        steam->SpriteData.sprite_height_negative = 18;
-        steam->SpriteData.sprite_height_positive = 16;
+        steam->SpriteData.Width = 20;
+        steam->SpriteData.HeightMin = 18;
+        steam->SpriteData.HeightMax = 16;
         steam->frame = 256;
         steam->time_to_move = 0;
         steam->MoveTo(coords);
@@ -280,9 +280,9 @@ void ExplosionCloud::Create(const CoordsXYZ& cloudPos)
     auto* entity = CreateEntity<ExplosionCloud>();
     if (entity != nullptr)
     {
-        entity->SpriteData.sprite_width = 44;
-        entity->SpriteData.sprite_height_negative = 32;
-        entity->SpriteData.sprite_height_positive = 34;
+        entity->SpriteData.Width = 44;
+        entity->SpriteData.HeightMin = 32;
+        entity->SpriteData.HeightMax = 34;
         entity->MoveTo(cloudPos + CoordsXYZ{ 0, 0, 4 });
         entity->frame = 0;
     }
@@ -325,9 +325,9 @@ void ExplosionFlare::Create(const CoordsXYZ& flarePos)
     auto* entity = CreateEntity<ExplosionFlare>();
     if (entity != nullptr)
     {
-        entity->SpriteData.sprite_width = 25;
-        entity->SpriteData.sprite_height_negative = 85;
-        entity->SpriteData.sprite_height_positive = 8;
+        entity->SpriteData.Width = 25;
+        entity->SpriteData.HeightMin = 85;
+        entity->SpriteData.HeightMax = 8;
         entity->MoveTo(flarePos + CoordsXYZ{ 0, 0, 4 });
         entity->frame = 0;
     }

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -387,9 +387,9 @@ void Peep::UpdateCurrentActionSpriteType()
     ActionSpriteType = newActionSpriteType;
 
     const SpriteBounds* spriteBounds = &GetSpriteBounds(SpriteType, ActionSpriteType);
-    sprite_width = spriteBounds->sprite_width;
-    sprite_height_negative = spriteBounds->sprite_height_negative;
-    sprite_height_positive = spriteBounds->sprite_height_positive;
+    SpriteData.sprite_width = spriteBounds->sprite_width;
+    SpriteData.sprite_height_negative = spriteBounds->sprite_height_negative;
+    SpriteData.sprite_height_positive = spriteBounds->sprite_height_positive;
 
     Invalidate();
 }
@@ -478,7 +478,7 @@ std::optional<CoordsXY> Peep::UpdateAction(int16_t& xy_distance)
                 nextDirection = 0;
             }
         }
-        sprite_direction = nextDirection;
+        SpriteData.sprite_direction = nextDirection;
         CoordsXY loc = { x, y };
         loc += word_981D7C[nextDirection / 8];
         WalkingFrameNum++;
@@ -524,7 +524,8 @@ std::optional<CoordsXY> Peep::UpdateAction(int16_t& xy_distance)
     WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_2;
 
     const auto curLoc = GetLocation();
-    Litter::Create({ curLoc, sprite_direction }, (Id.ToUnderlying() & 1) ? Litter::Type::VomitAlt : Litter::Type::Vomit);
+    Litter::Create(
+        { curLoc, SpriteData.sprite_direction }, (Id.ToUnderlying() & 1) ? Litter::Type::VomitAlt : Litter::Type::Vomit);
 
     static constexpr OpenRCT2::Audio::SoundId coughs[4] = {
         OpenRCT2::Audio::SoundId::Cough1,
@@ -872,7 +873,7 @@ void Peep::Update1()
     }
 
     SetDestination(GetLocation(), 10);
-    PeepDirection = sprite_direction >> 3;
+    PeepDirection = SpriteData.sprite_direction >> 3;
 }
 
 void Peep::SetState(PeepState new_state)
@@ -1274,13 +1275,13 @@ void PeepUpdateCrowdNoise()
     {
         if (peep->x == LOCATION_NULL)
             continue;
-        if (viewport->viewPos.x > peep->SpriteRect.GetRight())
+        if (viewport->viewPos.x > peep->SpriteData.SpriteRect.GetRight())
             continue;
-        if (viewport->viewPos.x + viewport->view_width < peep->SpriteRect.GetLeft())
+        if (viewport->viewPos.x + viewport->view_width < peep->SpriteData.SpriteRect.GetLeft())
             continue;
-        if (viewport->viewPos.y > peep->SpriteRect.GetBottom())
+        if (viewport->viewPos.y > peep->SpriteData.SpriteRect.GetBottom())
             continue;
-        if (viewport->viewPos.y + viewport->view_height < peep->SpriteRect.GetTop())
+        if (viewport->viewPos.y + viewport->view_height < peep->SpriteData.SpriteRect.GetTop())
             continue;
 
         visiblePeeps += peep->State == PeepState::Queuing ? 1 : 2;
@@ -1667,9 +1668,9 @@ void Peep::SwitchNextActionSpriteType()
         Invalidate();
         ActionSpriteType = NextActionSpriteType;
         const SpriteBounds* spriteBounds = &GetSpriteBounds(SpriteType, NextActionSpriteType);
-        sprite_width = spriteBounds->sprite_width;
-        sprite_height_negative = spriteBounds->sprite_height_negative;
-        sprite_height_positive = spriteBounds->sprite_height_positive;
+        SpriteData.sprite_width = spriteBounds->sprite_width;
+        SpriteData.sprite_height_negative = spriteBounds->sprite_height_negative;
+        SpriteData.sprite_height_positive = spriteBounds->sprite_height_positive;
         Invalidate();
     }
 }
@@ -2779,7 +2780,7 @@ void Peep::Paint(PaintSession& session, int32_t imageDirection) const
         if (Is<Staff>())
         {
             auto loc = GetLocation();
-            switch (sprite_direction)
+            switch (SpriteData.sprite_direction)
             {
                 case 0:
                     loc.x -= 10;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -387,9 +387,9 @@ void Peep::UpdateCurrentActionSpriteType()
     ActionSpriteType = newActionSpriteType;
 
     const SpriteBounds* spriteBounds = &GetSpriteBounds(SpriteType, ActionSpriteType);
-    SpriteData.sprite_width = spriteBounds->sprite_width;
-    SpriteData.sprite_height_negative = spriteBounds->sprite_height_negative;
-    SpriteData.sprite_height_positive = spriteBounds->sprite_height_positive;
+    SpriteData.Width = spriteBounds->sprite_width;
+    SpriteData.HeightMin = spriteBounds->sprite_height_negative;
+    SpriteData.HeightMax = spriteBounds->sprite_height_positive;
 
     Invalidate();
 }
@@ -478,7 +478,7 @@ std::optional<CoordsXY> Peep::UpdateAction(int16_t& xy_distance)
                 nextDirection = 0;
             }
         }
-        SpriteData.sprite_direction = nextDirection;
+        SpriteData.Direction = nextDirection;
         CoordsXY loc = { x, y };
         loc += word_981D7C[nextDirection / 8];
         WalkingFrameNum++;
@@ -524,8 +524,7 @@ std::optional<CoordsXY> Peep::UpdateAction(int16_t& xy_distance)
     WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_2;
 
     const auto curLoc = GetLocation();
-    Litter::Create(
-        { curLoc, SpriteData.sprite_direction }, (Id.ToUnderlying() & 1) ? Litter::Type::VomitAlt : Litter::Type::Vomit);
+    Litter::Create({ curLoc, SpriteData.Direction }, (Id.ToUnderlying() & 1) ? Litter::Type::VomitAlt : Litter::Type::Vomit);
 
     static constexpr OpenRCT2::Audio::SoundId coughs[4] = {
         OpenRCT2::Audio::SoundId::Cough1,
@@ -873,7 +872,7 @@ void Peep::Update1()
     }
 
     SetDestination(GetLocation(), 10);
-    PeepDirection = SpriteData.sprite_direction >> 3;
+    PeepDirection = SpriteData.Direction >> 3;
 }
 
 void Peep::SetState(PeepState new_state)
@@ -1668,9 +1667,9 @@ void Peep::SwitchNextActionSpriteType()
         Invalidate();
         ActionSpriteType = NextActionSpriteType;
         const SpriteBounds* spriteBounds = &GetSpriteBounds(SpriteType, NextActionSpriteType);
-        SpriteData.sprite_width = spriteBounds->sprite_width;
-        SpriteData.sprite_height_negative = spriteBounds->sprite_height_negative;
-        SpriteData.sprite_height_positive = spriteBounds->sprite_height_positive;
+        SpriteData.Width = spriteBounds->sprite_width;
+        SpriteData.HeightMin = spriteBounds->sprite_height_negative;
+        SpriteData.HeightMax = spriteBounds->sprite_height_positive;
         Invalidate();
     }
 }
@@ -2780,7 +2779,7 @@ void Peep::Paint(PaintSession& session, int32_t imageDirection) const
         if (Is<Staff>())
         {
             auto loc = GetLocation();
-            switch (SpriteData.sprite_direction)
+            switch (SpriteData.Direction)
             {
                 case 0:
                     loc.x -= 10;

--- a/src/openrct2/entity/Peep.cpp
+++ b/src/openrct2/entity/Peep.cpp
@@ -478,7 +478,7 @@ std::optional<CoordsXY> Peep::UpdateAction(int16_t& xy_distance)
                 nextDirection = 0;
             }
         }
-        SpriteData.Direction = nextDirection;
+        Orientation = nextDirection;
         CoordsXY loc = { x, y };
         loc += word_981D7C[nextDirection / 8];
         WalkingFrameNum++;
@@ -524,7 +524,7 @@ std::optional<CoordsXY> Peep::UpdateAction(int16_t& xy_distance)
     WindowInvalidateFlags |= PEEP_INVALIDATE_PEEP_2;
 
     const auto curLoc = GetLocation();
-    Litter::Create({ curLoc, SpriteData.Direction }, (Id.ToUnderlying() & 1) ? Litter::Type::VomitAlt : Litter::Type::Vomit);
+    Litter::Create({ curLoc, Orientation }, (Id.ToUnderlying() & 1) ? Litter::Type::VomitAlt : Litter::Type::Vomit);
 
     static constexpr OpenRCT2::Audio::SoundId coughs[4] = {
         OpenRCT2::Audio::SoundId::Cough1,
@@ -872,7 +872,7 @@ void Peep::Update1()
     }
 
     SetDestination(GetLocation(), 10);
-    PeepDirection = SpriteData.Direction >> 3;
+    PeepDirection = Orientation >> 3;
 }
 
 void Peep::SetState(PeepState new_state)
@@ -2779,7 +2779,7 @@ void Peep::Paint(PaintSession& session, int32_t imageDirection) const
         if (Is<Staff>())
         {
             auto loc = GetLocation();
-            switch (SpriteData.Direction)
+            switch (Orientation)
             {
                 case 0:
                     loc.x -= 10;

--- a/src/openrct2/entity/Peep.h
+++ b/src/openrct2/entity/Peep.h
@@ -362,7 +362,7 @@ struct Peep : EntityBase
     union
     {
         uint8_t MazeLastEdge;
-        Direction PeepDirection; // Direction ?
+        ::Direction PeepDirection; // Direction ?
     };
     RideId InteractionRideIndex;
     uint32_t PeepId;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1132,7 +1132,7 @@ void Staff::UpdateWatering()
         if (!(pathingResult & PATHING_DESTINATION_REACHED))
             return;
 
-        SpriteData.Direction = (Var37 & 3) << 3;
+        Orientation = (Var37 & 3) << 3;
         Action = PeepActionType::StaffWatering;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;
@@ -1196,7 +1196,7 @@ void Staff::UpdateEmptyingBin()
         if (!(pathingResult & PATHING_DESTINATION_REACHED))
             return;
 
-        SpriteData.Direction = (Var37 & 3) << 3;
+        Orientation = (Var37 & 3) << 3;
         Action = PeepActionType::StaffEmptyBin;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;
@@ -1375,7 +1375,7 @@ void Staff::UpdateHeadingToInspect()
 
         auto newDestination = CoordsXY{ 16, 16 } + NextLoc + (DirectionOffsets[PeepDirection] * 53);
         SetDestination(newDestination, 2);
-        SpriteData.Direction = PeepDirection << 3;
+        Orientation = PeepDirection << 3;
 
         z = rideEntranceExitElement->BaseHeight * 4;
         SubState = 4;
@@ -1485,7 +1485,7 @@ void Staff::UpdateAnswering()
         int32_t destY = NextLoc.y + 16 + DirectionOffsets[PeepDirection].y * 53;
 
         SetDestination({ destX, destY }, 2);
-        SpriteData.Direction = PeepDirection << 3;
+        Orientation = PeepDirection << 3;
 
         z = rideEntranceExitElement->BaseHeight * 4;
         SubState = 4;
@@ -2110,7 +2110,7 @@ bool Staff::UpdateFixingFixVehicle(bool firstRun, const Ride& ride)
 {
     if (!firstRun)
     {
-        SpriteData.Direction = PeepDirection << 3;
+        Orientation = PeepDirection << 3;
 
         Action = (ScenarioRand() & 1) ? PeepActionType::StaffFix2 : PeepActionType::StaffFix;
         ActionSpriteImageOffset = 0;
@@ -2152,7 +2152,7 @@ bool Staff::UpdateFixingFixVehicleMalfunction(bool firstRun, const Ride& ride)
 {
     if (!firstRun)
     {
-        SpriteData.Direction = PeepDirection << 3;
+        Orientation = PeepDirection << 3;
         Action = PeepActionType::StaffFix3;
         ActionSpriteImageOffset = 0;
         ActionFrame = 0;
@@ -2257,7 +2257,7 @@ bool Staff::UpdateFixingFixStationEnd(bool firstRun)
 {
     if (!firstRun)
     {
-        SpriteData.Direction = PeepDirection << 3;
+        Orientation = PeepDirection << 3;
         Action = PeepActionType::StaffCheckboard;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;
@@ -2369,7 +2369,7 @@ bool Staff::UpdateFixingFixStationStart(bool firstRun, const Ride& ride)
             return true;
         }
 
-        SpriteData.Direction = PeepDirection << 3;
+        Orientation = PeepDirection << 3;
 
         Action = PeepActionType::StaffFix;
         ActionFrame = 0;
@@ -2397,7 +2397,7 @@ bool Staff::UpdateFixingFixStationBrakes(bool firstRun, Ride& ride)
 {
     if (!firstRun)
     {
-        SpriteData.Direction = PeepDirection << 3;
+        Orientation = PeepDirection << 3;
 
         Action = PeepActionType::StaffFixGround;
         ActionFrame = 0;
@@ -2488,7 +2488,7 @@ bool Staff::UpdateFixingFinishFixOrInspect(bool firstRun, int32_t steps, Ride& r
         StaffRidesFixed++;
         WindowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME | RIDE_INVALIDATE_RIDE_LIST;
 
-        SpriteData.Direction = PeepDirection << 3;
+        Orientation = PeepDirection << 3;
         Action = PeepActionType::StaffAnswerCall2;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1132,7 +1132,7 @@ void Staff::UpdateWatering()
         if (!(pathingResult & PATHING_DESTINATION_REACHED))
             return;
 
-        SpriteData.sprite_direction = (Var37 & 3) << 3;
+        SpriteData.Direction = (Var37 & 3) << 3;
         Action = PeepActionType::StaffWatering;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;
@@ -1196,7 +1196,7 @@ void Staff::UpdateEmptyingBin()
         if (!(pathingResult & PATHING_DESTINATION_REACHED))
             return;
 
-        SpriteData.sprite_direction = (Var37 & 3) << 3;
+        SpriteData.Direction = (Var37 & 3) << 3;
         Action = PeepActionType::StaffEmptyBin;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;
@@ -1375,7 +1375,7 @@ void Staff::UpdateHeadingToInspect()
 
         auto newDestination = CoordsXY{ 16, 16 } + NextLoc + (DirectionOffsets[PeepDirection] * 53);
         SetDestination(newDestination, 2);
-        SpriteData.sprite_direction = PeepDirection << 3;
+        SpriteData.Direction = PeepDirection << 3;
 
         z = rideEntranceExitElement->BaseHeight * 4;
         SubState = 4;
@@ -1485,7 +1485,7 @@ void Staff::UpdateAnswering()
         int32_t destY = NextLoc.y + 16 + DirectionOffsets[PeepDirection].y * 53;
 
         SetDestination({ destX, destY }, 2);
-        SpriteData.sprite_direction = PeepDirection << 3;
+        SpriteData.Direction = PeepDirection << 3;
 
         z = rideEntranceExitElement->BaseHeight * 4;
         SubState = 4;
@@ -2110,7 +2110,7 @@ bool Staff::UpdateFixingFixVehicle(bool firstRun, const Ride& ride)
 {
     if (!firstRun)
     {
-        SpriteData.sprite_direction = PeepDirection << 3;
+        SpriteData.Direction = PeepDirection << 3;
 
         Action = (ScenarioRand() & 1) ? PeepActionType::StaffFix2 : PeepActionType::StaffFix;
         ActionSpriteImageOffset = 0;
@@ -2152,7 +2152,7 @@ bool Staff::UpdateFixingFixVehicleMalfunction(bool firstRun, const Ride& ride)
 {
     if (!firstRun)
     {
-        SpriteData.sprite_direction = PeepDirection << 3;
+        SpriteData.Direction = PeepDirection << 3;
         Action = PeepActionType::StaffFix3;
         ActionSpriteImageOffset = 0;
         ActionFrame = 0;
@@ -2257,7 +2257,7 @@ bool Staff::UpdateFixingFixStationEnd(bool firstRun)
 {
     if (!firstRun)
     {
-        SpriteData.sprite_direction = PeepDirection << 3;
+        SpriteData.Direction = PeepDirection << 3;
         Action = PeepActionType::StaffCheckboard;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;
@@ -2369,7 +2369,7 @@ bool Staff::UpdateFixingFixStationStart(bool firstRun, const Ride& ride)
             return true;
         }
 
-        SpriteData.sprite_direction = PeepDirection << 3;
+        SpriteData.Direction = PeepDirection << 3;
 
         Action = PeepActionType::StaffFix;
         ActionFrame = 0;
@@ -2397,7 +2397,7 @@ bool Staff::UpdateFixingFixStationBrakes(bool firstRun, Ride& ride)
 {
     if (!firstRun)
     {
-        SpriteData.sprite_direction = PeepDirection << 3;
+        SpriteData.Direction = PeepDirection << 3;
 
         Action = PeepActionType::StaffFixGround;
         ActionFrame = 0;
@@ -2488,7 +2488,7 @@ bool Staff::UpdateFixingFinishFixOrInspect(bool firstRun, int32_t steps, Ride& r
         StaffRidesFixed++;
         WindowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME | RIDE_INVALIDATE_RIDE_LIST;
 
-        SpriteData.sprite_direction = PeepDirection << 3;
+        SpriteData.Direction = PeepDirection << 3;
         Action = PeepActionType::StaffAnswerCall2;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;

--- a/src/openrct2/entity/Staff.cpp
+++ b/src/openrct2/entity/Staff.cpp
@@ -1132,7 +1132,7 @@ void Staff::UpdateWatering()
         if (!(pathingResult & PATHING_DESTINATION_REACHED))
             return;
 
-        sprite_direction = (Var37 & 3) << 3;
+        SpriteData.sprite_direction = (Var37 & 3) << 3;
         Action = PeepActionType::StaffWatering;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;
@@ -1196,7 +1196,7 @@ void Staff::UpdateEmptyingBin()
         if (!(pathingResult & PATHING_DESTINATION_REACHED))
             return;
 
-        sprite_direction = (Var37 & 3) << 3;
+        SpriteData.sprite_direction = (Var37 & 3) << 3;
         Action = PeepActionType::StaffEmptyBin;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;
@@ -1375,7 +1375,7 @@ void Staff::UpdateHeadingToInspect()
 
         auto newDestination = CoordsXY{ 16, 16 } + NextLoc + (DirectionOffsets[PeepDirection] * 53);
         SetDestination(newDestination, 2);
-        sprite_direction = PeepDirection << 3;
+        SpriteData.sprite_direction = PeepDirection << 3;
 
         z = rideEntranceExitElement->BaseHeight * 4;
         SubState = 4;
@@ -1485,7 +1485,7 @@ void Staff::UpdateAnswering()
         int32_t destY = NextLoc.y + 16 + DirectionOffsets[PeepDirection].y * 53;
 
         SetDestination({ destX, destY }, 2);
-        sprite_direction = PeepDirection << 3;
+        SpriteData.sprite_direction = PeepDirection << 3;
 
         z = rideEntranceExitElement->BaseHeight * 4;
         SubState = 4;
@@ -2110,7 +2110,7 @@ bool Staff::UpdateFixingFixVehicle(bool firstRun, const Ride& ride)
 {
     if (!firstRun)
     {
-        sprite_direction = PeepDirection << 3;
+        SpriteData.sprite_direction = PeepDirection << 3;
 
         Action = (ScenarioRand() & 1) ? PeepActionType::StaffFix2 : PeepActionType::StaffFix;
         ActionSpriteImageOffset = 0;
@@ -2152,7 +2152,7 @@ bool Staff::UpdateFixingFixVehicleMalfunction(bool firstRun, const Ride& ride)
 {
     if (!firstRun)
     {
-        sprite_direction = PeepDirection << 3;
+        SpriteData.sprite_direction = PeepDirection << 3;
         Action = PeepActionType::StaffFix3;
         ActionSpriteImageOffset = 0;
         ActionFrame = 0;
@@ -2257,7 +2257,7 @@ bool Staff::UpdateFixingFixStationEnd(bool firstRun)
 {
     if (!firstRun)
     {
-        sprite_direction = PeepDirection << 3;
+        SpriteData.sprite_direction = PeepDirection << 3;
         Action = PeepActionType::StaffCheckboard;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;
@@ -2369,7 +2369,7 @@ bool Staff::UpdateFixingFixStationStart(bool firstRun, const Ride& ride)
             return true;
         }
 
-        sprite_direction = PeepDirection << 3;
+        SpriteData.sprite_direction = PeepDirection << 3;
 
         Action = PeepActionType::StaffFix;
         ActionFrame = 0;
@@ -2397,7 +2397,7 @@ bool Staff::UpdateFixingFixStationBrakes(bool firstRun, Ride& ride)
 {
     if (!firstRun)
     {
-        sprite_direction = PeepDirection << 3;
+        SpriteData.sprite_direction = PeepDirection << 3;
 
         Action = PeepActionType::StaffFixGround;
         ActionFrame = 0;
@@ -2488,7 +2488,7 @@ bool Staff::UpdateFixingFinishFixOrInspect(bool firstRun, int32_t steps, Ride& r
         StaffRidesFixed++;
         WindowInvalidateFlags |= RIDE_INVALIDATE_RIDE_INCOME | RIDE_INVALIDATE_RIDE_LIST;
 
-        sprite_direction = PeepDirection << 3;
+        SpriteData.sprite_direction = PeepDirection << 3;
         Action = PeepActionType::StaffAnswerCall2;
         ActionFrame = 0;
         ActionSpriteImageOffset = 0;

--- a/src/openrct2/paint/Paint.Entity.cpp
+++ b/src/openrct2/paint/Paint.Entity.cpp
@@ -105,7 +105,7 @@ void EntityPaintSetup(PaintSession& session, const CoordsXY& pos)
 
         int32_t image_direction = session.CurrentRotation;
         image_direction <<= 3;
-        image_direction += spr->SpriteData.sprite_direction;
+        image_direction += spr->SpriteData.Direction;
         image_direction &= 0x1F;
 
         session.CurrentlyDrawnEntity = spr;

--- a/src/openrct2/paint/Paint.Entity.cpp
+++ b/src/openrct2/paint/Paint.Entity.cpp
@@ -97,15 +97,15 @@ void EntityPaintSetup(PaintSession& session, const CoordsXY& pos)
 
         dpi = &session.DPI;
 
-        if (dpi->y + dpi->height <= spr->SpriteRect.GetTop() || spr->SpriteRect.GetBottom() <= dpi->y
-            || dpi->x + dpi->width <= spr->SpriteRect.GetLeft() || spr->SpriteRect.GetRight() <= dpi->x)
+        if (dpi->y + dpi->height <= spr->SpriteData.SpriteRect.GetTop() || spr->SpriteData.SpriteRect.GetBottom() <= dpi->y
+            || dpi->x + dpi->width <= spr->SpriteData.SpriteRect.GetLeft() || spr->SpriteData.SpriteRect.GetRight() <= dpi->x)
         {
             continue;
         }
 
         int32_t image_direction = session.CurrentRotation;
         image_direction <<= 3;
-        image_direction += spr->sprite_direction;
+        image_direction += spr->SpriteData.sprite_direction;
         image_direction &= 0x1F;
 
         session.CurrentlyDrawnEntity = spr;

--- a/src/openrct2/paint/Paint.Entity.cpp
+++ b/src/openrct2/paint/Paint.Entity.cpp
@@ -105,7 +105,7 @@ void EntityPaintSetup(PaintSession& session, const CoordsXY& pos)
 
         int32_t image_direction = session.CurrentRotation;
         image_direction <<= 3;
-        image_direction += spr->SpriteData.Direction;
+        image_direction += spr->Orientation;
         image_direction &= 0x1F;
 
         session.CurrentlyDrawnEntity = spr;

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1581,13 +1581,13 @@ namespace OpenRCT2
         static void ReadWriteEntityCommon(OrcaStream::ChunkStream& cs, EntityBase& entity)
         {
             cs.ReadWrite(entity.Id);
-            cs.ReadWrite(entity.SpriteData.sprite_height_negative);
+            cs.ReadWrite(entity.SpriteData.HeightMin);
             cs.ReadWrite(entity.x);
             cs.ReadWrite(entity.y);
             cs.ReadWrite(entity.z);
-            cs.ReadWrite(entity.SpriteData.sprite_width);
-            cs.ReadWrite(entity.SpriteData.sprite_height_positive);
-            cs.ReadWrite(entity.SpriteData.sprite_direction);
+            cs.ReadWrite(entity.SpriteData.Width);
+            cs.ReadWrite(entity.SpriteData.HeightMax);
+            cs.ReadWrite(entity.SpriteData.Direction);
         }
 
         static std::vector<ObjectEntryIndex> LegacyGetRideTypesBeenOn(const std::array<uint8_t, 16>& srcArray)

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1581,13 +1581,13 @@ namespace OpenRCT2
         static void ReadWriteEntityCommon(OrcaStream::ChunkStream& cs, EntityBase& entity)
         {
             cs.ReadWrite(entity.Id);
-            cs.ReadWrite(entity.sprite_height_negative);
+            cs.ReadWrite(entity.SpriteData.sprite_height_negative);
             cs.ReadWrite(entity.x);
             cs.ReadWrite(entity.y);
             cs.ReadWrite(entity.z);
-            cs.ReadWrite(entity.sprite_width);
-            cs.ReadWrite(entity.sprite_height_positive);
-            cs.ReadWrite(entity.sprite_direction);
+            cs.ReadWrite(entity.SpriteData.sprite_width);
+            cs.ReadWrite(entity.SpriteData.sprite_height_positive);
+            cs.ReadWrite(entity.SpriteData.sprite_direction);
         }
 
         static std::vector<ObjectEntryIndex> LegacyGetRideTypesBeenOn(const std::array<uint8_t, 16>& srcArray)

--- a/src/openrct2/park/ParkFile.cpp
+++ b/src/openrct2/park/ParkFile.cpp
@@ -1587,7 +1587,7 @@ namespace OpenRCT2
             cs.ReadWrite(entity.z);
             cs.ReadWrite(entity.SpriteData.Width);
             cs.ReadWrite(entity.SpriteData.HeightMax);
-            cs.ReadWrite(entity.SpriteData.Direction);
+            cs.ReadWrite(entity.Orientation);
         }
 
         static std::vector<ObjectEntryIndex> LegacyGetRideTypesBeenOn(const std::array<uint8_t, 16>& srcArray)

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1280,7 +1280,7 @@ namespace RCT1
 
             dst->MoveTo({ src->x, src->y, src->z });
 
-            dst->SpriteData.Direction = src->EntityDirection;
+            dst->Orientation = src->EntityDirection;
 
             // Peep name
             if (IsUserStringID(src->NameStringID))
@@ -1366,7 +1366,7 @@ namespace RCT1
 
         void ImportEntityCommonProperties(EntityBase* dst, const RCT12EntityBase* src)
         {
-            dst->SpriteData.Direction = src->EntityDirection;
+            dst->Orientation = src->EntityDirection;
             dst->SpriteData.Width = src->SpriteWidth;
             dst->SpriteData.HeightMin = src->SpriteHeightNegative;
             dst->SpriteData.HeightMax = src->SpriteHeightPositive;
@@ -2726,7 +2726,7 @@ namespace RCT1
         dst->SpriteData.Width = src->SpriteWidth;
         dst->SpriteData.HeightMin = src->SpriteHeightNegative;
         dst->SpriteData.HeightMax = src->SpriteHeightPositive;
-        dst->SpriteData.Direction = src->EntityDirection;
+        dst->Orientation = src->EntityDirection;
 
         dst->SpriteData.SpriteRect = ScreenRect(src->SpriteLeft, src->SpriteTop, src->SpriteRight, src->SpriteBottom);
 

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1274,13 +1274,13 @@ namespace RCT1
             dst->ActionFrame = src->ActionFrame;
 
             const SpriteBounds* spriteBounds = &GetSpriteBounds(dst->SpriteType, dst->ActionSpriteType);
-            dst->sprite_width = spriteBounds->sprite_width;
-            dst->sprite_height_negative = spriteBounds->sprite_height_negative;
-            dst->sprite_height_positive = spriteBounds->sprite_height_positive;
+            dst->SpriteData.sprite_width = spriteBounds->sprite_width;
+            dst->SpriteData.sprite_height_negative = spriteBounds->sprite_height_negative;
+            dst->SpriteData.sprite_height_positive = spriteBounds->sprite_height_positive;
 
             dst->MoveTo({ src->x, src->y, src->z });
 
-            dst->sprite_direction = src->EntityDirection;
+            dst->SpriteData.sprite_direction = src->EntityDirection;
 
             // Peep name
             if (IsUserStringID(src->NameStringID))
@@ -1366,10 +1366,10 @@ namespace RCT1
 
         void ImportEntityCommonProperties(EntityBase* dst, const RCT12EntityBase* src)
         {
-            dst->sprite_direction = src->EntityDirection;
-            dst->sprite_width = src->SpriteWidth;
-            dst->sprite_height_negative = src->SpriteHeightNegative;
-            dst->sprite_height_positive = src->SpriteHeightPositive;
+            dst->SpriteData.sprite_direction = src->EntityDirection;
+            dst->SpriteData.sprite_width = src->SpriteWidth;
+            dst->SpriteData.sprite_height_negative = src->SpriteHeightNegative;
+            dst->SpriteData.sprite_height_positive = src->SpriteHeightPositive;
             dst->x = src->x;
             dst->y = src->y;
             dst->z = src->z;
@@ -2723,12 +2723,12 @@ namespace RCT1
         dst->remaining_distance = src->RemainingDistance;
 
         // Properties from vehicle entry
-        dst->sprite_width = src->SpriteWidth;
-        dst->sprite_height_negative = src->SpriteHeightNegative;
-        dst->sprite_height_positive = src->SpriteHeightPositive;
-        dst->sprite_direction = src->EntityDirection;
+        dst->SpriteData.sprite_width = src->SpriteWidth;
+        dst->SpriteData.sprite_height_negative = src->SpriteHeightNegative;
+        dst->SpriteData.sprite_height_positive = src->SpriteHeightPositive;
+        dst->SpriteData.sprite_direction = src->EntityDirection;
 
-        dst->SpriteRect = ScreenRect(src->SpriteLeft, src->SpriteTop, src->SpriteRight, src->SpriteBottom);
+        dst->SpriteData.SpriteRect = ScreenRect(src->SpriteLeft, src->SpriteTop, src->SpriteRight, src->SpriteBottom);
 
         dst->mass = src->Mass;
         dst->num_seats = src->NumSeats;

--- a/src/openrct2/rct1/S4Importer.cpp
+++ b/src/openrct2/rct1/S4Importer.cpp
@@ -1274,13 +1274,13 @@ namespace RCT1
             dst->ActionFrame = src->ActionFrame;
 
             const SpriteBounds* spriteBounds = &GetSpriteBounds(dst->SpriteType, dst->ActionSpriteType);
-            dst->SpriteData.sprite_width = spriteBounds->sprite_width;
-            dst->SpriteData.sprite_height_negative = spriteBounds->sprite_height_negative;
-            dst->SpriteData.sprite_height_positive = spriteBounds->sprite_height_positive;
+            dst->SpriteData.Width = spriteBounds->sprite_width;
+            dst->SpriteData.HeightMax = spriteBounds->sprite_height_negative;
+            dst->SpriteData.HeightMin = spriteBounds->sprite_height_positive;
 
             dst->MoveTo({ src->x, src->y, src->z });
 
-            dst->SpriteData.sprite_direction = src->EntityDirection;
+            dst->SpriteData.Direction = src->EntityDirection;
 
             // Peep name
             if (IsUserStringID(src->NameStringID))
@@ -1366,10 +1366,10 @@ namespace RCT1
 
         void ImportEntityCommonProperties(EntityBase* dst, const RCT12EntityBase* src)
         {
-            dst->SpriteData.sprite_direction = src->EntityDirection;
-            dst->SpriteData.sprite_width = src->SpriteWidth;
-            dst->SpriteData.sprite_height_negative = src->SpriteHeightNegative;
-            dst->SpriteData.sprite_height_positive = src->SpriteHeightPositive;
+            dst->SpriteData.Direction = src->EntityDirection;
+            dst->SpriteData.Width = src->SpriteWidth;
+            dst->SpriteData.HeightMin = src->SpriteHeightNegative;
+            dst->SpriteData.HeightMax = src->SpriteHeightPositive;
             dst->x = src->x;
             dst->y = src->y;
             dst->z = src->z;
@@ -2723,10 +2723,10 @@ namespace RCT1
         dst->remaining_distance = src->RemainingDistance;
 
         // Properties from vehicle entry
-        dst->SpriteData.sprite_width = src->SpriteWidth;
-        dst->SpriteData.sprite_height_negative = src->SpriteHeightNegative;
-        dst->SpriteData.sprite_height_positive = src->SpriteHeightPositive;
-        dst->SpriteData.sprite_direction = src->EntityDirection;
+        dst->SpriteData.Width = src->SpriteWidth;
+        dst->SpriteData.HeightMin = src->SpriteHeightNegative;
+        dst->SpriteData.HeightMax = src->SpriteHeightPositive;
+        dst->SpriteData.Direction = src->EntityDirection;
 
         dst->SpriteData.SpriteRect = ScreenRect(src->SpriteLeft, src->SpriteTop, src->SpriteRight, src->SpriteBottom);
 

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1850,7 +1850,7 @@ namespace RCT2
             dst->SpriteData.Width = src->SpriteWidth;
             dst->SpriteData.HeightMax = src->SpriteHeightPositive;
             dst->SpriteData.SpriteRect = ScreenRect(src->SpriteLeft, src->SpriteTop, src->SpriteRight, src->SpriteBottom);
-            dst->SpriteData.Direction = src->EntityDirection;
+            dst->Orientation = src->EntityDirection;
         }
 
         void ImportEntity(const RCT12EntityBase& src);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1842,15 +1842,15 @@ namespace RCT2
         void ImportEntityCommonProperties(EntityBase* dst, const RCT12EntityBase* src)
         {
             dst->Type = GetEntityTypeFromRCT2Sprite(src);
-            dst->SpriteData.sprite_height_negative = src->SpriteHeightNegative;
+            dst->SpriteData.HeightMin = src->SpriteHeightNegative;
             dst->Id = EntityId::FromUnderlying(src->EntityIndex);
             dst->x = src->x;
             dst->y = src->y;
             dst->z = src->z;
-            dst->SpriteData.sprite_width = src->SpriteWidth;
-            dst->SpriteData.sprite_height_positive = src->SpriteHeightPositive;
+            dst->SpriteData.Width = src->SpriteWidth;
+            dst->SpriteData.HeightMax = src->SpriteHeightPositive;
             dst->SpriteData.SpriteRect = ScreenRect(src->SpriteLeft, src->SpriteTop, src->SpriteRight, src->SpriteBottom);
-            dst->SpriteData.sprite_direction = src->EntityDirection;
+            dst->SpriteData.Direction = src->EntityDirection;
         }
 
         void ImportEntity(const RCT12EntityBase& src);

--- a/src/openrct2/rct2/S6Importer.cpp
+++ b/src/openrct2/rct2/S6Importer.cpp
@@ -1842,15 +1842,15 @@ namespace RCT2
         void ImportEntityCommonProperties(EntityBase* dst, const RCT12EntityBase* src)
         {
             dst->Type = GetEntityTypeFromRCT2Sprite(src);
-            dst->sprite_height_negative = src->SpriteHeightNegative;
+            dst->SpriteData.sprite_height_negative = src->SpriteHeightNegative;
             dst->Id = EntityId::FromUnderlying(src->EntityIndex);
             dst->x = src->x;
             dst->y = src->y;
             dst->z = src->z;
-            dst->sprite_width = src->SpriteWidth;
-            dst->sprite_height_positive = src->SpriteHeightPositive;
-            dst->SpriteRect = ScreenRect(src->SpriteLeft, src->SpriteTop, src->SpriteRight, src->SpriteBottom);
-            dst->sprite_direction = src->EntityDirection;
+            dst->SpriteData.sprite_width = src->SpriteWidth;
+            dst->SpriteData.sprite_height_positive = src->SpriteHeightPositive;
+            dst->SpriteData.SpriteRect = ScreenRect(src->SpriteLeft, src->SpriteTop, src->SpriteRight, src->SpriteBottom);
+            dst->SpriteData.sprite_direction = src->EntityDirection;
         }
 
         void ImportEntity(const RCT12EntityBase& src);

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -63,7 +63,7 @@ Vehicle* CableLiftSegmentCreate(
         peep = EntityId::GetNull();
     }
     current->TrackSubposition = VehicleTrackSubposition::Default;
-    current->SpriteData.Direction = direction << 3;
+    current->Orientation = direction << 3;
 
     z = z * COORDS_Z_STEP;
     current->TrackLocation = { x, y, z };
@@ -71,7 +71,7 @@ Vehicle* CableLiftSegmentCreate(
 
     current->MoveTo({ 16, 16, z });
     current->SetTrackType(TrackElemType::CableLiftHill);
-    current->SetTrackDirection(current->SpriteData.Direction >> 3);
+    current->SetTrackDirection(current->Orientation >> 3);
     current->track_progress = 164;
     current->Flags = VehicleFlags::CollisionDisabled;
     current->SetState(Vehicle::Status::MovingToEndOfStation, 0);
@@ -285,7 +285,7 @@ bool Vehicle::CableLiftUpdateTrackMotionForwards()
         _vehicleCurPosition.y = nextVehiclePosition.y;
         _vehicleCurPosition.z = nextVehiclePosition.z;
 
-        SpriteData.Direction = moveInfo->direction;
+        Orientation = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
         Pitch = moveInfo->Pitch;
 
@@ -351,7 +351,7 @@ bool Vehicle::CableLiftUpdateTrackMotionBackwards()
         _vehicleCurPosition.y = unk.y;
         _vehicleCurPosition.z = unk.z;
 
-        SpriteData.Direction = moveInfo->direction;
+        Orientation = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
         Pitch = moveInfo->Pitch;
 

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -34,9 +34,9 @@ Vehicle* CableLiftSegmentCreate(
     current->SubType = head ? Vehicle::Type::Head : Vehicle::Type::Tail;
     current->var_44 = var_44;
     current->remaining_distance = remaining_distance;
-    current->SpriteData.sprite_width = 10;
-    current->SpriteData.sprite_height_negative = 10;
-    current->SpriteData.sprite_height_positive = 10;
+    current->SpriteData.Width = 10;
+    current->SpriteData.HeightMin = 10;
+    current->SpriteData.HeightMax = 10;
     current->mass = 100;
     current->num_seats = 0;
     current->speed = 20;
@@ -63,7 +63,7 @@ Vehicle* CableLiftSegmentCreate(
         peep = EntityId::GetNull();
     }
     current->TrackSubposition = VehicleTrackSubposition::Default;
-    current->SpriteData.sprite_direction = direction << 3;
+    current->SpriteData.Direction = direction << 3;
 
     z = z * COORDS_Z_STEP;
     current->TrackLocation = { x, y, z };
@@ -71,7 +71,7 @@ Vehicle* CableLiftSegmentCreate(
 
     current->MoveTo({ 16, 16, z });
     current->SetTrackType(TrackElemType::CableLiftHill);
-    current->SetTrackDirection(current->SpriteData.sprite_direction >> 3);
+    current->SetTrackDirection(current->SpriteData.Direction >> 3);
     current->track_progress = 164;
     current->Flags = VehicleFlags::CollisionDisabled;
     current->SetState(Vehicle::Status::MovingToEndOfStation, 0);
@@ -285,7 +285,7 @@ bool Vehicle::CableLiftUpdateTrackMotionForwards()
         _vehicleCurPosition.y = nextVehiclePosition.y;
         _vehicleCurPosition.z = nextVehiclePosition.z;
 
-        SpriteData.sprite_direction = moveInfo->direction;
+        SpriteData.Direction = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
         Pitch = moveInfo->Pitch;
 
@@ -351,7 +351,7 @@ bool Vehicle::CableLiftUpdateTrackMotionBackwards()
         _vehicleCurPosition.y = unk.y;
         _vehicleCurPosition.z = unk.z;
 
-        SpriteData.sprite_direction = moveInfo->direction;
+        SpriteData.Direction = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
         Pitch = moveInfo->Pitch;
 

--- a/src/openrct2/ride/CableLift.cpp
+++ b/src/openrct2/ride/CableLift.cpp
@@ -34,9 +34,9 @@ Vehicle* CableLiftSegmentCreate(
     current->SubType = head ? Vehicle::Type::Head : Vehicle::Type::Tail;
     current->var_44 = var_44;
     current->remaining_distance = remaining_distance;
-    current->sprite_width = 10;
-    current->sprite_height_negative = 10;
-    current->sprite_height_positive = 10;
+    current->SpriteData.sprite_width = 10;
+    current->SpriteData.sprite_height_negative = 10;
+    current->SpriteData.sprite_height_positive = 10;
     current->mass = 100;
     current->num_seats = 0;
     current->speed = 20;
@@ -63,7 +63,7 @@ Vehicle* CableLiftSegmentCreate(
         peep = EntityId::GetNull();
     }
     current->TrackSubposition = VehicleTrackSubposition::Default;
-    current->sprite_direction = direction << 3;
+    current->SpriteData.sprite_direction = direction << 3;
 
     z = z * COORDS_Z_STEP;
     current->TrackLocation = { x, y, z };
@@ -71,7 +71,7 @@ Vehicle* CableLiftSegmentCreate(
 
     current->MoveTo({ 16, 16, z });
     current->SetTrackType(TrackElemType::CableLiftHill);
-    current->SetTrackDirection(current->sprite_direction >> 3);
+    current->SetTrackDirection(current->SpriteData.sprite_direction >> 3);
     current->track_progress = 164;
     current->Flags = VehicleFlags::CollisionDisabled;
     current->SetState(Vehicle::Status::MovingToEndOfStation, 0);
@@ -285,7 +285,7 @@ bool Vehicle::CableLiftUpdateTrackMotionForwards()
         _vehicleCurPosition.y = nextVehiclePosition.y;
         _vehicleCurPosition.z = nextVehiclePosition.z;
 
-        sprite_direction = moveInfo->direction;
+        SpriteData.sprite_direction = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
         Pitch = moveInfo->Pitch;
 
@@ -351,7 +351,7 @@ bool Vehicle::CableLiftUpdateTrackMotionBackwards()
         _vehicleCurPosition.y = unk.y;
         _vehicleCurPosition.z = unk.z;
 
-        sprite_direction = moveInfo->direction;
+        SpriteData.sprite_direction = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
         Pitch = moveInfo->Pitch;
 

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3216,7 +3216,7 @@ static Vehicle* VehicleCreateCar(
             if (numAttempts > 10000)
                 return nullptr;
 
-            vehicle->SpriteData.Direction = ScenarioRand() & 0x1E;
+            vehicle->Orientation = ScenarioRand() & 0x1E;
             chosenLoc.y = dodgemPos.y + (ScenarioRand() & 0xFF);
             chosenLoc.x = dodgemPos.x + (ScenarioRand() & 0xFF);
         } while (vehicle->DodgemsCarWouldCollideAt(chosenLoc).has_value());
@@ -3264,7 +3264,7 @@ static Vehicle* VehicleCreateCar(
         vehicle->TrackLocation = chosenLoc;
 
         int32_t direction = trackElement->GetDirection();
-        vehicle->SpriteData.Direction = direction << 3;
+        vehicle->Orientation = direction << 3;
 
         if (ride.type == RIDE_TYPE_SPACE_RINGS)
         {
@@ -3297,7 +3297,7 @@ static Vehicle* VehicleCreateCar(
 
         vehicle->MoveTo(chosenLoc);
         vehicle->SetTrackType(trackElement->GetTrackType());
-        vehicle->SetTrackDirection(vehicle->SpriteData.Direction >> 3);
+        vehicle->SetTrackDirection(vehicle->Orientation >> 3);
         vehicle->track_progress = 31;
         if (carEntry.flags & CAR_ENTRY_FLAG_MINI_GOLF)
         {

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3156,9 +3156,9 @@ static Vehicle* VehicleCreateCar(
     }
 
     // Loc6DD9A5:
-    vehicle->SpriteData.sprite_width = carEntry.sprite_width;
-    vehicle->SpriteData.sprite_height_negative = carEntry.sprite_height_negative;
-    vehicle->SpriteData.sprite_height_positive = carEntry.sprite_height_positive;
+    vehicle->SpriteData.Width = carEntry.sprite_width;
+    vehicle->SpriteData.HeightMin = carEntry.sprite_height_negative;
+    vehicle->SpriteData.HeightMax = carEntry.sprite_height_positive;
     vehicle->mass = carEntry.car_mass;
     vehicle->num_seats = carEntry.num_seats;
     vehicle->speed = carEntry.powered_max_speed;
@@ -3216,7 +3216,7 @@ static Vehicle* VehicleCreateCar(
             if (numAttempts > 10000)
                 return nullptr;
 
-            vehicle->SpriteData.sprite_direction = ScenarioRand() & 0x1E;
+            vehicle->SpriteData.Direction = ScenarioRand() & 0x1E;
             chosenLoc.y = dodgemPos.y + (ScenarioRand() & 0xFF);
             chosenLoc.x = dodgemPos.x + (ScenarioRand() & 0xFF);
         } while (vehicle->DodgemsCarWouldCollideAt(chosenLoc).has_value());
@@ -3264,7 +3264,7 @@ static Vehicle* VehicleCreateCar(
         vehicle->TrackLocation = chosenLoc;
 
         int32_t direction = trackElement->GetDirection();
-        vehicle->SpriteData.sprite_direction = direction << 3;
+        vehicle->SpriteData.Direction = direction << 3;
 
         if (ride.type == RIDE_TYPE_SPACE_RINGS)
         {
@@ -3297,7 +3297,7 @@ static Vehicle* VehicleCreateCar(
 
         vehicle->MoveTo(chosenLoc);
         vehicle->SetTrackType(trackElement->GetTrackType());
-        vehicle->SetTrackDirection(vehicle->SpriteData.sprite_direction >> 3);
+        vehicle->SetTrackDirection(vehicle->SpriteData.Direction >> 3);
         vehicle->track_progress = 31;
         if (carEntry.flags & CAR_ENTRY_FLAG_MINI_GOLF)
         {
@@ -5333,17 +5333,17 @@ void FixInvalidVehicleSpriteSizes()
                     break;
                 }
 
-                if (vehicle->SpriteData.sprite_width == 0)
+                if (vehicle->SpriteData.Width == 0)
                 {
-                    vehicle->SpriteData.sprite_width = carEntry->sprite_width;
+                    vehicle->SpriteData.Width = carEntry->sprite_width;
                 }
-                if (vehicle->SpriteData.sprite_height_negative == 0)
+                if (vehicle->SpriteData.HeightMin == 0)
                 {
-                    vehicle->SpriteData.sprite_height_negative = carEntry->sprite_height_negative;
+                    vehicle->SpriteData.HeightMin = carEntry->sprite_height_negative;
                 }
-                if (vehicle->SpriteData.sprite_height_positive == 0)
+                if (vehicle->SpriteData.HeightMax == 0)
                 {
-                    vehicle->SpriteData.sprite_height_positive = carEntry->sprite_height_positive;
+                    vehicle->SpriteData.HeightMax = carEntry->sprite_height_positive;
                 }
             }
         }

--- a/src/openrct2/ride/Ride.cpp
+++ b/src/openrct2/ride/Ride.cpp
@@ -3156,9 +3156,9 @@ static Vehicle* VehicleCreateCar(
     }
 
     // Loc6DD9A5:
-    vehicle->sprite_width = carEntry.sprite_width;
-    vehicle->sprite_height_negative = carEntry.sprite_height_negative;
-    vehicle->sprite_height_positive = carEntry.sprite_height_positive;
+    vehicle->SpriteData.sprite_width = carEntry.sprite_width;
+    vehicle->SpriteData.sprite_height_negative = carEntry.sprite_height_negative;
+    vehicle->SpriteData.sprite_height_positive = carEntry.sprite_height_positive;
     vehicle->mass = carEntry.car_mass;
     vehicle->num_seats = carEntry.num_seats;
     vehicle->speed = carEntry.powered_max_speed;
@@ -3216,7 +3216,7 @@ static Vehicle* VehicleCreateCar(
             if (numAttempts > 10000)
                 return nullptr;
 
-            vehicle->sprite_direction = ScenarioRand() & 0x1E;
+            vehicle->SpriteData.sprite_direction = ScenarioRand() & 0x1E;
             chosenLoc.y = dodgemPos.y + (ScenarioRand() & 0xFF);
             chosenLoc.x = dodgemPos.x + (ScenarioRand() & 0xFF);
         } while (vehicle->DodgemsCarWouldCollideAt(chosenLoc).has_value());
@@ -3264,7 +3264,7 @@ static Vehicle* VehicleCreateCar(
         vehicle->TrackLocation = chosenLoc;
 
         int32_t direction = trackElement->GetDirection();
-        vehicle->sprite_direction = direction << 3;
+        vehicle->SpriteData.sprite_direction = direction << 3;
 
         if (ride.type == RIDE_TYPE_SPACE_RINGS)
         {
@@ -3297,7 +3297,7 @@ static Vehicle* VehicleCreateCar(
 
         vehicle->MoveTo(chosenLoc);
         vehicle->SetTrackType(trackElement->GetTrackType());
-        vehicle->SetTrackDirection(vehicle->sprite_direction >> 3);
+        vehicle->SetTrackDirection(vehicle->SpriteData.sprite_direction >> 3);
         vehicle->track_progress = 31;
         if (carEntry.flags & CAR_ENTRY_FLAG_MINI_GOLF)
         {
@@ -5333,17 +5333,17 @@ void FixInvalidVehicleSpriteSizes()
                     break;
                 }
 
-                if (vehicle->sprite_width == 0)
+                if (vehicle->SpriteData.sprite_width == 0)
                 {
-                    vehicle->sprite_width = carEntry->sprite_width;
+                    vehicle->SpriteData.sprite_width = carEntry->sprite_width;
                 }
-                if (vehicle->sprite_height_negative == 0)
+                if (vehicle->SpriteData.sprite_height_negative == 0)
                 {
-                    vehicle->sprite_height_negative = carEntry->sprite_height_negative;
+                    vehicle->SpriteData.sprite_height_negative = carEntry->sprite_height_negative;
                 }
-                if (vehicle->sprite_height_positive == 0)
+                if (vehicle->SpriteData.sprite_height_positive == 0)
                 {
-                    vehicle->sprite_height_positive = carEntry->sprite_height_positive;
+                    vehicle->SpriteData.sprite_height_positive = carEntry->sprite_height_positive;
                 }
             }
         }

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -296,7 +296,7 @@ void Ride::RemovePeeps()
             else
             {
                 peep->MoveTo(exitPosition);
-                peep->SpriteData.Direction = exitPosition.direction;
+                peep->Orientation = exitPosition.direction;
             }
 
             peep->State = PeepState::Falling;
@@ -326,7 +326,7 @@ void Ride::RemovePeeps()
             else
             {
                 peep->MoveTo(exitPosition);
-                peep->SpriteData.Direction = exitPosition.direction;
+                peep->Orientation = exitPosition.direction;
             }
 
             peep->State = PeepState::Falling;

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -296,7 +296,7 @@ void Ride::RemovePeeps()
             else
             {
                 peep->MoveTo(exitPosition);
-                peep->SpriteData.sprite_direction = exitPosition.direction;
+                peep->SpriteData.Direction = exitPosition.direction;
             }
 
             peep->State = PeepState::Falling;
@@ -326,7 +326,7 @@ void Ride::RemovePeeps()
             else
             {
                 peep->MoveTo(exitPosition);
-                peep->SpriteData.sprite_direction = exitPosition.direction;
+                peep->SpriteData.Direction = exitPosition.direction;
             }
 
             peep->State = PeepState::Falling;

--- a/src/openrct2/ride/RideConstruction.cpp
+++ b/src/openrct2/ride/RideConstruction.cpp
@@ -296,7 +296,7 @@ void Ride::RemovePeeps()
             else
             {
                 peep->MoveTo(exitPosition);
-                peep->sprite_direction = exitPosition.direction;
+                peep->SpriteData.sprite_direction = exitPosition.direction;
             }
 
             peep->State = PeepState::Falling;
@@ -326,7 +326,7 @@ void Ride::RemovePeeps()
             else
             {
                 peep->MoveTo(exitPosition);
-                peep->sprite_direction = exitPosition.direction;
+                peep->SpriteData.sprite_direction = exitPosition.direction;
             }
 
             peep->State = PeepState::Falling;

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2995,12 +2995,12 @@ bool Vehicle::CurrentTowerElementIsTop()
  */
 void Vehicle::UpdateTravellingBoatHireSetup()
 {
-    var_34 = SpriteData.sprite_direction;
+    var_34 = SpriteData.Direction;
     TrackLocation.x = x;
     TrackLocation.y = y;
     TrackLocation = TrackLocation.ToTileStart();
 
-    CoordsXY location = CoordsXY(TrackLocation) + CoordsDirectionDelta[SpriteData.sprite_direction >> 3];
+    CoordsXY location = CoordsXY(TrackLocation) + CoordsDirectionDelta[SpriteData.Direction >> 3];
 
     BoatLocation = location;
     var_35 = 0;
@@ -3441,9 +3441,9 @@ void Vehicle::UpdateCollisionSetup()
         train->animationState = ScenarioRand() & 0xFFFF;
 
         train->animation_frame = ScenarioRand() & 0x7;
-        train->SpriteData.sprite_width = 13;
-        train->SpriteData.sprite_height_negative = 45;
-        train->SpriteData.sprite_height_positive = 5;
+        train->SpriteData.Width = 13;
+        train->SpriteData.HeightMin = 45;
+        train->SpriteData.HeightMax = 5;
 
         train->MoveTo(trainLoc);
 
@@ -3505,8 +3505,8 @@ void Vehicle::UpdateCrashSetup()
         lastVehicle = trainVehicle;
 
         trainVehicle->sub_state = 0;
-        int32_t trainX = stru_9A3AC4[trainVehicle->SpriteData.sprite_direction / 2].x;
-        int32_t trainY = stru_9A3AC4[trainVehicle->SpriteData.sprite_direction / 2].y;
+        int32_t trainX = stru_9A3AC4[trainVehicle->SpriteData.Direction / 2].x;
+        int32_t trainY = stru_9A3AC4[trainVehicle->SpriteData.Direction / 2].y;
         auto trainZ = Unk9A38D4[trainVehicle->Pitch] >> 23;
 
         int32_t ecx = Unk9A37E4[trainVehicle->Pitch] >> 15;
@@ -4303,7 +4303,7 @@ void Vehicle::UpdateMotionBoatHire()
 
             if (!(var_35 & (1 << 0)))
             {
-                uint8_t spriteDirection = SpriteData.sprite_direction;
+                uint8_t spriteDirection = SpriteData.Direction;
                 if (spriteDirection != var_34)
                 {
                     uint8_t dl = (var_34 + 16 - spriteDirection) & 0x1E;
@@ -4324,20 +4324,20 @@ void Vehicle::UpdateMotionBoatHire()
                         }
                     }
 
-                    SpriteData.sprite_direction = spriteDirection & 0x1E;
+                    SpriteData.Direction = spriteDirection & 0x1E;
                 }
             }
 
-            int32_t edi = (SpriteData.sprite_direction | (var_35 & 1)) & 0x1F;
+            int32_t edi = (SpriteData.Direction | (var_35 & 1)) & 0x1F;
             loc2 = { x + Unk9A36C4[edi].x, y + Unk9A36C4[edi].y };
             if (UpdateMotionCollisionDetection({ loc2, z }, nullptr))
             {
                 remaining_distance = 0;
-                if (SpriteData.sprite_direction == var_34)
+                if (SpriteData.Direction == var_34)
                 {
-                    SpriteData.sprite_direction ^= (1 << 4);
+                    SpriteData.Direction ^= (1 << 4);
                     UpdateBoatLocation();
-                    SpriteData.sprite_direction ^= (1 << 4);
+                    SpriteData.Direction ^= (1 << 4);
                 }
                 break;
             }
@@ -4370,7 +4370,7 @@ void Vehicle::UpdateMotionBoatHire()
                     if (do_Loc6DAA97)
                     {
                         remaining_distance = 0;
-                        if (SpriteData.sprite_direction == var_34)
+                        if (SpriteData.Direction == var_34)
                         {
                             UpdateBoatLocation();
                         }
@@ -4496,7 +4496,7 @@ void Vehicle::UpdateBoatLocation()
     }
 
     sub_state = 0;
-    uint8_t curDirection = ((SpriteData.sprite_direction + 19) >> 3) & 3;
+    uint8_t curDirection = ((SpriteData.Direction + 19) >> 3) & 3;
     uint8_t randDirection = ScenarioRand() & 3;
 
     if (lost_time_out > 1920)
@@ -5214,7 +5214,7 @@ void Vehicle::CrashOnLand()
     ExplosionCloud::Create(curLoc);
     ExplosionFlare::Create(curLoc);
 
-    uint8_t numParticles = std::min(SpriteData.sprite_width, static_cast<uint8_t>(7));
+    uint8_t numParticles = std::min(SpriteData.Width, static_cast<uint8_t>(7));
 
     while (numParticles-- != 0)
         VehicleCrashParticle::Create(colours, curLoc);
@@ -5222,9 +5222,9 @@ void Vehicle::CrashOnLand()
     SetFlag(VehicleFlags::Crashed);
     animation_frame = 0;
     animationState = 0;
-    SpriteData.sprite_width = 13;
-    SpriteData.sprite_height_negative = 45;
-    SpriteData.sprite_height_positive = 5;
+    SpriteData.Width = 13;
+    SpriteData.HeightMin = 45;
+    SpriteData.HeightMax = 5;
 
     MoveTo(curLoc);
 
@@ -5291,9 +5291,9 @@ void Vehicle::CrashOnWater()
     SetFlag(VehicleFlags::Crashed);
     animation_frame = 0;
     animationState = 0;
-    SpriteData.sprite_width = 13;
-    SpriteData.sprite_height_negative = 45;
-    SpriteData.sprite_height_positive = 5;
+    SpriteData.Width = 13;
+    SpriteData.HeightMin = 45;
+    SpriteData.HeightMax = 5;
 
     MoveTo(curLoc);
 
@@ -5494,7 +5494,7 @@ void Vehicle::UpdateSound()
     sound2_volume = soundIdVolume.volume;
 
     // Calculate Sound Vector (used for sound frequency calcs)
-    int32_t soundDirection = SpriteDirectionToSoundDirection[SpriteData.sprite_direction];
+    int32_t soundDirection = SpriteDirectionToSoundDirection[SpriteData.Direction];
     int32_t soundVector = ((velocity >> 14) * soundDirection) >> 14;
     soundVector = std::clamp(soundVector, -127, 127);
 
@@ -5719,23 +5719,23 @@ int32_t Vehicle::UpdateMotionDodgems()
             if (var_34 > 0)
             {
                 var_34--;
-                SpriteData.sprite_direction += 2;
+                SpriteData.Direction += 2;
             }
             else
             {
                 var_34++;
-                SpriteData.sprite_direction -= 2;
+                SpriteData.Direction -= 2;
             }
-            SpriteData.sprite_direction &= 0x1E;
+            SpriteData.Direction &= 0x1E;
             Invalidate();
         }
         else if ((ScenarioRand() & 0xFFFF) <= 2849)
         {
             if (var_35 & (1 << 6))
-                SpriteData.sprite_direction -= 2;
+                SpriteData.Direction -= 2;
             else
-                SpriteData.sprite_direction += 2;
-            SpriteData.sprite_direction &= 0x1E;
+                SpriteData.Direction += 2;
+            SpriteData.Direction &= 0x1E;
             Invalidate();
         }
     }
@@ -5771,7 +5771,7 @@ int32_t Vehicle::UpdateMotionDodgems()
         while (true)
         {
             var_35++;
-            uint8_t direction = SpriteData.sprite_direction;
+            uint8_t direction = SpriteData.Direction;
             direction |= var_35 & 1;
 
             CoordsXY location = _vehicleCurPosition;
@@ -5798,7 +5798,7 @@ int32_t Vehicle::UpdateMotionDodgems()
             int32_t oldVelocity = velocity;
             remaining_distance = 0;
             velocity = 0;
-            uint8_t direction = SpriteData.sprite_direction | 1;
+            uint8_t direction = SpriteData.Direction | 1;
 
             Vehicle* collideVehicle = GetEntity<Vehicle>(collideSprite.value());
             if (collideVehicle != nullptr)
@@ -6661,7 +6661,7 @@ static void AnimateSteamLocomotive(Vehicle& vehicle, const CarEntry& carEntry)
                 {
                     CoordsXYZ steamOffset = ComputeSteamOffset(
                         carEntry.SteamEffect.Vertical, carEntry.SteamEffect.Longitudinal, vehicle.Pitch,
-                        vehicle.SpriteData.sprite_direction);
+                        vehicle.SpriteData.Direction);
                     SteamParticle::Create(CoordsXYZ(vehicle.x, vehicle.y, vehicle.z) + steamOffset);
                 }
             }
@@ -7116,7 +7116,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
         if (x_diff + y_diff + z_diff >= ecx)
             return false;
 
-        uint8_t direction = (SpriteData.sprite_direction - collideVehicle->SpriteData.sprite_direction + 7) & 0x1F;
+        uint8_t direction = (SpriteData.Direction - collideVehicle->SpriteData.Direction + 7) & 0x1F;
         return direction < 0xF;
     }
 
@@ -7177,12 +7177,12 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
                 break;
             }
 
-            uint8_t direction = (SpriteData.sprite_direction - vehicle2->SpriteData.sprite_direction - 6) & 0x1F;
+            uint8_t direction = (SpriteData.Direction - vehicle2->SpriteData.Direction - 6) & 0x1F;
 
             if (direction < 0x14)
                 continue;
 
-            uint32_t offsetSpriteDirection = (SpriteData.sprite_direction + 4) & 31;
+            uint32_t offsetSpriteDirection = (SpriteData.Direction + 4) & 31;
             uint32_t offsetDirection = offsetSpriteDirection >> 3;
             uint32_t next_x_diff = abs(loc.x + AvoidCollisionMoveOffset[offsetDirection].x - vehicle2->x);
             uint32_t next_y_diff = abs(loc.y + AvoidCollisionMoveOffset[offsetDirection].y - vehicle2->y);
@@ -7219,28 +7219,28 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
 
     if (status == Vehicle::Status::MovingToEndOfStation)
     {
-        if (SpriteData.sprite_direction == 0)
+        if (SpriteData.Direction == 0)
         {
             if (x <= collideVehicle->x)
             {
                 return false;
             }
         }
-        else if (SpriteData.sprite_direction == 8)
+        else if (SpriteData.Direction == 8)
         {
             if (y >= collideVehicle->y)
             {
                 return false;
             }
         }
-        else if (SpriteData.sprite_direction == 16)
+        else if (SpriteData.Direction == 16)
         {
             if (x >= collideVehicle->x)
             {
                 return false;
             }
         }
-        else if (SpriteData.sprite_direction == 24)
+        else if (SpriteData.Direction == 24)
         {
             if (y <= collideVehicle->y)
             {
@@ -7721,7 +7721,7 @@ Loc6DAEB9:
         // Loc6DB8A5
         remaining_distance -= SubpositionTranslationDistances[remainingDistanceFlags];
         _vehicleCurPosition = nextVehiclePosition;
-        SpriteData.sprite_direction = moveInfo->direction;
+        SpriteData.Direction = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
         Pitch = moveInfo->Pitch;
 
@@ -8033,7 +8033,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             remaining_distance += SubpositionTranslationDistances[remainingDistanceFlags];
 
             _vehicleCurPosition = nextVehiclePosition;
-            SpriteData.sprite_direction = moveInfo->direction;
+            SpriteData.Direction = moveInfo->direction;
             bank_rotation = moveInfo->bank_rotation;
             Pitch = moveInfo->Pitch;
             moveInfoVehicleSpriteType = moveInfo->Pitch;
@@ -8391,7 +8391,7 @@ Loc6DC743:
     }
 
     _vehicleCurPosition = trackPos;
-    SpriteData.sprite_direction = moveInfo->direction;
+    SpriteData.Direction = moveInfo->direction;
     bank_rotation = moveInfo->bank_rotation;
     Pitch = moveInfo->Pitch;
 
@@ -8506,7 +8506,7 @@ Loc6DCC2C:
     }
 
     _vehicleCurPosition = trackPos;
-    SpriteData.sprite_direction = moveInfo->direction;
+    SpriteData.Direction = moveInfo->direction;
     bank_rotation = moveInfo->bank_rotation;
     Pitch = moveInfo->Pitch;
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -686,7 +686,7 @@ bool Vehicle::SoundCanPlay() const
         bottom -= quarter_h;
     }
 
-    if (left >= SpriteRect.GetRight() || bottom >= SpriteRect.GetBottom())
+    if (left >= SpriteData.SpriteRect.GetRight() || bottom >= SpriteData.SpriteRect.GetBottom())
         return false;
 
     auto right = g_music_tracking_viewport->view_width + left;
@@ -698,7 +698,7 @@ bool Vehicle::SoundCanPlay() const
         top += quarter_h + quarter_h;
     }
 
-    if (right < SpriteRect.GetRight() || top < SpriteRect.GetTop())
+    if (right < SpriteData.SpriteRect.GetRight() || top < SpriteData.SpriteRect.GetTop())
         return false;
 
     return true;
@@ -728,7 +728,8 @@ OpenRCT2::Audio::VehicleSoundParams Vehicle::CreateSoundParam(uint16_t priority)
 {
     OpenRCT2::Audio::VehicleSoundParams param;
     param.priority = priority;
-    int32_t panX = (SpriteRect.GetLeft() / 2) + (SpriteRect.GetRight() / 2) - g_music_tracking_viewport->viewPos.x;
+    int32_t panX = (SpriteData.SpriteRect.GetLeft() / 2) + (SpriteData.SpriteRect.GetRight() / 2)
+        - g_music_tracking_viewport->viewPos.x;
     panX = g_music_tracking_viewport->zoom.ApplyInversedTo(panX);
     panX += g_music_tracking_viewport->pos.x;
 
@@ -739,7 +740,8 @@ OpenRCT2::Audio::VehicleSoundParams Vehicle::CreateSoundParam(uint16_t priority)
     }
     param.pan_x = ((((panX * 65536) / screenWidth) - 0x8000) >> 4);
 
-    int32_t panY = (SpriteRect.GetTop() / 2) + (SpriteRect.GetBottom() / 2) - g_music_tracking_viewport->viewPos.y;
+    int32_t panY = (SpriteData.SpriteRect.GetTop() / 2) + (SpriteData.SpriteRect.GetBottom() / 2)
+        - g_music_tracking_viewport->viewPos.y;
     panY = g_music_tracking_viewport->zoom.ApplyInversedTo(panY);
     panY += g_music_tracking_viewport->pos.y;
 
@@ -2993,12 +2995,12 @@ bool Vehicle::CurrentTowerElementIsTop()
  */
 void Vehicle::UpdateTravellingBoatHireSetup()
 {
-    var_34 = sprite_direction;
+    var_34 = SpriteData.sprite_direction;
     TrackLocation.x = x;
     TrackLocation.y = y;
     TrackLocation = TrackLocation.ToTileStart();
 
-    CoordsXY location = CoordsXY(TrackLocation) + CoordsDirectionDelta[sprite_direction >> 3];
+    CoordsXY location = CoordsXY(TrackLocation) + CoordsDirectionDelta[SpriteData.sprite_direction >> 3];
 
     BoatLocation = location;
     var_35 = 0;
@@ -3439,9 +3441,9 @@ void Vehicle::UpdateCollisionSetup()
         train->animationState = ScenarioRand() & 0xFFFF;
 
         train->animation_frame = ScenarioRand() & 0x7;
-        train->sprite_width = 13;
-        train->sprite_height_negative = 45;
-        train->sprite_height_positive = 5;
+        train->SpriteData.sprite_width = 13;
+        train->SpriteData.sprite_height_negative = 45;
+        train->SpriteData.sprite_height_positive = 5;
 
         train->MoveTo(trainLoc);
 
@@ -3503,8 +3505,8 @@ void Vehicle::UpdateCrashSetup()
         lastVehicle = trainVehicle;
 
         trainVehicle->sub_state = 0;
-        int32_t trainX = stru_9A3AC4[trainVehicle->sprite_direction / 2].x;
-        int32_t trainY = stru_9A3AC4[trainVehicle->sprite_direction / 2].y;
+        int32_t trainX = stru_9A3AC4[trainVehicle->SpriteData.sprite_direction / 2].x;
+        int32_t trainY = stru_9A3AC4[trainVehicle->SpriteData.sprite_direction / 2].y;
         auto trainZ = Unk9A38D4[trainVehicle->Pitch] >> 23;
 
         int32_t ecx = Unk9A37E4[trainVehicle->Pitch] >> 15;
@@ -4301,7 +4303,7 @@ void Vehicle::UpdateMotionBoatHire()
 
             if (!(var_35 & (1 << 0)))
             {
-                uint8_t spriteDirection = sprite_direction;
+                uint8_t spriteDirection = SpriteData.sprite_direction;
                 if (spriteDirection != var_34)
                 {
                     uint8_t dl = (var_34 + 16 - spriteDirection) & 0x1E;
@@ -4322,20 +4324,20 @@ void Vehicle::UpdateMotionBoatHire()
                         }
                     }
 
-                    sprite_direction = spriteDirection & 0x1E;
+                    SpriteData.sprite_direction = spriteDirection & 0x1E;
                 }
             }
 
-            int32_t edi = (sprite_direction | (var_35 & 1)) & 0x1F;
+            int32_t edi = (SpriteData.sprite_direction | (var_35 & 1)) & 0x1F;
             loc2 = { x + Unk9A36C4[edi].x, y + Unk9A36C4[edi].y };
             if (UpdateMotionCollisionDetection({ loc2, z }, nullptr))
             {
                 remaining_distance = 0;
-                if (sprite_direction == var_34)
+                if (SpriteData.sprite_direction == var_34)
                 {
-                    sprite_direction ^= (1 << 4);
+                    SpriteData.sprite_direction ^= (1 << 4);
                     UpdateBoatLocation();
-                    sprite_direction ^= (1 << 4);
+                    SpriteData.sprite_direction ^= (1 << 4);
                 }
                 break;
             }
@@ -4368,7 +4370,7 @@ void Vehicle::UpdateMotionBoatHire()
                     if (do_Loc6DAA97)
                     {
                         remaining_distance = 0;
-                        if (sprite_direction == var_34)
+                        if (SpriteData.sprite_direction == var_34)
                         {
                             UpdateBoatLocation();
                         }
@@ -4494,7 +4496,7 @@ void Vehicle::UpdateBoatLocation()
     }
 
     sub_state = 0;
-    uint8_t curDirection = ((sprite_direction + 19) >> 3) & 3;
+    uint8_t curDirection = ((SpriteData.sprite_direction + 19) >> 3) & 3;
     uint8_t randDirection = ScenarioRand() & 3;
 
     if (lost_time_out > 1920)
@@ -5212,7 +5214,7 @@ void Vehicle::CrashOnLand()
     ExplosionCloud::Create(curLoc);
     ExplosionFlare::Create(curLoc);
 
-    uint8_t numParticles = std::min(sprite_width, static_cast<uint8_t>(7));
+    uint8_t numParticles = std::min(SpriteData.sprite_width, static_cast<uint8_t>(7));
 
     while (numParticles-- != 0)
         VehicleCrashParticle::Create(colours, curLoc);
@@ -5220,9 +5222,9 @@ void Vehicle::CrashOnLand()
     SetFlag(VehicleFlags::Crashed);
     animation_frame = 0;
     animationState = 0;
-    sprite_width = 13;
-    sprite_height_negative = 45;
-    sprite_height_positive = 5;
+    SpriteData.sprite_width = 13;
+    SpriteData.sprite_height_negative = 45;
+    SpriteData.sprite_height_positive = 5;
 
     MoveTo(curLoc);
 
@@ -5289,9 +5291,9 @@ void Vehicle::CrashOnWater()
     SetFlag(VehicleFlags::Crashed);
     animation_frame = 0;
     animationState = 0;
-    sprite_width = 13;
-    sprite_height_negative = 45;
-    sprite_height_positive = 5;
+    SpriteData.sprite_width = 13;
+    SpriteData.sprite_height_negative = 45;
+    SpriteData.sprite_height_positive = 5;
 
     MoveTo(curLoc);
 
@@ -5492,7 +5494,7 @@ void Vehicle::UpdateSound()
     sound2_volume = soundIdVolume.volume;
 
     // Calculate Sound Vector (used for sound frequency calcs)
-    int32_t soundDirection = SpriteDirectionToSoundDirection[sprite_direction];
+    int32_t soundDirection = SpriteDirectionToSoundDirection[SpriteData.sprite_direction];
     int32_t soundVector = ((velocity >> 14) * soundDirection) >> 14;
     soundVector = std::clamp(soundVector, -127, 127);
 
@@ -5717,23 +5719,23 @@ int32_t Vehicle::UpdateMotionDodgems()
             if (var_34 > 0)
             {
                 var_34--;
-                sprite_direction += 2;
+                SpriteData.sprite_direction += 2;
             }
             else
             {
                 var_34++;
-                sprite_direction -= 2;
+                SpriteData.sprite_direction -= 2;
             }
-            sprite_direction &= 0x1E;
+            SpriteData.sprite_direction &= 0x1E;
             Invalidate();
         }
         else if ((ScenarioRand() & 0xFFFF) <= 2849)
         {
             if (var_35 & (1 << 6))
-                sprite_direction -= 2;
+                SpriteData.sprite_direction -= 2;
             else
-                sprite_direction += 2;
-            sprite_direction &= 0x1E;
+                SpriteData.sprite_direction += 2;
+            SpriteData.sprite_direction &= 0x1E;
             Invalidate();
         }
     }
@@ -5769,7 +5771,7 @@ int32_t Vehicle::UpdateMotionDodgems()
         while (true)
         {
             var_35++;
-            uint8_t direction = sprite_direction;
+            uint8_t direction = SpriteData.sprite_direction;
             direction |= var_35 & 1;
 
             CoordsXY location = _vehicleCurPosition;
@@ -5796,7 +5798,7 @@ int32_t Vehicle::UpdateMotionDodgems()
             int32_t oldVelocity = velocity;
             remaining_distance = 0;
             velocity = 0;
-            uint8_t direction = sprite_direction | 1;
+            uint8_t direction = SpriteData.sprite_direction | 1;
 
             Vehicle* collideVehicle = GetEntity<Vehicle>(collideSprite.value());
             if (collideVehicle != nullptr)
@@ -6659,7 +6661,7 @@ static void AnimateSteamLocomotive(Vehicle& vehicle, const CarEntry& carEntry)
                 {
                     CoordsXYZ steamOffset = ComputeSteamOffset(
                         carEntry.SteamEffect.Vertical, carEntry.SteamEffect.Longitudinal, vehicle.Pitch,
-                        vehicle.sprite_direction);
+                        vehicle.SpriteData.sprite_direction);
                     SteamParticle::Create(CoordsXYZ(vehicle.x, vehicle.y, vehicle.z) + steamOffset);
                 }
             }
@@ -7114,7 +7116,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
         if (x_diff + y_diff + z_diff >= ecx)
             return false;
 
-        uint8_t direction = (sprite_direction - collideVehicle->sprite_direction + 7) & 0x1F;
+        uint8_t direction = (SpriteData.sprite_direction - collideVehicle->SpriteData.sprite_direction + 7) & 0x1F;
         return direction < 0xF;
     }
 
@@ -7175,12 +7177,12 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
                 break;
             }
 
-            uint8_t direction = (sprite_direction - vehicle2->sprite_direction - 6) & 0x1F;
+            uint8_t direction = (SpriteData.sprite_direction - vehicle2->SpriteData.sprite_direction - 6) & 0x1F;
 
             if (direction < 0x14)
                 continue;
 
-            uint32_t offsetSpriteDirection = (sprite_direction + 4) & 31;
+            uint32_t offsetSpriteDirection = (SpriteData.sprite_direction + 4) & 31;
             uint32_t offsetDirection = offsetSpriteDirection >> 3;
             uint32_t next_x_diff = abs(loc.x + AvoidCollisionMoveOffset[offsetDirection].x - vehicle2->x);
             uint32_t next_y_diff = abs(loc.y + AvoidCollisionMoveOffset[offsetDirection].y - vehicle2->y);
@@ -7217,28 +7219,28 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
 
     if (status == Vehicle::Status::MovingToEndOfStation)
     {
-        if (sprite_direction == 0)
+        if (SpriteData.sprite_direction == 0)
         {
             if (x <= collideVehicle->x)
             {
                 return false;
             }
         }
-        else if (sprite_direction == 8)
+        else if (SpriteData.sprite_direction == 8)
         {
             if (y >= collideVehicle->y)
             {
                 return false;
             }
         }
-        else if (sprite_direction == 16)
+        else if (SpriteData.sprite_direction == 16)
         {
             if (x >= collideVehicle->x)
             {
                 return false;
             }
         }
-        else if (sprite_direction == 24)
+        else if (SpriteData.sprite_direction == 24)
         {
             if (y <= collideVehicle->y)
             {
@@ -7719,7 +7721,7 @@ Loc6DAEB9:
         // Loc6DB8A5
         remaining_distance -= SubpositionTranslationDistances[remainingDistanceFlags];
         _vehicleCurPosition = nextVehiclePosition;
-        sprite_direction = moveInfo->direction;
+        SpriteData.sprite_direction = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
         Pitch = moveInfo->Pitch;
 
@@ -8031,7 +8033,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             remaining_distance += SubpositionTranslationDistances[remainingDistanceFlags];
 
             _vehicleCurPosition = nextVehiclePosition;
-            sprite_direction = moveInfo->direction;
+            SpriteData.sprite_direction = moveInfo->direction;
             bank_rotation = moveInfo->bank_rotation;
             Pitch = moveInfo->Pitch;
             moveInfoVehicleSpriteType = moveInfo->Pitch;
@@ -8389,7 +8391,7 @@ Loc6DC743:
     }
 
     _vehicleCurPosition = trackPos;
-    sprite_direction = moveInfo->direction;
+    SpriteData.sprite_direction = moveInfo->direction;
     bank_rotation = moveInfo->bank_rotation;
     Pitch = moveInfo->Pitch;
 
@@ -8504,7 +8506,7 @@ Loc6DCC2C:
     }
 
     _vehicleCurPosition = trackPos;
-    sprite_direction = moveInfo->direction;
+    SpriteData.sprite_direction = moveInfo->direction;
     bank_rotation = moveInfo->bank_rotation;
     Pitch = moveInfo->Pitch;
 

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -6660,8 +6660,7 @@ static void AnimateSteamLocomotive(Vehicle& vehicle, const CarEntry& carEntry)
                     || (vehicle.status != Vehicle::Status::MovingToEndOfStation && vehicle.status != Vehicle::Status::Arriving))
                 {
                     CoordsXYZ steamOffset = ComputeSteamOffset(
-                        carEntry.SteamEffect.Vertical, carEntry.SteamEffect.Longitudinal, vehicle.Pitch,
-                        vehicle.Orientation);
+                        carEntry.SteamEffect.Vertical, carEntry.SteamEffect.Longitudinal, vehicle.Pitch, vehicle.Orientation);
                     SteamParticle::Create(CoordsXYZ(vehicle.x, vehicle.y, vehicle.z) + steamOffset);
                 }
             }

--- a/src/openrct2/ride/Vehicle.cpp
+++ b/src/openrct2/ride/Vehicle.cpp
@@ -2995,12 +2995,12 @@ bool Vehicle::CurrentTowerElementIsTop()
  */
 void Vehicle::UpdateTravellingBoatHireSetup()
 {
-    var_34 = SpriteData.Direction;
+    var_34 = Orientation;
     TrackLocation.x = x;
     TrackLocation.y = y;
     TrackLocation = TrackLocation.ToTileStart();
 
-    CoordsXY location = CoordsXY(TrackLocation) + CoordsDirectionDelta[SpriteData.Direction >> 3];
+    CoordsXY location = CoordsXY(TrackLocation) + CoordsDirectionDelta[Orientation >> 3];
 
     BoatLocation = location;
     var_35 = 0;
@@ -3505,8 +3505,8 @@ void Vehicle::UpdateCrashSetup()
         lastVehicle = trainVehicle;
 
         trainVehicle->sub_state = 0;
-        int32_t trainX = stru_9A3AC4[trainVehicle->SpriteData.Direction / 2].x;
-        int32_t trainY = stru_9A3AC4[trainVehicle->SpriteData.Direction / 2].y;
+        int32_t trainX = stru_9A3AC4[trainVehicle->Orientation / 2].x;
+        int32_t trainY = stru_9A3AC4[trainVehicle->Orientation / 2].y;
         auto trainZ = Unk9A38D4[trainVehicle->Pitch] >> 23;
 
         int32_t ecx = Unk9A37E4[trainVehicle->Pitch] >> 15;
@@ -4303,7 +4303,7 @@ void Vehicle::UpdateMotionBoatHire()
 
             if (!(var_35 & (1 << 0)))
             {
-                uint8_t spriteDirection = SpriteData.Direction;
+                uint8_t spriteDirection = Orientation;
                 if (spriteDirection != var_34)
                 {
                     uint8_t dl = (var_34 + 16 - spriteDirection) & 0x1E;
@@ -4324,20 +4324,20 @@ void Vehicle::UpdateMotionBoatHire()
                         }
                     }
 
-                    SpriteData.Direction = spriteDirection & 0x1E;
+                    Orientation = spriteDirection & 0x1E;
                 }
             }
 
-            int32_t edi = (SpriteData.Direction | (var_35 & 1)) & 0x1F;
+            int32_t edi = (Orientation | (var_35 & 1)) & 0x1F;
             loc2 = { x + Unk9A36C4[edi].x, y + Unk9A36C4[edi].y };
             if (UpdateMotionCollisionDetection({ loc2, z }, nullptr))
             {
                 remaining_distance = 0;
-                if (SpriteData.Direction == var_34)
+                if (Orientation == var_34)
                 {
-                    SpriteData.Direction ^= (1 << 4);
+                    Orientation ^= (1 << 4);
                     UpdateBoatLocation();
-                    SpriteData.Direction ^= (1 << 4);
+                    Orientation ^= (1 << 4);
                 }
                 break;
             }
@@ -4370,7 +4370,7 @@ void Vehicle::UpdateMotionBoatHire()
                     if (do_Loc6DAA97)
                     {
                         remaining_distance = 0;
-                        if (SpriteData.Direction == var_34)
+                        if (Orientation == var_34)
                         {
                             UpdateBoatLocation();
                         }
@@ -4496,7 +4496,7 @@ void Vehicle::UpdateBoatLocation()
     }
 
     sub_state = 0;
-    uint8_t curDirection = ((SpriteData.Direction + 19) >> 3) & 3;
+    uint8_t curDirection = ((Orientation + 19) >> 3) & 3;
     uint8_t randDirection = ScenarioRand() & 3;
 
     if (lost_time_out > 1920)
@@ -5494,7 +5494,7 @@ void Vehicle::UpdateSound()
     sound2_volume = soundIdVolume.volume;
 
     // Calculate Sound Vector (used for sound frequency calcs)
-    int32_t soundDirection = SpriteDirectionToSoundDirection[SpriteData.Direction];
+    int32_t soundDirection = SpriteDirectionToSoundDirection[Orientation];
     int32_t soundVector = ((velocity >> 14) * soundDirection) >> 14;
     soundVector = std::clamp(soundVector, -127, 127);
 
@@ -5719,23 +5719,23 @@ int32_t Vehicle::UpdateMotionDodgems()
             if (var_34 > 0)
             {
                 var_34--;
-                SpriteData.Direction += 2;
+                Orientation += 2;
             }
             else
             {
                 var_34++;
-                SpriteData.Direction -= 2;
+                Orientation -= 2;
             }
-            SpriteData.Direction &= 0x1E;
+            Orientation &= 0x1E;
             Invalidate();
         }
         else if ((ScenarioRand() & 0xFFFF) <= 2849)
         {
             if (var_35 & (1 << 6))
-                SpriteData.Direction -= 2;
+                Orientation -= 2;
             else
-                SpriteData.Direction += 2;
-            SpriteData.Direction &= 0x1E;
+                Orientation += 2;
+            Orientation &= 0x1E;
             Invalidate();
         }
     }
@@ -5771,7 +5771,7 @@ int32_t Vehicle::UpdateMotionDodgems()
         while (true)
         {
             var_35++;
-            uint8_t direction = SpriteData.Direction;
+            uint8_t direction = Orientation;
             direction |= var_35 & 1;
 
             CoordsXY location = _vehicleCurPosition;
@@ -5798,7 +5798,7 @@ int32_t Vehicle::UpdateMotionDodgems()
             int32_t oldVelocity = velocity;
             remaining_distance = 0;
             velocity = 0;
-            uint8_t direction = SpriteData.Direction | 1;
+            uint8_t direction = Orientation | 1;
 
             Vehicle* collideVehicle = GetEntity<Vehicle>(collideSprite.value());
             if (collideVehicle != nullptr)
@@ -6661,7 +6661,7 @@ static void AnimateSteamLocomotive(Vehicle& vehicle, const CarEntry& carEntry)
                 {
                     CoordsXYZ steamOffset = ComputeSteamOffset(
                         carEntry.SteamEffect.Vertical, carEntry.SteamEffect.Longitudinal, vehicle.Pitch,
-                        vehicle.SpriteData.Direction);
+                        vehicle.Orientation);
                     SteamParticle::Create(CoordsXYZ(vehicle.x, vehicle.y, vehicle.z) + steamOffset);
                 }
             }
@@ -7116,7 +7116,7 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
         if (x_diff + y_diff + z_diff >= ecx)
             return false;
 
-        uint8_t direction = (SpriteData.Direction - collideVehicle->SpriteData.Direction + 7) & 0x1F;
+        uint8_t direction = (Orientation - collideVehicle->Orientation + 7) & 0x1F;
         return direction < 0xF;
     }
 
@@ -7177,12 +7177,12 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
                 break;
             }
 
-            uint8_t direction = (SpriteData.Direction - vehicle2->SpriteData.Direction - 6) & 0x1F;
+            uint8_t direction = (Orientation - vehicle2->Orientation - 6) & 0x1F;
 
             if (direction < 0x14)
                 continue;
 
-            uint32_t offsetSpriteDirection = (SpriteData.Direction + 4) & 31;
+            uint32_t offsetSpriteDirection = (Orientation + 4) & 31;
             uint32_t offsetDirection = offsetSpriteDirection >> 3;
             uint32_t next_x_diff = abs(loc.x + AvoidCollisionMoveOffset[offsetDirection].x - vehicle2->x);
             uint32_t next_y_diff = abs(loc.y + AvoidCollisionMoveOffset[offsetDirection].y - vehicle2->y);
@@ -7219,28 +7219,28 @@ bool Vehicle::UpdateMotionCollisionDetection(const CoordsXYZ& loc, EntityId* oth
 
     if (status == Vehicle::Status::MovingToEndOfStation)
     {
-        if (SpriteData.Direction == 0)
+        if (Orientation == 0)
         {
             if (x <= collideVehicle->x)
             {
                 return false;
             }
         }
-        else if (SpriteData.Direction == 8)
+        else if (Orientation == 8)
         {
             if (y >= collideVehicle->y)
             {
                 return false;
             }
         }
-        else if (SpriteData.Direction == 16)
+        else if (Orientation == 16)
         {
             if (x >= collideVehicle->x)
             {
                 return false;
             }
         }
-        else if (SpriteData.Direction == 24)
+        else if (Orientation == 24)
         {
             if (y <= collideVehicle->y)
             {
@@ -7721,7 +7721,7 @@ Loc6DAEB9:
         // Loc6DB8A5
         remaining_distance -= SubpositionTranslationDistances[remainingDistanceFlags];
         _vehicleCurPosition = nextVehiclePosition;
-        SpriteData.Direction = moveInfo->direction;
+        Orientation = moveInfo->direction;
         bank_rotation = moveInfo->bank_rotation;
         Pitch = moveInfo->Pitch;
 
@@ -8033,7 +8033,7 @@ bool Vehicle::UpdateTrackMotionBackwards(const CarEntry* carEntry, const Ride& c
             remaining_distance += SubpositionTranslationDistances[remainingDistanceFlags];
 
             _vehicleCurPosition = nextVehiclePosition;
-            SpriteData.Direction = moveInfo->direction;
+            Orientation = moveInfo->direction;
             bank_rotation = moveInfo->bank_rotation;
             Pitch = moveInfo->Pitch;
             moveInfoVehicleSpriteType = moveInfo->Pitch;
@@ -8391,7 +8391,7 @@ Loc6DC743:
     }
 
     _vehicleCurPosition = trackPos;
-    SpriteData.Direction = moveInfo->direction;
+    Orientation = moveInfo->direction;
     bank_rotation = moveInfo->bank_rotation;
     Pitch = moveInfo->Pitch;
 
@@ -8506,7 +8506,7 @@ Loc6DCC2C:
     }
 
     _vehicleCurPosition = trackPos;
-    SpriteData.Direction = moveInfo->direction;
+    Orientation = moveInfo->direction;
     bank_rotation = moveInfo->bank_rotation;
     Pitch = moveInfo->Pitch;
 

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -3763,7 +3763,7 @@ static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0 + ((((vehicle->SpriteData.Direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0 + ((((vehicle->Orientation / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
@@ -3774,7 +3774,7 @@ static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, cons
  */
 static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
-    if (vehicle->SpriteData.Direction & 7)
+    if (vehicle->Orientation & 7)
     {
         return;
     }
@@ -3786,7 +3786,7 @@ static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_3_NE_0 + ((((vehicle->SpriteData.Direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_3_NE_0 + ((((vehicle->Orientation / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
@@ -3797,7 +3797,7 @@ static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, cons
  */
 static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
-    if (vehicle->SpriteData.Direction & 7)
+    if (vehicle->Orientation & 7)
     {
         return;
     }
@@ -3809,7 +3809,7 @@ static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0 + ((((vehicle->SpriteData.Direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0 + ((((vehicle->Orientation / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
@@ -3829,7 +3829,7 @@ static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle->SpriteData.Direction & 7)
+    if (vehicle->Orientation & 7)
     {
         return;
     }
@@ -3837,7 +3837,7 @@ static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0 + ((((vehicle->SpriteData.Direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0 + ((((vehicle->Orientation / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 1, 1, 0 } });
 }
@@ -3857,7 +3857,7 @@ static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle->SpriteData.Direction & 7)
+    if (vehicle->Orientation & 7)
     {
         return;
     }
@@ -3869,7 +3869,7 @@ static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0 + ((((vehicle->SpriteData.Direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0 + ((((vehicle->Orientation / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 1, 1, 0 } });
 }

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -3763,7 +3763,8 @@ static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0 + ((((vehicle->sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0
+        + ((((vehicle->SpriteData.sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
@@ -3774,7 +3775,7 @@ static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, cons
  */
 static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
-    if (vehicle->sprite_direction & 7)
+    if (vehicle->SpriteData.sprite_direction & 7)
     {
         return;
     }
@@ -3786,7 +3787,8 @@ static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_3_NE_0 + ((((vehicle->sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_3_NE_0
+        + ((((vehicle->SpriteData.sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
@@ -3797,7 +3799,7 @@ static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, cons
  */
 static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
-    if (vehicle->sprite_direction & 7)
+    if (vehicle->SpriteData.sprite_direction & 7)
     {
         return;
     }
@@ -3809,7 +3811,8 @@ static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0 + ((((vehicle->sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0
+        + ((((vehicle->SpriteData.sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
@@ -3829,7 +3832,7 @@ static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle->sprite_direction & 7)
+    if (vehicle->SpriteData.sprite_direction & 7)
     {
         return;
     }
@@ -3837,7 +3840,8 @@ static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0 + ((((vehicle->sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0
+        + ((((vehicle->SpriteData.sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 1, 1, 0 } });
 }
@@ -3857,7 +3861,7 @@ static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle->sprite_direction & 7)
+    if (vehicle->SpriteData.sprite_direction & 7)
     {
         return;
     }
@@ -3869,7 +3873,8 @@ static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0 + ((((vehicle->sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0
+        + ((((vehicle->SpriteData.sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 1, 1, 0 } });
 }

--- a/src/openrct2/ride/VehiclePaint.cpp
+++ b/src/openrct2/ride/VehiclePaint.cpp
@@ -3763,8 +3763,7 @@ static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0
-        + ((((vehicle->SpriteData.sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0 + ((((vehicle->SpriteData.Direction / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
@@ -3775,7 +3774,7 @@ static void vehicle_visual_splash1_effect(PaintSession& session, int32_t z, cons
  */
 static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
-    if (vehicle->SpriteData.sprite_direction & 7)
+    if (vehicle->SpriteData.Direction & 7)
     {
         return;
     }
@@ -3787,8 +3786,7 @@ static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_3_NE_0
-        + ((((vehicle->SpriteData.sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_3_NE_0 + ((((vehicle->SpriteData.Direction / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
@@ -3799,7 +3797,7 @@ static void vehicle_visual_splash2_effect(PaintSession& session, int32_t z, cons
  */
 static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, const Vehicle* vehicle)
 {
-    if (vehicle->SpriteData.sprite_direction & 7)
+    if (vehicle->SpriteData.Direction & 7)
     {
         return;
     }
@@ -3811,8 +3809,7 @@ static void vehicle_visual_splash3_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0
-        + ((((vehicle->SpriteData.sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_1_NE_0 + ((((vehicle->SpriteData.Direction / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 0, 0, 0 } });
 }
@@ -3832,7 +3829,7 @@ static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle->SpriteData.sprite_direction & 7)
+    if (vehicle->SpriteData.Direction & 7)
     {
         return;
     }
@@ -3840,8 +3837,7 @@ static void vehicle_visual_splash4_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0
-        + ((((vehicle->SpriteData.sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0 + ((((vehicle->SpriteData.Direction / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 1, 1, 0 } });
 }
@@ -3861,7 +3857,7 @@ static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    if (vehicle->SpriteData.sprite_direction & 7)
+    if (vehicle->SpriteData.Direction & 7)
     {
         return;
     }
@@ -3873,8 +3869,7 @@ static void vehicle_visual_splash5_effect(PaintSession& session, int32_t z, cons
     {
         return;
     }
-    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0
-        + ((((vehicle->SpriteData.sprite_direction / 8) + session.CurrentRotation) & 3) * 8)
+    int32_t image_id = SPR_SPLASH_EFFECT_5_NE_0 + ((((vehicle->SpriteData.Direction / 8) + session.CurrentRotation) & 3) * 8)
         + ((gCurrentTicks / 2) & 7);
     PaintAddImageAsChild(session, ImageId(image_id), { 0, 0, z }, { { 0, 0, z }, { 1, 1, 0 } });
 }

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -75,7 +75,7 @@ static void PaintCarousel(
     auto rotationOffset = 0;
     if (vehicle != nullptr)
     {
-        auto rotation = ((vehicle->SpriteData.sprite_direction >> 3) + session.CurrentRotation) << 5;
+        auto rotation = ((vehicle->SpriteData.Direction >> 3) + session.CurrentRotation) << 5;
         rotationOffset = (vehicle->Pitch + rotation) % 128;
     }
 

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -75,7 +75,7 @@ static void PaintCarousel(
     auto rotationOffset = 0;
     if (vehicle != nullptr)
     {
-        auto rotation = ((vehicle->SpriteData.Direction >> 3) + session.CurrentRotation) << 5;
+        auto rotation = ((vehicle->Orientation >> 3) + session.CurrentRotation) << 5;
         rotationOffset = (vehicle->Pitch + rotation) % 128;
     }
 

--- a/src/openrct2/ride/gentle/MerryGoRound.cpp
+++ b/src/openrct2/ride/gentle/MerryGoRound.cpp
@@ -75,7 +75,7 @@ static void PaintCarousel(
     auto rotationOffset = 0;
     if (vehicle != nullptr)
     {
-        auto rotation = ((vehicle->sprite_direction >> 3) + session.CurrentRotation) << 5;
+        auto rotation = ((vehicle->SpriteData.sprite_direction >> 3) + session.CurrentRotation) << 5;
         rotationOffset = (vehicle->Pitch + rotation) % 128;
     }
 

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -66,7 +66,7 @@ static void PaintEnterpriseStructure(
     uint32_t imageOffset = trackElement.GetDirectionWithOffset(session.CurrentRotation);
     if (vehicle != nullptr)
     {
-        imageOffset = (vehicle->Pitch << 2) + (((vehicle->SpriteData.Direction >> 3) + session.CurrentRotation) % 4);
+        imageOffset = (vehicle->Pitch << 2) + (((vehicle->Orientation >> 3) + session.CurrentRotation) % 4);
     }
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -66,7 +66,7 @@ static void PaintEnterpriseStructure(
     uint32_t imageOffset = trackElement.GetDirectionWithOffset(session.CurrentRotation);
     if (vehicle != nullptr)
     {
-        imageOffset = (vehicle->Pitch << 2) + (((vehicle->sprite_direction >> 3) + session.CurrentRotation) % 4);
+        imageOffset = (vehicle->Pitch << 2) + (((vehicle->SpriteData.sprite_direction >> 3) + session.CurrentRotation) % 4);
     }
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);

--- a/src/openrct2/ride/thrill/Enterprise.cpp
+++ b/src/openrct2/ride/thrill/Enterprise.cpp
@@ -66,7 +66,7 @@ static void PaintEnterpriseStructure(
     uint32_t imageOffset = trackElement.GetDirectionWithOffset(session.CurrentRotation);
     if (vehicle != nullptr)
     {
-        imageOffset = (vehicle->Pitch << 2) + (((vehicle->SpriteData.sprite_direction >> 3) + session.CurrentRotation) % 4);
+        imageOffset = (vehicle->Pitch << 2) + (((vehicle->SpriteData.Direction >> 3) + session.CurrentRotation) % 4);
     }
 
     auto imageTemplate = ImageId(0, ride.vehicle_colours[0].Body, ride.vehicle_colours[0].Trim);

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -44,7 +44,7 @@ static void PaintTwistStructure(
     uint32_t frameNum = (direction * 88) % 216;
     if (vehicle != nullptr)
     {
-        frameNum += (vehicle->sprite_direction >> 3) << 4;
+        frameNum += (vehicle->SpriteData.sprite_direction >> 3) << 4;
         frameNum += vehicle->Pitch;
         frameNum = frameNum % 216;
     }

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -44,7 +44,7 @@ static void PaintTwistStructure(
     uint32_t frameNum = (direction * 88) % 216;
     if (vehicle != nullptr)
     {
-        frameNum += (vehicle->SpriteData.Direction >> 3) << 4;
+        frameNum += (vehicle->Orientation >> 3) << 4;
         frameNum += vehicle->Pitch;
         frameNum = frameNum % 216;
     }

--- a/src/openrct2/ride/thrill/Twist.cpp
+++ b/src/openrct2/ride/thrill/Twist.cpp
@@ -44,7 +44,7 @@ static void PaintTwistStructure(
     uint32_t frameNum = (direction * 88) % 216;
     if (vehicle != nullptr)
     {
-        frameNum += (vehicle->SpriteData.sprite_direction >> 3) << 4;
+        frameNum += (vehicle->SpriteData.Direction >> 3) << 4;
         frameNum += vehicle->Pitch;
         frameNum = frameNum % 216;
     }

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -1259,7 +1259,7 @@ void VehicleVisualSplashBoatsOrWaterCoaster(
 
     session.CurrentlyDrawnEntity = vehicleToPaint;
     imageDirection = OpenRCT2::Entity::Yaw::Add(
-        OpenRCT2::Entity::Yaw::YawFrom4(session.CurrentRotation), vehicleToPaint->sprite_direction);
+        OpenRCT2::Entity::Yaw::YawFrom4(session.CurrentRotation), vehicleToPaint->SpriteData.sprite_direction);
     session.SpritePosition.x = vehicleToPaint->x;
     session.SpritePosition.y = vehicleToPaint->y;
     vehicleToPaint->Paint(session, imageDirection);

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -1259,7 +1259,7 @@ void VehicleVisualSplashBoatsOrWaterCoaster(
 
     session.CurrentlyDrawnEntity = vehicleToPaint;
     imageDirection = OpenRCT2::Entity::Yaw::Add(
-        OpenRCT2::Entity::Yaw::YawFrom4(session.CurrentRotation), vehicleToPaint->SpriteData.Direction);
+        OpenRCT2::Entity::Yaw::YawFrom4(session.CurrentRotation), vehicleToPaint->Orientation);
     session.SpritePosition.x = vehicleToPaint->x;
     session.SpritePosition.y = vehicleToPaint->y;
     vehicleToPaint->Paint(session, imageDirection);

--- a/src/openrct2/ride/water/SplashBoats.cpp
+++ b/src/openrct2/ride/water/SplashBoats.cpp
@@ -1259,7 +1259,7 @@ void VehicleVisualSplashBoatsOrWaterCoaster(
 
     session.CurrentlyDrawnEntity = vehicleToPaint;
     imageDirection = OpenRCT2::Entity::Yaw::Add(
-        OpenRCT2::Entity::Yaw::YawFrom4(session.CurrentRotation), vehicleToPaint->SpriteData.sprite_direction);
+        OpenRCT2::Entity::Yaw::YawFrom4(session.CurrentRotation), vehicleToPaint->SpriteData.Direction);
     session.SpritePosition.x = vehicleToPaint->x;
     session.SpritePosition.y = vehicleToPaint->y;
     vehicleToPaint->Paint(session, imageDirection);

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -710,7 +710,7 @@ Guest* Park::GenerateGuest()
         peep = Guest::Generate({ spawn->x, spawn->y, spawn->z });
         if (peep != nullptr)
         {
-            peep->SpriteData.sprite_direction = direction << 3;
+            peep->SpriteData.Direction = direction << 3;
 
             auto destination = peep->GetLocation().ToTileCentre();
             peep->SetDestination(destination, 5);

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -710,7 +710,7 @@ Guest* Park::GenerateGuest()
         peep = Guest::Generate({ spawn->x, spawn->y, spawn->z });
         if (peep != nullptr)
         {
-            peep->SpriteData.Direction = direction << 3;
+            peep->Orientation = direction << 3;
 
             auto destination = peep->GetLocation().ToTileCentre();
             peep->SetDestination(destination, 5);

--- a/src/openrct2/world/Park.cpp
+++ b/src/openrct2/world/Park.cpp
@@ -710,7 +710,7 @@ Guest* Park::GenerateGuest()
         peep = Guest::Generate({ spawn->x, spawn->y, spawn->z });
         if (peep != nullptr)
         {
-            peep->sprite_direction = direction << 3;
+            peep->SpriteData.sprite_direction = direction << 3;
 
             auto destination = peep->GetLocation().ToTileCentre();
             peep->SetDestination(destination, 5);


### PR DESCRIPTION
Also cleanup the variable names, I had to use Orientation instead of Direction as the coding style will have a name clash on the type and adding `::` infront of it is just ugly and would add more changes, Orientation also makes a bit more sense for entities or Rotation if you will, Direction would mean the vector its facing towards.