### PR TITLE
Fix #19733: Favorite ride of X guests integer overflow

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -1220,8 +1220,8 @@ STR_1838    :Satisfaction: {COMMA16}%
 STR_1839    :Reliability: {COMMA16}%
 STR_1840    :Down-time: {COMMA16}%
 STR_1841    :Profit: {CURRENCY2DP} per hour
-STR_1842    :Favourite of: {COMMA16} guest
-STR_1843    :Favourite of: {COMMA16} guests
+STR_1842    :Favourite of: {COMMA32} guest
+STR_1843    :Favourite of: {COMMA32} guests
 STR_1844    :Select information type to show in ride/attraction list
 STR_1845    :{MONTHYEAR}
 STR_1846    :{COMMA32} guests
@@ -2190,8 +2190,8 @@ STR_3118    :{BLACK}{STRINGID} is heading for the ride
 STR_3119    :{BLACK}{STRINGID} is fixing the ride
 STR_3120    :Locate nearest available mechanic, or mechanic fixing ride
 STR_3121    :Unable to locate mechanic, or all nearby mechanics are busy
-STR_3122    :{WINDOW_COLOUR_2}Favourite ride of: {BLACK}{COMMA16} guest
-STR_3123    :{WINDOW_COLOUR_2}Favourite ride of: {BLACK}{COMMA16} guests
+STR_3122    :{WINDOW_COLOUR_2}Favourite ride of: {BLACK}{COMMA32} guest
+STR_3123    :{WINDOW_COLOUR_2}Favourite ride of: {BLACK}{COMMA32} guests
 STR_3124    :Broken {STRINGID}
 STR_3125    :{WINDOW_COLOUR_2}Excitement Factor: {BLACK}+{COMMA16}%
 STR_3126    :{WINDOW_COLOUR_2}Intensity Factor: {BLACK}+{COMMA16}%

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Fix: [#19767] No message when path is not connected to ride exit and is therefore unreachable for mechanics.
 - Fix: [#19801] The in-game load/save window cannot be resized anymore.
 - Fix: [#19854] Looping Coaster trains clipping through steep quarter turns down.
+- Fix: [#19733] Favorite ride of X guests integer overflow
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,11 +10,11 @@
 - Fix: [#18895] Responding mechanic blocked at level crossing.
 - Fix: [#19231] Crash due to null pointer to previously deleted banner in tile copy/paste functionality
 - Fix: [#19296] Crash due to a race condition for parallel object loading.
+- Fix: [#19733] Favorite ride of X guests integer overflow
 - Fix: [#19756] Crash with title sequences containing no commands.
 - Fix: [#19767] No message when path is not connected to ride exit and is therefore unreachable for mechanics.
 - Fix: [#19801] The in-game load/save window cannot be resized anymore.
 - Fix: [#19854] Looping Coaster trains clipping through steep quarter turns down.
-- Fix: [#19733] Favorite ride of X guests integer overflow
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -7077,7 +7077,7 @@ static void WindowRideCustomerPaint(WindowBase* w, DrawPixelInfo* dpi)
     if (ride->IsRide())
     {
         ft = Formatter();
-        ft.Add<uint16_t>(ride->guests_favourite);
+        ft.Add<uint32_t>(ride->guests_favourite);
         stringId = ride->guests_favourite == 1 ? STR_FAVOURITE_RIDE_OF_GUEST : STR_FAVOURITE_RIDE_OF_GUESTS;
         DrawTextBasic(*dpi, screenCoords, stringId, ft);
         screenCoords.y += LIST_ROW_HEIGHT;

--- a/src/openrct2-ui/windows/RideList.cpp
+++ b/src/openrct2-ui/windows/RideList.cpp
@@ -688,7 +688,7 @@ public:
                     formatSecondary = 0;
                     if (ridePtr->IsRide())
                     {
-                        ft.Add<uint16_t>(ridePtr->guests_favourite);
+                        ft.Add<uint32_t>(ridePtr->guests_favourite);
                         formatSecondary = ridePtr->guests_favourite == 1 ? STR_GUESTS_FAVOURITE_LABEL
                                                                          : STR_GUESTS_FAVOURITE_PLURAL_LABEL;
                     }

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "7"
+#define NETWORK_STREAM_VERSION "8"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -9,10 +9,10 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 25;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 26;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t PARK_FILE_MIN_VERSION = 25;
+    constexpr uint32_t PARK_FILE_MIN_VERSION = 26;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!

--- a/src/openrct2/ride/Ride.h
+++ b/src/openrct2/ride/Ride.h
@@ -265,7 +265,7 @@ struct Ride
     uint16_t vehicle_change_timeout;
     uint8_t num_block_brakes;
     uint8_t lift_hill_speed;
-    uint16_t guests_favourite;
+    uint32_t guests_favourite;
     uint32_t lifecycle_flags;
     uint16_t total_air_time;
     StationIndex current_test_station;


### PR DESCRIPTION
Changed the variable for the number of guests favoring a ride to match the maximum number of guests able to be in a park.

This fixes #19733 