### PR TITLE
Fix #19989: Crash with small scenery objects having no offsets defined

### DIFF
--- a/src/openrct2/object/SmallSceneryEntry.h
+++ b/src/openrct2/object/SmallSceneryEntry.h
@@ -62,6 +62,7 @@ struct SmallSceneryEntry
     money64 price;
     money64 removal_price;
     uint8_t* frame_offsets;
+    uint16_t FrameOffsetCount;
     uint16_t animation_delay;
     uint16_t animation_mask;
     uint16_t num_frames;

--- a/src/openrct2/object/SmallSceneryObject.cpp
+++ b/src/openrct2/object/SmallSceneryObject.cpp
@@ -76,10 +76,12 @@ void SmallSceneryObject::Load()
     _legacyType.image = LoadImages();
 
     _legacyType.scenery_tab_id = OBJECT_ENTRY_INDEX_NULL;
+    _legacyType.FrameOffsetCount = 0;
 
     if (_legacyType.HasFlag(SMALL_SCENERY_FLAG_HAS_FRAME_OFFSETS))
     {
         _legacyType.frame_offsets = _frameOffsets.data();
+        _legacyType.FrameOffsetCount = static_cast<uint16_t>(_frameOffsets.size());
     }
 
     PerformFixes();

--- a/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
+++ b/src/openrct2/paint/tile_element/Paint.SmallScenery.cpp
@@ -277,7 +277,7 @@ static void PaintSmallSceneryBody(
                 frame = (frame >> delay) & sceneryEntry->animation_mask;
 
                 auto imageIndex = 0;
-                if (frame < sceneryEntry->num_frames)
+                if (frame < sceneryEntry->FrameOffsetCount)
                 {
                     imageIndex = sceneryEntry->frame_offsets[frame];
                 }


### PR DESCRIPTION
It seems like the amount of offsets is not directly tied to the amount of frames, this keeps now track on how many offsets are readable in frame_offsets, when the vector is empty then data() would result null, the referenced crash attempts to read nullptr[4] because the offsets were somehow empty, this PR avoids those crashes and ensures it won't read more than what it can.

Closes #19989