### PR TITLE
Fix: version info is not filled on bug report

### DIFF
--- a/src/openrct2-ui/windows/TopToolbar.cpp
+++ b/src/openrct2-ui/windows/TopToolbar.cpp
@@ -2722,10 +2722,11 @@ public:
                         break;
                     case DDIDX_FILE_BUG_ON_GITHUB:
                     {
-                        std::string url = "https://github.com/OpenRCT2/OpenRCT2/issues/"
-                                          "new?assignees=&labels=bug&template=bug_report.yaml";
+                        std::string url = "https://github.com/OpenRCT2/OpenRCT2/issues/new?"
+                                          "assignees=&labels=bug&template=bug_report.yaml";
+                        // Automatically fill the "OpenRCT2 build" input
                         auto versionStr = String::URLEncode(gVersionInfoFull);
-                        url.append("&openrct2_build=" + versionStr);
+                        url.append("&f299dd2a20432827d99b648f73eb4649b23f8ec98d158d6f82b81e43196ee36b=" + versionStr);
                         OpenRCT2::GetContext()->GetUiContext()->OpenURL(url);
                     }
                     break;


### PR DESCRIPTION
The named label does not seem to work any more. Each field has a unique ID that does work. This was an undocumented feature anyway. I can't find any info on this new alternative, but it has been a couple of hours now, and the IDs have not changed so far. I suspect they may be constant.

I'm creating this as a draft, to be merged in a couple of days if the IDs are still the same.

A quick and easy way to test this is to open [this link](https://github.com/OpenRCT2/OpenRCT2/issues/new?assignees=&labels=bug&template=bug_report.yaml&f299dd2a20432827d99b648f73eb4649b23f8ec98d158d6f82b81e43196ee36b=just+a+test), and check if the version info is set to "just a test".