### PR TITLE
Implement scenery groups to plugin API

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -7,6 +7,7 @@
 - Feature: [#19446] Add new color options to color dropdown.
 - Feature: [#19547] Add large sloped turns to hybrid coaster and single rail coaster.
 - Feature: [#19930] Add plugin APIs for research.
+- Feature: [#19979] Add plugin API for scenery groups.
 - Feature: [OpenMusic#25] Added Prehistoric ride music style.
 - Improved: [#17739] Raise water and land height limits to 254 units/182m/600ft.
 - Improved: [#18490] Reduce guests walking through trains on level crossing next to station.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -222,7 +222,6 @@ declare global {
          * @param index The index.
          */
         getObject(type: ObjectType, index: number): LoadedImageObject;
-        getObject(type: "music", index: number): LoadedObject;
         getObject(type: "ride", index: number): RideObject;
         getObject(type: "small_scenery", index: number): SmallSceneryObject;
         getObject(type: "large_scenery", index: number): LargeSceneryObject;
@@ -230,10 +229,17 @@ declare global {
         getObject(type: "footpath_addition", index: number): FootpathAdditionObject;
         getObject(type: "banner", index: number): BannerObject;
         getObject(type: "scenery_group", index: number): SceneryGroupObject;
+        getObject(type: "music", index: number): LoadedObject;
 
         getAllObjects(type: ObjectType): LoadedImageObject[];
-        getAllObjects(type: "music"): LoadedObject[];
         getAllObjects(type: "ride"): RideObject[];
+        getAllObjects(type: "small_scenery"): SmallSceneryObject[];
+        getAllObjects(type: "large_scenery"): LargeSceneryObject[];
+        getAllObjects(type: "wall"): WallObject[];
+        getAllObjects(type: "footpath_addition"): FootpathAdditionObject[];
+        getAllObjects(type: "banner"): BannerObject[];
+        getAllObjects(type: "scenery_group"): SceneryGroupObject[];
+        getAllObjects(type: "music"): LoadedObject[];
 
         /**
          * Gets the {@link TrackSegment} for the given type.
@@ -1753,34 +1759,7 @@ declare global {
          * scenery groups that contain this object by default. This is typically
          * used for custom objects to be part of existing scenery groups.
          */
-        readonly sceneryGroups: ObjectReference[];
-    }
-
-    /**
-     * Represents a reference to an object which may or may not be loaded.
-     */
-    interface ObjectReference {
-        /**
-         * The JSON identifier of the object.
-         * Undefined if object only has a legacy identifier.
-         */
-        readonly identifier?: string;
-
-        /**
-         * The DAT identifier of the object.
-         * Undefined if object only has a JSON identifier.
-         */
-        readonly legacyIdentifier?: string;
-
-        /**
-         * The type of object
-         */
-        readonly type?: ObjectType;
-
-        /**
-         * The object index
-         */
-        readonly object: number | null;
+        readonly sceneryGroups: string[];
     }
 
     /**
@@ -1831,7 +1810,7 @@ declare global {
         /**
          * The scenery items that belong to this scenery group.
          */
-        readonly items: ObjectReference[];
+        readonly items: string[];
     }
 
     /**
@@ -2394,11 +2373,11 @@ declare global {
          * The current tilt of the car in the X/Y axis.
          */
         bankRotation: number;
-		
-		/**
-		 * Whether the car sprite is reversed or not.
-		 */ 
-		isReversed: boolean;
+
+        /**
+         * Whether the car sprite is reversed or not.
+         */
+        isReversed: boolean;
 
         /**
          * The colour of the car.

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -226,9 +226,10 @@ declare global {
         getObject(type: "ride", index: number): RideObject;
         getObject(type: "small_scenery", index: number): SmallSceneryObject;
         getObject(type: "large_scenery", index: number): LargeSceneryObject;
-        getObject(type: "wall", index: number): WallSceneryObject;
-        getObject(type: "footpath_addition", index: number): FootpathAdditionSceneryObject;
-        getObject(type: "banner", index: number): BannerSceneryObject;
+        getObject(type: "wall", index: number): WallObject;
+        getObject(type: "footpath_addition", index: number): FootpathAdditionObject;
+        getObject(type: "banner", index: number): BannerObject;
+        getObject(type: "scenery_group", index: number): SceneryGroupObject;
 
         getAllObjects(type: ObjectType): LoadedImageObject[];
         getAllObjects(type: "music"): LoadedObject[];
@@ -1763,23 +1764,23 @@ declare global {
          * The JSON identifier of the object.
          * Undefined if object only has a legacy identifier.
          */
-        identifier?: string;
+        readonly identifier?: string;
 
         /**
          * The DAT identifier of the object.
          * Undefined if object only has a JSON identifier.
          */
-        legacyIdentifier?: string;
+        readonly legacyIdentifier?: string;
 
         /**
          * The type of object
          */
-        type?: ObjectType;
+        readonly type?: ObjectType;
 
         /**
          * The object index
          */
-        object: number | null;
+        readonly object: number | null;
     }
 
     /**
@@ -1811,15 +1812,15 @@ declare global {
 
     }
 
-    interface WallSceneryObject extends SceneryObject {
+    interface WallObject extends SceneryObject {
 
     }
 
-    interface FootpathAdditionSceneryObject extends SceneryObject {
+    interface FootpathAdditionObject extends SceneryObject {
 
     }
 
-    interface BannerSceneryObject extends SceneryObject {
+    interface BannerObject extends SceneryObject {
 
     }
 

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -225,6 +225,10 @@ declare global {
         getObject(type: "music", index: number): LoadedObject;
         getObject(type: "ride", index: number): RideObject;
         getObject(type: "small_scenery", index: number): SmallSceneryObject;
+        getObject(type: "large_scenery", index: number): LargeSceneryObject;
+        getObject(type: "wall", index: number): WallSceneryObject;
+        getObject(type: "footpath_addition", index: number): FootpathAdditionSceneryObject;
+        getObject(type: "banner", index: number): BannerSceneryObject;
 
         getAllObjects(type: ObjectType): LoadedImageObject[];
         getAllObjects(type: "music"): LoadedObject[];
@@ -1742,10 +1746,46 @@ declare global {
         readonly numVerticalFramesOverride: number;
     }
 
+    interface SceneryObject extends LoadedImageObject {
+        /**
+         * A list of scenery groups this object belongs to. This may not contain any
+         * scenery groups that contain this object by default. This is typically
+         * used for custom objects to be part of existing scenery groups.
+         */
+        readonly sceneryGroups: ObjectReference[];
+    }
+
+    /**
+     * Represents a reference to an object which may or may not be loaded.
+     */
+    interface ObjectReference {
+        /**
+         * The JSON identifier of the object.
+         * Undefined if object only has a legacy identifier.
+         */
+        identifier?: string;
+
+        /**
+         * The DAT identifier of the object.
+         * Undefined if object only has a JSON identifier.
+         */
+        legacyIdentifier?: string;
+
+        /**
+         * The type of object
+         */
+        type?: ObjectType;
+
+        /**
+         * The object index
+         */
+        object: number | null;
+    }
+
     /**
      * Represents the object definition of a small scenery item such a tree.
      */
-    interface SmallSceneryObject extends LoadedImageObject {
+    interface SmallSceneryObject extends SceneryObject {
         /**
          * Raw bit flags that describe characteristics of the scenery item.
          */
@@ -1767,6 +1807,22 @@ declare global {
         readonly removalPrice: number;
     }
 
+    interface LargeSceneryObject extends SceneryObject {
+
+    }
+
+    interface WallSceneryObject extends SceneryObject {
+
+    }
+
+    interface FootpathAdditionSceneryObject extends SceneryObject {
+
+    }
+
+    interface BannerSceneryObject extends SceneryObject {
+
+    }
+
     /**
      * Represents the object definition of a scenery group.
      */
@@ -1774,31 +1830,7 @@ declare global {
         /**
          * The scenery items that belong to this scenery group.
          */
-        readonly items: SceneryGroupObjectItem[];
-    }
-
-    interface SceneryGroupObjectItem {
-        /**
-         * The JSON identifier of the object.
-         * Undefined if object only has a legacy identifier.
-         */
-        identifier?: string;
-
-        /**
-         * The DAT identifier of the object.
-         * Undefined if object only has a JSON identifier.
-         */
-        legacyIdentifier?: string;
-
-        /**
-         * The type of object
-         */
-        type: ObjectType;
-
-        /**
-         * The object index
-         */
-        object: number | null;
+        readonly items: ObjectReference[];
     }
 
     /**

--- a/distribution/openrct2.d.ts
+++ b/distribution/openrct2.d.ts
@@ -1768,6 +1768,40 @@ declare global {
     }
 
     /**
+     * Represents the object definition of a scenery group.
+     */
+    interface SceneryGroupObject extends LoadedImageObject {
+        /**
+         * The scenery items that belong to this scenery group.
+         */
+        readonly items: SceneryGroupObjectItem[];
+    }
+
+    interface SceneryGroupObjectItem {
+        /**
+         * The JSON identifier of the object.
+         * Undefined if object only has a legacy identifier.
+         */
+        identifier?: string;
+
+        /**
+         * The DAT identifier of the object.
+         * Undefined if object only has a JSON identifier.
+         */
+        legacyIdentifier?: string;
+
+        /**
+         * The type of object
+         */
+        type: ObjectType;
+
+        /**
+         * The object index
+         */
+        object: number | null;
+    }
+
+    /**
      * Represents a ride or stall within the park.
      */
     interface Ride {

--- a/src/openrct2/object/Object.cpp
+++ b/src/openrct2/object/Object.cpp
@@ -80,6 +80,24 @@ std::string_view ObjectEntryDescriptor::GetName() const
     return Generation == ObjectGeneration::JSON ? Identifier : Entry.GetName();
 }
 
+std::string ObjectEntryDescriptor::ToString() const
+{
+    if (Generation == ObjectGeneration::DAT)
+    {
+        char buffer[32];
+        std::snprintf(&buffer[0], 9, "%08X", Entry.flags);
+        buffer[8] = '|';
+        std::memcpy(&buffer[9], Entry.name, 8);
+        buffer[17] = '|';
+        std::snprintf(&buffer[18], 9, "%8X", Entry.checksum);
+        return std::string(buffer);
+    }
+    else
+    {
+        return std::string(GetName());
+    }
+}
+
 bool ObjectEntryDescriptor::operator==(const ObjectEntryDescriptor& rhs) const
 {
     if (Generation != rhs.Generation)

--- a/src/openrct2/object/Object.h
+++ b/src/openrct2/object/Object.h
@@ -139,6 +139,7 @@ struct ObjectEntryDescriptor
     bool HasValue() const;
     ObjectType GetType() const;
     std::string_view GetName() const;
+    std::string ToString() const;
 
     bool operator==(const ObjectEntryDescriptor& rhs) const;
     bool operator!=(const ObjectEntryDescriptor& rhs) const;

--- a/src/openrct2/object/SceneryGroupObject.cpp
+++ b/src/openrct2/object/SceneryGroupObject.cpp
@@ -243,3 +243,8 @@ uint16_t SceneryGroupObject::GetNumIncludedObjects() const
 {
     return static_cast<uint16_t>(_items.size());
 }
+
+const std::vector<ObjectEntryDescriptor>& SceneryGroupObject::GetItems() const
+{
+    return _items;
+}

--- a/src/openrct2/object/SceneryGroupObject.h
+++ b/src/openrct2/object/SceneryGroupObject.h
@@ -41,6 +41,7 @@ public:
     void SetRepositoryItem(ObjectRepositoryItem* item) const override;
 
     uint16_t GetNumIncludedObjects() const;
+    const std::vector<ObjectEntryDescriptor>& GetItems() const;
 
 private:
     static std::vector<ObjectEntryDescriptor> ReadItems(OpenRCT2::IStream* stream);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -407,9 +407,9 @@ void ScriptEngine::Initialise()
     ScSceneryObject::Register(ctx);
     ScSmallSceneryObject::Register(ctx);
     ScLargeSceneryObject::Register(ctx);
-    ScWallSceneryObject::Register(ctx);
-    ScFootpathAdditionSceneryObject::Register(ctx);
-    ScBannerSceneryObject::Register(ctx);
+    ScWallObject::Register(ctx);
+    ScFootpathAdditionObject::Register(ctx);
+    ScBannerObject::Register(ctx);
     ScSceneryGroupObject::Register(ctx);
     ScPark::Register(ctx);
     ScParkMessage::Register(ctx);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -405,6 +405,7 @@ void ScriptEngine::Initialise()
     ScNetwork::Register(ctx);
     ScObject::Register(ctx);
     ScSmallSceneryObject::Register(ctx);
+    ScSceneryGroupObject::Register(ctx);
     ScPark::Register(ctx);
     ScParkMessage::Register(ctx);
     ScPlayer::Register(ctx);

--- a/src/openrct2/scripting/ScriptEngine.cpp
+++ b/src/openrct2/scripting/ScriptEngine.cpp
@@ -404,7 +404,12 @@ void ScriptEngine::Initialise()
     ScMap::Register(ctx);
     ScNetwork::Register(ctx);
     ScObject::Register(ctx);
+    ScSceneryObject::Register(ctx);
     ScSmallSceneryObject::Register(ctx);
+    ScLargeSceneryObject::Register(ctx);
+    ScWallSceneryObject::Register(ctx);
+    ScFootpathAdditionSceneryObject::Register(ctx);
+    ScBannerSceneryObject::Register(ctx);
     ScSceneryGroupObject::Register(ctx);
     ScPark::Register(ctx);
     ScParkMessage::Register(ctx);

--- a/src/openrct2/scripting/ScriptEngine.h
+++ b/src/openrct2/scripting/ScriptEngine.h
@@ -47,7 +47,7 @@ namespace OpenRCT2
 
 namespace OpenRCT2::Scripting
 {
-    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 75;
+    static constexpr int32_t OPENRCT2_PLUGIN_API_VERSION = 76;
 
     // Versions marking breaking changes.
     static constexpr int32_t API_VERSION_33_PEEP_DEPRECATION = 33;

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -171,11 +171,11 @@ namespace OpenRCT2::Scripting
                 case ObjectType::LargeScenery:
                     return GetObjectAsDukValue(ctx, std::make_shared<ScLargeSceneryObject>(type, index));
                 case ObjectType::Walls:
-                    return GetObjectAsDukValue(ctx, std::make_shared<ScWallSceneryObject>(type, index));
+                    return GetObjectAsDukValue(ctx, std::make_shared<ScWallObject>(type, index));
                 case ObjectType::PathBits:
-                    return GetObjectAsDukValue(ctx, std::make_shared<ScFootpathAdditionSceneryObject>(type, index));
+                    return GetObjectAsDukValue(ctx, std::make_shared<ScFootpathAdditionObject>(type, index));
                 case ObjectType::Banners:
-                    return GetObjectAsDukValue(ctx, std::make_shared<ScBannerSceneryObject>(type, index));
+                    return GetObjectAsDukValue(ctx, std::make_shared<ScBannerObject>(type, index));
                 case ObjectType::SceneryGroup:
                     return GetObjectAsDukValue(ctx, std::make_shared<ScSceneryGroupObject>(type, index));
                 default:

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -168,6 +168,14 @@ namespace OpenRCT2::Scripting
                     return GetObjectAsDukValue(ctx, std::make_shared<ScRideObject>(type, index));
                 case ObjectType::SmallScenery:
                     return GetObjectAsDukValue(ctx, std::make_shared<ScSmallSceneryObject>(type, index));
+                case ObjectType::LargeScenery:
+                    return GetObjectAsDukValue(ctx, std::make_shared<ScLargeSceneryObject>(type, index));
+                case ObjectType::Walls:
+                    return GetObjectAsDukValue(ctx, std::make_shared<ScWallSceneryObject>(type, index));
+                case ObjectType::PathBits:
+                    return GetObjectAsDukValue(ctx, std::make_shared<ScFootpathAdditionSceneryObject>(type, index));
+                case ObjectType::Banners:
+                    return GetObjectAsDukValue(ctx, std::make_shared<ScBannerSceneryObject>(type, index));
                 case ObjectType::SceneryGroup:
                     return GetObjectAsDukValue(ctx, std::make_shared<ScSceneryGroupObject>(type, index));
                 default:

--- a/src/openrct2/scripting/bindings/game/ScContext.hpp
+++ b/src/openrct2/scripting/bindings/game/ScContext.hpp
@@ -168,6 +168,8 @@ namespace OpenRCT2::Scripting
                     return GetObjectAsDukValue(ctx, std::make_shared<ScRideObject>(type, index));
                 case ObjectType::SmallScenery:
                     return GetObjectAsDukValue(ctx, std::make_shared<ScSmallSceneryObject>(type, index));
+                case ObjectType::SceneryGroup:
+                    return GetObjectAsDukValue(ctx, std::make_shared<ScSceneryGroupObject>(type, index));
                 default:
                     return GetObjectAsDukValue(ctx, std::make_shared<ScObject>(type, index));
             }

--- a/src/openrct2/scripting/bindings/object/ScObject.hpp
+++ b/src/openrct2/scripting/bindings/object/ScObject.hpp
@@ -990,7 +990,7 @@ namespace OpenRCT2::Scripting
                 auto& items = obj->GetItems();
                 for (const auto& item : items)
                 {
-                    result.push_back(std::move(item.ToString()));
+                    result.push_back(item.ToString());
                 }
             }
             return result;

--- a/src/openrct2/scripting/bindings/object/ScObject.hpp
+++ b/src/openrct2/scripting/bindings/object/ScObject.hpp
@@ -917,22 +917,22 @@ namespace OpenRCT2::Scripting
             return 0;
         }
 
-        uint8_t price_get() const
-        {
-            auto sceneryEntry = GetLegacyData();
-            if (sceneryEntry != nullptr)
-            {
-                return sceneryEntry->price;
-            }
-            return 0;
-        }
-
         uint8_t height_get() const
         {
             auto sceneryEntry = GetLegacyData();
             if (sceneryEntry != nullptr)
             {
                 return sceneryEntry->height;
+            }
+            return 0;
+        }
+
+        uint8_t price_get() const
+        {
+            auto sceneryEntry = GetLegacyData();
+            if (sceneryEntry != nullptr)
+            {
+                return sceneryEntry->price;
             }
             return 0;
         }

--- a/src/openrct2/scripting/bindings/object/ScObject.hpp
+++ b/src/openrct2/scripting/bindings/object/ScObject.hpp
@@ -978,45 +978,45 @@ namespace OpenRCT2::Scripting
         }
     };
 
-    class ScWallSceneryObject : public ScSceneryObject
+    class ScWallObject : public ScSceneryObject
     {
     public:
-        ScWallSceneryObject(ObjectType type, int32_t index)
+        ScWallObject(ObjectType type, int32_t index)
             : ScSceneryObject(type, index)
         {
         }
 
         static void Register(duk_context* ctx)
         {
-            dukglue_set_base_class<ScSceneryObject, ScWallSceneryObject>(ctx);
+            dukglue_set_base_class<ScSceneryObject, ScWallObject>(ctx);
         }
     };
 
-    class ScFootpathAdditionSceneryObject : public ScSceneryObject
+    class ScFootpathAdditionObject : public ScSceneryObject
     {
     public:
-        ScFootpathAdditionSceneryObject(ObjectType type, int32_t index)
+        ScFootpathAdditionObject(ObjectType type, int32_t index)
             : ScSceneryObject(type, index)
         {
         }
 
         static void Register(duk_context* ctx)
         {
-            dukglue_set_base_class<ScSceneryObject, ScFootpathAdditionSceneryObject>(ctx);
+            dukglue_set_base_class<ScSceneryObject, ScFootpathAdditionObject>(ctx);
         }
     };
 
-    class ScBannerSceneryObject : public ScSceneryObject
+    class ScBannerObject : public ScSceneryObject
     {
     public:
-        ScBannerSceneryObject(ObjectType type, int32_t index)
+        ScBannerObject(ObjectType type, int32_t index)
             : ScSceneryObject(type, index)
         {
         }
 
         static void Register(duk_context* ctx)
         {
-            dukglue_set_base_class<ScSceneryObject, ScBannerSceneryObject>(ctx);
+            dukglue_set_base_class<ScSceneryObject, ScBannerObject>(ctx);
         }
     };
 


### PR DESCRIPTION
This focuses on the ability to get all the scenery objects (loaded or unloaded) that belong to a scenery group.

We can get all the scenery group's default items by executing:
```ts
var scg = context.getObject('scenery_group', 0);
console.log(scg.items);
```

And we can get the scenery groups that a custom object adds itself to by executing:
```ts
var ss = context.getObject('small_scenery', 0);
console.log(ss.sceneryGroups);
```

`items` and `sceneryGroups` are a list of object identifiers.
Object identifiers will either be in this format:
* JSON format (`rct2.water.cyan`)
* DAT format (`12345678|CYAN    |12345678`)

Using both together will allow you to get all the loaded scenery objects that in a scenery group.