### PR TITLE
Add keyboard shortcut to Keyboard Shortcuts window

### DIFF
--- a/data/language/en-GB.txt
+++ b/data/language/en-GB.txt
@@ -3685,6 +3685,7 @@ STR_6579    :Block brakes will be set to default speed when saved as track desig
 
 STR_6580    :Reset
 STR_6581    :Are you sure you want to reset all shortcut keys on this tab?
+STR_6582    :Open keyboard shortcuts window
 
 #############
 # Scenarios #

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -10,6 +10,7 @@
 - Improved: [#19764] Miscellaneous scenery tab now grouped next to the all-scenery tab.
 - Improved: [#19830] “Highlight path issues” will now hide wall elements.
 - Improved: [#19905] Add prompt before resetting shortcut keys.
+- Improved: [#19953] Add keyboard shorcut to Keyboard Shortcuts window.
 - Fix: [#12598] Number of holes is not set correctly when saving track designs.
 - Fix: [#13130] Android always defaulting to UK locale for language, currency and temperature.
 - Fix: [#18895] Responding mechanic blocked at level crossing.

--- a/src/openrct2-ui/input/ShortcutIds.h
+++ b/src/openrct2-ui/input/ShortcutIds.h
@@ -52,6 +52,7 @@ namespace OpenRCT2::Ui::ShortcutId
     constexpr std::string_view InterfaceOpenMessages = "interface.open.messages";
     constexpr std::string_view InterfaceOpenMap = "interface.open.map";
     constexpr std::string_view InterfaceShowOptions = "interface.open.options";
+    constexpr std::string_view InterfaceOpenKeyboardShortcuts = "interface.open.keyboard_shortcuts";
     constexpr std::string_view InterfaceOpenTransparencyOptions = "interface.open.transparency_options";
     constexpr std::string_view InterfaceOpenCheats = "interface.open.cheats";
     constexpr std::string_view InterfaceOpenTileInspector = "interface.open.tileinspector";

--- a/src/openrct2-ui/input/Shortcuts.cpp
+++ b/src/openrct2-ui/input/Shortcuts.cpp
@@ -392,6 +392,11 @@ static void ShortcutOpenCheatWindow()
     ContextOpenWindow(WindowClass::Cheats);
 }
 
+static void ShortcutOpenKeyboardShortcutsWindow()
+{
+    WindowShortcutKeysOpen();
+}
+
 static void ShortcutOpenTransparencyWindow()
 {
     if (gScreenFlags != SCREEN_FLAGS_PLAYING)
@@ -816,6 +821,7 @@ void ShortcutManager::RegisterDefaultShortcuts()
     RegisterShortcut(ShortcutId::InterfaceOpenMessages, STR_SHORTCUT_SHOW_RECENT_MESSAGES, "M", ShortcutShowRecentMessages);
     RegisterShortcut(ShortcutId::InterfaceOpenMap, STR_SHORTCUT_SHOW_MAP, "TAB", ShortcutShowMap);
     RegisterShortcut(ShortcutId::InterfaceShowOptions, STR_SHORTCUT_SHOW_OPTIONS, std::bind(ContextOpenWindow, WindowClass::Options));
+    RegisterShortcut(ShortcutId::InterfaceOpenKeyboardShortcuts, STR_SHORTCUT_OPEN_KEYBOARD_SHORTCUTS_WINDOW, "SHIFT+/", ShortcutOpenKeyboardShortcutsWindow);
     RegisterShortcut(ShortcutId::InterfaceOpenTransparencyOptions, STR_SHORTCUT_OPEN_TRANSPARENCY_OPTIONS, "CTRL+T", ShortcutOpenTransparencyWindow);
     RegisterShortcut(ShortcutId::InterfaceOpenCheats, STR_SHORTCUT_OPEN_CHEATS_WINDOW, "CTRL+ALT+C", ShortcutOpenCheatWindow);
     RegisterShortcut(ShortcutId::InterfaceOpenTileInspector, STR_SHORTCUT_OPEN_TILE_INSPECTOR, []() {

--- a/src/openrct2/localisation/StringIds.h
+++ b/src/openrct2/localisation/StringIds.h
@@ -3982,7 +3982,9 @@ enum : uint16_t
     STR_TRACK_DESIGN_BLOCK_BRAKE_SPEED_RESET = 6579,
 
     STR_RESET = 6580,
-    STR_RESET_SHORTCUT_KEYS_PROMPT = 6581
+    STR_RESET_SHORTCUT_KEYS_PROMPT = 6581,
+
+    STR_SHORTCUT_OPEN_KEYBOARD_SHORTCUTS_WINDOW = 6582,
 
     // Have to include resource strings (from scenarios and objects) for the time being now that language is partially working
     /* MAX_STR_COUNT = 32768 */ // MAX_STR_COUNT - upper limit for number of strings, not the current count strings


### PR DESCRIPTION
It sounds a bit meta, but now you can register a keyboard shortcut to the Keyboard Shortcuts window. 

I added it below the options window in the keyboard shortcut list, with a default shortcut key of `?` (i.e. `Shift+/`), which is common in many apps (it also works here in GitHub, for example).  

Resolves #11223.

![image](https://user-images.githubusercontent.com/30838294/232291583-e8ef8df8-4851-433b-8e2b-e4c314c4a368.png)
