### PR TITLE
Add research plugin API

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -4,6 +4,7 @@
 - Feature: [#19276] Add Powered Lifthill to Giga Coaster.
 - Feature: [#19446] Add new color options to color dropdown.
 - Feature: [#19547] Add large sloped turns to hybrid coaster and single rail coaster.
+- Feature: [#19930] Add plugin APIs for research.
 - Feature: [OpenMusic#25] Added Prehistoric ride music style.
 - Improved: [#18490] Reduce guests walking through trains on level crossing next to station.
 - Improved: [#18996] When marketing campaigns are disabled, disable the Marketing tab in the Finances window.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -2123,7 +2123,7 @@ declare global {
          * The track segment adds to inversion counter. Usually applied to the first half of inversions.
          */
         readonly countsAsInversion: boolean;
-        
+
         /**
          * Gets a length of the subpositions list for this track segment.
          */
@@ -3149,6 +3149,103 @@ declare global {
         postMessage(message: string): void;
         postMessage(message: ParkMessageDesc): void;
     }
+
+    interface Research {
+        /**
+         * The list of rides and scenery sets that have already been researched.
+         */
+        inventedItems: ResearchItemType[];
+
+        /**
+         * The order of rides and scenery sets to be researched.
+         */
+        uninventedItems: ResearchItemType[];
+
+        /**
+         * The amount of funding currently spent on research.
+         */
+        funding: ResearchFundingLevel;
+
+        /**
+         * Flags representing which research categories are enabled.
+         */
+        priorities: number;
+
+        /**
+         * The current stage for the ride or scenery set being researched.
+         */
+        stage: ResearchFundingStage;
+
+        /**
+         * The progress for the current stage between 0 and 65535.
+         * This will increment more quickly the higher the research funding.
+         */
+        progress: number;
+
+        /**
+         * The expected month the current item being researched will complete.
+         * Value is between 0 and 7, 0 being March and 7 being October.
+         * Value is null if there is not yet an expected month.
+         */
+        readonly expectedMonth: number | null;
+
+        /**
+         * The expected day of the month the current item being researched will complete.
+         * Value is between 0 and 30, add 1 to it for the human readable date.
+         * Value is null if there is not yet an expected month.
+         */
+        readonly expectedDay: number | null;
+
+        /**
+         * Gets whether a particular object has been researched and is available to construct.
+         * @param type The type of object, e.g. ride, scenery group, or small scenery.
+         * @param index The object index.
+         */
+        isObjectResearched(type: ObjectType, index: number): boolean;
+    }
+
+    interface ResearchItem {
+        /**
+         * The research category this item belongs in.
+         * E.g. gentle rides, thrill rides, shops etc.
+         */
+        category: ResearchCategory;
+
+        /**
+         * Weather the research item is a ride or scenery set.
+         */
+        type: ResearchItemType;
+
+        /**
+         * The ride or scenery set object index.
+         */
+        object: number;
+    }
+
+    type ResearchItemType = "scenery" | "ride";
+
+    enum ResearchCategory {
+        Transport,
+        Gentle,
+        Rollercoaster,
+        Thrill,
+        Water,
+        Shop
+    }
+
+    enum ResearchFundingLevel {
+        None,
+        Minimum,
+        Normal,
+        Maximum
+    }
+
+    type ResearchFundingStage =
+        "initial_research" |
+        "designing" |
+        "completing_design" |
+        "unknown" |
+        "finished_all";
 
     type ScenarioObjectiveType =
         "none" |

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -3130,8 +3130,21 @@ declare global {
          */
         readonly parkSize: number;
 
+        /**
+         * The name of the park, shown on the park entrance.
+         * Not the name of the scenario.
+         */
         name: string;
-        research: Research;
+
+        /**
+         * The current research status, and what
+         * has and hasn't yet been researched.
+         */
+        readonly research: Research;
+
+        /**
+         * The park message / notification queue, and historical messages.
+         */
         messages: ParkMessage[];
 
         /**
@@ -3163,6 +3176,18 @@ declare global {
         uninventedItems: ResearchItem[];
 
         /**
+         * The last item that was researched, or null if no
+         * item has been researched yet.
+         */
+        readonly lastResearchedItem: ResearchItem | null;
+
+        /**
+         * The item currently being researched, or null if
+         * research is complete.
+         */
+        readonly expectedItem: ResearchItem | null;
+
+        /**
          * The amount of funding currently spent on research.
          */
         funding: ResearchFundingLevel;
@@ -3192,7 +3217,7 @@ declare global {
 
         /**
          * The expected day of the month the current item being researched will complete.
-         * Value is between 0 and 30, add 1 to it for the human readable date.
+         * Value is between 1 and 31.
          * Value is null if there is not yet an expected month.
          */
         readonly expectedDay: number | null;
@@ -3213,6 +3238,7 @@ declare global {
         /**
          * The research category this item belongs in.
          * E.g. gentle rides, thrill rides, shops etc.
+         * Note: This field is ignored by OpenRCT2, the category will be determined by the ride type.
          */
         category?: ResearchCategory;
 

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -3193,9 +3193,9 @@ declare global {
         funding: ResearchFundingLevel;
 
         /**
-         * Flags representing which research categories are enabled.
+         * The categories of research which should be prioritised.
          */
-        priorities: number;
+        priorities: ResearchCategory[];
 
         /**
          * The current stage for the ride or scenery set being researched.
@@ -3233,47 +3233,46 @@ declare global {
     type ResearchItem = RideResearchItem | SceneryResearchItem;
 
     interface RideResearchItem {
-        type: "ride";
+        readonly type: "ride";
 
         /**
          * The research category this item belongs in.
          * E.g. gentle rides, thrill rides, shops etc.
-         * Note: This field is ignored by OpenRCT2, the category will be determined by the ride type.
+         * Note: Any updates to this field are ignored by OpenRCT2, the category will be derived from the ride type.
          */
-        category?: ResearchCategory;
+        readonly category?: ResearchCategory;
 
         /**
          * The ride type. Each vehicle can have a seperate invention for each ride type.
          */
-        rideType: number;
+        readonly rideType: number;
 
         /**
          * The ride (vehicle) object index.
          */
-        object: number;
+        readonly object: number;
     }
 
     interface SceneryResearchItem {
-        category?: ResearchCategory.SceneryGroup;
-        type: "scenery";
+        readonly category?: "scenery_group";
+        readonly type: "scenery";
 
         /**
          * The scenery set object index.
          */
-        object: number;
+        readonly object: number;
     }
 
     type ResearchItemType = "scenery" | "ride";
 
-    enum ResearchCategory {
-        Transport,
-        Gentle,
-        Rollercoaster,
-        Thrill,
-        Water,
-        Shop,
-        SceneryGroup
-    }
+    type ResearchCategory =
+        "transport" |
+        "gentle" |
+        "rollercoaster" |
+        "thrill" |
+        "water" |
+        "shop" |
+        "scenery";
 
     enum ResearchFundingLevel {
         None,

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -3131,6 +3131,7 @@ declare global {
         readonly parkSize: number;
 
         name: string;
+        research: Research;
         messages: ParkMessage[];
 
         /**
@@ -3154,12 +3155,12 @@ declare global {
         /**
          * The list of rides and scenery sets that have already been researched.
          */
-        inventedItems: ResearchItemType[];
+        inventedItems: ResearchItem[];
 
         /**
          * The order of rides and scenery sets to be researched.
          */
-        uninventedItems: ResearchItemType[];
+        uninventedItems: ResearchItem[];
 
         /**
          * The amount of funding currently spent on research.
@@ -3204,20 +3205,34 @@ declare global {
         isObjectResearched(type: ObjectType, index: number): boolean;
     }
 
-    interface ResearchItem {
+    type ResearchItem = RideResearchItem | SceneryResearchItem;
+
+    interface RideResearchItem {
+        type: "ride";
+
         /**
          * The research category this item belongs in.
          * E.g. gentle rides, thrill rides, shops etc.
          */
-        category: ResearchCategory;
+        category?: ResearchCategory;
 
         /**
-         * Weather the research item is a ride or scenery set.
+         * The ride type. Each vehicle can have a seperate invention for each ride type.
          */
-        type: ResearchItemType;
+        rideType: number;
 
         /**
-         * The ride or scenery set object index.
+         * The ride (vehicle) object index.
+         */
+        object: number;
+    }
+
+    interface SceneryResearchItem {
+        category?: ResearchCategory.SceneryGroup;
+        type: "scenery";
+
+        /**
+         * The scenery set object index.
          */
         object: number;
     }
@@ -3230,7 +3245,8 @@ declare global {
         Rollercoaster,
         Thrill,
         Water,
-        Shop
+        Shop,
+        SceneryGroup
     }
 
     enum ResearchFundingLevel {

--- a/src/openrct2/core/EnumMap.hpp
+++ b/src/openrct2/core/EnumMap.hpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <array>
+#include <optional>
 #include <string_view>
 #include <vector>
 
@@ -98,6 +99,16 @@ public:
     {
         auto it = find(k);
         return it->second;
+    }
+
+    std::optional<T> TryGet(std::string_view k) const
+    {
+        auto it = find(k);
+        if (it != end())
+        {
+            return it->second;
+        }
+        return std::nullopt;
     }
 
     auto find(const std::string_view k) const

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -513,6 +513,7 @@
     <ClInclude Include="scripting\bindings\ride\ScTrackIterator.h" />
     <ClInclude Include="scripting\bindings\ride\ScTrackSegment.h" />
     <ClInclude Include="scripting\bindings\world\ScParkMessage.hpp" />
+    <ClInclude Include="scripting\bindings\world\ScResearch.hpp" />
     <ClInclude Include="scripting\bindings\world\ScTileElement.hpp" />
     <ClInclude Include="scripting\Duktape.hpp" />
     <ClInclude Include="scripting\IconNames.hpp" />

--- a/src/openrct2/libopenrct2.vcxproj
+++ b/src/openrct2/libopenrct2.vcxproj
@@ -993,6 +993,7 @@
     <ClCompile Include="scripting\bindings\world\ScMap.cpp" />
     <ClCompile Include="scripting\bindings\world\ScPark.cpp" />
     <ClCompile Include="scripting\bindings\world\ScParkMessage.cpp" />
+    <ClCompile Include="scripting\bindings\world\ScResearch.cpp" />
     <ClCompile Include="scripting\bindings\world\ScTile.cpp" />
     <ClCompile Include="scripting\bindings\world\ScTileElement.cpp" />
     <ClCompile Include="scripting\HookEngine.cpp" />

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -164,15 +164,23 @@ static void ResearchNextDesign()
         it = gResearchItemsUninvented.begin();
     }
 
-    const ResearchItem researchItem = *it;
-    gResearchNextItem = researchItem;
+    gResearchNextItem = *it;
     gResearchProgress = 0;
     gResearchProgressStage = RESEARCH_STAGE_DESIGNING;
 
-    gResearchItemsUninvented.erase(it);
-    gResearchItemsInvented.push_back(researchItem);
-
     ResearchInvalidateRelatedWindows();
+}
+
+static void MarkResearchItemInvented(const ResearchItem& researchItem)
+{
+    gResearchItemsUninvented.erase(
+        std::remove(gResearchItemsUninvented.begin(), gResearchItemsUninvented.end(), researchItem),
+        gResearchItemsUninvented.end());
+
+    if (std::find(gResearchItemsInvented.begin(), gResearchItemsInvented.end(), researchItem) == gResearchItemsInvented.end())
+    {
+        gResearchItemsInvented.push_back(researchItem);
+    }
 }
 
 /**
@@ -346,6 +354,7 @@ void ResearchUpdate()
                 ResearchInvalidateRelatedWindows();
                 break;
             case RESEARCH_STAGE_COMPLETING_DESIGN:
+                MarkResearchItemInvented(*gResearchNextItem);
                 ResearchFinishItem(*gResearchNextItem);
                 gResearchProgress = 0;
                 gResearchProgressStage = RESEARCH_STAGE_INITIAL_RESEARCH;

--- a/src/openrct2/management/Research.cpp
+++ b/src/openrct2/management/Research.cpp
@@ -519,6 +519,25 @@ bool ResearchInsertSceneryGroupEntry(ObjectEntryIndex entryIndex, bool researche
     return false;
 }
 
+bool ResearchIsInvented(ObjectType objectType, ObjectEntryIndex index)
+{
+    switch (objectType)
+    {
+        case ObjectType::Ride:
+            return RideEntryIsInvented(index);
+        case ObjectType::SceneryGroup:
+            return SceneryGroupIsInvented(index);
+        case ObjectType::SmallScenery:
+        case ObjectType::LargeScenery:
+        case ObjectType::Walls:
+        case ObjectType::Banners:
+        case ObjectType::PathBits:
+            return SceneryIsInvented({ static_cast<uint8_t>(objectType), index });
+        default:
+            return true;
+    }
+}
+
 bool RideTypeIsInvented(uint32_t rideType)
 {
     return RideTypeIsValid(rideType) ? _researchedRideTypes[rideType] : false;

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -139,7 +139,6 @@ void ResearchInsertRideEntry(ObjectEntryIndex entryIndex, bool researched);
 bool ResearchInsertSceneryGroupEntry(ObjectEntryIndex entryIndex, bool researched);
 
 bool ResearchIsInvented(ObjectType objectType, ObjectEntryIndex index);
-bool ResearchSetInvented(ObjectType objectType, ObjectEntryIndex index, bool value);
 void RideTypeSetInvented(uint32_t rideType);
 void RideEntrySetInvented(ObjectEntryIndex rideEntryIndex);
 void ScenerySetInvented(const ScenerySelection& sceneryItem);

--- a/src/openrct2/management/Research.h
+++ b/src/openrct2/management/Research.h
@@ -138,6 +138,8 @@ bool ResearchInsertRideEntry(ride_type_t rideType, ObjectEntryIndex entryIndex, 
 void ResearchInsertRideEntry(ObjectEntryIndex entryIndex, bool researched);
 bool ResearchInsertSceneryGroupEntry(ObjectEntryIndex entryIndex, bool researched);
 
+bool ResearchIsInvented(ObjectType objectType, ObjectEntryIndex index);
+bool ResearchSetInvented(ObjectType objectType, ObjectEntryIndex index, bool value);
 void RideTypeSetInvented(uint32_t rideType);
 void RideEntrySetInvented(ObjectEntryIndex rideEntryIndex);
 void ScenerySetInvented(const ScenerySelection& sceneryItem);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -47,6 +47,7 @@
 #    include "bindings/world/ScMap.hpp"
 #    include "bindings/world/ScPark.hpp"
 #    include "bindings/world/ScParkMessage.hpp"
+#    include "bindings/world/ScResearch.hpp"
 #    include "bindings/world/ScScenario.hpp"
 #    include "bindings/world/ScTile.hpp"
 #    include "bindings/world/ScTileElement.hpp"
@@ -409,6 +410,7 @@ void ScriptEngine::Initialise()
     ScPlayer::Register(ctx);
     ScPlayerGroup::Register(ctx);
     ScProfiler::Register(ctx);
+    ScResearch::Register(ctx);
     ScRide::Register(ctx);
     ScRideStation::Register(ctx);
     ScRideObject::Register(ctx);
@@ -439,7 +441,7 @@ void ScriptEngine::Initialise()
     dukglue_register_global(ctx, std::make_shared<ScDate>(), "date");
     dukglue_register_global(ctx, std::make_shared<ScMap>(ctx), "map");
     dukglue_register_global(ctx, std::make_shared<ScNetwork>(ctx), "network");
-    dukglue_register_global(ctx, std::make_shared<ScPark>(), "park");
+    dukglue_register_global(ctx, std::make_shared<ScPark>(ctx), "park");
     dukglue_register_global(ctx, std::make_shared<ScProfiler>(ctx), "profiler");
     dukglue_register_global(ctx, std::make_shared<ScScenario>(), "scenario");
 

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 74;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 75;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/world/ScPark.cpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.cpp
@@ -44,6 +44,11 @@ namespace OpenRCT2::Scripting
         { "unlockAllPrices", PARK_FLAGS_UNLOCK_ALL_PRICES },
     });
 
+    ScPark::ScPark(duk_context* ctx)
+        : _context(ctx)
+    {
+    }
+
     money64 ScPark::cash_get() const
     {
         return gCash;
@@ -294,6 +299,11 @@ namespace OpenRCT2::Scripting
         GfxInvalidateScreen();
     }
 
+    std::shared_ptr<ScResearch> ScPark::research_get() const
+    {
+        return std::make_shared<ScResearch>(_context);
+    }
+
     std::vector<std::shared_ptr<ScParkMessage>> ScPark::messages_get() const
     {
         std::vector<std::shared_ptr<ScParkMessage>> result;
@@ -405,6 +415,7 @@ namespace OpenRCT2::Scripting
             ctx, &ScPark::constructionRightsPrice_get, &ScPark::constructionRightsPrice_set, "constructionRightsPrice");
         dukglue_register_property(ctx, &ScPark::parkSize_get, nullptr, "parkSize");
         dukglue_register_property(ctx, &ScPark::name_get, &ScPark::name_set, "name");
+        dukglue_register_property(ctx, &ScPark::research_get, nullptr, "research");
         dukglue_register_property(ctx, &ScPark::messages_get, &ScPark::messages_set, "messages");
         dukglue_register_property(ctx, &ScPark::casualtyPenalty_get, &ScPark::casualtyPenalty_set, "casualtyPenalty");
         dukglue_register_method(ctx, &ScPark::getFlag, "getFlag");

--- a/src/openrct2/scripting/bindings/world/ScPark.hpp
+++ b/src/openrct2/scripting/bindings/world/ScPark.hpp
@@ -15,6 +15,7 @@
 #    include "../../../common.h"
 #    include "../../Duktape.hpp"
 #    include "ScParkMessage.hpp"
+#    include "ScResearch.hpp"
 
 #    include <algorithm>
 #    include <vector>
@@ -23,7 +24,12 @@ namespace OpenRCT2::Scripting
 {
     class ScPark
     {
+    private:
+        duk_context* _context;
+
     public:
+        ScPark(duk_context* ctx);
+
         money64 cash_get() const;
         void cash_set(money64 value);
 
@@ -84,6 +90,8 @@ namespace OpenRCT2::Scripting
         bool getFlag(const std::string& key) const;
 
         void setFlag(const std::string& key, bool value);
+
+        std::shared_ptr<ScResearch> research_get() const;
 
         std::vector<std::shared_ptr<ScParkMessage>> messages_get() const;
 

--- a/src/openrct2/scripting/bindings/world/ScResearch.cpp
+++ b/src/openrct2/scripting/bindings/world/ScResearch.cpp
@@ -1,0 +1,286 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "ScResearch.hpp"
+
+#    include "../../../Context.h"
+#    include "../../../common.h"
+#    include "../../../core/String.hpp"
+#    include "../../../management/Research.h"
+#    include "../../../ride/RideData.h"
+#    include "../../Duktape.hpp"
+#    include "../../ScriptEngine.h"
+#    include "../object/ScObject.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    static const DukEnumMap<uint8_t> ResearchStageMap({
+        { "initial_research", RESEARCH_STAGE_INITIAL_RESEARCH },
+        { "designing", RESEARCH_STAGE_DESIGNING },
+        { "completing_design", RESEARCH_STAGE_COMPLETING_DESIGN },
+        { "unknown", RESEARCH_STAGE_UNKNOWN },
+        { "finished_all", RESEARCH_STAGE_FINISHED_ALL },
+    });
+
+    static const DukEnumMap<ResearchCategory> ResearchCategoryMap({
+        { "transport", ResearchCategory::Transport },
+        { "gentle", ResearchCategory::Gentle },
+        { "rollercoaster", ResearchCategory::Rollercoaster },
+        { "thrill", ResearchCategory::Thrill },
+        { "water", ResearchCategory::Water },
+        { "shop", ResearchCategory::Shop },
+        { "scenery", ResearchCategory::SceneryGroup },
+    });
+
+    static const DukEnumMap<Research::EntryType> ResearchEntryTypeMap({
+        { "ride", Research::EntryType::Ride },
+        { "scenery", Research::EntryType::Scenery },
+    });
+
+    template<> inline DukValue ToDuk(duk_context* ctx, const ResearchItem& value)
+    {
+        DukObject obj(ctx);
+        obj.Set("category", ResearchCategoryMap[value.category]);
+        obj.Set("type", ResearchEntryTypeMap[value.type]);
+        if (value.type == Research::EntryType::Ride)
+        {
+            obj.Set("rideType", value.baseRideType);
+        }
+        obj.Set("object", value.entryIndex);
+        return obj.Take();
+    }
+
+    template<> Research::EntryType inline FromDuk(const DukValue& d)
+    {
+        if (d.type() == DukValue::STRING)
+        {
+            auto it = ResearchEntryTypeMap.find(d.as_string());
+            if (it != ResearchEntryTypeMap.end())
+            {
+                return it->second;
+            }
+        }
+        return Research::EntryType::Scenery;
+    }
+
+    template<> ResearchItem inline FromDuk(const DukValue& d)
+    {
+        ResearchItem result;
+        result.baseRideType = 0;
+        result.category = {}; // We ignore category because it will be derived from ride type
+        result.flags = 0;
+        result.type = FromDuk<Research::EntryType>(d["type"]);
+        auto baseRideType = d["rideType"];
+        if (baseRideType.type() == DukValue::NUMBER)
+            result.baseRideType = baseRideType.as_int();
+        result.entryIndex = d["object"].as_int();
+        return result;
+    }
+
+    ScResearch::ScResearch(duk_context* ctx)
+        : _context(ctx)
+    {
+    }
+
+    uint8_t ScResearch::funding_get() const
+    {
+        return gResearchFundingLevel;
+    }
+
+    void ScResearch::funding_set(uint8_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        gResearchFundingLevel = std::clamp<uint8_t>(value, RESEARCH_FUNDING_NONE, RESEARCH_FUNDING_MAXIMUM);
+    }
+
+    std::vector<std::string> ScResearch::priorities_get() const
+    {
+        std::vector<std::string> result;
+        for (auto i = EnumValue(ResearchCategory::Transport); i <= EnumValue(ResearchCategory::SceneryGroup); i++)
+        {
+            auto category = static_cast<ResearchCategory>(i);
+            if (gResearchPriorities & EnumToFlag(category))
+            {
+                result.emplace_back(ResearchCategoryMap[category]);
+            }
+        }
+        return result;
+    }
+
+    void ScResearch::priorities_set(const std::vector<std::string>& values)
+    {
+        ThrowIfGameStateNotMutable();
+
+        auto priorities = 0;
+        for (const auto& value : values)
+        {
+            auto category = ResearchCategoryMap.TryGet(value);
+            if (category)
+            {
+                priorities |= EnumToFlag(*category);
+            }
+        }
+        gResearchPriorities = priorities;
+    }
+
+    std::string ScResearch::stage_get() const
+    {
+        return std::string(ResearchStageMap[gResearchProgressStage]);
+    }
+
+    void ScResearch::stage_set(const std::string& value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto it = ResearchStageMap.find(value);
+        if (it != ResearchStageMap.end())
+        {
+            gResearchProgressStage = it->second;
+        }
+    }
+
+    uint16_t ScResearch::progress_get() const
+    {
+        return gResearchProgress;
+    }
+
+    void ScResearch::progress_set(uint16_t value)
+    {
+        ThrowIfGameStateNotMutable();
+        gResearchProgress = value;
+    }
+
+    DukValue ScResearch::expectedMonth_get() const
+    {
+        if (gResearchProgressStage == RESEARCH_STAGE_INITIAL_RESEARCH || gResearchExpectedDay == 255)
+            return ToDuk(_context, nullptr);
+        return ToDuk(_context, gResearchExpectedMonth);
+    }
+
+    DukValue ScResearch::expectedDay_get() const
+    {
+        if (gResearchProgressStage == RESEARCH_STAGE_INITIAL_RESEARCH || gResearchExpectedDay == 255)
+            return ToDuk(_context, nullptr);
+        return ToDuk(_context, gResearchExpectedDay + 1);
+    }
+
+    DukValue ScResearch::lastResearchedItem_get() const
+    {
+        if (!gResearchLastItem)
+            return ToDuk(_context, nullptr);
+        return ToDuk(_context, *gResearchLastItem);
+    }
+
+    DukValue ScResearch::expectedItem_get() const
+    {
+        if (gResearchProgressStage == RESEARCH_STAGE_INITIAL_RESEARCH || !gResearchNextItem)
+            return ToDuk(_context, nullptr);
+        return ToDuk(_context, *gResearchNextItem);
+    }
+
+    std::vector<DukValue> ScResearch::inventedItems_get() const
+    {
+        std::vector<DukValue> result;
+        for (auto& item : gResearchItemsInvented)
+        {
+            result.push_back(ToDuk(_context, item));
+        }
+        return result;
+    }
+
+    void ScResearch::inventedItems_set(const std::vector<DukValue>& value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto list = ConvertResearchList(value);
+        gResearchItemsInvented = std::move(list);
+        ResearchFix();
+    }
+
+    std::vector<DukValue> ScResearch::uninventedItems_get() const
+    {
+        std::vector<DukValue> result;
+        for (auto& item : gResearchItemsUninvented)
+        {
+            result.push_back(ToDuk(_context, item));
+        }
+        return result;
+    }
+
+    void ScResearch::uninventedItems_set(const std::vector<DukValue>& value)
+    {
+        ThrowIfGameStateNotMutable();
+        auto list = ConvertResearchList(value);
+        gResearchItemsUninvented = std::move(list);
+        ResearchFix();
+    }
+
+    bool ScResearch::isObjectResearched(const std::string& typez, ObjectEntryIndex index)
+    {
+        auto result = false;
+        auto type = ScObject::StringToObjectType(typez);
+        if (type)
+        {
+            result = ResearchIsInvented(*type, index);
+        }
+        else
+        {
+            duk_error(_context, DUK_ERR_ERROR, "Invalid object type.");
+        }
+        return result;
+    }
+
+    void ScResearch::Register(duk_context* ctx)
+    {
+        dukglue_register_property(ctx, &ScResearch::funding_get, &ScResearch::funding_set, "funding");
+        dukglue_register_property(ctx, &ScResearch::priorities_get, &ScResearch::priorities_set, "priorities");
+        dukglue_register_property(ctx, &ScResearch::stage_get, &ScResearch::stage_set, "stage");
+        dukglue_register_property(ctx, &ScResearch::progress_get, &ScResearch::progress_set, "progress");
+        dukglue_register_property(ctx, &ScResearch::expectedMonth_get, nullptr, "expectedMonth");
+        dukglue_register_property(ctx, &ScResearch::expectedDay_get, nullptr, "expectedDay");
+        dukglue_register_property(ctx, &ScResearch::lastResearchedItem_get, nullptr, "lastResearchedItem");
+        dukglue_register_property(ctx, &ScResearch::expectedItem_get, nullptr, "expectedItem");
+        dukglue_register_property(ctx, &ScResearch::inventedItems_get, &ScResearch::inventedItems_set, "inventedItems");
+        dukglue_register_property(ctx, &ScResearch::uninventedItems_get, &ScResearch::uninventedItems_set, "uninventedItems");
+        dukglue_register_method(ctx, &ScResearch::isObjectResearched, "isObjectResearched");
+    }
+
+    std::vector<ResearchItem> ScResearch::ConvertResearchList(const std::vector<DukValue>& value)
+    {
+        auto& objManager = GetContext()->GetObjectManager();
+        std::vector<ResearchItem> result;
+        for (auto& item : value)
+        {
+            auto researchItem = FromDuk<ResearchItem>(item);
+            researchItem.flags = 0;
+            if (researchItem.type == Research::EntryType::Ride)
+            {
+                auto rideEntry = GetRideEntryByIndex(researchItem.entryIndex);
+                if (rideEntry != nullptr)
+                {
+                    researchItem.category = GetRideTypeDescriptor(researchItem.baseRideType).GetResearchCategory();
+                    result.push_back(researchItem);
+                }
+            }
+            else
+            {
+                auto sceneryGroup = objManager.GetLoadedObject(ObjectType::SceneryGroup, researchItem.entryIndex);
+                if (sceneryGroup != nullptr)
+                {
+                    researchItem.baseRideType = 0;
+                    researchItem.category = ResearchCategory::SceneryGroup;
+                    result.push_back(researchItem);
+                }
+            }
+        }
+        return result;
+    }
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/world/ScResearch.hpp
+++ b/src/openrct2/scripting/bindings/world/ScResearch.hpp
@@ -1,0 +1,274 @@
+/*****************************************************************************
+ * Copyright (c) 2014-2023 OpenRCT2 developers
+ *
+ * For a complete list of all authors, please refer to contributors.md
+ * Interested in contributing? Visit https://github.com/OpenRCT2/OpenRCT2
+ *
+ * OpenRCT2 is licensed under the GNU General Public License version 3.
+ *****************************************************************************/
+
+#pragma once
+
+#ifdef ENABLE_SCRIPTING
+
+#    include "../../../Context.h"
+#    include "../../../common.h"
+#    include "../../../core/String.hpp"
+#    include "../../../management/Research.h"
+#    include "../../../ride/RideData.h"
+#    include "../../Duktape.hpp"
+#    include "../../ScriptEngine.h"
+#    include "../object/ScObject.hpp"
+
+namespace OpenRCT2::Scripting
+{
+    static const DukEnumMap<uint8_t> ResearchStageMap({
+        { "initial_research", RESEARCH_STAGE_INITIAL_RESEARCH },
+        { "designing", RESEARCH_STAGE_DESIGNING },
+        { "completing_design", RESEARCH_STAGE_COMPLETING_DESIGN },
+        { "unknown", RESEARCH_STAGE_UNKNOWN },
+        { "finished_all", RESEARCH_STAGE_FINISHED_ALL },
+    });
+
+    static const DukEnumMap<ResearchCategory> ResearchCategoryMap({
+        { "transport", ResearchCategory::Transport },
+        { "gentle", ResearchCategory::Gentle },
+        { "rollercoaster", ResearchCategory::Rollercoaster },
+        { "thrill", ResearchCategory::Thrill },
+        { "water", ResearchCategory::Water },
+        { "shop", ResearchCategory::Shop },
+        { "scenery_group", ResearchCategory::SceneryGroup },
+    });
+
+    static const DukEnumMap<Research::EntryType> ResearchEntryTypeMap({
+        { "ride", Research::EntryType::Ride },
+        { "scenery", Research::EntryType::Scenery },
+    });
+
+    template<> inline DukValue ToDuk(duk_context* ctx, const ResearchItem& value)
+    {
+        DukObject obj(ctx);
+        obj.Set("category", ResearchCategoryMap[value.category]);
+        obj.Set("type", ResearchEntryTypeMap[value.type]);
+        if (value.type == Research::EntryType::Ride)
+        {
+            obj.Set("rideType", value.baseRideType);
+        }
+        obj.Set("object", value.entryIndex);
+        return obj.Take();
+    }
+
+    template<> Research::EntryType inline FromDuk(const DukValue& d)
+    {
+        if (d.type() == DukValue::STRING)
+        {
+            auto it = ResearchEntryTypeMap.find(d.as_string());
+            if (it != ResearchEntryTypeMap.end())
+            {
+                return it->second;
+            }
+        }
+        return Research::EntryType::Scenery;
+    }
+
+    template<> ResearchItem inline FromDuk(const DukValue& d)
+    {
+        ResearchItem result;
+        result.baseRideType = 0;
+        result.category = ResearchCategory::Transport;
+        result.flags = 0;
+        result.type = FromDuk<Research::EntryType>(d["type"]);
+        auto baseRideType = d["rideType"];
+        if (baseRideType.type() == DukValue::NUMBER)
+            result.baseRideType = baseRideType.as_int();
+        result.entryIndex = d["object"].as_int();
+        return result;
+    }
+
+    class ScResearch
+    {
+    private:
+        duk_context* _context;
+
+    public:
+        ScResearch(duk_context* ctx)
+            : _context(ctx)
+        {
+        }
+
+        uint8_t funding_get() const
+        {
+            return gResearchFundingLevel;
+        }
+
+        void funding_set(uint8_t value)
+        {
+            ThrowIfGameStateNotMutable();
+            gResearchFundingLevel = value;
+        }
+
+        uint8_t priorities_get() const
+        {
+            return gResearchPriorities;
+        }
+
+        void priorities_set(uint8_t value)
+        {
+            ThrowIfGameStateNotMutable();
+            gResearchPriorities = value;
+        }
+
+        std::string stage_get() const
+        {
+            return std::string(ResearchStageMap[gResearchProgressStage]);
+        }
+
+        void stage_set(const std::string& value)
+        {
+            ThrowIfGameStateNotMutable();
+            auto it = ResearchStageMap.find(value);
+            if (it != ResearchStageMap.end())
+            {
+                gResearchProgressStage = it->second;
+            }
+        }
+
+        uint16_t progress_get() const
+        {
+            return gResearchProgress;
+        }
+
+        void progress_set(uint16_t value)
+        {
+            ThrowIfGameStateNotMutable();
+            gResearchProgress = value;
+        }
+
+        DukValue expectedMonth_get() const
+        {
+            if (gResearchProgressStage == RESEARCH_STAGE_INITIAL_RESEARCH || gResearchExpectedDay == 255)
+                return ToDuk(_context, nullptr);
+            return ToDuk(_context, gResearchExpectedMonth);
+        }
+
+        DukValue expectedDay_get() const
+        {
+            if (gResearchProgressStage == RESEARCH_STAGE_INITIAL_RESEARCH || gResearchExpectedDay == 255)
+                return ToDuk(_context, nullptr);
+            return ToDuk(_context, gResearchExpectedDay);
+        }
+
+        DukValue lastResearchedItem_get() const
+        {
+            if (!gResearchLastItem)
+                return ToDuk(_context, nullptr);
+            return ToDuk(_context, *gResearchLastItem);
+        }
+
+        DukValue expectedItem_get() const
+        {
+            if (gResearchProgressStage == RESEARCH_STAGE_INITIAL_RESEARCH || !gResearchNextItem)
+                return ToDuk(_context, nullptr);
+            return ToDuk(_context, *gResearchNextItem);
+        }
+
+        std::vector<DukValue> inventedItems_get() const
+        {
+            std::vector<DukValue> result;
+            for (auto& item : gResearchItemsInvented)
+            {
+                result.push_back(ToDuk(_context, item));
+            }
+            return result;
+        }
+
+        void inventedItems_set(const std::vector<DukValue>& value)
+        {
+            auto list = ConvertResearchList(value);
+            gResearchItemsInvented = std::move(list);
+            ResearchFix();
+        }
+
+        std::vector<DukValue> uninventedItems_get() const
+        {
+            std::vector<DukValue> result;
+            for (auto& item : gResearchItemsUninvented)
+            {
+                result.push_back(ToDuk(_context, item));
+            }
+            return result;
+        }
+
+        void uninventedItems_set(const std::vector<DukValue>& value)
+        {
+            auto list = ConvertResearchList(value);
+            gResearchItemsUninvented = std::move(list);
+            ResearchFix();
+        }
+
+        bool isObjectResearched(const std::string& typez, ObjectEntryIndex index)
+        {
+            auto result = false;
+            auto type = ScObject::StringToObjectType(typez);
+            if (type)
+            {
+                result = ResearchIsInvented(*type, index);
+            }
+            else
+            {
+                duk_error(_context, DUK_ERR_ERROR, "Invalid object type.");
+            }
+            return result;
+        }
+
+        static void Register(duk_context* ctx)
+        {
+            dukglue_register_property(ctx, &ScResearch::funding_get, &ScResearch::funding_set, "funding");
+            dukglue_register_property(ctx, &ScResearch::priorities_get, &ScResearch::priorities_set, "priorities");
+            dukglue_register_property(ctx, &ScResearch::stage_get, &ScResearch::stage_set, "stage");
+            dukglue_register_property(ctx, &ScResearch::progress_get, &ScResearch::progress_set, "progress");
+            dukglue_register_property(ctx, &ScResearch::expectedMonth_get, nullptr, "expectedMonth");
+            dukglue_register_property(ctx, &ScResearch::expectedDay_get, nullptr, "expectedDay");
+            dukglue_register_property(ctx, &ScResearch::lastResearchedItem_get, nullptr, "lastResearchedItem");
+            dukglue_register_property(ctx, &ScResearch::expectedItem_get, nullptr, "expectedItem");
+            dukglue_register_property(ctx, &ScResearch::inventedItems_get, &ScResearch::inventedItems_set, "inventedItems");
+            dukglue_register_property(
+                ctx, &ScResearch::uninventedItems_get, &ScResearch::uninventedItems_set, "uninventedItems");
+            dukglue_register_method(ctx, &ScResearch::isObjectResearched, "isObjectResearched");
+        }
+
+        static std::vector<ResearchItem> ConvertResearchList(const std::vector<DukValue>& value)
+        {
+            auto& objManager = GetContext()->GetObjectManager();
+            std::vector<ResearchItem> result;
+            for (auto& item : value)
+            {
+                auto researchItem = FromDuk<ResearchItem>(item);
+                researchItem.flags = 0;
+                if (researchItem.type == Research::EntryType::Ride)
+                {
+                    auto rideEntry = GetRideEntryByIndex(researchItem.entryIndex);
+                    if (rideEntry != nullptr)
+                    {
+                        researchItem.category = GetRideTypeDescriptor(researchItem.baseRideType).GetResearchCategory();
+                        result.push_back(researchItem);
+                    }
+                }
+                else
+                {
+                    auto sceneryGroup = objManager.GetLoadedObject(ObjectType::SceneryGroup, researchItem.entryIndex);
+                    if (sceneryGroup != nullptr)
+                    {
+                        researchItem.baseRideType = 0;
+                        researchItem.category = ResearchCategory::SceneryGroup;
+                        result.push_back(researchItem);
+                    }
+                }
+            }
+            return result;
+        }
+    };
+
+} // namespace OpenRCT2::Scripting
+
+#endif

--- a/src/openrct2/scripting/bindings/world/ScResearch.hpp
+++ b/src/openrct2/scripting/bindings/world/ScResearch.hpp
@@ -30,16 +30,6 @@ namespace OpenRCT2::Scripting
         { "finished_all", RESEARCH_STAGE_FINISHED_ALL },
     });
 
-    static const DukEnumMap<ResearchCategory> ResearchCategoryMap({
-        { "transport", ResearchCategory::Transport },
-        { "gentle", ResearchCategory::Gentle },
-        { "rollercoaster", ResearchCategory::Rollercoaster },
-        { "thrill", ResearchCategory::Thrill },
-        { "water", ResearchCategory::Water },
-        { "shop", ResearchCategory::Shop },
-        { "scenery_group", ResearchCategory::SceneryGroup },
-    });
-
     static const DukEnumMap<Research::EntryType> ResearchEntryTypeMap({
         { "ride", Research::EntryType::Ride },
         { "scenery", Research::EntryType::Scenery },
@@ -48,7 +38,7 @@ namespace OpenRCT2::Scripting
     template<> inline DukValue ToDuk(duk_context* ctx, const ResearchItem& value)
     {
         DukObject obj(ctx);
-        obj.Set("category", ResearchCategoryMap[value.category]);
+        obj.Set("category", EnumValue(value.category));
         obj.Set("type", ResearchEntryTypeMap[value.type]);
         if (value.type == Research::EntryType::Ride)
         {

--- a/src/openrct2/scripting/bindings/world/ScResearch.hpp
+++ b/src/openrct2/scripting/bindings/world/ScResearch.hpp
@@ -65,7 +65,7 @@ namespace OpenRCT2::Scripting
     {
         ResearchItem result;
         result.baseRideType = 0;
-        result.category = ResearchCategory::Transport;
+        result.category = {}; // We ignore category because it will be derived from ride type
         result.flags = 0;
         result.type = FromDuk<Research::EntryType>(d["type"]);
         auto baseRideType = d["rideType"];
@@ -94,7 +94,7 @@ namespace OpenRCT2::Scripting
         void funding_set(uint8_t value)
         {
             ThrowIfGameStateNotMutable();
-            gResearchFundingLevel = value;
+            gResearchFundingLevel = std::clamp<uint8_t>(value, RESEARCH_FUNDING_NONE, RESEARCH_FUNDING_MAXIMUM);
         }
 
         uint8_t priorities_get() const

--- a/src/openrct2/scripting/bindings/world/ScResearch.hpp
+++ b/src/openrct2/scripting/bindings/world/ScResearch.hpp
@@ -145,7 +145,7 @@ namespace OpenRCT2::Scripting
         {
             if (gResearchProgressStage == RESEARCH_STAGE_INITIAL_RESEARCH || gResearchExpectedDay == 255)
                 return ToDuk(_context, nullptr);
-            return ToDuk(_context, gResearchExpectedDay);
+            return ToDuk(_context, gResearchExpectedDay + 1);
         }
 
         DukValue lastResearchedItem_get() const

--- a/src/openrct2/scripting/bindings/world/ScResearch.hpp
+++ b/src/openrct2/scripting/bindings/world/ScResearch.hpp
@@ -11,281 +11,47 @@
 
 #ifdef ENABLE_SCRIPTING
 
-#    include "../../../Context.h"
-#    include "../../../common.h"
-#    include "../../../core/String.hpp"
-#    include "../../../management/Research.h"
-#    include "../../../ride/RideData.h"
-#    include "../../Duktape.hpp"
 #    include "../../ScriptEngine.h"
-#    include "../object/ScObject.hpp"
 
 namespace OpenRCT2::Scripting
 {
-    static const DukEnumMap<uint8_t> ResearchStageMap({
-        { "initial_research", RESEARCH_STAGE_INITIAL_RESEARCH },
-        { "designing", RESEARCH_STAGE_DESIGNING },
-        { "completing_design", RESEARCH_STAGE_COMPLETING_DESIGN },
-        { "unknown", RESEARCH_STAGE_UNKNOWN },
-        { "finished_all", RESEARCH_STAGE_FINISHED_ALL },
-    });
-
-    static const DukEnumMap<ResearchCategory> ResearchCategoryMap({
-        { "transport", ResearchCategory::Transport },
-        { "gentle", ResearchCategory::Gentle },
-        { "rollercoaster", ResearchCategory::Rollercoaster },
-        { "thrill", ResearchCategory::Thrill },
-        { "water", ResearchCategory::Water },
-        { "shop", ResearchCategory::Shop },
-        { "scenery", ResearchCategory::SceneryGroup },
-    });
-
-    static const DukEnumMap<Research::EntryType> ResearchEntryTypeMap({
-        { "ride", Research::EntryType::Ride },
-        { "scenery", Research::EntryType::Scenery },
-    });
-
-    template<> inline DukValue ToDuk(duk_context* ctx, const ResearchItem& value)
-    {
-        DukObject obj(ctx);
-        obj.Set("category", ResearchCategoryMap[value.category]);
-        obj.Set("type", ResearchEntryTypeMap[value.type]);
-        if (value.type == Research::EntryType::Ride)
-        {
-            obj.Set("rideType", value.baseRideType);
-        }
-        obj.Set("object", value.entryIndex);
-        return obj.Take();
-    }
-
-    template<> Research::EntryType inline FromDuk(const DukValue& d)
-    {
-        if (d.type() == DukValue::STRING)
-        {
-            auto it = ResearchEntryTypeMap.find(d.as_string());
-            if (it != ResearchEntryTypeMap.end())
-            {
-                return it->second;
-            }
-        }
-        return Research::EntryType::Scenery;
-    }
-
-    template<> ResearchItem inline FromDuk(const DukValue& d)
-    {
-        ResearchItem result;
-        result.baseRideType = 0;
-        result.category = {}; // We ignore category because it will be derived from ride type
-        result.flags = 0;
-        result.type = FromDuk<Research::EntryType>(d["type"]);
-        auto baseRideType = d["rideType"];
-        if (baseRideType.type() == DukValue::NUMBER)
-            result.baseRideType = baseRideType.as_int();
-        result.entryIndex = d["object"].as_int();
-        return result;
-    }
-
     class ScResearch
     {
     private:
         duk_context* _context;
 
     public:
-        ScResearch(duk_context* ctx)
-            : _context(ctx)
-        {
-        }
+        ScResearch(duk_context* ctx);
 
-        uint8_t funding_get() const
-        {
-            return gResearchFundingLevel;
-        }
+        static void Register(duk_context* ctx);
 
-        void funding_set(uint8_t value)
-        {
-            ThrowIfGameStateNotMutable();
-            gResearchFundingLevel = std::clamp<uint8_t>(value, RESEARCH_FUNDING_NONE, RESEARCH_FUNDING_MAXIMUM);
-        }
+    private:
+        uint8_t funding_get() const;
+        void funding_set(uint8_t value);
 
-        std::vector<std::string> priorities_get() const
-        {
-            std::vector<std::string> result;
-            for (auto i = EnumValue(ResearchCategory::Transport); i <= EnumValue(ResearchCategory::SceneryGroup); i++)
-            {
-                auto category = static_cast<ResearchCategory>(i);
-                if (gResearchPriorities & EnumToFlag(category))
-                {
-                    result.emplace_back(ResearchCategoryMap[category]);
-                }
-            }
-            return result;
-        }
+        std::vector<std::string> priorities_get() const;
+        void priorities_set(const std::vector<std::string>& values);
 
-        void priorities_set(const std::vector<std::string>& values)
-        {
-            ThrowIfGameStateNotMutable();
+        std::string stage_get() const;
+        void stage_set(const std::string& value);
 
-            auto priorities = 0;
-            for (const auto& value : values)
-            {
-                auto category = ResearchCategoryMap.TryGet(value);
-                if (category)
-                {
-                    priorities |= EnumToFlag(*category);
-                }
-            }
-            gResearchPriorities = priorities;
-        }
+        uint16_t progress_get() const;
+        void progress_set(uint16_t value);
 
-        std::string stage_get() const
-        {
-            return std::string(ResearchStageMap[gResearchProgressStage]);
-        }
+        DukValue expectedMonth_get() const;
+        DukValue expectedDay_get() const;
+        DukValue lastResearchedItem_get() const;
+        DukValue expectedItem_get() const;
 
-        void stage_set(const std::string& value)
-        {
-            ThrowIfGameStateNotMutable();
-            auto it = ResearchStageMap.find(value);
-            if (it != ResearchStageMap.end())
-            {
-                gResearchProgressStage = it->second;
-            }
-        }
+        std::vector<DukValue> inventedItems_get() const;
+        void inventedItems_set(const std::vector<DukValue>& value);
 
-        uint16_t progress_get() const
-        {
-            return gResearchProgress;
-        }
+        std::vector<DukValue> uninventedItems_get() const;
+        void uninventedItems_set(const std::vector<DukValue>& value);
 
-        void progress_set(uint16_t value)
-        {
-            ThrowIfGameStateNotMutable();
-            gResearchProgress = value;
-        }
+        bool isObjectResearched(const std::string& typez, ObjectEntryIndex index);
 
-        DukValue expectedMonth_get() const
-        {
-            if (gResearchProgressStage == RESEARCH_STAGE_INITIAL_RESEARCH || gResearchExpectedDay == 255)
-                return ToDuk(_context, nullptr);
-            return ToDuk(_context, gResearchExpectedMonth);
-        }
-
-        DukValue expectedDay_get() const
-        {
-            if (gResearchProgressStage == RESEARCH_STAGE_INITIAL_RESEARCH || gResearchExpectedDay == 255)
-                return ToDuk(_context, nullptr);
-            return ToDuk(_context, gResearchExpectedDay + 1);
-        }
-
-        DukValue lastResearchedItem_get() const
-        {
-            if (!gResearchLastItem)
-                return ToDuk(_context, nullptr);
-            return ToDuk(_context, *gResearchLastItem);
-        }
-
-        DukValue expectedItem_get() const
-        {
-            if (gResearchProgressStage == RESEARCH_STAGE_INITIAL_RESEARCH || !gResearchNextItem)
-                return ToDuk(_context, nullptr);
-            return ToDuk(_context, *gResearchNextItem);
-        }
-
-        std::vector<DukValue> inventedItems_get() const
-        {
-            std::vector<DukValue> result;
-            for (auto& item : gResearchItemsInvented)
-            {
-                result.push_back(ToDuk(_context, item));
-            }
-            return result;
-        }
-
-        void inventedItems_set(const std::vector<DukValue>& value)
-        {
-            auto list = ConvertResearchList(value);
-            gResearchItemsInvented = std::move(list);
-            ResearchFix();
-        }
-
-        std::vector<DukValue> uninventedItems_get() const
-        {
-            std::vector<DukValue> result;
-            for (auto& item : gResearchItemsUninvented)
-            {
-                result.push_back(ToDuk(_context, item));
-            }
-            return result;
-        }
-
-        void uninventedItems_set(const std::vector<DukValue>& value)
-        {
-            auto list = ConvertResearchList(value);
-            gResearchItemsUninvented = std::move(list);
-            ResearchFix();
-        }
-
-        bool isObjectResearched(const std::string& typez, ObjectEntryIndex index)
-        {
-            auto result = false;
-            auto type = ScObject::StringToObjectType(typez);
-            if (type)
-            {
-                result = ResearchIsInvented(*type, index);
-            }
-            else
-            {
-                duk_error(_context, DUK_ERR_ERROR, "Invalid object type.");
-            }
-            return result;
-        }
-
-        static void Register(duk_context* ctx)
-        {
-            dukglue_register_property(ctx, &ScResearch::funding_get, &ScResearch::funding_set, "funding");
-            dukglue_register_property(ctx, &ScResearch::priorities_get, &ScResearch::priorities_set, "priorities");
-            dukglue_register_property(ctx, &ScResearch::stage_get, &ScResearch::stage_set, "stage");
-            dukglue_register_property(ctx, &ScResearch::progress_get, &ScResearch::progress_set, "progress");
-            dukglue_register_property(ctx, &ScResearch::expectedMonth_get, nullptr, "expectedMonth");
-            dukglue_register_property(ctx, &ScResearch::expectedDay_get, nullptr, "expectedDay");
-            dukglue_register_property(ctx, &ScResearch::lastResearchedItem_get, nullptr, "lastResearchedItem");
-            dukglue_register_property(ctx, &ScResearch::expectedItem_get, nullptr, "expectedItem");
-            dukglue_register_property(ctx, &ScResearch::inventedItems_get, &ScResearch::inventedItems_set, "inventedItems");
-            dukglue_register_property(
-                ctx, &ScResearch::uninventedItems_get, &ScResearch::uninventedItems_set, "uninventedItems");
-            dukglue_register_method(ctx, &ScResearch::isObjectResearched, "isObjectResearched");
-        }
-
-        static std::vector<ResearchItem> ConvertResearchList(const std::vector<DukValue>& value)
-        {
-            auto& objManager = GetContext()->GetObjectManager();
-            std::vector<ResearchItem> result;
-            for (auto& item : value)
-            {
-                auto researchItem = FromDuk<ResearchItem>(item);
-                researchItem.flags = 0;
-                if (researchItem.type == Research::EntryType::Ride)
-                {
-                    auto rideEntry = GetRideEntryByIndex(researchItem.entryIndex);
-                    if (rideEntry != nullptr)
-                    {
-                        researchItem.category = GetRideTypeDescriptor(researchItem.baseRideType).GetResearchCategory();
-                        result.push_back(researchItem);
-                    }
-                }
-                else
-                {
-                    auto sceneryGroup = objManager.GetLoadedObject(ObjectType::SceneryGroup, researchItem.entryIndex);
-                    if (sceneryGroup != nullptr)
-                    {
-                        researchItem.baseRideType = 0;
-                        researchItem.category = ResearchCategory::SceneryGroup;
-                        result.push_back(researchItem);
-                    }
-                }
-            }
-            return result;
-        }
+        static std::vector<ResearchItem> ConvertResearchList(const std::vector<DukValue>& value);
     };
 
 } // namespace OpenRCT2::Scripting


### PR DESCRIPTION
**New APIs:**
```ts
interface Park {
    ...
    readonly research: Research;
}

interface Research {
    inventedItems: ResearchItem[];
    uninventedItems: ResearchItem[];
    funding: ResearchFundingLevel;
    priorities: ResearchCategory[];
    stage: ResearchFundingStage;
    progress: number;
    readonly lastResearchedItem: ResearchItem | null;
    readonly expectedItem: ResearchItem | null;
    readonly expectedMonth: number | null;
    readonly expectedDay: number | null;

    isObjectResearched(type: ObjectType, index: number): boolean;
}

type ResearchItem = RideResearchItem | SceneryResearchItem;

interface RideResearchItem {
    readonly type: "ride";
    readonly category?: ResearchCategory;
    readonly rideType: number;
    readonly object: number;
}

interface SceneryResearchItem {
    readonly category?: ResearchCategory.SceneryGroup;
    readonly type: "scenery";
    readonly object: number;
}

type ResearchItemType = "scenery" | "ride";

type ResearchCategory =
    "transport" |
    "gentle" |
    "rollercoaster" |
    "thrill" |
    "water" |
    "shop" |
    "scenery";

enum ResearchFundingLevel {
    None,
    Minimum,
    Normal,
    Maximum
}

type ResearchFundingStage =
    "initial_research" |
    "designing" |
    "completing_design" |
    "unknown" |
    "finished_all";
```