### PR TITLE
Fix #19916. Crash when changing language

### DIFF
--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -197,6 +197,7 @@ void Object::UnloadImages()
     if (_baseImageId != ImageIndexUndefined)
     {
         GfxObjectFreeImages(_baseImageId, GetImageTable().GetCount());
+        _baseImageId = ImageIndexUndefined;
     }
 }
 

--- a/src/openrct2/object/WaterObject.cpp
+++ b/src/openrct2/object/WaterObject.cpp
@@ -51,6 +51,8 @@ void WaterObject::Unload()
 
     _legacyType.string_idx = 0;
     _legacyType.image_id = 0;
+    _legacyType.palette_index_1 = 0;
+    _legacyType.palette_index_2 = 0;
 }
 
 void WaterObject::DrawPreview(DrawPixelInfo& dpi, int32_t width, int32_t height) const


### PR DESCRIPTION
Regression from #17567. Issue caused by the unload image function not resetting the image id back to invalid. Also noticed that water wasn't correctly cleaning up.

Fix #19918, #19926, #19927, #19928, #19929, #19931