### PR TITLE
NextQuadrantEntry not initialized to null

### DIFF
--- a/src/openrct2/paint/Paint.cpp
+++ b/src/openrct2/paint/Paint.cpp
@@ -186,6 +186,7 @@ static PaintStruct* CreateNormalPaintStruct(
     ps->Bounds.z = rotBoundBoxOffset.z;
     ps->Attached = nullptr;
     ps->Children = nullptr;
+    ps->NextQuadrantEntry = nullptr;
     ps->InteractionItem = session.InteractionType;
     ps->MapPos = session.MapPosition;
     ps->Element = session.CurrentlyDrawnTileElement;


### PR DESCRIPTION
I'm not 100% confident that this will fix #19938, probably not as this does seem a bit unrelated, its definitely one of those things that should be set to null however.