### PR TITLE
Fix #19906: Destructible cheat does not allow ride modification

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -218,6 +218,7 @@ The following people are not part of the development team, but have been contrib
 * Ernest Wong (ErnWong)
 * Joel H. (HtotheTML)
 * John Mulcahy (jayjay300)
+* Chase Percy (Chase-Percy)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -19,6 +19,7 @@
 - Fix: [#19801] The in-game load/save window cannot be resized anymore.
 - Fix: [#19854] Looping Coaster trains clipping through steep quarter turns down.
 - Fix: [#19901] Random shop colours never assigning last colour.
+- Fix: [#19924] Destructible cheat does not allow partial ride modification.
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/src/openrct2-ui/windows/Cheats.cpp
+++ b/src/openrct2-ui/windows/Cheats.cpp
@@ -157,7 +157,6 @@ enum WindowCheatsWidgetIdx
 
     WIDX_FIX_ALL = WIDX_TAB_CONTENT,
     WIDX_RENEW_RIDES,
-    WIDX_MAKE_DESTRUCTIBLE,
     WIDX_RESET_CRASH_STATUS,
     WIDX_10_MINUTE_INSPECTIONS,
     WIDX_CONSTRUCTION_GROUP,
@@ -165,6 +164,7 @@ enum WindowCheatsWidgetIdx
     WIDX_ENABLE_ALL_DRAWABLE_TRACK_PIECES,
     WIDX_ENABLE_CHAIN_LIFT_ON_ALL_TRACK,
     WIDX_ALLOW_TRACK_PLACE_INVALID_HEIGHTS,
+    WIDX_MAKE_DESTRUCTIBLE,
     WIDX_OPERATION_MODES_GROUP,
     WIDX_SHOW_ALL_OPERATING_MODES,
     WIDX_UNLOCK_OPERATING_LIMITS,
@@ -299,14 +299,14 @@ static Widget window_cheats_rides_widgets[] =
     MAIN_CHEATS_WIDGETS,
     MakeWidget({ 11,  48}, CHEAT_BUTTON, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHEAT_FIX_ALL_RIDES,                        STR_CHEAT_FIX_ALL_RIDES_TIP                    ), // Fix all rides
     MakeWidget({127,  48}, CHEAT_BUTTON, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHEAT_RENEW_RIDES,                          STR_CHEAT_RENEW_RIDES_TIP                      ), // Renew rides
-    MakeWidget({ 11,  69}, CHEAT_BUTTON, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHEAT_MAKE_DESTRUCTABLE,                    STR_CHEAT_MAKE_DESTRUCTABLE_TIP                ), // All destructible
     MakeWidget({127,  69}, CHEAT_BUTTON, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHEAT_RESET_CRASH_STATUS,                   STR_CHEAT_RESET_CRASH_STATUS_TIP               ), // Reset crash status
-    MakeWidget({ 11,  90}, CHEAT_BUTTON, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHEAT_10_MINUTE_INSPECTIONS,                STR_CHEAT_10_MINUTE_INSPECTIONS_TIP            ), // 10 minute inspections
-    MakeWidget({  5, 116}, {238, 101},   WindowWidgetType::Groupbox, WindowColour::Secondary, STR_CHEAT_GROUP_CONSTRUCTION                                                                   ), // Construction group
-    MakeWidget({ 11, 132}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_BUILD_IN_PAUSE_MODE,                  STR_CHEAT_BUILD_IN_PAUSE_MODE_TIP              ), // Build in pause mode
-    MakeWidget({ 11, 153}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_ENABLE_ALL_DRAWABLE_TRACK_PIECES,     STR_CHEAT_ENABLE_ALL_DRAWABLE_TRACK_PIECES_TIP ), // Show all drawable track pieces
-    MakeWidget({ 11, 174}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK,       STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK_TIP   ), // Enable chain lift on all track
-    MakeWidget({ 11, 195}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_ALLOW_TRACK_PLACE_INVALID_HEIGHTS,    STR_CHEAT_ALLOW_TRACK_PLACE_INVALID_HEIGHTS_TIP), // Allow track place at invalid heights
+    MakeWidget({ 11,  69}, CHEAT_BUTTON, WindowWidgetType::Button,   WindowColour::Secondary, STR_CHEAT_10_MINUTE_INSPECTIONS,                STR_CHEAT_10_MINUTE_INSPECTIONS_TIP            ), // 10 minute inspections
+    MakeWidget({  5, 95},  {238, 122},   WindowWidgetType::Groupbox, WindowColour::Secondary, STR_CHEAT_GROUP_CONSTRUCTION                                                                   ), // Construction group
+    MakeWidget({ 11, 111}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_BUILD_IN_PAUSE_MODE,                  STR_CHEAT_BUILD_IN_PAUSE_MODE_TIP              ), // Build in pause mode
+    MakeWidget({ 11, 132}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_ENABLE_ALL_DRAWABLE_TRACK_PIECES,     STR_CHEAT_ENABLE_ALL_DRAWABLE_TRACK_PIECES_TIP ), // Show all drawable track pieces
+    MakeWidget({ 11, 153}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK,       STR_CHEAT_ENABLE_CHAIN_LIFT_ON_ALL_TRACK_TIP   ), // Enable chain lift on all track
+    MakeWidget({ 11, 174}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_ALLOW_TRACK_PLACE_INVALID_HEIGHTS,    STR_CHEAT_ALLOW_TRACK_PLACE_INVALID_HEIGHTS_TIP), // Allow track place at invalid heights
+    MakeWidget({ 11, 195}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_MAKE_DESTRUCTABLE,                    STR_CHEAT_MAKE_DESTRUCTABLE_TIP                ), // All destructible
     MakeWidget({  5, 221}, {238, 122},   WindowWidgetType::Groupbox, WindowColour::Secondary, STR_CHEAT_GROUP_OPERATION                                                                      ), // Operation group
     MakeWidget({ 11, 237}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_SHOW_ALL_OPERATING_MODES                                                             ), // Show all operating modes
     MakeWidget({ 11, 258}, CHEAT_CHECK,  WindowWidgetType::Checkbox, WindowColour::Secondary, STR_CHEAT_UNLOCK_OPERATING_LIMITS,              STR_CHEAT_UNLOCK_OPERATING_LIMITS_TIP          ), // 410 km/h lift hill etc.
@@ -502,6 +502,7 @@ public:
                 SetCheckboxValue(WIDX_IGNORE_RESEARCH_STATUS, gCheatsIgnoreResearchStatus);
                 SetCheckboxValue(WIDX_ENABLE_ALL_DRAWABLE_TRACK_PIECES, gCheatsEnableAllDrawableTrackPieces);
                 SetCheckboxValue(WIDX_ALLOW_TRACK_PLACE_INVALID_HEIGHTS, gCheatsAllowTrackPlaceInvalidHeights);
+                SetCheckboxValue(WIDX_MAKE_DESTRUCTIBLE, gCheatsMakeAllDestructible);
                 break;
         }
 
@@ -1038,7 +1039,7 @@ private:
                 CheatsSet(CheatType::RenewRides);
                 break;
             case WIDX_MAKE_DESTRUCTIBLE:
-                CheatsSet(CheatType::MakeDestructible);
+                CheatsSet(CheatType::MakeDestructible, !gCheatsMakeAllDestructible);
                 break;
             case WIDX_FIX_ALL:
                 CheatsSet(CheatType::FixRides);

--- a/src/openrct2-ui/windows/Ride.cpp
+++ b/src/openrct2-ui/windows/Ride.cpp
@@ -2318,7 +2318,8 @@ static void WindowRideMainInvalidate(WindowBase* w)
         return;
 
     w->disabled_widgets &= ~((1uLL << WIDX_DEMOLISH) | (1uLL << WIDX_CONSTRUCTION));
-    if (ride->lifecycle_flags & (RIDE_LIFECYCLE_INDESTRUCTIBLE | RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK))
+    if (ride->lifecycle_flags & (RIDE_LIFECYCLE_INDESTRUCTIBLE | RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK)
+        && !gCheatsMakeAllDestructible)
         w->disabled_widgets |= (1uLL << WIDX_DEMOLISH);
 
     auto ft = Formatter::Common();

--- a/src/openrct2/Cheats.cpp
+++ b/src/openrct2/Cheats.cpp
@@ -54,6 +54,7 @@ bool gCheatsEnableAllDrawableTrackPieces = false;
 bool gCheatsAllowTrackPlaceInvalidHeights = false;
 bool gCheatsAllowRegularPathAsQueue = false;
 bool gCheatsAllowSpecialColourSchemes = false;
+bool gCheatsMakeAllDestructible = false;
 
 void CheatsReset()
 {
@@ -81,6 +82,7 @@ void CheatsReset()
     gCheatsAllowTrackPlaceInvalidHeights = false;
     gCheatsAllowRegularPathAsQueue = false;
     gCheatsAllowSpecialColourSchemes = false;
+    gCheatsMakeAllDestructible = false;
 }
 
 void CheatsSet(CheatType cheatType, int32_t param1 /* = 0*/, int32_t param2 /* = 0*/)
@@ -131,6 +133,7 @@ void CheatsSerialise(DataSerialiser& ds)
         CheatEntrySerialise(ds, CheatType::AllowTrackPlaceInvalidHeights, gCheatsAllowTrackPlaceInvalidHeights, count);
         CheatEntrySerialise(ds, CheatType::AllowRegularPathAsQueue, gCheatsAllowRegularPathAsQueue, count);
         CheatEntrySerialise(ds, CheatType::AllowSpecialColourSchemes, gCheatsAllowSpecialColourSchemes, count);
+        CheatEntrySerialise(ds, CheatType::MakeDestructible, gCheatsMakeAllDestructible, count);
 
         // Remember current position and update count.
         uint64_t endOffset = stream.GetPosition();
@@ -228,6 +231,9 @@ void CheatsSerialise(DataSerialiser& ds)
                     break;
                 case CheatType::AllowSpecialColourSchemes:
                     ds << gCheatsAllowSpecialColourSchemes;
+                    break;
+                case CheatType::MakeDestructible:
+                    ds << gCheatsMakeAllDestructible;
                     break;
                 default:
                     break;

--- a/src/openrct2/Cheats.h
+++ b/src/openrct2/Cheats.h
@@ -35,6 +35,7 @@ extern bool gCheatsEnableAllDrawableTrackPieces;
 extern bool gCheatsAllowTrackPlaceInvalidHeights;
 extern bool gCheatsAllowRegularPathAsQueue;
 extern bool gCheatsAllowSpecialColourSchemes;
+extern bool gCheatsMakeAllDestructible;
 
 enum class CheatType : int32_t
 {

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -183,7 +183,7 @@ GameActions::Result CheatSetAction::Execute() const
             RenewRides();
             break;
         case CheatType::MakeDestructible:
-            gCheatsMakeAllDestructible = !gCheatsMakeAllDestructible;
+            gCheatsMakeAllDestructible = _param1 != 0;
             WindowInvalidateByClass(WindowClass::Ride);
             break;
         case CheatType::FixRides:

--- a/src/openrct2/actions/CheatSetAction.cpp
+++ b/src/openrct2/actions/CheatSetAction.cpp
@@ -183,7 +183,8 @@ GameActions::Result CheatSetAction::Execute() const
             RenewRides();
             break;
         case CheatType::MakeDestructible:
-            MakeDestructible();
+            gCheatsMakeAllDestructible = !gCheatsMakeAllDestructible;
+            WindowInvalidateByClass(WindowClass::Ride);
             break;
         case CheatType::FixRides:
             FixBrokenRides();
@@ -471,16 +472,6 @@ void CheatSetAction::RenewRides() const
     for (auto& ride : GetRideManager())
     {
         ride.Renew();
-    }
-    WindowInvalidateByClass(WindowClass::Ride);
-}
-
-void CheatSetAction::MakeDestructible() const
-{
-    for (auto& ride : GetRideManager())
-    {
-        ride.lifecycle_flags &= ~RIDE_LIFECYCLE_INDESTRUCTIBLE;
-        ride.lifecycle_flags &= ~RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK;
     }
     WindowInvalidateByClass(WindowClass::Ride);
 }

--- a/src/openrct2/actions/CheatSetAction.h
+++ b/src/openrct2/actions/CheatSetAction.h
@@ -40,7 +40,6 @@ private:
     void RemoveLitter() const;
     void FixBrokenRides() const;
     void RenewRides() const;
-    void MakeDestructible() const;
     void ResetRideCrashStatus() const;
     void Set10MinuteInspection() const;
     void SetScenarioNoMoney(bool enabled) const;

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -65,7 +65,8 @@ GameActions::Result RideDemolishAction::Query() const
     }
 
     if ((ride->lifecycle_flags & (RIDE_LIFECYCLE_INDESTRUCTIBLE | RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK)
-        && _modifyType == RIDE_MODIFY_DEMOLISH) && !gCheatsMakeAllDestructible)
+         && _modifyType == RIDE_MODIFY_DEMOLISH)
+        && !gCheatsMakeAllDestructible)
     {
         return GameActions::Result(
             GameActions::Status::NoClearance, STR_CANT_DEMOLISH_RIDE,

--- a/src/openrct2/actions/RideDemolishAction.cpp
+++ b/src/openrct2/actions/RideDemolishAction.cpp
@@ -64,8 +64,8 @@ GameActions::Result RideDemolishAction::Query() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_CANT_DEMOLISH_RIDE, STR_NONE);
     }
 
-    if (ride->lifecycle_flags & (RIDE_LIFECYCLE_INDESTRUCTIBLE | RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK)
-        && _modifyType == RIDE_MODIFY_DEMOLISH)
+    if ((ride->lifecycle_flags & (RIDE_LIFECYCLE_INDESTRUCTIBLE | RIDE_LIFECYCLE_INDESTRUCTIBLE_TRACK)
+        && _modifyType == RIDE_MODIFY_DEMOLISH) && !gCheatsMakeAllDestructible)
     {
         return GameActions::Result(
             GameActions::Status::NoClearance, STR_CANT_DEMOLISH_RIDE,

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -114,7 +114,7 @@ GameActions::Result TrackRemoveAction::Query() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS, STR_NONE);
     }
 
-    if (tileElement->AsTrack()->IsIndestructible())
+    if (tileElement->AsTrack()->IsIndestructible() && !gCheatsMakeAllDestructible)
     {
         return GameActions::Result(
             GameActions::Status::Disallowed, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS,

--- a/src/openrct2/actions/TrackRemoveAction.cpp
+++ b/src/openrct2/actions/TrackRemoveAction.cpp
@@ -114,7 +114,7 @@ GameActions::Result TrackRemoveAction::Query() const
         return GameActions::Result(GameActions::Status::InvalidParameters, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS, STR_NONE);
     }
 
-    if (tileElement->AsTrack()->IsIndestructible() && !gCheatsMakeAllDestructible)
+    if (tileElement->AsTrack()->IsIndestructible())
     {
         return GameActions::Result(
             GameActions::Status::Disallowed, STR_RIDE_CONSTRUCTION_CANT_REMOVE_THIS,

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "10"
+#define NETWORK_STREAM_VERSION "11"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -9,10 +9,10 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 27;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 28;
 
     // The minimum version that is forwards compatible with the current version.
-    constexpr uint32_t PARK_FILE_MIN_VERSION = 27;
+    constexpr uint32_t PARK_FILE_MIN_VERSION = 28;
 
     // The minimum version that is backwards compatible with the current version.
     // If this is increased beyond 0, uncomment the checks in ParkFile.cpp and Context.cpp!

--- a/src/openrct2/ride/Track.cpp
+++ b/src/openrct2/ride/Track.cpp
@@ -882,7 +882,7 @@ void TrackElement::SetBrakeClosed(bool isClosed)
 
 bool TrackElement::IsIndestructible() const
 {
-    return (Flags2 & TRACK_ELEMENT_FLAGS2_INDESTRUCTIBLE_TRACK_PIECE) != 0;
+    return (Flags2 & TRACK_ELEMENT_FLAGS2_INDESTRUCTIBLE_TRACK_PIECE) != 0 && !gCheatsMakeAllDestructible;
 }
 
 void TrackElement::SetIsIndestructible(bool isIndestructible)


### PR DESCRIPTION
- Fixes the all-destructible cheat issue GH-19906.
- Adds a variable to represent if the indestructible flags should be ignored.
- Remove the old function that altered the flags on all the rides.
- Makes the cheat toggleable, but I'm not sure if this is desired.
- Added serialization and deserialization for the new cheat variable.