### PR TITLE
Fix #19991: Crash when using cut-away view

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -27,6 +27,7 @@
 - Fix: [#19924] Destructible cheat does not allow partial ride modification.
 - Fix: [#19950] Mine train block brake supports drawn incorrectly.
 - Fix: [#19987] [Plugin] ‘SetCheatAction’ has wrong ID in plugin API.
+- Fix: [#19991] Crash using cut-away view.
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/src/openrct2/interface/Viewport.cpp
+++ b/src/openrct2/interface/Viewport.cpp
@@ -1834,10 +1834,10 @@ InteractionInfo SetInteractionInfoFromPaintSession(PaintSession* session, uint32
 {
     PROFILED_FUNCTION();
 
-    PaintStruct* ps = &session->PaintHead;
     InteractionInfo info{};
 
-    while ((ps = ps->NextQuadrantEntry) != nullptr)
+    PaintStruct* ps = session->PaintHead;
+    while (ps != nullptr)
     {
         PaintStruct* old_ps = ps;
         PaintStruct* next_ps = ps;
@@ -1868,7 +1868,7 @@ InteractionInfo SetInteractionInfoFromPaintSession(PaintSession* session, uint32
         }
 #pragma GCC diagnostic pop
 
-        ps = old_ps;
+        ps = old_ps->NextQuadrantEntry;
     }
     return info;
 }

--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -477,6 +477,9 @@ template<int TRotation> static void PaintSessionArrangeImpl(PaintSessionCore& se
         return;
     }
 
+    // psHead is an intermediate node that is used to link all the quadrant lists together,
+    // this was previously stored in PaintSession but only the NextQuadrantEntry is relevant here.
+    // The head node is not part of the linked list and just serves as an entry point.
     PaintStruct psHead{};
     PaintStructsLinkQuadrants(session, psHead);
 

--- a/src/openrct2/paint/Paint.h
+++ b/src/openrct2/paint/Paint.h
@@ -179,7 +179,7 @@ public:
 
 struct PaintSessionCore
 {
-    PaintStruct PaintHead;
+    PaintStruct* PaintHead;
     PaintStruct* Quadrants[MaxPaintQuadrants];
     PaintStruct* LastPS;
     PaintStringStruct* PSStringHead;

--- a/src/openrct2/paint/Painter.cpp
+++ b/src/openrct2/paint/Painter.cpp
@@ -160,6 +160,7 @@ PaintSession* Painter::CreateSession(DrawPixelInfo& dpi, uint32_t viewFlags)
     session->Flags = 0;
 
     std::fill(std::begin(session->Quadrants), std::end(session->Quadrants), nullptr);
+    session->PaintHead = nullptr;
     session->LastPS = nullptr;
     session->LastAttachedPS = nullptr;
     session->PSStringHead = nullptr;


### PR DESCRIPTION
PaintHead was just there to point to the next node for the quadrant list and had no useful data stored there, 120 bytes for nothing really. Now its actually the first node in the list and not a temporary. I've tested this a bit as it affects drawing and interactions, as far as I can tell interactions still work the same way and I can't see any artifacts.

Closes #19991, Closes #19984, Closes #19983, Closes #19981, Closes #19971, Closes #19977, Closes #19973, Closes #19963, Closes #19959, Closes #19956, Closes #19762, Closes #19991, Closes #19637, Closes #19562, Closes #19556