### PR TITLE
Store SurfaceElement directly in PaintSessionCore

### DIFF
--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -22,6 +22,7 @@
 
 struct EntityBase;
 struct TileElement;
+struct SurfaceElement;
 enum class RailingEntrySupportType : uint8_t;
 enum class ViewportInteractionItem : uint8_t;
 
@@ -187,7 +188,7 @@ struct PaintSessionCore
     PaintStringStruct* PSStringHead;
     PaintStringStruct* LastPSString;
     AttachedPaintStruct* LastAttachedPS;
-    const TileElement* SurfaceElement;
+    const SurfaceElement* Surface;
     EntityBase* CurrentlyDrawnEntity;
     TileElement* CurrentlyDrawnTileElement;
     const TileElement* PathElementOnSameHeight;

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -167,7 +167,7 @@ PaintSession* Painter::CreateSession(DrawPixelInfo* dpi, uint32_t viewFlags)
     session->WoodenSupportsPrependTo = nullptr;
     session->CurrentlyDrawnEntity = nullptr;
     session->CurrentlyDrawnTileElement = nullptr;
-    session->SurfaceElement = nullptr;
+    session->Surface = nullptr;
 
     return session;
 }

--- a/src/openrct2/paint/tile_element/Paint.Surface.cpp
+++ b/src/openrct2/paint/tile_element/Paint.Surface.cpp
@@ -1026,7 +1026,7 @@ void PaintSurface(PaintSession& session, uint8_t direction, uint16_t height, con
     DrawPixelInfo* dpi = &session.DPI;
     session.InteractionType = ViewportInteractionItem::Terrain;
     session.Flags |= PaintSessionFlags::PassedSurface;
-    session.SurfaceElement = reinterpret_cast<const TileElement*>(&tileElement);
+    session.Surface = &tileElement;
 
     const auto zoomLevel = dpi->zoom_level;
     const uint8_t rotation = session.CurrentRotation;

--- a/src/openrct2/ride/gentle/MiniGolf.cpp
+++ b/src/openrct2/ride/gentle/MiniGolf.cpp
@@ -452,13 +452,13 @@ static bool MiniGolfPaintUtilShouldDrawFence(PaintSession& session, const TrackE
         return false;
     }
 
-    const TileElement* surfaceElement = session.SurfaceElement;
+    const SurfaceElement* surfaceElement = session.Surface;
     if (surfaceElement->BaseHeight != trackElement.BaseHeight)
     {
         return true;
     }
 
-    if (surfaceElement->AsSurface()->GetSlope() != TILE_ELEMENT_SLOPE_FLAT)
+    if (surfaceElement->GetSlope() != TILE_ELEMENT_SLOPE_FLAT)
     {
         return true;
     }


### PR DESCRIPTION
This removes the `reinterpret_cast` and the call to `AsSurface()`.