### PR TITLE
Raise water and land height limits to 254 units/182m/600ft

### DIFF
--- a/distribution/changelog.txt
+++ b/distribution/changelog.txt
@@ -5,6 +5,7 @@
 - Feature: [#19446] Add new color options to color dropdown.
 - Feature: [#19547] Add large sloped turns to hybrid coaster and single rail coaster.
 - Feature: [OpenMusic#25] Added Prehistoric ride music style.
+- Improved: [#17739] Raise water and land height limits to 254 units/182m/600ft.
 - Improved: [#18490] Reduce guests walking through trains on level crossing next to station.
 - Improved: [#18996] When marketing campaigns are disabled, disable the Marketing tab in the Finances window.
 - Improved: [#19764] Miscellaneous scenery tab now grouped next to the all-scenery tab.

--- a/src/openrct2/network/NetworkBase.cpp
+++ b/src/openrct2/network/NetworkBase.cpp
@@ -43,7 +43,7 @@
 // It is used for making sure only compatible builds get connected, even within
 // single OpenRCT2 version.
 
-#define NETWORK_STREAM_VERSION "11"
+#define NETWORK_STREAM_VERSION "12"
 
 #define NETWORK_STREAM_ID OPENRCT2_VERSION "-" NETWORK_STREAM_VERSION
 

--- a/src/openrct2/park/ParkFile.h
+++ b/src/openrct2/park/ParkFile.h
@@ -9,7 +9,7 @@ struct ObjectRepositoryItem;
 namespace OpenRCT2
 {
     // Current version that is saved.
-    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 28;
+    constexpr uint32_t PARK_FILE_CURRENT_VERSION = 29;
 
     // The minimum version that is forwards compatible with the current version.
     constexpr uint32_t PARK_FILE_MIN_VERSION = 28;

--- a/src/openrct2/world/Map.h
+++ b/src/openrct2/world/Map.h
@@ -16,10 +16,10 @@
 #include <initializer_list>
 #include <vector>
 
-#define MINIMUM_LAND_HEIGHT 2
-#define MAXIMUM_LAND_HEIGHT 142
-#define MINIMUM_WATER_HEIGHT 2
-#define MAXIMUM_WATER_HEIGHT 142
+constexpr uint8_t MINIMUM_LAND_HEIGHT = 2;
+constexpr uint8_t MAXIMUM_LAND_HEIGHT = 254;
+constexpr uint8_t MINIMUM_WATER_HEIGHT = 2;
+constexpr uint8_t MAXIMUM_WATER_HEIGHT = 254;
 
 #define MINIMUM_MAP_SIZE_TECHNICAL 5
 #define MAXIMUM_MAP_SIZE_TECHNICAL 1001


### PR DESCRIPTION
New parks load correctly in older versions, but cannot be altered there.

Fixes #17739