### PR TITLE
Introduce normalised Wooden A supports functions

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -26,6 +26,7 @@
 - Fix: [#19901] Random shop colours never assigning last colour.
 - Fix: [#19924] Destructible cheat does not allow partial ride modification.
 - Fix: [#19950] Mine train block brake supports drawn incorrectly.
+- Fix: [#19955] Mine Train Roller Coaster has incorrect supports on the sloped left small turn (original bug).
 - Fix: [#19987] [Plugin] ‘SetCheatAction’ has wrong ID in plugin API.
 
 0.4.4 (2023-03-28)

--- a/src/openrct2/paint/Supports.cpp
+++ b/src/openrct2/paint/Supports.cpp
@@ -446,6 +446,45 @@ static constexpr const uint16_t word_97B3C4[] = {
 
 // clang-format on
 
+static WoodenSupportSubType rotatedWoodenSupportSubTypes[6][NumOrthogonalDirections] = {
+    {
+        WoodenSupportSubType::NeSw,
+        WoodenSupportSubType::NwSe,
+        WoodenSupportSubType::NeSw,
+        WoodenSupportSubType::NwSe,
+    },
+    {
+        WoodenSupportSubType::NwSe,
+        WoodenSupportSubType::NeSw,
+        WoodenSupportSubType::NwSe,
+        WoodenSupportSubType::NeSw,
+    },
+    {
+        WoodenSupportSubType::Corner0,
+        WoodenSupportSubType::Corner1,
+        WoodenSupportSubType::Corner2,
+        WoodenSupportSubType::Corner3,
+    },
+    {
+        WoodenSupportSubType::Corner1,
+        WoodenSupportSubType::Corner2,
+        WoodenSupportSubType::Corner3,
+        WoodenSupportSubType::Corner0,
+    },
+    {
+        WoodenSupportSubType::Corner2,
+        WoodenSupportSubType::Corner3,
+        WoodenSupportSubType::Corner0,
+        WoodenSupportSubType::Corner1,
+    },
+    {
+        WoodenSupportSubType::Corner3,
+        WoodenSupportSubType::Corner0,
+        WoodenSupportSubType::Corner1,
+        WoodenSupportSubType::Corner2,
+    },
+};
+
 /**
  * Draw repeated supports for left over space
  *
@@ -639,6 +678,28 @@ bool WoodenASupportsPaintSetup(
     }
 
     return hasSupports;
+}
+
+bool WoodenASupportsPaintSetup(
+    PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, int32_t height, ImageId imageTemplate,
+    WoodenSupportTransitionType transitionType, Direction direction)
+{
+    int32_t oldSupportType = (EnumValue(supportType) * 6) + EnumValue(subType);
+    int32_t special = 0;
+    if (transitionType != WoodenSupportTransitionType::None)
+    {
+        special = (EnumValue(transitionType) * NumOrthogonalDirections) + direction + 1;
+    }
+
+    return WoodenASupportsPaintSetup(session, oldSupportType, special, height, imageTemplate);
+}
+
+bool WoodenASupportsPaintSetupRotated(
+    PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, Direction direction, int32_t height,
+    ImageId imageTemplate, WoodenSupportTransitionType transitionType)
+{
+    subType = rotatedWoodenSupportSubTypes[EnumValue(subType)][direction];
+    return WoodenASupportsPaintSetup(session, supportType, subType, height, imageTemplate, transitionType, direction);
 }
 
 /**

--- a/src/openrct2/paint/Supports.h
+++ b/src/openrct2/paint/Supports.h
@@ -17,8 +17,41 @@ struct FootpathPaintInfo;
 
 constexpr const uint8_t NumVanillaWoodenSupportTypes = 49;
 
+enum class WoodenSupportType : uint8_t
+{
+    Truss = 0,
+    Mine = 1,
+};
+
+enum class WoodenSupportSubType : uint8_t
+{
+    NeSw = 0,
+    NwSe = 1,
+    Corner0 = 2,
+    Corner1 = 3,
+    Corner2 = 4,
+    Corner3 = 5,
+};
+
+enum class WoodenSupportTransitionType : uint8_t
+{
+    None = 255,
+    FlatToUp25Deg = 0,
+    Up25DegToFlat = 1,
+    Up25Deg = 2,
+    Up25DegToUp60Deg = 3,
+    Up60DegToUp25Deg = 4,
+    Up60Deg = 5,
+};
+
 bool WoodenASupportsPaintSetup(
     PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate);
+bool WoodenASupportsPaintSetup(
+    PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, int32_t height, ImageId imageTemplate,
+    WoodenSupportTransitionType transitionType = WoodenSupportTransitionType::None, Direction direction = 0);
+bool WoodenASupportsPaintSetupRotated(
+    PaintSession& session, WoodenSupportType supportType, WoodenSupportSubType subType, Direction direction, int32_t height,
+    ImageId imageTemplate, WoodenSupportTransitionType transitionType = WoodenSupportTransitionType::None);
 bool WoodenBSupportsPaintSetup(
     PaintSession& session, int32_t supportType, int32_t special, int32_t height, ImageId imageTemplate);
 bool MetalASupportsPaintSetup(

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -43,25 +43,33 @@ static void MineTrainRCTrackFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20054), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenASupportsPaintSetup(
+                    session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20055), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenASupportsPaintSetup(
+                    session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20056), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenASupportsPaintSetup(
+                    session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20057), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenASupportsPaintSetup(
+                    session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -74,14 +82,18 @@ static void MineTrainRCTrackFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20052), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenASupportsPaintSetup(
+                    session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20053), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                WoodenASupportsPaintSetup(
+                    session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                    session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -138,25 +150,21 @@ static void MineTrainRCTrack25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20102), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20103), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20104), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20105), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -168,28 +176,29 @@ static void MineTrainRCTrack25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20074), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20075), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20076), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20077), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up25Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -213,27 +222,28 @@ static void MineTrainRCTrack60DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20090), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 21, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20091), { 0, 0, height },
                 { { 27, 0, height }, { 1, 32, 98 } });
-            WoodenASupportsPaintSetup(session, 7, 22, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20092), { 0, 0, height },
                 { { 27, 0, height }, { 1, 32, 98 } });
-            WoodenASupportsPaintSetup(session, 6, 23, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20093), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 24, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up60Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -259,25 +269,21 @@ static void MineTrainRCTrackFlatTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20094), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20095), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20096), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20097), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -289,28 +295,29 @@ static void MineTrainRCTrackFlatTo25DegUp(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20066), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20067), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20068), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20069), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::FlatToUp25Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -334,7 +341,6 @@ static void MineTrainRCTrack25DegUpTo60DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20078), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 13, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -343,7 +349,6 @@ static void MineTrainRCTrack25DegUpTo60DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20082), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 66 } });
-            WoodenASupportsPaintSetup(session, 7, 14, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -352,15 +357,18 @@ static void MineTrainRCTrack25DegUpTo60DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20083), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 66 } });
-            WoodenASupportsPaintSetup(session, 6, 15, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20081), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 16, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up25DegToUp60Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -384,7 +392,6 @@ static void MineTrainRCTrack60DegUpTo25DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20084), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 17, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -393,7 +400,6 @@ static void MineTrainRCTrack60DegUpTo25DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20088), { 0, 0, height },
                 { { 0, 4, height }, { 32, 2, 66 } });
-            WoodenASupportsPaintSetup(session, 7, 18, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             session.WoodenSupportsPrependTo = PaintAddImageAsParentRotated(
@@ -402,15 +408,18 @@ static void MineTrainRCTrack60DegUpTo25DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20089), { 0, 0, height },
                 { { 0, 4, height }, { 32, 2, 66 } });
-            WoodenASupportsPaintSetup(session, 6, 19, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20087), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 20, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up60DegToUp25Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -436,25 +445,21 @@ static void MineTrainRCTrack25DegUpToFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20098), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20099), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20100), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20101), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
@@ -466,28 +471,29 @@ static void MineTrainRCTrack25DegUpToFlat(
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20070), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 1:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20071), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 2:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20072), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
             case 3:
                 PaintAddImageAsParentRotated(
                     session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20073), { 0, 0, height },
                     { { 0, 6, height }, { 32, 20, 1 } });
-                WoodenASupportsPaintSetup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
                 break;
         }
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up25DegToFlat);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -562,25 +568,33 @@ static void MineTrainRCTrackLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20155), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20160), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20165), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20150), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -602,25 +616,33 @@ static void MineTrainRCTrackLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20154), { 0, 0, height },
                         { 32, 16, 1 });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20159), { 0, 0, height },
                         { 32, 16, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20164), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20149), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -636,25 +658,33 @@ static void MineTrainRCTrackLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20153), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20158), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20163), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20148), { 0, 0, height },
                         { 16, 16, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -677,25 +707,33 @@ static void MineTrainRCTrackLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20152), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20157), { 0, 0, height },
                         { 16, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20162), { 0, 0, height },
                         { 16, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20147), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -711,25 +749,33 @@ static void MineTrainRCTrackLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20151), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20156), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20161), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20146), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -770,7 +816,8 @@ static void MineTrainRCTrackFlatToLeftBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20114), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 26 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -779,19 +826,22 @@ static void MineTrainRCTrackFlatToLeftBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20115), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 26 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20108), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20109), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -810,13 +860,15 @@ static void MineTrainRCTrackFlatToRightBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20110), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20111), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -825,7 +877,8 @@ static void MineTrainRCTrackFlatToRightBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20116), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 26 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
@@ -834,7 +887,8 @@ static void MineTrainRCTrackFlatToRightBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20117), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 26 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -856,7 +910,8 @@ static void MineTrainRCTrackLeftBankToFlat(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20116), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 26 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -865,19 +920,22 @@ static void MineTrainRCTrackLeftBankToFlat(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20117), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 26 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20110), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20111), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -896,13 +954,15 @@ static void MineTrainRCTrackRightBankToFlat(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20108), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20109), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -911,7 +971,8 @@ static void MineTrainRCTrackRightBankToFlat(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20114), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 26 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
@@ -920,7 +981,8 @@ static void MineTrainRCTrackRightBankToFlat(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20115), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 26 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -945,25 +1007,33 @@ static void MineTrainRCTrackBankedLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20186), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20180), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20185), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20170), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -985,25 +1055,33 @@ static void MineTrainRCTrackBankedLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20174), { 0, 0, height },
                         { 32, 16, 1 });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20179), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20184), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20169), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1019,27 +1097,38 @@ static void MineTrainRCTrackBankedLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20173), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20178), { 0, 0, height },
                         { { 16, 16, height + 27 }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20183), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20168), { 0, 0, height },
                         { 16, 16, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS]);
+
             PaintUtilSetSegmentSupportHeight(
                 session,
                 PaintUtilRotateSegments(
@@ -1060,25 +1149,33 @@ static void MineTrainRCTrackBankedLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20172), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20177), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20182), { 0, 0, height },
                         { 16, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20167), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1094,13 +1191,17 @@ static void MineTrainRCTrackBankedLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20171), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20176), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -1109,13 +1210,17 @@ static void MineTrainRCTrackBankedLeftQuarterTurn5(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20187), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20166), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -1156,7 +1261,6 @@ static void MineTrainRCTrackLeftBankTo25DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20122), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 34 } });
-            WoodenASupportsPaintSetup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -1165,21 +1269,23 @@ static void MineTrainRCTrackLeftBankTo25DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20123), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 34 } });
-            WoodenASupportsPaintSetup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20120), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20121), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::FlatToUp25Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -1203,13 +1309,11 @@ static void MineTrainRCTrackRightBankTo25DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20124), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 1, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20125), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 2, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -1218,7 +1322,6 @@ static void MineTrainRCTrackRightBankTo25DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20128), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 34 } });
-            WoodenASupportsPaintSetup(session, 6, 3, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
@@ -1227,9 +1330,13 @@ static void MineTrainRCTrackRightBankTo25DegUp(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20129), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 34 } });
-            WoodenASupportsPaintSetup(session, 7, 4, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::FlatToUp25Deg);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -1256,7 +1363,6 @@ static void MineTrainRCTrack25DegUpToLeftBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20134), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 34 } });
-            WoodenASupportsPaintSetup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
@@ -1265,21 +1371,23 @@ static void MineTrainRCTrack25DegUpToLeftBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20135), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 34 } });
-            WoodenASupportsPaintSetup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20132), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20133), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up25DegToFlat);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -1303,13 +1411,11 @@ static void MineTrainRCTrack25DegUpToRightBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20136), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 5, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20137), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 6, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
@@ -1318,7 +1424,6 @@ static void MineTrainRCTrack25DegUpToRightBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20140), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 34 } });
-            WoodenASupportsPaintSetup(session, 6, 7, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
@@ -1327,9 +1432,13 @@ static void MineTrainRCTrack25DegUpToRightBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20141), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 34 } });
-            WoodenASupportsPaintSetup(session, 7, 8, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
+
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS],
+        WoodenSupportTransitionType::Up25DegToFlat);
+
     if (direction == 0 || direction == 3)
     {
         PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_SQUARE_FLAT);
@@ -1385,25 +1494,29 @@ static void MineTrainRCTrackLeftBank(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20142), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 26 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20143), { 0, 0, height },
                 { { 0, 27, height }, { 32, 1, 26 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20144), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20145), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -1433,27 +1546,28 @@ static void MineTrainRCTrackLeftQuarterTurn525DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20250), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20255), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20260), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20265), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25Deg);
+
             if (direction == 0 || direction == 3)
             {
                 PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -1473,25 +1587,33 @@ static void MineTrainRCTrackLeftQuarterTurn525DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20251), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20256), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20261), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20266), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1507,25 +1629,33 @@ static void MineTrainRCTrackLeftQuarterTurn525DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20252), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20257), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20262), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20267), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1548,25 +1678,33 @@ static void MineTrainRCTrackLeftQuarterTurn525DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20253), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20258), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20263), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20268), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1582,25 +1720,33 @@ static void MineTrainRCTrackLeftQuarterTurn525DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20254), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25Deg, 3);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20259), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25Deg, 0);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20264), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25Deg, 1);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20269), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25Deg, 2);
                     break;
             }
             switch (direction)
@@ -1632,27 +1778,28 @@ static void MineTrainRCTrackRightQuarterTurn525DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20230), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20235), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20240), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20245), { 0, 0, height },
                         { { 0, 2, height }, { 32, 27, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
+
+            WoodenASupportsPaintSetupRotated(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height,
+                session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25Deg);
+
             if (direction == 0 || direction == 3)
             {
                 PaintUtilPushTunnelRotated(session, direction, height - 8, TUNNEL_SQUARE_7);
@@ -1672,25 +1819,33 @@ static void MineTrainRCTrackRightQuarterTurn525DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20231), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20236), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20241), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20246), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1706,25 +1861,33 @@ static void MineTrainRCTrackRightQuarterTurn525DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20232), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20237), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20242), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20247), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1747,25 +1910,33 @@ static void MineTrainRCTrackRightQuarterTurn525DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20233), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20238), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20243), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20248), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1781,25 +1952,33 @@ static void MineTrainRCTrackRightQuarterTurn525DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20234), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 10, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25Deg, 1);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20239), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 11, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25Deg, 2);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20244), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 12, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25Deg, 3);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20249), { 0, 0, height },
                         { { 2, 0, height }, { 27, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 9, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS], WoodenSupportTransitionType::Up25Deg, 0);
                     break;
             }
             switch (direction)
@@ -1849,25 +2028,33 @@ static void MineTrainRCTrackSBendLeft(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20270), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20274), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20273), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20277), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -1884,25 +2071,33 @@ static void MineTrainRCTrackSBendLeft(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20271), { 0, 0, height },
                         { 32, 26, 1 });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20275), { 0, 0, height },
                         { 32, 26, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20272), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20276), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1918,25 +2113,33 @@ static void MineTrainRCTrackSBendLeft(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20272), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20276), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20271), { 0, 0, height },
                         { 32, 26, 1 });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20275), { 0, 0, height },
                         { 32, 26, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -1952,25 +2155,33 @@ static void MineTrainRCTrackSBendLeft(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20273), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20277), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20270), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20274), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2002,25 +2213,33 @@ static void MineTrainRCTrackSBendRight(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20278), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20282), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20281), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20285), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2037,25 +2256,33 @@ static void MineTrainRCTrackSBendRight(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20279), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20283), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20280), { 0, 0, height },
                         { 32, 26, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20284), { 0, 0, height },
                         { 32, 26, 1 });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -2071,25 +2298,33 @@ static void MineTrainRCTrackSBendRight(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20280), { 0, 0, height },
                         { 32, 26, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20284), { 0, 0, height },
                         { 32, 26, 1 });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20279), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20283), { 0, 0, height },
                         { { 0, 6, height }, { 32, 26, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -2105,25 +2340,33 @@ static void MineTrainRCTrackSBendRight(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20281), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20285), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20278), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20282), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2155,25 +2398,33 @@ static void MineTrainRCTrackLeftQuarterTurn3(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20193), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20196), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20199), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20190), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2187,16 +2438,24 @@ static void MineTrainRCTrackLeftQuarterTurn3(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -2236,25 +2495,33 @@ static void MineTrainRCTrackLeftQuarterTurn3(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20191), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20194), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20197), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20188), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2298,25 +2565,33 @@ static void MineTrainRCTrackLeftQuarterTurn3Bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20212), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20208), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20211), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20202), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2330,16 +2605,24 @@ static void MineTrainRCTrackLeftQuarterTurn3Bank(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -2379,13 +2662,17 @@ static void MineTrainRCTrackLeftQuarterTurn3Bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20203), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20206), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2394,13 +2681,17 @@ static void MineTrainRCTrackLeftQuarterTurn3Bank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20213), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20200), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2441,25 +2732,33 @@ static void MineTrainRCTrackLeftQuarterTurn325DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20225), { 0, 6, height },
                         { 32, 20, 1 });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20227), { 0, 6, height },
                         { 32, 20, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20229), { 0, 6, height },
                         { 32, 20, 1 });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20223), { 0, 6, height },
                         { 32, 20, 1 });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2473,16 +2772,24 @@ static void MineTrainRCTrackLeftQuarterTurn325DegUp(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
@@ -2499,25 +2806,33 @@ static void MineTrainRCTrackLeftQuarterTurn325DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20224), { 6, 0, height },
                         { 20, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20226), { 6, 0, height },
                         { 20, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20228), { 6, 0, height },
                         { 20, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20222), { 6, 0, height },
                         { 20, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2549,25 +2864,33 @@ static void MineTrainRCTrackRightQuarterTurn325DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20214), { 0, 6, height },
                         { 32, 20, 1 });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20216), { 0, 6, height },
                         { 32, 20, 1 });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20218), { 0, 6, height },
                         { 32, 20, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20220), { 0, 6, height },
                         { 32, 20, 1 });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2581,16 +2904,24 @@ static void MineTrainRCTrackRightQuarterTurn325DegUp(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 56, 0x20);
@@ -2607,25 +2938,33 @@ static void MineTrainRCTrackRightQuarterTurn325DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20215), { 6, 0, height },
                         { 20, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20217), { 6, 0, height },
                         { 20, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20219), { 6, 0, height },
                         { 20, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20221), { 6, 0, height },
                         { 20, 32, 1 });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2678,25 +3017,33 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20312), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20308), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20311), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20302), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2714,16 +3061,24 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -2763,13 +3118,17 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20303), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20306), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -2778,13 +3137,17 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20313), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20300), { 0, 0, height },
                         { { 6, 0, height + 8 }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2810,7 +3173,9 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20302), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -2819,19 +3184,25 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20312), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20308), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20311), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -2854,16 +3225,24 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -2903,19 +3282,25 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20300), { 0, 0, height },
                         { { 0, 6, height + 8 }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20303), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20306), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2924,7 +3309,9 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20313), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2955,19 +3342,25 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20286), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20289), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20292), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -2976,7 +3369,9 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20299), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -2994,16 +3389,24 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -3043,7 +3446,9 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20288), { 0, 0, height },
                         { { 6, 0, height + 8 }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3052,19 +3457,25 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20298), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20294), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20297), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3090,13 +3501,17 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20289), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20292), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3105,13 +3520,17 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20299), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20286), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3134,16 +3553,24 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);
@@ -3186,25 +3613,33 @@ static void MineTrainRCTrackRightHalfBankedHelixUpSmall(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20298), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20294), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20297), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20288), { 0, 0, height },
                         { { 0, 6, height + 8 }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3266,25 +3701,33 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20356), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20350), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20355), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20340), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3310,25 +3753,33 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20344), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20349), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20354), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20339), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3344,7 +3795,9 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20343), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3353,19 +3806,25 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20178), { 0, 0, height },
                         { { 16, 16, height + 27 }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20353), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20338), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3386,7 +3845,9 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20342), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3395,19 +3856,25 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20177), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20352), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20337), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3423,13 +3890,17 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20341), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20346), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3438,13 +3909,17 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20357), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20336), { 0, 0, height },
                         { { 6, 0, height + 8 }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3470,7 +3945,9 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20340), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3479,19 +3956,25 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20356), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20350), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20355), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3522,25 +4005,33 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20339), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20344), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20349), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20354), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3556,13 +4047,17 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20338), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20343), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3571,13 +4066,17 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20178), { 0, 0, height },
                         { { 16, 16, height + 27 }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20353), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3598,13 +4097,17 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20337), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20342), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3613,13 +4116,17 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20177), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20352), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3635,19 +4142,25 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20336), { 0, 0, height },
                         { { 0, 6, height + 8 }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20341), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20346), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3656,7 +4169,9 @@ static void MineTrainRCTrackLeftHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20357), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3687,19 +4202,25 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20314), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20319), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20324), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
@@ -3708,7 +4229,9 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20335), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -3734,25 +4257,33 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20315), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20320), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20325), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20330), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3768,25 +4299,33 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20316), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20321), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20326), { 0, 0, height },
                         { { 16, 16, height + 27 }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20331), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3807,25 +4346,33 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20317), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20322), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20327), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20332), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3841,7 +4388,9 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20318), { 0, 0, height },
                         { { 6, 0, height + 8 }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
@@ -3850,19 +4399,25 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20334), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20328), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20333), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3888,13 +4443,17 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20319), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20324), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -3903,13 +4462,17 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20335), { 0, 0, height },
                         { { 27, 0, height }, { 1, 32, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20314), { 0, 0, height },
                         { { 6, 0, height }, { 20, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             switch (direction)
@@ -3940,25 +4503,33 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20320), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20325), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20330), { 0, 0, height },
                         { { 0, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20315), { 0, 0, height },
                         { { 16, 0, height }, { 16, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -3974,25 +4545,33 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20321), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20326), { 0, 0, height },
                         { { 16, 16, height + 27 }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20331), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20316), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -4013,25 +4592,33 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20322), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20327), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20332), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20317), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -4050,25 +4637,33 @@ static void MineTrainRCTrackRightHalfBankedHelixUpLarge(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20334), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20328), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20333), { 0, 0, height },
                         { { 0, 6, height }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20318), { 0, 0, height },
                         { { 0, 6, height + 8 }, { 32, 20, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4125,14 +4720,16 @@ static void MineTrainRCTrackBrakes(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20058), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20059), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
@@ -4151,25 +4748,29 @@ static void MineTrainRCTrackOnRidePhoto(
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20052), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 1:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20053), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 2:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20052), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
         case 3:
             PaintAddImageAsParentRotated(
                 session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20053), { 0, 0, height },
                 { { 0, 6, height }, { 32, 20, 1 } });
-            WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+            WoodenASupportsPaintSetup(
+                session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height, session.TrackColours[SCHEME_SUPPORTS]);
             break;
     }
     TrackPaintUtilOnridePhotoPaint(session, direction, height + 2, trackElement);
@@ -4192,25 +4793,33 @@ static void MineTrainRCTrackLeftEighthToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20452), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20456), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20460), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20464), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4227,25 +4836,33 @@ static void MineTrainRCTrackLeftEighthToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20453), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20457), { 0, 0, height },
                         { { 0, 0, height }, { 34, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20461), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20465), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4258,25 +4875,33 @@ static void MineTrainRCTrackLeftEighthToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20454), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20458), { 0, 0, height },
                         { { 16, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20462), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20466), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4286,16 +4911,24 @@ static void MineTrainRCTrackLeftEighthToDiag(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4345,25 +4978,33 @@ static void MineTrainRCTrackRightEighthToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20436), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20440), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20444), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20448), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4380,25 +5021,33 @@ static void MineTrainRCTrackRightEighthToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20437), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20441), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20445), { 0, 0, height },
                         { { 0, 0, height }, { 34, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20449), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4411,25 +5060,33 @@ static void MineTrainRCTrackRightEighthToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20438), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20442), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20446), { 0, 0, height },
                         { { 4, 4, height }, { 28, 28, 1 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20450), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4439,16 +5096,24 @@ static void MineTrainRCTrackRightEighthToDiag(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4516,25 +5181,33 @@ static void MineTrainRCTrackLeftEighthBankToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20484), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20488), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20492), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20496), { 0, 0, height },
                         { { 0, 27, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4551,25 +5224,33 @@ static void MineTrainRCTrackLeftEighthBankToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20485), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20489), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 34, 16, 0 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20493), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20497), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4582,25 +5263,33 @@ static void MineTrainRCTrackLeftEighthBankToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20486), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20490), { 0, 0, height },
                         { { 16, 16, height + 27 }, { 16, 16, 0 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20494), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20498), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4610,16 +5299,24 @@ static void MineTrainRCTrackLeftEighthBankToDiag(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4669,25 +5366,33 @@ static void MineTrainRCTrackRightEighthBankToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20468), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20472), { 0, 0, height },
                         { { 0, 0, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20476), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20480), { 0, 0, height },
                         { { 0, 27, height }, { 32, 1, 26 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             if (direction == 0 || direction == 3)
@@ -4704,25 +5409,33 @@ static void MineTrainRCTrackRightEighthBankToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20469), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20473), { 0, 0, height },
                         { { 0, 16, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20477), { 0, 0, height },
                         { { 0, 0, height + 27 }, { 34, 16, 0 } });
-                    WoodenASupportsPaintSetup(session, 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20481), { 0, 0, height },
                         { { 0, 0, height }, { 32, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 7, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::NwSe, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4735,25 +5448,33 @@ static void MineTrainRCTrackRightEighthBankToDiag(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20470), { 0, 0, height },
                         { { 0, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20474), { 0, 0, height },
                         { { 16, 0, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20478), { 0, 0, height },
                         { { 4, 4, height + 27 }, { 28, 28, 0 } });
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20482), { 0, 0, height },
                         { { 0, 16, height }, { 16, 16, 1 } });
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4763,16 +5484,24 @@ static void MineTrainRCTrackRightEighthBankToDiag(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -4868,16 +5597,24 @@ static void MineTrainRCTrackDiagFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20386), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4889,16 +5626,24 @@ static void MineTrainRCTrackDiagFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20358), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4911,19 +5656,27 @@ static void MineTrainRCTrackDiagFlat(
                 switch (direction)
                 {
                     case 0:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20388), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -4932,19 +5685,27 @@ static void MineTrainRCTrackDiagFlat(
                 switch (direction)
                 {
                     case 0:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20360), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5254,16 +6015,24 @@ static void MineTrainRCTrackDiagFlatTo25DegUp(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20390), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5275,16 +6044,24 @@ static void MineTrainRCTrackDiagFlatTo25DegUp(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20362), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5297,19 +6074,27 @@ static void MineTrainRCTrackDiagFlatTo25DegUp(
                 switch (direction)
                 {
                     case 0:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20392), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -5318,19 +6103,27 @@ static void MineTrainRCTrackDiagFlatTo25DegUp(
                 switch (direction)
                 {
                     case 0:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20364), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -6258,16 +7051,24 @@ static void MineTrainRCTrackDiag25DegDownToFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20392), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -6279,16 +7080,24 @@ static void MineTrainRCTrackDiag25DegDownToFlat(
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20364), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -6301,19 +7110,27 @@ static void MineTrainRCTrackDiag25DegDownToFlat(
                 switch (direction)
                 {
                     case 0:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20390), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -6322,19 +7139,27 @@ static void MineTrainRCTrackDiag25DegDownToFlat(
                 switch (direction)
                 {
                     case 0:
-                        WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 1:
-                        WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 2:
                         PaintAddImageAsParentRotated(
                             session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20362), { -16, -16, height },
                             { { -16, -16, height }, { 32, 32, 1 } });
-                        WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                     case 3:
-                        WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                        WoodenASupportsPaintSetup(
+                            session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                            session.TrackColours[SCHEME_SUPPORTS]);
                         break;
                 }
             }
@@ -6399,16 +7224,24 @@ static void MineTrainRCTrackDiagFlatToLeftBank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20410), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6418,19 +7251,27 @@ static void MineTrainRCTrackDiagFlatToLeftBank(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20408), { -16, -16, height },
                         { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6477,16 +7318,24 @@ static void MineTrainRCTrackDiagFlatToRightBank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
                         { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6496,10 +7345,14 @@ static void MineTrainRCTrackDiagFlatToRightBank(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6508,10 +7361,14 @@ static void MineTrainRCTrackDiagFlatToRightBank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6561,16 +7418,24 @@ static void MineTrainRCTrackDiagLeftBankToFlat(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20415), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6580,19 +7445,27 @@ static void MineTrainRCTrackDiagLeftBankToFlat(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20411), { -16, -16, height },
                         { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6639,16 +7512,24 @@ static void MineTrainRCTrackDiagRightBankToFlat(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20408), { -16, -16, height },
                         { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6658,10 +7539,14 @@ static void MineTrainRCTrackDiagRightBankToFlat(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6670,10 +7555,14 @@ static void MineTrainRCTrackDiagRightBankToFlat(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20410), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6723,16 +7612,24 @@ static void MineTrainRCTrackDiagLeftBankTo25DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20430), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6742,19 +7639,27 @@ static void MineTrainRCTrackDiagLeftBankTo25DegUp(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20428), { -16, -16, height },
                         { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6801,16 +7706,24 @@ static void MineTrainRCTrackDiagRightBankTo25DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20431), { -16, -16, height },
                         { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -6820,10 +7733,14 @@ static void MineTrainRCTrackDiagRightBankTo25DegUp(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -6832,10 +7749,14 @@ static void MineTrainRCTrackDiagRightBankTo25DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20435), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7199,16 +8120,24 @@ static void MineTrainRCTrackDiag25DegDownToLeftBank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20435), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7218,19 +8147,27 @@ static void MineTrainRCTrackDiag25DegDownToLeftBank(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20431), { -16, -16, height },
                         { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7277,16 +8214,24 @@ static void MineTrainRCTrackDiag25DegDownToRightBank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20428), { -16, -16, height },
                         { { -16, -16, height }, { 32, 32, 1 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7296,10 +8241,14 @@ static void MineTrainRCTrackDiag25DegDownToRightBank(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
@@ -7308,10 +8257,14 @@ static void MineTrainRCTrackDiag25DegDownToRightBank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20430), { -16, -16, height },
                         { { -16, -16, height + 35 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
@@ -7359,16 +8312,24 @@ static void MineTrainRCTrackDiagLeftBank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20402), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -7379,19 +8340,27 @@ static void MineTrainRCTrackDiagLeftBank(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20404), { -16, -16, height },
                         { { -16, -16, height }, { 32, 32, 3 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -7441,16 +8410,24 @@ static void MineTrainRCTrackDiagRightBank(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20404), { -16, -16, height },
                         { { -16, -16, height }, { 32, 32, 3 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -7461,19 +8438,27 @@ static void MineTrainRCTrackDiagRightBank(
             switch (direction)
             {
                 case 0:
-                    WoodenASupportsPaintSetup(session, 10, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner2, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 1:
-                    WoodenASupportsPaintSetup(session, 11, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner3, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 2:
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20402), { -16, -16, height },
                         { { -16, -16, height + 27 }, { 32, 32, 0 } });
-                    WoodenASupportsPaintSetup(session, 8, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner0, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
-                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(
+                        session, WoodenSupportType::Mine, WoodenSupportSubType::Corner1, height,
+                        session.TrackColours[SCHEME_SUPPORTS]);
                     break;
             }
             PaintUtilSetSegmentSupportHeight(
@@ -7505,7 +8490,8 @@ static void MineTrainRCTrackBlockBrakes(
     PaintAddImageAsParentRotated(
         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(_MineTrainBlockBrakeImages[direction][isClosed]),
         { 0, 0, height }, { { 0, 6, height }, { 32, 20, 1 } });
-    WoodenASupportsPaintSetup(session, (direction & 1) ? 7 : 6, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+    WoodenASupportsPaintSetupRotated(
+        session, WoodenSupportType::Mine, WoodenSupportSubType::NeSw, direction, height, session.TrackColours[SCHEME_SUPPORTS]);
     PaintUtilPushTunnelRotated(session, direction, height, TUNNEL_SQUARE_FLAT);
     PaintUtilSetSegmentSupportHeight(session, SEGMENTS_ALL, 0xFFFF, 0);
     PaintUtilSetGeneralSupportHeight(session, height + 32, 0x20);

--- a/src/openrct2/ride/coaster/MineTrainCoaster.cpp
+++ b/src/openrct2/ride/coaster/MineTrainCoaster.cpp
@@ -2453,7 +2453,7 @@ static void MineTrainRCTrackLeftQuarterTurn325DegUp(
                     PaintAddImageAsParentRotated(
                         session, direction, session.TrackColours[SCHEME_TRACK].WithIndex(20229), { 0, 6, height },
                         { 32, 20, 1 });
-                    WoodenASupportsPaintSetup(session, 3, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
+                    WoodenASupportsPaintSetup(session, 9, 0, height, session.TrackColours[SCHEME_SUPPORTS]);
                     break;
                 case 3:
                     PaintAddImageAsParentRotated(


### PR DESCRIPTION
Both "supportType" and "special" parameters were actually doing multi-duty. The former contained both the type (regular truss, mine train) and the "rotation" (SwNe, NwSe, plus 4 corner pieces), the latter contained both vertical transition and rotation.

This PR introduces overloads. One that just takes new parameters, one that also perform rotation in the same way that many other paint setup functions do.

I modified just MineTrainCoaster.cpp to use this new system. This is to break up the refactor into manageable chunks, and to avoid having to throw away hours of work if changes are requested.