### PR TITLE
Enhancement: Add option to use only base game colors

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3679,6 +3679,8 @@ STR_6573    :Invisible
 STR_6574    :Void
 STR_6575    :Allow special colour schemes
 STR_6576    :Adds special colours to colour dropdown
+STR_6577    :Only show base game colours
+STR_6578    :Only show base RCT2 colours in colour dropdown
 
 #############
 # Scenarios #

--- a/src/openrct2-ui/input/MouseInput.cpp
+++ b/src/openrct2-ui/input/MouseInput.cpp
@@ -94,6 +94,7 @@ static void InputScrollPartUpdateVThumb(WindowBase& w, WidgetIndex widgetIndex, 
 static void InputScrollPartUpdateVTop(WindowBase& w, WidgetIndex widgetIndex, int32_t scroll_id);
 static void InputScrollPartUpdateVBottom(WindowBase& w, WidgetIndex widgetIndex, int32_t scroll_id);
 static void InputUpdateTooltip(WindowBase* w, WidgetIndex widgetIndex, const ScreenCoordsXY& screenCoords);
+uint8_t GetColourFromDropdown(uint8_t dropdownIndex);
 
 #pragma region Mouse input
 
@@ -1341,9 +1342,12 @@ void InputStateWidgetPressed(
                                 dropdown_index = gDropdownDefaultIndex;
                             }
                         }
+                        if (gDropdownIsColour)
+                        {
+                            dropdown_index = GetColourFromDropdown(dropdown_index);
+                        }
                         WindowEventDropdownCall(
-                            cursor_w, cursor_widgetIndex,
-                            (gDropdownIsColour) ? ColourToPaletteIndex(dropdown_index) : dropdown_index);
+                            cursor_w, cursor_widgetIndex, dropdown_index);
                     }
                 }
             }
@@ -1472,7 +1476,7 @@ void InputStateWidgetPressed(
                 STR_COLOUR_INVISIBLE_TIP,
                 STR_COLOUR_VOID_TIP,
             };
-            WindowTooltipShow(OpenRCT2String{ _colourTooltips[ColourToPaletteIndex(dropdown_index)], {} }, screenCoords);
+            WindowTooltipShow(OpenRCT2String{ _colourTooltips[GetColourFromDropdown(dropdown_index)], {} }, screenCoords);
         }
 
         if (dropdown_index < Dropdown::ItemsMaxSize && Dropdown::IsDisabled(dropdown_index))
@@ -1492,6 +1496,26 @@ void InputStateWidgetPressed(
     {
         gDropdownLastColourHover = -1;
         WindowTooltipClose();
+    }
+}
+
+uint8_t GetColourFromDropdown(uint8_t dropdownIndex)
+{
+    if (gConfigGeneral.ShowOnlyBaseGameColours)
+    {
+        if (dropdownIndex < COLOUR_NUM_ORIGINAL)
+        {
+            // Non cheat colour
+            return dropdownIndex;
+        }
+        else
+        {
+            return ColourToPaletteIndex(dropdownIndex + (COLOUR_NUM_NORMAL - COLOUR_NUM_ORIGINAL));
+        }
+    }
+    else
+    {
+        return ColourToPaletteIndex(dropdownIndex);
     }
 }
 

--- a/src/openrct2-ui/windows/Options.cpp
+++ b/src/openrct2-ui/windows/Options.cpp
@@ -190,6 +190,7 @@ enum WindowOptionsWidgetIdx {
     WIDX_REAL_NAME_CHECKBOX,
     WIDX_AUTO_STAFF_PLACEMENT,
     WIDX_AUTO_OPEN_SHOPS,
+    WIDX_SHOW_ONLY_BASE_GAME_COLOURS,
     WIDX_DEFAULT_INSPECTION_INTERVAL_LABEL,
     WIDX_DEFAULT_INSPECTION_INTERVAL,
     WIDX_DEFAULT_INSPECTION_INTERVAL_DROPDOWN,
@@ -365,13 +366,14 @@ static Widget window_options_misc_widgets[] = {
     MakeWidget({ 5,  SCENARIO_OPTIONS_START + 0}, {300, 35}, WindowWidgetType::Groupbox, WindowColour::Secondary, STR_SCENARIO_OPTIONS                                ),
     MakeWidget({10, SCENARIO_OPTIONS_START + 15}, {290, 15}, WindowWidgetType::Checkbox, WindowColour::Tertiary , STR_ALLOW_EARLY_COMPLETION, STR_EARLY_COMPLETION_TIP), // Allow early scenario completion
 
-    MakeWidget({  5,  TWEAKS_START + 0}, {300, 81}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_OPTIONS_TWEAKS                                                  ),
+    MakeWidget({  5,  TWEAKS_START + 0}, {300, 96}, WindowWidgetType::Groupbox,     WindowColour::Secondary, STR_OPTIONS_TWEAKS                                                  ),
     MakeWidget({ 10, TWEAKS_START + 15}, {290, 15}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_REAL_NAME,            STR_REAL_NAME_TIP                         ), // Show 'real' names of guests
     MakeWidget({ 10, TWEAKS_START + 30}, {290, 15}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_AUTO_STAFF_PLACEMENT, STR_AUTO_STAFF_PLACEMENT_TIP              ), // Auto staff placement
     MakeWidget({ 10, TWEAKS_START + 45}, {290, 15}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_AUTO_OPEN_SHOPS,      STR_AUTO_OPEN_SHOPS_TIP                   ), // Automatically open shops & stalls
-    MakeWidget({ 10, TWEAKS_START + 62}, {165, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DEFAULT_INSPECTION_INTERVAL, STR_DEFAULT_INSPECTION_INTERVAL_TIP),
-    MakeWidget({175, TWEAKS_START + 61}, {125, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                      ), // Default inspection time dropdown
-    MakeWidget({288, TWEAKS_START + 62}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,       STR_DEFAULT_INSPECTION_INTERVAL_TIP       ), // Default inspection time dropdown button
+    MakeWidget({ 10, TWEAKS_START + 60}, {290, 15}, WindowWidgetType::Checkbox,     WindowColour::Tertiary , STR_SHOW_ONLY_BASE_GAME_COLOURS, STR_SHOW_ONLY_BASE_GAME_COLOURS_TIP), // Only use base RCT2 colors in dropdown
+    MakeWidget({ 10, TWEAKS_START + 77}, {165, 12}, WindowWidgetType::Label,        WindowColour::Secondary, STR_DEFAULT_INSPECTION_INTERVAL, STR_DEFAULT_INSPECTION_INTERVAL_TIP),
+    MakeWidget({175, TWEAKS_START + 76}, {125, 12}, WindowWidgetType::DropdownMenu, WindowColour::Secondary                                                                      ), // Default inspection time dropdown
+    MakeWidget({288, TWEAKS_START + 77}, { 11, 10}, WindowWidgetType::Button,       WindowColour::Secondary, STR_DROPDOWN_GLYPH,       STR_DEFAULT_INSPECTION_INTERVAL_TIP       ), // Default inspection time dropdown button
     WIDGETS_END,
 };
 
@@ -1689,6 +1691,11 @@ private:
                 ConfigSaveDefault();
                 Invalidate();
                 break;
+            case WIDX_SHOW_ONLY_BASE_GAME_COLOURS:
+                gConfigGeneral.ShowOnlyBaseGameColours ^= 1;
+                ConfigSaveDefault();
+                Invalidate();
+                break;
             case WIDX_ALLOW_EARLY_COMPLETION:
                 gConfigGeneral.AllowEarlyCompletion ^= 1;
                 // Only the server can control this setting and needs to send the
@@ -1840,6 +1847,7 @@ private:
         SetCheckboxValue(WIDX_REAL_NAME_CHECKBOX, gConfigGeneral.ShowRealNamesOfGuests);
         SetCheckboxValue(WIDX_AUTO_STAFF_PLACEMENT, gConfigGeneral.AutoStaffPlacement);
         SetCheckboxValue(WIDX_AUTO_OPEN_SHOPS, gConfigGeneral.AutoOpenShops);
+        SetCheckboxValue(WIDX_SHOW_ONLY_BASE_GAME_COLOURS, gConfigGeneral.ShowOnlyBaseGameColours);
         SetCheckboxValue(WIDX_ALLOW_EARLY_COMPLETION, gConfigGeneral.AllowEarlyCompletion);
 
         if (gConfigGeneral.ScenarioSelectMode == SCENARIO_SELECT_MODE_DIFFICULTY)

--- a/src/openrct2/config/Config.cpp
+++ b/src/openrct2/config/Config.cpp
@@ -198,6 +198,7 @@ namespace Config
             model->MultiThreading = reader->GetBoolean("multi_threading", false);
             model->TrapCursor = reader->GetBoolean("trap_cursor", false);
             model->AutoOpenShops = reader->GetBoolean("auto_open_shops", false);
+            model->ShowOnlyBaseGameColours = reader->GetBoolean("show_only_base_game_colours", false);
             model->ScenarioSelectMode = reader->GetInt32("scenario_select_mode", SCENARIO_SELECT_MODE_ORIGIN);
             model->ScenarioUnlockingEnabled = reader->GetBoolean("scenario_unlocking_enabled", true);
             model->ScenarioHideMegaPark = reader->GetBoolean("scenario_hide_mega_park", true);
@@ -283,6 +284,7 @@ namespace Config
         writer->WriteBoolean("multi_threading", model->MultiThreading);
         writer->WriteBoolean("trap_cursor", model->TrapCursor);
         writer->WriteBoolean("auto_open_shops", model->AutoOpenShops);
+        writer->WriteBoolean("show_only_base_game_colours", model->ShowOnlyBaseGameColours);
         writer->WriteInt32("scenario_select_mode", model->ScenarioSelectMode);
         writer->WriteBoolean("scenario_unlocking_enabled", model->ScenarioUnlockingEnabled);
         writer->WriteBoolean("scenario_hide_mega_park", model->ScenarioHideMegaPark);

--- a/src/openrct2/config/Config.h
+++ b/src/openrct2/config/Config.h
@@ -96,6 +96,7 @@ struct GeneralConfiguration
     bool AutoStaffPlacement;
     bool HandymenMowByDefault;
     bool AutoOpenShops;
+    bool ShowOnlyBaseGameColours;
     int32_t DefaultInspectionInterval;
     int32_t WindowLimit;
     int32_t ScenarioSelectMode;

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3976,6 +3976,8 @@ enum : uint16_t
     STR_COLOUR_VOID_TIP = 6574,
     STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES = 6575,
     STR_CHEAT_ALLOW_SPECIAL_COLOUR_SCHEMES_TIP = 6576,
+    STR_SHOW_ONLY_BASE_GAME_COLOURS = 6577,
+    STR_SHOW_ONLY_BASE_GAME_COLOURS_TIP = 6577,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings


### PR DESCRIPTION
This feature was a common request on the NE discord.

This PR adds a new miscellaneous option, "Only show base game colours". With this enabled, the color dropdown will only show the original 32 colors, in the original order. If the "Allow special colour schemes" cheat is enabled, those will also be shown.