### PR TITLE
Fix rotodrop top piece replication issue (#16791)

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -219,6 +219,7 @@ The following people are not part of the development team, but have been contrib
 * Joel H. (HtotheTML)
 * John Mulcahy (jayjay300)
 * Chase Percy (Chase-Percy)
+* Wenzhao Qiu (qwzhaox)
 
 ## Toolchain
 * (Balletie) - macOS

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -28,6 +28,7 @@
 - Fix: [#19950] Mine train block brake supports drawn incorrectly.
 - Fix: [#19987] [Plugin] ‘SetCheatAction’ has wrong ID in plugin API.
 - Fix: [#19991] Crash using cut-away view.
+- Fix: [#16791] Rotodrop top piece replicates when walls are placed around it and clearance checks are disabled.
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -14,6 +14,7 @@
 - Improved: [#19953] Add keyboard shortcut to Keyboard Shortcuts window.
 - Fix: [#12598] Number of holes is not set correctly when saving track designs.
 - Fix: [#13130] Android always defaulting to UK locale for language, currency and temperature.
+- Fix: [#16791] Rotodrop top piece replicates when walls are placed around it and clearance checks are disabled (original bug).
 - Fix: [#18895] Responding mechanic blocked at level crossing.
 - Fix: [#19231] Crash due to null pointer to previously deleted banner in tile copy/paste functionality
 - Fix: [#19296] Crash due to a race condition for parallel object loading.
@@ -28,7 +29,6 @@
 - Fix: [#19950] Mine train block brake supports drawn incorrectly.
 - Fix: [#19987] [Plugin] ‘SetCheatAction’ has wrong ID in plugin API.
 - Fix: [#19991] Crash using cut-away view.
-- Fix: [#16791] Rotodrop top piece replicates when walls are placed around it and clearance checks are disabled.
 
 0.4.4 (2023-03-28)
 ------------------------------------------------------------------------

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/ride/thrill/RotoDrop.cpp
+++ b/src/openrct2/ride/thrill/RotoDrop.cpp
@@ -186,6 +186,12 @@ static void PaintRotoDropTowerSection(
     PaintAddImageAsParent(session, imageId, { 0, 0, height }, { { 8, 8, height }, { 2, 2, 30 } });
 
     const TileElement* nextTileElement = reinterpret_cast<const TileElement*>(&trackElement) + 1;
+
+    while (nextTileElement->GetType() != TileElementType::Track && !nextTileElement->IsLastForTile())
+    {
+        nextTileElement++;
+    }
+
     if (trackElement.IsLastForTile() || trackElement.GetClearanceZ() != nextTileElement->GetBaseZ())
     {
         imageId = session.TrackColours[SCHEME_TRACK].WithIndex(SPR_ROTO_DROP_TOWER_SEGMENT_TOP);


### PR DESCRIPTION
Fix rotodrop top piece replication issue (#16791). 
- Add a loop that iterates until the TileElement is of type track.

I was able to reproduce the bug and confirmed that the bug was fixed and nothing else in relation to the rotodrop was broken (was still able to rotate / finish construction / build another rotodrop). Let me know if there's anything else I need to do!